### PR TITLE
[alarm] IOS-011: Continuous alarm sound, vibration, critical alerts

### DIFF
--- a/SnoozePay/SnoozePay/AppDelegate.swift
+++ b/SnoozePay/SnoozePay/AppDelegate.swift
@@ -53,8 +53,14 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         willPresent notification: UNNotification,
         withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
     ) {
+        let userInfo = notification.request.content.userInfo
+
+        // Start continuous alarm sound immediately (before presenting the VC)
+        let soundID = userInfo["soundID"] as? String ?? "default"
+        AudioService.shared.startAlarmSound(soundID: soundID)
+
         // Show the alarm firing screen
-        presentAlarmFiringScreen(for: notification.request.content.userInfo)
+        presentAlarmFiringScreen(for: userInfo)
         completionHandler([])
     }
 
@@ -67,15 +73,25 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         let userInfo = response.notification.request.content.userInfo
 
         switch response.actionIdentifier {
-        case "DISMISS_ACTION", UNNotificationDefaultActionIdentifier:
-            // Just dismiss — no charge
-            break
+        case "DISMISS_ACTION":
+            // Dismiss from notification action — stop sound, no charge
+            AudioService.shared.stopAlarmSound()
+
+        case UNNotificationDefaultActionIdentifier:
+            // User tapped notification banner — present alarm screen
+            // AudioService will be started by AlarmFiringViewController
+            presentAlarmFiringScreen(for: userInfo)
 
         case "SNOOZE_ACTION":
+            AudioService.shared.stopAlarmSound()
             handleSnoozeFromNotification(userInfo: userInfo)
 
+        case UNNotificationDismissActionIdentifier:
+            // User swiped away notification — stop sound
+            AudioService.shared.stopAlarmSound()
+
         default:
-            break
+            AudioService.shared.stopAlarmSound()
         }
 
         completionHandler()
@@ -94,10 +110,29 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
 
         DispatchQueue.main.async {
             let firingVC = AlarmFiringViewController(alarm: alarm, snoozeCount: userInfo["snoozeCount"] as? Int ?? 0)
-            firingVC.modalPresentationStyle = .overFullScreen
-            UIApplication.shared.connectedScenes
-                .compactMap { $0 as? UIWindowScene }
-                .first?.windows.first?.rootViewController?.present(firingVC, animated: false)
+            firingVC.modalPresentationStyle = .fullScreen
+
+            // Find the topmost presented view controller to avoid "already presenting" issues
+            guard
+                let windowScene = UIApplication.shared.connectedScenes
+                    .compactMap({ $0 as? UIWindowScene })
+                    .first,
+                let rootVC = windowScene.windows.first?.rootViewController
+            else { return }
+
+            var topVC = rootVC
+            while let presented = topVC.presentedViewController {
+                // If an alarm firing screen is already showing, dismiss it first
+                if presented is AlarmFiringViewController {
+                    presented.dismiss(animated: false) {
+                        topVC.present(firingVC, animated: false)
+                    }
+                    return
+                }
+                topVC = presented
+            }
+
+            topVC.present(firingVC, animated: false)
         }
     }
 

