### PR TITLE
[fix] Serialize BalanceService via serial queue (#20)

### DIFF
--- a/SnoozePay/SnoozePay/Services/BalanceService.swift
+++ b/SnoozePay/SnoozePay/Services/BalanceService.swift
@@ -2,6 +2,9 @@ import Foundation
 
 /// Manages the user's local balance stored in UserDefaults.
 /// All operations are synchronous and offline-first.
+/// Mutations and reads are serialized via a private serial queue
+/// to prevent check-then-write races between concurrent callers
+/// (e.g. notification action + foreground UI).
 final class BalanceService {
 
     static let shared = BalanceService()
@@ -9,11 +12,12 @@ final class BalanceService {
     private let defaults: UserDefaults
     private let balanceKey = "user_balance"
     private let transactionRepository: TransactionRepository
+    private let queue = DispatchQueue(label: "com.snoozepay.balance.serial")
 
     // Observers can subscribe to balance changes
     var onBalanceChanged: ((Double) -> Void)?
 
-    private init(
+    init(
         defaults: UserDefaults = .standard,
         transactionRepository: TransactionRepository = TransactionRepository()
     ) {
@@ -24,7 +28,7 @@ final class BalanceService {
     // MARK: - Read
 
     var balance: Double {
-        defaults.double(forKey: balanceKey)
+        queue.sync { defaults.double(forKey: balanceKey) }
     }
 
     // MARK: - Deduct (snooze penalty)
@@ -33,33 +37,45 @@ final class BalanceService {
     /// Returns true if successful, false if insufficient funds.
     @discardableResult
     func charge(amount: Double, alarmID: UUID?) -> Bool {
-        guard balance >= amount else { return false }
+        let result: (charged: Bool, newBalance: Double) = queue.sync {
+            let current = defaults.double(forKey: balanceKey)
+            guard current >= amount else { return (false, current) }
 
-        let newBalance = balance - amount
-        defaults.set(newBalance, forKey: balanceKey)
+            let newBalance = current - amount
+            defaults.set(newBalance, forKey: balanceKey)
 
-        let transaction = Transaction(
-            type: .charge,
-            amount: amount,
-            alarmID: alarmID?.uuidString
-        )
-        transactionRepository.record(transaction)
+            let transaction = Transaction(
+                type: .charge,
+                amount: amount,
+                alarmID: alarmID?.uuidString
+            )
+            transactionRepository.record(transaction)
 
-        onBalanceChanged?(newBalance)
-        return true
+            return (true, newBalance)
+        }
+
+        if result.charged {
+            onBalanceChanged?(result.newBalance)
+        }
+        return result.charged
     }
 
     // MARK: - Top up (IAP)
 
     func topUp(amount: Double) {
-        let newBalance = balance + amount
-        defaults.set(newBalance, forKey: balanceKey)
+        let newBalance: Double = queue.sync {
+            let current = defaults.double(forKey: balanceKey)
+            let updated = current + amount
+            defaults.set(updated, forKey: balanceKey)
 
-        let transaction = Transaction(
-            type: .topup,
-            amount: amount
-        )
-        transactionRepository.record(transaction)
+            let transaction = Transaction(
+                type: .topup,
+                amount: amount
+            )
+            transactionRepository.record(transaction)
+
+            return updated
+        }
 
         onBalanceChanged?(newBalance)
     }
@@ -67,6 +83,6 @@ final class BalanceService {
     // MARK: - Validation
 
     func canAfford(_ amount: Double) -> Bool {
-        balance >= amount
+        queue.sync { defaults.double(forKey: balanceKey) >= amount }
     }
 }

--- a/SnoozePay/SnoozePay/Services/BalanceService.swift
+++ b/SnoozePay/SnoozePay/Services/BalanceService.swift
@@ -17,6 +17,11 @@ final class BalanceService {
     // Observers can subscribe to balance changes
     var onBalanceChanged: ((Double) -> Void)?
 
+    /// Production code MUST use `BalanceService.shared`.
+    /// Direct construction creates an isolated instance with its own serial queue —
+    /// two such instances racing on the same UserDefaults key reintroduce the race
+    /// this class exists to prevent.
+    #if DEBUG
     init(
         defaults: UserDefaults = .standard,
         transactionRepository: TransactionRepository = TransactionRepository()
@@ -24,6 +29,15 @@ final class BalanceService {
         self.defaults = defaults
         self.transactionRepository = transactionRepository
     }
+    #else
+    private init(
+        defaults: UserDefaults = .standard,
+        transactionRepository: TransactionRepository = TransactionRepository()
+    ) {
+        self.defaults = defaults
+        self.transactionRepository = transactionRepository
+    }
+    #endif
 
     // MARK: - Read
 
@@ -55,7 +69,7 @@ final class BalanceService {
         }
 
         if result.charged {
-            onBalanceChanged?(result.newBalance)
+            notifyBalanceChanged(result.newBalance)
         }
         return result.charged
     }
@@ -77,12 +91,24 @@ final class BalanceService {
             return updated
         }
 
-        onBalanceChanged?(newBalance)
+        notifyBalanceChanged(newBalance)
     }
 
     // MARK: - Validation
 
     func canAfford(_ amount: Double) -> Bool {
         queue.sync { defaults.double(forKey: balanceKey) >= amount }
+    }
+
+    /// Hop to main since `charge`/`topUp` may be called from a background queue
+    /// (notification action handler) and listeners drive UIKit.
+    private func notifyBalanceChanged(_ newBalance: Double) {
+        if Thread.isMainThread {
+            onBalanceChanged?(newBalance)
+        } else {
+            DispatchQueue.main.async { [weak self] in
+                self?.onBalanceChanged?(newBalance)
+            }
+        }
     }
 }

--- a/SnoozePay/SnoozePayTests/BalanceServiceTests.swift
+++ b/SnoozePay/SnoozePayTests/BalanceServiceTests.swift
@@ -24,7 +24,52 @@ final class BalanceServiceTests: XCTestCase {
 
     private func makeService(balance: Double = 0) -> BalanceService {
         testDefaults.set(balance, forKey: "user_balance")
-        return BalanceService.shared
+        return BalanceService(defaults: testDefaults)
+    }
+
+    // MARK: - Concurrency
+
+    func testConcurrentCharge_neverGoesNegative() {
+        let initialBalance: Double = 1000
+        let amount: Double = 10
+        let iterations = 100
+        let service = makeService(balance: initialBalance)
+
+        let successCount = NSCountedSet()
+        let lock = NSLock()
+
+        DispatchQueue.concurrentPerform(iterations: iterations) { _ in
+            let charged = service.charge(amount: amount, alarmID: nil)
+            if charged {
+                lock.lock()
+                successCount.add("ok")
+                lock.unlock()
+            }
+        }
+
+        let successes = successCount.count(for: "ok")
+        let expectedSuccesses = Int(initialBalance / amount)
+
+        XCTAssertGreaterThanOrEqual(service.balance, 0)
+        XCTAssertEqual(successes, expectedSuccesses)
+        XCTAssertEqual(service.balance, initialBalance - Double(successes) * amount)
+    }
+
+    func testConcurrentChargeAndTopUp_remainsConsistent() {
+        let initialBalance: Double = 500
+        let amount: Double = 5
+        let iterations = 200
+        let service = makeService(balance: initialBalance)
+
+        DispatchQueue.concurrentPerform(iterations: iterations) { idx in
+            if idx % 2 == 0 {
+                service.charge(amount: amount, alarmID: nil)
+            } else {
+                service.topUp(amount: amount)
+            }
+        }
+
+        XCTAssertGreaterThanOrEqual(service.balance, 0)
     }
 }
 


### PR DESCRIPTION
Fixes #20

## Что сделано
- Доступ к балансу (read + mutate) сериализован через приватный `DispatchQueue(label: "com.snoozepay.balance.serial")`.
- `charge`, `topUp`, `canAfford` и геттер `balance` выполняются `queue.sync { ... }`. Check-then-write теперь атомарен — гонка `snooze из notification action + foreground UI` устранена.
- `onBalanceChanged` вызывается **после** выхода из критической секции, чтобы listener не выполнялся под локом.
- Публичный API сохранён (sync, никакого `async` / `actor`).
- `init` промотирован с `private` на `internal` — нужен для DI тестового `UserDefaults` suite, без этого concurrent stress нельзя запустить изолированно.

## Tests
- `testConcurrentCharge_neverGoesNegative` — 100× параллельных `charge` через `DispatchQueue.concurrentPerform`. Проверяет: `balance >= 0`, `successCount == initial / amount`, `balance == initial - successCount * amount`.
- `testConcurrentChargeAndTopUp_remainsConsistent` — 200× смешанных `charge`/`topUp`. Баланс остаётся неотрицательным.

## Verify
- swiftlint: 0 errors
- build_sim: succeeded (iPhone 16 Pro)
- test_sim: skipped (gate отключён в CLAUDE.md)
- screenshot: skipped (gate отключён)