### PR TITLE
Add onboarding screen and update alarm firing to match Figma

### DIFF
--- a/SnoozePay/SnoozePay/SceneDelegate.swift
+++ b/SnoozePay/SnoozePay/SceneDelegate.swift
@@ -17,9 +17,29 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = scene as? UIWindowScene else { return }
 
         let window = UIWindow(windowScene: windowScene)
-        window.rootViewController = makeRootViewController()
-        window.makeKeyAndVisible()
         self.window = window
+
+        if OnboardingViewController.isCompleted {
+            window.rootViewController = makeRootViewController()
+        } else {
+            let onboarding = OnboardingViewController()
+            onboarding.onFinished = { [weak self] in
+                self?.transitionToMainApp()
+            }
+            window.rootViewController = onboarding
+        }
+
+        window.makeKeyAndVisible()
+    }
+
+    // MARK: - Onboarding transition
+
+    private func transitionToMainApp() {
+        guard let window = window else { return }
+        let tabBar = makeRootViewController()
+        UIView.transition(with: window, duration: 0.4, options: .transitionCrossDissolve) {
+            window.rootViewController = tabBar
+        }
     }
 
     // MARK: - Root UI setup

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
@@ -1,9 +1,8 @@
 import UIKit
 
 /// Fullscreen alarm firing screen.
