### PR TITLE
Fix alarm staying enabled after dismiss

### DIFF
--- a/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
@@ -75,7 +75,12 @@ final class AlarmFiringViewModel {
     }
 
     /// Dismiss the alarm without charge.
+    /// Non-repeating alarms are disabled after dismissal.
     func dismiss() {
         scheduler.cancel(alarm.id)
+
+        if alarm.repeatDays.isEmpty {
+            alarmRepository.setEnabled(false, id: alarm.id)
+        }
     }
 }

--- a/SnoozePay/SnoozePayTests/AlarmFiringViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmFiringViewModelTests.swift
@@ -121,6 +121,42 @@ final class AlarmFiringViewModelIOS011Tests: XCTestCase {
                        "Dismiss should not deduct any balance")
     }
 
+    func testDismiss_disablesNonRepeatingAlarm() {
+        let repo = AlarmRepository()
+        var alarm = Alarm(penaltyAmount: 50)
+        alarm.repeatDays = []
+        alarm.enabled = true
+        repo.save(alarm)
+
+        let vm = AlarmFiringViewModel(alarm: alarm, snoozeCount: 0, alarmRepository: repo)
+        vm.dismiss()
+
+        let saved = repo.fetch(id: alarm.id)
+        XCTAssertEqual(saved?.enabled, false,
+                       "Non-repeating alarm should be disabled after dismiss")
+
+        // Cleanup
+        repo.delete(id: alarm.id)
+    }
+
+    func testDismiss_keepsRepeatingAlarmEnabled() {
+        let repo = AlarmRepository()
+        var alarm = Alarm(penaltyAmount: 50)
+        alarm.repeatDays = [0, 1, 2, 3, 4] // Weekdays
+        alarm.enabled = true
+        repo.save(alarm)
+
+        let vm = AlarmFiringViewModel(alarm: alarm, snoozeCount: 0, alarmRepository: repo)
+        vm.dismiss()
+
+        let saved = repo.fetch(id: alarm.id)
+        XCTAssertEqual(saved?.enabled, true,
+                       "Repeating alarm should stay enabled after dismiss")
+
+        // Cleanup
+        repo.delete(id: alarm.id)
+    }
+
     // MARK: - Penalty calculation (progressive scale)
 
     func testCurrentPenalty_firstSnooze_returnsBase() {


### PR DESCRIPTION
## Summary
- Non-repeating alarms now set `enabled = false` in AlarmRepository when dismissed
- Repeating alarms stay enabled (they should fire on the next scheduled day)
- Root cause: `dismiss()` only cancelled notifications but didn't update the alarm's enabled state

## Test plan
- [x] `testDismiss_disablesNonRepeatingAlarm` — verifies one-time alarm is disabled
- [x] `testDismiss_keepsRepeatingAlarmEnabled` — verifies repeating alarm stays on
- [x] `testDismiss_doesNotChargeBalance` — existing test, still passes