### PR TITLE
Update main alarm list screen to match Figma design

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmCell.swift
@@ -1,21 +1,30 @@
 import UIKit
 
-/// Table view cell for displaying a single alarm in the list.
+/// Table view cell styled as a dark card for displaying a single alarm in the list.
 final class AlarmCell: UITableViewCell {
 
     static let reuseID = "AlarmCell"
 
     // MARK: - UI Elements
 
+    private let cardView: UIView = {
+        let view = UIView()
+        view.backgroundColor = AppColors.surface
+        view.layer.cornerRadius = AppRadius.md
+        view.clipsToBounds = true
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
     private let timeLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 36, weight: .thin)
+        label.font = UIFont.monospacedDigitSystemFont(ofSize: 52, weight: .medium)
         label.textColor = .label
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
 
-    private let subtitleLabel: UILabel = {
+    private let detailLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 13, weight: .regular)
         label.textColor = .secondaryLabel
@@ -23,10 +32,10 @@ final class AlarmCell: UITableViewCell {
         return label
     }()
 
-    private let nameLabel: UILabel = {
+    private let penaltyLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 13, weight: .regular)
-        label.textColor = .secondaryLabel
+        label.font = UIFont.systemFont(ofSize: 12, weight: .semibold)
+        label.textColor = AppColors.accentOrange
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
@@ -52,40 +61,57 @@ final class AlarmCell: UITableViewCell {
     // MARK: - Setup
 
     private func setupUI() {
-        backgroundColor = AppColors.surface
+        backgroundColor = .clear
+        contentView.backgroundColor = .clear
         selectionStyle = .none
 
-        let textStack = UIStackView(arrangedSubviews: [timeLabel, subtitleLabel, nameLabel])
-        textStack.axis = .vertical
-        textStack.spacing = 2
-        textStack.translatesAutoresizingMaskIntoConstraints = false
-
-        contentView.addSubview(textStack)
-        contentView.addSubview(toggleSwitch)
+        contentView.addSubview(cardView)
+        cardView.addSubview(timeLabel)
+        cardView.addSubview(detailLabel)
+        cardView.addSubview(penaltyLabel)
+        cardView.addSubview(toggleSwitch)
 
         NSLayoutConstraint.activate([
-            textStack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.lg),
-            textStack.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            textStack.trailingAnchor.constraint(lessThanOrEqualTo: toggleSwitch.leadingAnchor, constant: -AppSpacing.md),
+            // Card with horizontal and vertical insets
+            cardView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: AppSpacing.sm / 2),
+            cardView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.lg),
+            cardView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.lg),
+            cardView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -AppSpacing.sm / 2),
 
-            toggleSwitch.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.lg),
-            toggleSwitch.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            // Toggle in top-right corner of card
+            toggleSwitch.topAnchor.constraint(equalTo: cardView.topAnchor, constant: AppSpacing.lg),
+            toggleSwitch.trailingAnchor.constraint(equalTo: cardView.trailingAnchor, constant: -AppSpacing.lg),
 
-            contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: 80)
+            // Time label (large, top-left)
+            timeLabel.topAnchor.constraint(equalTo: cardView.topAnchor, constant: AppSpacing.md),
+            timeLabel.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: AppSpacing.lg),
+            timeLabel.trailingAnchor.constraint(lessThanOrEqualTo: toggleSwitch.leadingAnchor, constant: -AppSpacing.sm),
+
+            // Detail line: "Name - Days"
+            detailLabel.topAnchor.constraint(equalTo: timeLabel.bottomAnchor, constant: AppSpacing.xs),
+            detailLabel.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: AppSpacing.lg),
+            detailLabel.trailingAnchor.constraint(lessThanOrEqualTo: cardView.trailingAnchor, constant: -AppSpacing.lg),
+
+            // Penalty line at the bottom
+            penaltyLabel.topAnchor.constraint(equalTo: detailLabel.bottomAnchor, constant: AppSpacing.sm),
+            penaltyLabel.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: AppSpacing.lg),
+            penaltyLabel.trailingAnchor.constraint(lessThanOrEqualTo: cardView.trailingAnchor, constant: -AppSpacing.lg),
+            penaltyLabel.bottomAnchor.constraint(equalTo: cardView.bottomAnchor, constant: -AppSpacing.md),
         ])
     }
 
     // MARK: - Configure
 
