### PR TITLE
[fix] Persist best streak instead of placeholder (#30)

### DIFF
--- a/SnoozePay/SnoozePay/ViewModels/StatisticsViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/StatisticsViewModel.swift
@@ -27,6 +27,7 @@ final class StatisticsViewModel {
     // MARK: - Dependencies
 
     private let transactionRepository: TransactionRepository
+    private let defaults: UserDefaults
 
     // MARK: - State
 
@@ -38,8 +39,12 @@ final class StatisticsViewModel {
 
     // MARK: - Init
 
-    init(repository: TransactionRepository = TransactionRepository()) {
+    init(
+        repository: TransactionRepository = TransactionRepository(),
+        defaults: UserDefaults = .standard
+    ) {
         self.transactionRepository = repository
+        self.defaults = defaults
     }
 
     // MARK: - Load
@@ -55,6 +60,11 @@ final class StatisticsViewModel {
         }
 
         streak = transactionRepository.currentStreak()
+        // Bump persisted best streak only forward — never reset on streak = 0,
+        // so the user's all-time record survives a slip-up.
+        if streak > defaults.integer(forKey: "best_streak") {
+            defaults.set(streak, forKey: "best_streak")
+        }
         onDataUpdated?()
     }
 
@@ -87,9 +97,9 @@ final class StatisticsViewModel {
         String(format: "%.1f / утро", averagePerDay)
     }
 
-    /// Best streak (for MVP, use current streak as best — can be improved later with persistence).
+    /// All-time best streak, persisted across launches and never reset on a slip-up.
     var bestStreak: Int {
-        max(streak, streak) // Placeholder — same as current streak for MVP
+        defaults.integer(forKey: "best_streak")
     }
 
     var bestStreakFormatted: String {

--- a/SnoozePay/SnoozePayTests/StatisticsViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/StatisticsViewModelTests.swift
@@ -23,7 +23,7 @@ final class StatisticsViewModelDataTests: XCTestCase {
     // MARK: - Helpers
 
     private func makeVM() -> StatisticsViewModel {
-        StatisticsViewModel(repository: txRepo)
+        StatisticsViewModel(repository: txRepo, defaults: testDefaults)
     }
 
     private func addCharge(amount: Double, daysAgo: Int = 0) {
@@ -354,14 +354,42 @@ final class StatisticsViewModelDataTests: XCTestCase {
 
     // MARK: - bestStreak
 
-    func testBestStreak_equalToCurrentStreak() {
-        // In MVP, bestStreak is always the same as current streak
+    func testBestStreak_growsWhenCurrentExceedsStored() {
+        testDefaults.set(2, forKey: "best_streak")
+        // Charge 5 days ago + topup today → streak should be ~5 (no charges in last 5 days)
         addCharge(amount: 50, daysAgo: 5)
+        addTopup(amount: 100, daysAgo: 0)
 
         let vm = makeVM()
         vm.loadData(period: .week)
 
-        XCTAssertEqual(vm.bestStreak, vm.streak)
+        XCTAssertGreaterThan(vm.streak, 2, "Test setup precondition: current streak should exceed stored")
+        XCTAssertEqual(vm.bestStreak, vm.streak, "Best streak should bump up to new high")
+        XCTAssertEqual(testDefaults.integer(forKey: "best_streak"), vm.streak)
+    }
+
+    func testBestStreak_doesNotResetWhenCurrentIsZero() {
+        testDefaults.set(7, forKey: "best_streak")
+        // Charge today → current streak = 0
+        addCharge(amount: 50, daysAgo: 0)
+
+        let vm = makeVM()
+        vm.loadData(period: .week)
+
+        XCTAssertEqual(vm.streak, 0)
+        XCTAssertEqual(vm.bestStreak, 7, "Stored best streak must survive a slip-up")
+    }
+
+    func testBestStreak_doesNotShrinkWhenCurrentIsLower() {
+        testDefaults.set(10, forKey: "best_streak")
+        addCharge(amount: 50, daysAgo: 3)
+        addTopup(amount: 100, daysAgo: 0)
+
+        let vm = makeVM()
+        vm.loadData(period: .week)
+
+        XCTAssertLessThan(vm.streak, 10, "Test setup precondition: current streak should be below stored")
+        XCTAssertEqual(vm.bestStreak, 10, "Best streak should hold the previous high")
     }
 
     func testBestStreakFormatted_format() {


### PR DESCRIPTION
Fixes #30

## Что сделано
- `StatisticsViewModel.bestStreak` теперь читает `UserDefaults["best_streak"]` вместо `max(streak, streak)` placeholder
- `loadData` обновляет хранимый best forward-only: `if streak > stored { stored = streak }`
- Best streak **не сбрасывается** когда `current = 0` (юзер сорвался — рекорд жив)
- Добавлен injection `defaults: UserDefaults = .standard` в init (тест-friendly, как в `TransactionRepository`)

## Tests
- `testBestStreak_growsWhenCurrentExceedsStored` — current > stored → bump
- `testBestStreak_doesNotResetWhenCurrentIsZero` — slip-up не стирает рекорд
- `testBestStreak_doesNotShrinkWhenCurrentIsLower` — current < stored → keep stored
- Старый `testBestStreak_equalToCurrentStreak` заменён (был верифицировал bug)

## Verify
- swiftlint: 0 errors на изменённых файлах (warnings — pre-existing `vm` identifier_name + file_length)
- build_sim: succeeded (iPhone 17 Pro, iOS 26.3.1)
- test_sim: пропущено (gate отключён, см. CLAUDE.md)
- screenshot: пропущено (gate отключён)

## Не трогали
- No-touch zones чисто: entitlements, Info.plist, signing, deps — без изменений
- Один новый ключ `"best_streak"` как string literal (без enum абстракции — конвенция CLAUDE.md)