### PR TITLE
[ui] Refresh alarm cell appearance immediately on toggle

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmCell.swift
@@ -107,8 +107,12 @@ final class AlarmCell: UITableViewCell {
         detailLabel.text = detail
         penaltyLabel.text = penalty
         toggleSwitch.isOn = enabled
+        setEnabledAppearance(enabled)
+    }
 
-        // Dim text when alarm is disabled
+    /// Updates the dim/full opacity of text labels to match enabled state.
+    /// Called both during initial configuration and live from the toggle handler.
+    func setEnabledAppearance(_ enabled: Bool) {
         let alpha: CGFloat = enabled ? 1.0 : 0.4
         timeLabel.alpha = alpha
         detailLabel.alpha = alpha

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
@@ -275,7 +275,11 @@ extension AlarmsListViewController: UITableViewDataSource {
     }
 
     @objc private func toggleChanged(_ sender: UISwitch) {
-        viewModel.toggleAlarm(at: sender.tag, enabled: sender.isOn)
+        let index = sender.tag
+        viewModel.toggleAlarm(at: index, enabled: sender.isOn)
+        if let cell = tableView.cellForRow(at: IndexPath(row: index, section: 0)) as? AlarmCell {
+            cell.setEnabledAppearance(sender.isOn)
+        }
     }
 }
 

--- a/SnoozePay/SnoozePayTests/AlarmFiringViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmFiringViewModelTests.swift
@@ -12,9 +12,9 @@ final class AlarmFiringViewModelIOS011Tests: XCTestCase {
         snoozeMinutes: Int = 9
     ) -> Alarm {
         Alarm(
+            snoozeMinutes: snoozeMinutes,
             penaltyAmount: penalty,
-            progressiveScale: progressive,
-            snoozeMinutes: snoozeMinutes
+            progressiveScale: progressive
         )
     }
 

--- a/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
@@ -5,18 +5,18 @@ import XCTest
 final class AlarmsListViewModelTests: XCTestCase {
 
     private var testDefaults: UserDefaults!
+    private var suiteName: String!
     private var repo: AlarmRepository!
 
     override func setUp() {
         super.setUp()
-        testDefaults = UserDefaults(suiteName: "test.alarmsList.\(UUID().uuidString)")!
+        suiteName = "test.alarmsList.\(UUID().uuidString)"
+        testDefaults = UserDefaults(suiteName: suiteName)!
         repo = AlarmRepository(defaults: testDefaults)
     }
 
     override func tearDown() {
-        if let name = testDefaults.suiteName {
-            UserDefaults.removePersistentDomain(forName: name)
-        }
+        testDefaults.removePersistentDomain(forName: suiteName)
         super.tearDown()
     }
 
@@ -82,5 +82,46 @@ final class AlarmsListViewModelTests: XCTestCase {
 
         let penalty = vm.alarmPenaltyString(at: 0)
         XCTAssertEqual(penalty, "▲ ОТЛОЖИТЬ: 1000 ₽")
+    }
+
+    // MARK: - Safe index handling
+
+    func testAlarmTimeString_emptyAlarmsReturnsEmptyString() {
+        let vm = makeViewModel()
+        vm.loadData()
+        XCTAssertEqual(vm.alarmTimeString(at: 0), "")
+        XCTAssertEqual(vm.alarmSubtitle(at: 0), "")
+    }
+
+    func testFormattedBalance_containsRubleSign() {
+        let vm = makeViewModel()
+        XCTAssertTrue(vm.formattedBalance.contains("₽"))
+    }
+
+    // MARK: - toggleAlarm(at:enabled:)
+
+    func testToggleAlarm_updatesInMemoryState() {
+        let alarm = Alarm(penaltyAmount: 50, enabled: true)
+        repo.save(alarm)
+
+        let vm = makeViewModel()
+        vm.loadData()
+        XCTAssertTrue(vm.alarms[0].enabled)
+
+        vm.toggleAlarm(at: 0, enabled: false)
+        XCTAssertFalse(vm.alarms[0].enabled, "In-memory alarm must reflect the new enabled state immediately")
+    }
+
+    func testToggleAlarm_persistsToRepository() {
+        let alarm = Alarm(penaltyAmount: 50, enabled: true)
+        repo.save(alarm)
+
+        let vm = makeViewModel()
+        vm.loadData()
+
+        vm.toggleAlarm(at: 0, enabled: false)
+        let stored = repo.fetchAll()
+        XCTAssertEqual(stored.count, 1)
+        XCTAssertFalse(stored[0].enabled, "Toggle must persist through the repository")
     }
 }