-    func configure(time: String, subtitle: String, name: String, enabled: Bool) {
+    func configure(time: String, detail: String, penalty: String, enabled: Bool) {
         timeLabel.text = time
-        subtitleLabel.text = subtitle
-        nameLabel.text = name
+        detailLabel.text = detail
+        penaltyLabel.text = penalty
         toggleSwitch.isOn = enabled
 
-        // Dim text when disabled
-        timeLabel.alpha = enabled ? 1.0 : 0.4
-        subtitleLabel.alpha = enabled ? 1.0 : 0.4
-        nameLabel.alpha = enabled ? 1.0 : 0.4
+        // Dim text when alarm is disabled
+        let alpha: CGFloat = enabled ? 1.0 : 0.4
+        timeLabel.alpha = alpha
+        detailLabel.alpha = alpha
+        penaltyLabel.alpha = alpha
     }
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-/// Main screen: alarm list with balance header and navigation to create/edit alarms.
+/// Main screen: alarm list with balance card header and navigation to create/edit alarms.
 class AlarmsListViewController: UIViewController {
 
     // MARK: - ViewModel
@@ -10,7 +10,7 @@ class AlarmsListViewController: UIViewController {
     // MARK: - UI Elements
 
     private let tableView: UITableView = {
-        let tv = UITableView(frame: .zero, style: .insetGrouped)
+        let tv = UITableView(frame: .zero, style: .plain)
         tv.backgroundColor = .systemGroupedBackground
         tv.separatorStyle = .none
         tv.translatesAutoresizingMaskIntoConstraints = false
@@ -55,27 +55,20 @@ class AlarmsListViewController: UIViewController {
         return view
     }()
 
-    // Balance header (shown in navigation bar area)
-    private let balanceHeaderView: UIView = {
-        let view = UIView()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        return view
-    }()
+    // MARK: - Balance Card (table header)
 
-    private let balanceLabel: UILabel = {
-        let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
-        label.textColor = .label
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
-    }()
+    private let balanceCard = UIView()
+    private let balanceAmountLabel = UILabel()
+    private let topUpButton = UIButton(type: .system)
 
     // MARK: - Lifecycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        view.backgroundColor = .systemGroupedBackground
         setupNavigationBar()
         setupTableView()
+        setupBalanceHeader()
         setupEmptyState()
         bindViewModel()
     }
@@ -90,25 +83,16 @@ class AlarmsListViewController: UIViewController {
 
     private func setupNavigationBar() {
         navigationItem.title = "Будильники"
-        navigationController?.navigationBar.prefersLargeTitles = true
+        navigationController?.navigationBar.prefersLargeTitles = false
 
-        // Add alarm button
+        // "+" button using SF Symbol
         let addButton = UIBarButtonItem(
-            barButtonSystemItem: .add,
+            image: UIImage(systemName: "plus.circle.fill"),
+            style: .plain,
             target: self,
             action: #selector(addAlarmTapped)
         )
         navigationItem.rightBarButtonItem = addButton
-
-        // Balance button in left
-        let balanceButton = UIBarButtonItem(
-            title: viewModel.formattedBalance,
-            style: .plain,
-            target: self,
-            action: #selector(balanceTapped)
-        )
-        balanceButton.tintColor = AppColors.accentGreen
-        navigationItem.leftBarButtonItem = balanceButton
     }
 
     private func setupTableView() {
@@ -123,6 +107,101 @@ class AlarmsListViewController: UIViewController {
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
+    }
+
+    private func setupBalanceHeader() {
+        // Container for the balance card with padding
+        let headerContainer = UIView()
+
+        // Balance card styling — blue background
+        balanceCard.backgroundColor = AppColors.accentBlue
+        balanceCard.layer.cornerRadius = AppRadius.md
+        balanceCard.clipsToBounds = true
+        balanceCard.translatesAutoresizingMaskIntoConstraints = false
+
+        // "БАЛАНС" small label
+        let titleLabel = UILabel()
+        titleLabel.text = "БАЛАНС"
+        titleLabel.font = UIFont.systemFont(ofSize: 11, weight: .semibold)
+        titleLabel.textColor = UIColor.white.withAlphaComponent(0.7)
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        // Amount label (large, white)
+        balanceAmountLabel.font = UIFont.monospacedDigitSystemFont(ofSize: 28, weight: .bold)
+        balanceAmountLabel.textColor = .white
+        balanceAmountLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        // Top-up button (white pill with wallet icon)
+        var buttonConfig = UIButton.Configuration.filled()
+        buttonConfig.baseBackgroundColor = .white
+        buttonConfig.baseForegroundColor = AppColors.accentBlue
+        buttonConfig.cornerStyle = .capsule
+        buttonConfig.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16)
+
+        let walletImage = UIImage(systemName: "wallet.pass.fill")?
+            .withConfiguration(UIImage.SymbolConfiguration(pointSize: 13, weight: .semibold))
+        buttonConfig.image = walletImage
+        buttonConfig.imagePadding = 6
+        buttonConfig.imagePlacement = .leading
+
+        var titleAttr = AttributedString("Пополнить")
+        titleAttr.font = UIFont.systemFont(ofSize: 14, weight: .semibold)
+        buttonConfig.attributedTitle = titleAttr
+
+        topUpButton.configuration = buttonConfig
+        topUpButton.addTarget(self, action: #selector(topUpTapped), for: .touchUpInside)
+        topUpButton.translatesAutoresizingMaskIntoConstraints = false
+
+        balanceCard.addSubview(titleLabel)
+        balanceCard.addSubview(balanceAmountLabel)
+        balanceCard.addSubview(topUpButton)
+
+        headerContainer.addSubview(balanceCard)
+
+        NSLayoutConstraint.activate([
+            balanceCard.topAnchor.constraint(equalTo: headerContainer.topAnchor, constant: AppSpacing.sm),
+            balanceCard.leadingAnchor.constraint(equalTo: headerContainer.leadingAnchor, constant: AppSpacing.lg),
+            balanceCard.trailingAnchor.constraint(equalTo: headerContainer.trailingAnchor, constant: -AppSpacing.lg),
+            balanceCard.bottomAnchor.constraint(equalTo: headerContainer.bottomAnchor, constant: -AppSpacing.sm),
+
+            titleLabel.topAnchor.constraint(equalTo: balanceCard.topAnchor, constant: AppSpacing.md),
+            titleLabel.leadingAnchor.constraint(equalTo: balanceCard.leadingAnchor, constant: AppSpacing.lg),
+
+            balanceAmountLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: AppSpacing.xs),
+            balanceAmountLabel.leadingAnchor.constraint(equalTo: balanceCard.leadingAnchor, constant: AppSpacing.lg),
+            balanceAmountLabel.bottomAnchor.constraint(equalTo: balanceCard.bottomAnchor, constant: -AppSpacing.md),
+
+            topUpButton.centerYAnchor.constraint(equalTo: balanceCard.centerYAnchor),
+            topUpButton.trailingAnchor.constraint(equalTo: balanceCard.trailingAnchor, constant: -AppSpacing.lg),
+            topUpButton.leadingAnchor.constraint(greaterThanOrEqualTo: balanceAmountLabel.trailingAnchor, constant: AppSpacing.md),
+        ])
+
+        // Size the header to fit its content
+        let targetSize = CGSize(width: view.bounds.width, height: UIView.layoutFittingCompressedSize.height)
+        headerContainer.frame.size.width = view.bounds.width
+        headerContainer.setNeedsLayout()
+        headerContainer.layoutIfNeeded()
+        let height = headerContainer.systemLayoutSizeFitting(targetSize,
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel).height
+        headerContainer.frame = CGRect(x: 0, y: 0, width: view.bounds.width, height: height)
+
+        tableView.tableHeaderView = headerContainer
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        // Recalculate header height on layout changes (rotation, etc.)
+        guard let header = tableView.tableHeaderView else { return }
+        let targetSize = CGSize(width: tableView.bounds.width, height: UIView.layoutFittingCompressedSize.height)
+        let newHeight = header.systemLayoutSizeFitting(targetSize,
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel).height
+        if header.frame.height != newHeight {
+            header.frame.size = CGSize(width: tableView.bounds.width, height: newHeight)
+            tableView.tableHeaderView = header
+        }
     }
 
     private func setupEmptyState() {
@@ -143,9 +222,9 @@ class AlarmsListViewController: UIViewController {
             self.tableView.isHidden = self.viewModel.alarms.isEmpty
         }
 
-        viewModel.onBalanceUpdated = { [weak self] balance in
+        viewModel.onBalanceUpdated = { [weak self] _ in
             guard let self else { return }
-            self.navigationItem.leftBarButtonItem?.title = self.viewModel.formattedBalance
+            self.balanceAmountLabel.text = "₽ \(self.viewModel.formattedBalance)"
         }
     }
 
@@ -160,7 +239,7 @@ class AlarmsListViewController: UIViewController {
         present(nav, animated: true)
     }
 
-    @objc private func balanceTapped() {
+    @objc private func topUpTapped() {
         let topUpVC = TopUpViewController()
         let nav = UINavigationController(rootViewController: topUpVC)
         present(nav, animated: true)
@@ -184,8 +263,8 @@ extension AlarmsListViewController: UITableViewDataSource {
         let alarm = viewModel.alarms[indexPath.row]
         cell.configure(
             time: viewModel.alarmTimeString(at: indexPath.row),
-            subtitle: viewModel.alarmSubtitle(at: indexPath.row),
-            name: alarm.name,
+            detail: viewModel.alarmDetail(at: indexPath.row),
+            penalty: viewModel.alarmPenaltyString(at: indexPath.row),
             enabled: alarm.enabled
         )
 

--- a/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
@@ -85,11 +85,24 @@ final class AlarmsListViewModel {
         return formatter.string(from: alarms[index].time)
     }
 
+    /// Detail line for alarm card: "Name - Days" (e.g. "Работа - Будни")
+    func alarmDetail(at index: Int) -> String {
+        guard index < alarms.count else { return "" }
+        let alarm = alarms[index]
+        return "\(alarm.name) \u{2022} \(alarm.repeatDaysDescription)"
+    }
+
+    /// Penalty line for alarm card (e.g. "▲ ОТЛОЖИТЬ: 50 ₽")
+    func alarmPenaltyString(at index: Int) -> String {
+        guard index < alarms.count else { return "" }
+        return "▲ ОТЛОЖИТЬ: \(Int(alarms[index].penaltyAmount)) ₽"
+    }
+
     func alarmSubtitle(at index: Int) -> String {
         guard index < alarms.count else { return "" }
         let alarm = alarms[index]
         let days = alarm.repeatDaysDescription
         let penalty = "\(Int(alarm.penaltyAmount)) ₽"
-        return "\(days) · \(penalty)"
+        return "\(days) \u{00B7} \(penalty)"
     }
 }

--- a/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+@testable import SnoozePay
+
+/// Unit tests for AlarmsListViewModel helper methods — detail and penalty formatting.
+final class AlarmsListViewModelTests: XCTestCase {
+
+    private var testDefaults: UserDefaults!
+    private var repo: AlarmRepository!
+
+    override func setUp() {
+        super.setUp()
+        testDefaults = UserDefaults(suiteName: "test.alarmsList.\(UUID().uuidString)")!
+        repo = AlarmRepository(defaults: testDefaults)
+    }
+
+    override func tearDown() {
+        if let name = testDefaults.suiteName {
+            UserDefaults.removePersistentDomain(forName: name)
+        }
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeViewModel() -> AlarmsListViewModel {
+        AlarmsListViewModel(alarmRepository: repo, balanceService: .shared)
+    }
+
+    // MARK: - alarmDetail(at:)
+
+    func testAlarmDetail_withNameAndDays() {
+        // Weekdays Mon-Fri (0-4) should display as "Будни"
+        let alarm = Alarm(
+            repeatDays: [0, 1, 2, 3, 4],
+            name: "Работа",
+            penaltyAmount: 50
+        )
+        repo.save(alarm)
+
+        let vm = makeViewModel()
+        vm.loadData()
+
+        let detail = vm.alarmDetail(at: 0)
+        XCTAssertEqual(detail, "Работа \u{2022} Будни")
+    }
+
+    func testAlarmDetail_withNameNoDays() {
+        // No repeat days should display as "Единожды"
+        let alarm = Alarm(
+            repeatDays: [],
+            name: "Утро",
+            penaltyAmount: 100
+        )
+        repo.save(alarm)
+
+        let vm = makeViewModel()
+        vm.loadData()
+
+        let detail = vm.alarmDetail(at: 0)
+        XCTAssertEqual(detail, "Утро \u{2022} Единожды")
+    }
+
+    // MARK: - alarmPenaltyString(at:)
+
+    func testAlarmPenaltyString_format() {
+        let alarm = Alarm(penaltyAmount: 50)
+        repo.save(alarm)
+
+        let vm = makeViewModel()
+        vm.loadData()
+
+        let penalty = vm.alarmPenaltyString(at: 0)
+        XCTAssertEqual(penalty, "▲ ОТЛОЖИТЬ: 50 ₽")
+    }
+
+    func testAlarmPenaltyString_highPenalty() {
+        let alarm = Alarm(penaltyAmount: 1000)
+        repo.save(alarm)
+
+        let vm = makeViewModel()
+        vm.loadData()
+
+        let penalty = vm.alarmPenaltyString(at: 0)
+        XCTAssertEqual(penalty, "▲ ОТЛОЖИТЬ: 1000 ₽")
+    }
+}


### PR DESCRIPTION
## Summary
- Replace simple alarm cells with card-based design: dark background, 52pt time, penalty display
- Add blue balance bar header with amount + "Пополнить" button  
- Update alarm card layout: "Работа • Будни" single line, "▲ ОТЛОЖИТЬ: 50 ₽" penalty
- Disable large titles, update + button to circle icon

## Test plan
- [ ] Alarm list displays cards with correct layout
- [ ] Balance bar shows current balance, tapping "Пополнить" opens top-up
- [ ] Swipe to delete and tap to edit still work
- [ ] Toggle switch enables/disables alarm
- [ ] Unit tests for new ViewModel helpers