### PR TITLE
[fix] IOS-015, IOS-016: Streak bug + snooze stepper layout

### DIFF
--- a/SnoozePay/SnoozePay/Services/TransactionRepository.swift
+++ b/SnoozePay/SnoozePay/Services/TransactionRepository.swift
@@ -32,18 +32,26 @@ final class TransactionRepository {
     // MARK: - Streak calculation
 
     /// Returns count of consecutive days ending today with no charge transactions.
+    /// Returns 0 if there are no transactions at all (new user).
     func currentStreak() -> Int {
+        let allTransactions = fetchAll()
+        guard !allTransactions.isEmpty else { return 0 }
+
         let calendar = Calendar.current
         var streak = 0
         var checkDate = calendar.startOfDay(for: Date())
-        let allCharges = fetchAll().filter { $0.type == .charge }
+        let allCharges = allTransactions.filter { $0.type == .charge }
         let chargeDates = Set(allCharges.map { calendar.startOfDay(for: $0.createdAt) })
 
-        while !chargeDates.contains(checkDate) {
+        // Only count back to the date of the first transaction
+        let firstTransactionDate = calendar.startOfDay(
+            for: allTransactions.map { $0.createdAt }.min() ?? Date()
+        )
+
+        while !chargeDates.contains(checkDate) && checkDate >= firstTransactionDate {
             streak += 1
             guard let previous = calendar.date(byAdding: .day, value: -1, to: checkDate) else { break }
             checkDate = previous
-            if streak > 365 { break }
         }
 
         return streak

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
@@ -356,10 +356,14 @@ extension CreateAlarmViewController: UITableViewDataSource {
 
         case .snoozeTime:
             cell.textLabel?.text = "Откладывать на"
+            snoozeValueLabel.text = "\(viewModel.snoozeMinutes) мин"
+            snoozeValueLabel.sizeToFit()
             let stack = UIStackView(arrangedSubviews: [snoozeValueLabel, snoozeStepper])
             stack.axis = .horizontal
             stack.spacing = AppSpacing.sm
+            stack.alignment = .center
             snoozeStepper.addTarget(self, action: #selector(stepperChanged(_:)), for: .valueChanged)
+            stack.sizeToFit()
             cell.accessoryView = stack
         }
 


### PR DESCRIPTION
## Summary
- **IOS-015**: `currentStreak()` returned 366 for new users with no transactions. Now returns 0 when no transactions exist, and only counts back to the first transaction date.
- **IOS-016**: Snooze time stepper in alarm editor had broken layout (value and +/- in top-left corner). Fixed with proper `sizeToFit()` and alignment.

## Test plan
- [ ] Fresh install → Statistics → streak should show 0 or empty, not 366
- [ ] Add a top-up → streak starts counting from that day
- [ ] Create alarm editor → snooze time stepper displays correctly (value + buttons centered right)