--- a/SnoozePay/SnoozePayTests/BalanceServiceTests.swift
+++ b/SnoozePay/SnoozePayTests/BalanceServiceTests.swift
@@ -6,15 +6,17 @@ final class BalanceServiceTests: XCTestCase {
 
     /// Use a fresh UserDefaults suite to avoid polluting real app data.
     private var testDefaults: UserDefaults!
+    private var suiteName: String!
     private var service: BalanceService!
 
     override func setUp() {
         super.setUp()
-        testDefaults = UserDefaults(suiteName: "test_\(UUID().uuidString)")!
+        suiteName = "test_\(UUID().uuidString)"
+        testDefaults = UserDefaults(suiteName: suiteName)!
     }
 
     override func tearDown() {
-        testDefaults.removePersistentDomain(forName: testDefaults.suiteName ?? "")
+        testDefaults.removePersistentDomain(forName: suiteName)
         super.tearDown()
     }
 
@@ -90,25 +92,6 @@ final class AlarmFiringViewModelTests: XCTestCase {
 
         XCTAssertFalse(vm.canSnooze)
         XCTAssertEqual(vm.snoozeButtonTitle, "Баланс пуст")
-    }
-}
-
-/// Tests for AlarmsListViewModel.
-final class AlarmsListViewModelTests: XCTestCase {
-
-    func testAlarmTimeFormatting() {
-        let repo = AlarmRepository()
-        let vm = AlarmsListViewModel(alarmRepository: repo)
-
-        // No alarms — verify safe index handling
-        XCTAssertEqual(vm.alarmTimeString(at: 0), "")
-        XCTAssertEqual(vm.alarmSubtitle(at: 0), "")
-    }
-
-    func testFormattedBalance() {
-        let vm = AlarmsListViewModel()
-        // formattedBalance should always contain ₽
-        XCTAssertTrue(vm.formattedBalance.contains("₽"))
     }
 }
 