--- a/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
@@ -109,9 +109,20 @@ final class AlarmScheduler {
         let penalty = alarm.penalty(forSnoozeCount: snoozeCount + 1)
         content.subtitle = "Отложить · \(Int(penalty)) ₽"
 
-        content.sound = UNNotificationSound.defaultCriticalSound(withAudioVolume: 1.0)
+        // Use critical alert sound to bypass Do Not Disturb and Silent Mode.
+        // Requires NSCriticalAlertUsageDescription in Info.plist and
+        // com.apple.developer.usernotifications.critical-alerts entitlement.
+        if let soundName = alarmSoundFileName(for: alarm.soundID) {
+            content.sound = UNNotificationSound.criticalSoundNamed(
+                UNNotificationSoundName(soundName),
+                withAudioVolume: 1.0
+            )
+        } else {
+            content.sound = UNNotificationSound.defaultCriticalSound(withAudioVolume: 1.0)
+        }
+
         content.categoryIdentifier = categoryID
-        content.interruptionLevel = .timeSensitive
+        content.interruptionLevel = .critical
 
         // Pass alarm metadata via userInfo for handling in AppDelegate
         content.userInfo = [
@@ -119,7 +130,8 @@ final class AlarmScheduler {
             "penaltyAmount": alarm.penaltyAmount,
             "progressiveScale": alarm.progressiveScale,
             "snoozeCount": snoozeCount,
-            "snoozeMinutes": alarm.snoozeMinutes
+            "snoozeMinutes": alarm.snoozeMinutes,
+            "soundID": alarm.soundID
         ]
 
         return content
@@ -164,5 +176,23 @@ final class AlarmScheduler {
 
     private func snoozeNotificationID(for alarmID: UUID) -> String {
         "snooze_\(alarmID.uuidString)"
+    }
+
+    /// Resolve alarm soundID to an actual file name with extension in the bundle.
+    /// Returns nil if no matching file is found (falls back to default critical sound).
+    private func alarmSoundFileName(for soundID: String) -> String? {
+        let extensions = ["caf", "m4a", "wav", "mp3"]
+        for ext in extensions {
+            if Bundle.main.url(forResource: soundID, withExtension: ext) != nil {
+                return "\(soundID).\(ext)"
+            }
+        }
+        // Try default alarm sound
+        for ext in extensions {
+            if Bundle.main.url(forResource: "default_alarm", withExtension: ext) != nil {
+                return "default_alarm.\(ext)"
+            }
+        }
+        return nil
     }
 }

--- a/SnoozePay/SnoozePay/Services/AudioService.swift
+++ b/SnoozePay/SnoozePay/Services/AudioService.swift
@@ -1,0 +1,110 @@
+import AVFoundation
+import AudioToolbox
+
+/// Manages continuous alarm sound playback and vibration.
+/// Configures AVAudioSession for playback even when screen is locked,
+/// loops the alarm sound until explicitly stopped, and provides
+/// a repeating vibration pattern via AudioToolbox.
+final class AudioService {
+
+    static let shared = AudioService()
+
+    private var audioPlayer: AVAudioPlayer?
+    private var vibrationTimer: Timer?
+    private var isPlaying = false
+
+    private init() {}
+
+    // MARK: - Audio Session
+
+    /// Configure the audio session for alarm playback.
+    /// Uses `.playback` category so audio continues when screen is locked.
+    private func configureAudioSession() {
+        do {
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(.playback, options: [.duckOthers])
+            try session.setActive(true, options: [])
+        } catch {
+            print("Failed to configure audio session: \(error)")
+        }
+    }
+
+    /// Deactivate the audio session when alarm is stopped.
+    private func deactivateAudioSession() {
+        do {
+            try AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
+        } catch {
+            print("Failed to deactivate audio session: \(error)")
+        }
+    }
+
+    // MARK: - Alarm Sound
+
+    /// Start playing alarm sound in a loop.
+    /// - Parameter soundID: Name of the sound file (without extension) in the app bundle.
+    ///   Falls back to a system-generated tone if file is not found.
+    func startAlarmSound(soundID: String) {
+        guard !isPlaying else { return }
+
+        configureAudioSession()
+
+        // Try to find the sound file in the bundle
+        let url: URL? = Bundle.main.url(forResource: soundID, withExtension: "caf")
+            ?? Bundle.main.url(forResource: soundID, withExtension: "m4a")
+            ?? Bundle.main.url(forResource: soundID, withExtension: "wav")
+            ?? Bundle.main.url(forResource: soundID, withExtension: "mp3")
+            ?? Bundle.main.url(forResource: "default_alarm", withExtension: "caf")
+            ?? Bundle.main.url(forResource: "default_alarm", withExtension: "m4a")
+
+        guard let soundURL = url else {
+            print("Alarm sound file not found for soundID: \(soundID)")
+            // Even without sound, start vibration
+            startVibration()
+            isPlaying = true
+            return
+        }
+
+        do {
+            audioPlayer = try AVAudioPlayer(contentsOf: soundURL)
+            audioPlayer?.numberOfLoops = -1 // Loop indefinitely
+            audioPlayer?.volume = 1.0
+            audioPlayer?.prepareToPlay()
+            audioPlayer?.play()
+            isPlaying = true
+        } catch {
+            print("Failed to create audio player: \(error)")
+        }
+
+        startVibration()
+    }
+
+    /// Stop alarm sound and vibration immediately.
+    func stopAlarmSound() {
+        audioPlayer?.stop()
+        audioPlayer = nil
+        stopVibration()
+        deactivateAudioSession()
+        isPlaying = false
+    }
+
+    // MARK: - Vibration
+
+    /// Start a repeating vibration pattern (vibrate every ~1 second).
+    private func startVibration() {
+        stopVibration()
+
+        // Trigger first vibration immediately
+        AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)
+
+        // Repeat vibration on a timer
+        vibrationTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
+            AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)
+        }
+    }
+
+    /// Stop the vibration timer.
+    private func stopVibration() {
+        vibrationTimer?.invalidate()
+        vibrationTimer = nil
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
@@ -110,11 +110,17 @@ class AlarmFiringViewController: UIViewController {
         bindViewModel()
         startClock()
         startPulseAnimation()
+
+        // Start continuous alarm sound and vibration
+        AudioService.shared.startAlarmSound(soundID: viewModel.alarm.soundID)
     }
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         clockTimer?.invalidate()
+
+        // Stop alarm sound and vibration when screen is dismissed
+        AudioService.shared.stopAlarmSound()
     }
 
     override var prefersStatusBarHidden: Bool { true }


### PR DESCRIPTION
## Summary
- New `AudioService` singleton for continuous alarm sound via AVAudioPlayer (looping)
- AVAudioSession configured for `.playback` category — sound plays with screen locked
- Vibration loop via AudioToolbox timer (1-second intervals)
- Changed notification `interruptionLevel` to `.critical` — bypasses DND/Focus
- AlarmFiringViewController starts/stops AudioService on appear/disappear
- AppDelegate starts sound immediately on foreground notification arrival
- Fullscreen modal presentation with topmost VC resolution

## Info.plist requirements (manual)
- `NSCriticalAlertUsageDescription` — explain critical alert usage
- `UIBackgroundModes` — add `audio`
- Entitlement: `com.apple.developer.usernotifications.critical-alerts`

## Test plan
- [ ] Alarm fires with continuous sound (doesn't stop after notification tone)
- [ ] Sound stops on Dismiss tap
- [ ] Sound stops on Snooze tap
- [ ] Vibration works alongside sound
- [ ] Works in Do Not Disturb mode (critical alert)
- [ ] Works when app is in background
- [ ] Works on lock screen