-/// Mirrors the native iOS 26 AlarmKit UI: blurred wallpaper background,
-/// ALARM label at top, large time, alarm name, two frosted-glass buttons side-by-side.
-/// The only customisation: Snooze button shows the penalty price.
+/// Dark background with decorative purple gradient circles,
+/// large time display, alarm name, and two pill-shaped action buttons with icons.
 class AlarmFiringViewController: UIViewController {
 
     // MARK: - ViewModel
@@ -18,6 +17,26 @@ class AlarmFiringViewController: UIViewController {
         let view = UIVisualEffectView(effect: blur)
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
+    }()
+
+    /// Decorative purple circle — top left area
+    private let topLeftCircle: UIView = {
+        let size: CGFloat = 200
+        let circle = UIView(frame: CGRect(x: -40, y: -20, width: size, height: size))
+        circle.backgroundColor = UIColor(red: 0.55, green: 0.30, blue: 0.85, alpha: 0.40)
+        circle.layer.cornerRadius = size / 2
+        circle.layer.masksToBounds = true
+        return circle
+    }()
+
+    /// Decorative purple circle — bottom right area
+    private let bottomRightCircle: UIView = {
+        let size: CGFloat = 150
+        let circle = UIView(frame: CGRect(x: 0, y: 0, width: size, height: size))
+        circle.backgroundColor = UIColor(red: 0.55, green: 0.30, blue: 0.85, alpha: 0.30)
+        circle.layer.cornerRadius = size / 2
+        circle.layer.masksToBounds = true
+        return circle
     }()
 
     /// "БУДИЛЬНИК" label at top (matches native iOS alarm)
@@ -53,13 +72,19 @@ class AlarmFiringViewController: UIViewController {
         return label
     }()
 
-    /// "Выключить" — green frosted glass, left side
+    /// "Выключить" — light gray pill with xmark icon
     private let dismissButton: UIButton = {
+        // #EBEBF0 at 60% opacity
+        let bgColor = UIColor(red: 0.92, green: 0.92, blue: 0.94, alpha: 0.60)
+
         var config = UIButton.Configuration.filled()
         config.title = "Выключить"
-        config.baseBackgroundColor = UIColor(red: 0.19, green: 0.82, blue: 0.34, alpha: 0.85)
+        config.image = UIImage(systemName: "xmark")
+        config.imagePadding = 8
+        config.imagePlacement = .leading
+        config.baseBackgroundColor = bgColor
         config.baseForegroundColor = .white
-        config.cornerStyle = .large
+        config.cornerStyle = .capsule
         config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { attrs in
             var a = attrs
             a.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
@@ -70,12 +95,18 @@ class AlarmFiringViewController: UIViewController {
         return button
     }()
 
-    /// "Отложить · X₽" — orange frosted glass, right side
+    /// "Отложить · X₽" — golden/warm orange pill with bell icon
     private let snoozeButton: UIButton = {
+        // #E8A838 warm orange/gold
+        let activeColor = UIColor(red: 0.91, green: 0.66, blue: 0.22, alpha: 1.0)
+
         var config = UIButton.Configuration.filled()
-        config.baseBackgroundColor = UIColor.systemOrange.withAlphaComponent(0.85)
+        config.image = UIImage(systemName: "bell.fill")
+        config.imagePadding = 8
+        config.imagePlacement = .leading
+        config.baseBackgroundColor = activeColor
         config.baseForegroundColor = .white
-        config.cornerStyle = .large
+        config.cornerStyle = .capsule
         config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { attrs in
             var a = attrs
             a.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
@@ -140,6 +171,10 @@ class AlarmFiringViewController: UIViewController {
             blurView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
 
+        // Decorative gradient circles
+        view.addSubview(topLeftCircle)
+        view.addSubview(bottomRightCircle)
+
         // Content
         view.addSubview(alarmTypeLabel)
         view.addSubview(timeLabel)
@@ -181,6 +216,21 @@ class AlarmFiringViewController: UIViewController {
         updateUI()
     }
 
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        // Position decorative circles relative to screen bounds
+        let bounds = view.bounds
+        topLeftCircle.frame = CGRect(x: -40, y: bounds.height * 0.10, width: 200, height: 200)
+        bottomRightCircle.frame = CGRect(
+            x: bounds.width - 110,
+            y: bounds.height * 0.65,
+            width: 150,
+            height: 150
+        )
+
+    }
+
     private func bindViewModel() {
         viewModel.onStateChanged = { [weak self] in
             self?.updateUI()
@@ -189,17 +239,19 @@ class AlarmFiringViewController: UIViewController {
 
     private func updateUI() {
         nameLabel.text = viewModel.alarmName
-        snoozeButton.setTitle(viewModel.snoozeButtonTitle, for: .normal)
+
+        // Snooze button title (with config to preserve icon)
+        var snoozeConfig = snoozeButton.configuration
+        snoozeConfig?.title = viewModel.snoozeButtonTitle
 
         if viewModel.canSnooze {
-            var config = snoozeButton.configuration
-            config?.baseBackgroundColor = UIColor.systemOrange.withAlphaComponent(0.85)
-            snoozeButton.configuration = config
+            // #E8A838 warm orange/gold
+            snoozeConfig?.baseBackgroundColor = UIColor(red: 0.91, green: 0.66, blue: 0.22, alpha: 1.0)
+            snoozeButton.configuration = snoozeConfig
             snoozeButton.isEnabled = true
         } else {
-            var config = snoozeButton.configuration
-            config?.baseBackgroundColor = UIColor.systemGray.withAlphaComponent(0.5)
-            snoozeButton.configuration = config
+            snoozeConfig?.baseBackgroundColor = UIColor.systemGray.withAlphaComponent(0.5)
+            snoozeButton.configuration = snoozeConfig
             snoozeButton.isEnabled = false
         }
     }

--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController.swift
@@ -1,0 +1,248 @@
+import UIKit
+
+/// Onboarding flow shown on first launch.
+/// Three fullscreen pages with swipe navigation and pagination dots.
+final class OnboardingViewController: UIViewController {
+
+    // MARK: - Constants
+
+    private static let completedKey = "onboarding_completed"
+
+    static var isCompleted: Bool {
+        UserDefaults.standard.bool(forKey: completedKey)
+    }
+
+    // MARK: - Page Data
+
+    private struct Page {
+        let emoji: String
+        let title: String
+        let description: String
+        let buttonTitle: String
+    }
+
+    private let pages: [Page] = [
+        Page(
+            emoji: "\u{23F0}",
+            title: "Откладывание стоит денег",
+            description: "Каждый раз, когда вы откладываете будильник, с вашего баланса списывается штраф. Это мотивирует просыпаться вовремя.",
+            buttonTitle: "Далее"
+        ),
+        Page(
+            emoji: "\u{1F4B0}",
+            title: "Штраф 10–1000\u{20BD}",
+            description: "Вы устанавливаете размер штрафа сами. Если баланс = 0, откладывание блокируется.",
+            buttonTitle: "Далее"
+        ),
+        Page(
+            emoji: "\u{1F525}",
+            title: "Статистика и streak",
+            description: "Следите за своими успехами и экономьте деньги. Каждый день без откладывания увеличивает ваш streak!",
+            buttonTitle: "Начать"
+        )
+    ]
+
+    // MARK: - Callback
+
+    var onFinished: (() -> Void)?
+
+    // MARK: - UI Elements
+
+    private let scrollView: UIScrollView = {
+        let sv = UIScrollView()
+        sv.isPagingEnabled = true
+        sv.showsHorizontalScrollIndicator = false
+        sv.showsVerticalScrollIndicator = false
+        sv.bounces = false
+        sv.translatesAutoresizingMaskIntoConstraints = false
+        return sv
+    }()
+
+    private let pageControl: UIPageControl = {
+        let pc = UIPageControl()
+        pc.currentPageIndicatorTintColor = .systemBlue
+        pc.pageIndicatorTintColor = UIColor.systemGray.withAlphaComponent(0.5)
+        pc.translatesAutoresizingMaskIntoConstraints = false
+        pc.isUserInteractionEnabled = false
+        return pc
+    }()
+
+    private let skipButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("Пропустить", for: .normal)
+        button.setTitleColor(.systemBlue, for: .normal)
+        button.titleLabel?.font = UIFont.systemFont(ofSize: 15, weight: .regular)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    private let actionButton: UIButton = {
+        var config = UIButton.Configuration.filled()
+        config.baseBackgroundColor = .systemBlue
+        config.baseForegroundColor = .white
+        config.cornerStyle = .large
+        config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { attrs in
+            var a = attrs
+            a.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
+            return a
+        }
+        let button = UIButton(configuration: config)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    private var pageViews: [UIView] = []
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .black
+        setupUI()
+        updateActionButton(forPage: 0)
+    }
+
+    override var prefersStatusBarHidden: Bool { true }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        // Recalculate page widths after layout
+        let width = scrollView.bounds.width
+        guard width > 0 else { return }
+        for (index, pageView) in pageViews.enumerated() {
+            pageView.frame = CGRect(
+                x: width * CGFloat(index),
+                y: 0,
+                width: width,
+                height: scrollView.bounds.height
+            )
+        }
+        scrollView.contentSize = CGSize(width: width * CGFloat(pages.count), height: scrollView.bounds.height)
+    }
+
+    // MARK: - Setup
+
+    private func setupUI() {
+        view.addSubview(scrollView)
+        view.addSubview(skipButton)
+        view.addSubview(pageControl)
+        view.addSubview(actionButton)
+
+        pageControl.numberOfPages = pages.count
+        pageControl.currentPage = 0
+
+        NSLayoutConstraint.activate([
+            // Skip button — top right
+            skipButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 8),
+            skipButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+
+            // Scroll view — full screen behind everything
+            scrollView.topAnchor.constraint(equalTo: view.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            // Action button — bottom, full width with margins
+            actionButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
+            actionButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+            actionButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -24),
+            actionButton.heightAnchor.constraint(equalToConstant: 50),
+
+            // Page control — above button
+            pageControl.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            pageControl.bottomAnchor.constraint(equalTo: actionButton.topAnchor, constant: -24)
+        ])
+
+        scrollView.delegate = self
+        skipButton.addTarget(self, action: #selector(finishOnboarding), for: .touchUpInside)
+        actionButton.addTarget(self, action: #selector(actionTapped), for: .touchUpInside)
+
+        // Create page content views
+        for page in pages {
+            let pageView = makePageView(page: page)
+            scrollView.addSubview(pageView)
+            pageViews.append(pageView)
+        }
+    }
+
+    private func makePageView(page: Page) -> UIView {
+        let container = UIView()
+
+        let emojiLabel = UILabel()
+        emojiLabel.text = page.emoji
+        emojiLabel.font = UIFont.systemFont(ofSize: 64)
+        emojiLabel.textAlignment = .center
+        emojiLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        let titleLabel = UILabel()
+        titleLabel.text = page.title
+        titleLabel.font = UIFont.systemFont(ofSize: 24, weight: .bold)
+        titleLabel.textColor = .white
+        titleLabel.textAlignment = .center
+        titleLabel.numberOfLines = 0
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        let descLabel = UILabel()
+        descLabel.text = page.description
+        descLabel.font = UIFont.systemFont(ofSize: 15, weight: .regular)
+        descLabel.textColor = UIColor.white.withAlphaComponent(0.6)
+        descLabel.textAlignment = .center
+        descLabel.numberOfLines = 0
+        descLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        let stack = UIStackView(arrangedSubviews: [emojiLabel, titleLabel, descLabel])
+        stack.axis = .vertical
+        stack.spacing = 16
+        stack.alignment = .center
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        container.addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            stack.centerYAnchor.constraint(equalTo: container.centerYAnchor, constant: -60),
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 32),
+            stack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -32)
+        ])
+
+        return container
+    }
+
+    // MARK: - Actions
+
+    @objc private func actionTapped() {
+        let currentPage = pageControl.currentPage
+        if currentPage < pages.count - 1 {
+            // Advance to next page
+            let nextPage = currentPage + 1
+            let offsetX = scrollView.bounds.width * CGFloat(nextPage)
+            scrollView.setContentOffset(CGPoint(x: offsetX, y: 0), animated: true)
+            pageControl.currentPage = nextPage
+            updateActionButton(forPage: nextPage)
+        } else {
+            // Last page — finish
+            finishOnboarding()
+        }
+    }
+
+    @objc private func finishOnboarding() {
+        UserDefaults.standard.set(true, forKey: Self.completedKey)
+        onFinished?()
+    }
+
+    private func updateActionButton(forPage page: Int) {
+        actionButton.setTitle(pages[page].buttonTitle, for: .normal)
+
+        // Hide skip on last page
+        skipButton.isHidden = (page == pages.count - 1)
+    }
+}
+
+// MARK: - UIScrollViewDelegate
+
+extension OnboardingViewController: UIScrollViewDelegate {
+    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        let page = Int(round(scrollView.contentOffset.x / scrollView.bounds.width))
+        pageControl.currentPage = page
+        updateActionButton(forPage: page)
+    }
+}

--- a/SnoozePay/SnoozePayTests/OnboardingTests.swift
+++ b/SnoozePay/SnoozePayTests/OnboardingTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import SnoozePay
+
+/// Unit tests for OnboardingViewController — completion flag and page count.
+final class OnboardingTests: XCTestCase {
+
+    private let completedKey = "onboarding_completed"
+
+    override func setUp() {
+        super.setUp()
+        // Reset onboarding flag before each test
+        UserDefaults.standard.removeObject(forKey: completedKey)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: completedKey)
+        super.tearDown()
+    }
+
+    // MARK: - Completion flag
+
+    func testIsCompleted_defaultFalse() {
+        // Fresh state: onboarding should not be marked as completed
+        XCTAssertFalse(OnboardingViewController.isCompleted)
+    }
+
+    func testIsCompleted_trueAfterSet() {
+        UserDefaults.standard.set(true, forKey: completedKey)
+
+        XCTAssertTrue(OnboardingViewController.isCompleted)
+    }
+
+    // MARK: - Page count
+
+    func testOnboardingPages_count() {
+        let vc = OnboardingViewController()
+        vc.loadViewIfNeeded()
+
+        // The page control should reflect 3 onboarding pages
+        let pageControl = vc.view.subviews.compactMap { $0 as? UIPageControl }.first
+        XCTAssertNotNil(pageControl, "OnboardingViewController should contain a UIPageControl")
+        XCTAssertEqual(pageControl?.numberOfPages, 3, "Onboarding should have exactly 3 pages")
+    }
+}


### PR DESCRIPTION
## Summary
- New OnboardingViewController: 3 pages with emoji, title, description, pagination dots
- Shows only on first launch (UserDefaults flag), cross-dissolve transition to main app
- Alarm firing: decorative purple gradient circles, pill-shaped buttons with icons
- Dismiss button: light gray with xmark, Snooze: golden with bell icon

## Test plan
- [ ] Onboarding shows on first launch
- [ ] Onboarding does not show on subsequent launches
- [ ] Skip button works
- [ ] Pagination dots update
- [ ] Alarm firing has purple circles and icon buttons
- [ ] Unit tests for onboarding completion flag