--- a/SnoozePay/SnoozePayTests/CreateAlarmViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/CreateAlarmViewModelTests.swift
@@ -5,18 +5,18 @@ import XCTest
 final class CreateAlarmViewModelSoundTests: XCTestCase {
 
     private var testDefaults: UserDefaults!
+    private var suiteName: String!
     private var repo: AlarmRepository!
 
     override func setUp() {
         super.setUp()
-        testDefaults = UserDefaults(suiteName: "test.createAlarm.\(UUID().uuidString)")!
+        suiteName = "test.createAlarm.\(UUID().uuidString)"
+        testDefaults = UserDefaults(suiteName: suiteName)!
         repo = AlarmRepository(defaults: testDefaults)
     }
 
     override func tearDown() {
-        if let name = testDefaults.suiteName {
-            UserDefaults.removePersistentDomain(forName: name)
-        }
+        testDefaults.removePersistentDomain(forName: suiteName)
         super.tearDown()
     }
 

--- a/SnoozePay/SnoozePayTests/SettingsViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/SettingsViewModelTests.swift
@@ -5,17 +5,17 @@ import XCTest
 final class SettingsViewModelTests: XCTestCase {
 
     private var testDefaults: UserDefaults!
+    private var suiteName: String!
     private let themeKey = "preferred_theme"
 
     override func setUp() {
         super.setUp()
-        testDefaults = UserDefaults(suiteName: "test.settings.\(UUID().uuidString)")!
+        suiteName = "test.settings.\(UUID().uuidString)"
+        testDefaults = UserDefaults(suiteName: suiteName)!
     }
 
     override func tearDown() {
-        if let name = testDefaults.suiteName {
-            UserDefaults.removePersistentDomain(forName: name)
-        }
+        testDefaults.removePersistentDomain(forName: suiteName)
         super.tearDown()
     }
 

--- a/SnoozePay/SnoozePayTests/StatisticsViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/StatisticsViewModelTests.swift
@@ -5,18 +5,18 @@ import XCTest
 final class StatisticsViewModelDataTests: XCTestCase {
 
     private var testDefaults: UserDefaults!
+    private var suiteName: String!
     private var txRepo: TransactionRepository!
 
     override func setUp() {
         super.setUp()
-        testDefaults = UserDefaults(suiteName: "test.statistics.\(UUID().uuidString)")!
+        suiteName = "test.statistics.\(UUID().uuidString)"
+        testDefaults = UserDefaults(suiteName: suiteName)!
         txRepo = TransactionRepository(defaults: testDefaults)
     }
 
     override func tearDown() {
-        if let name = testDefaults.suiteName {
-            UserDefaults.removePersistentDomain(forName: name)
-        }
+        testDefaults.removePersistentDomain(forName: suiteName)
         super.tearDown()
     }
 

--- a/SnoozePay/SnoozePayTests/TransactionRepositoryTests.swift
+++ b/SnoozePay/SnoozePayTests/TransactionRepositoryTests.swift
@@ -5,18 +5,18 @@ import XCTest
 final class TransactionRepositoryTests: XCTestCase {
 
     private var testDefaults: UserDefaults!
+    private var suiteName: String!
     private var repo: TransactionRepository!
 
     override func setUp() {
         super.setUp()
-        testDefaults = UserDefaults(suiteName: "test.txRepo.\(UUID().uuidString)")!
+        suiteName = "test.txRepo.\(UUID().uuidString)"
+        testDefaults = UserDefaults(suiteName: suiteName)!
         repo = TransactionRepository(defaults: testDefaults)
     }
 
     override func tearDown() {
-        if let name = testDefaults.suiteName {
-            UserDefaults.removePersistentDomain(forName: name)
-        }
+        testDefaults.removePersistentDomain(forName: suiteName)
         super.tearDown()
     }
 
@@ -169,7 +169,8 @@ final class TransactionRepositoryTests: XCTestCase {
 
     func testIsolation_separateSuites() {
         // Verify that our test UserDefaults suite is isolated
-        let otherDefaults = UserDefaults(suiteName: "test.txRepo.other.\(UUID().uuidString)")!
+        let otherSuiteName = "test.txRepo.other.\(UUID().uuidString)"
+        let otherDefaults = UserDefaults(suiteName: otherSuiteName)!
         let otherRepo = TransactionRepository(defaults: otherDefaults)
 
         repo.record(charge(amount: 50))
@@ -177,6 +178,6 @@ final class TransactionRepositoryTests: XCTestCase {
         XCTAssertEqual(repo.fetchAll().count, 1)
         XCTAssertEqual(otherRepo.fetchAll().count, 0, "Different suites should be isolated")
 
-        UserDefaults.removePersistentDomain(forName: otherDefaults.suiteName ?? "")
+        otherDefaults.removePersistentDomain(forName: otherSuiteName)
     }
 }


### PR DESCRIPTION
## Что сделано
- Извлечён `setEnabledAppearance(_:)` из `AlarmCell.configure` — теперь его можно вызывать независимо для обновления opacity лейблов без полного re-render ячейки.
- `AlarmsListViewController.toggleChanged` после изменения модели обновляет ячейку in-place, убирая необходимость переходить на другой таб чтобы увидеть новое состояние.

## Тесты
- Новые: `AlarmsListViewModelTests` покрывают `toggleAlarm` (in-memory state + persistence через repository).
- Фикс: в `BalanceServiceTests` был дубликат `AlarmsListViewModelTests` — удалён (отдельный файл canonical).
- Фикс: `AlarmFiringViewModelTests` вызывал `Alarm()` с аргументами в неправильном порядке — переставил.
- Cleanup: `tearDown` во всех test-suites теперь хранит `suiteName` явно вместо чтения из (уже очищенных) UserDefaults.

## Gates
- swiftlint: ✅ (0 errors в изменённых файлах)
- build_sim: ✅ succeeded
- test_sim: ⏭️ gate temporarily disabled (см. CLAUDE.md/SKILL.md от 2026-04-26 — нестабильно). Тесты добавлены и компилируются (входят в build_sim).
- Screenshot/Figma-compare: ⏭️ gate temporarily disabled. UI-верификацию делает qa-tester в gauntlet.

## Визуальная верификация
qa-tester в gauntlet физически прокликает toggle на iPhone 17 simulator.

Fixes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)