### PR TITLE
[fix] Break retain cycle in AlarmFiringViewController repeat animation (#28)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
@@ -150,6 +150,10 @@ class AlarmFiringViewController: UIViewController {
         super.viewDidDisappear(animated)
         clockTimer?.invalidate()
 
+        // Stop the repeating pulse animation explicitly so the
+        // animator does not retain self past dismissal.
+        nameLabel.layer.removeAllAnimations()
+
         // Stop alarm sound and vibration when screen is dismissed
         AudioService.shared.stopAlarmSound()
     }
@@ -278,8 +282,8 @@ class AlarmFiringViewController: UIViewController {
             withDuration: 1.4,
             delay: 0,
             options: [.autoreverse, .repeat, .allowUserInteraction],
-            animations: {
-                self.nameLabel.alpha = 0.5
+            animations: { [weak self] in
+                self?.nameLabel.alpha = 0.5
             }
         )
     }


### PR DESCRIPTION
Fixes #28

## Что сделано

- `startPulseAnimation()` теперь захватывает `[weak self]` в `animations:` closure, чтобы repeat-анимация не удерживала VC до бесконечности.
- В `viewDidDisappear(_:)` явно вызывается `nameLabel.layer.removeAllAnimations()` — это останавливает repeat-анимацию и освобождает ссылку, которую держит animator.
- Других `UIView.animate` с `.repeat` в `AlarmFiringViewController` нет — проверено `grep`.

## Почему это лечит leak

`UIView.animate(..., options: [.repeat], animations: { self... })` создаёт анимацию, которая никогда не завершится сама. Кэптчуренный `self` держится анимационной системой до явного `removeAllAnimations()` или удаления view из иерархии. При chain'е snooze каждый dismiss оставлял zombie VC в памяти.

Слабый capture + явная остановка — закрывают оба конца.

## Verify

- swiftlint: 0 errors **в моих строках** (две pre-existing violations в кнопках, не тронуты этим PR).
- `xcodebuild build -destination 'platform=iOS Simulator,name=iPhone Air'` → **BUILD SUCCEEDED**.
- Smoke unit-test пропущен: для memory-leak проверки нужен Instruments / `XCTWaiter` против `weak var` — `init(alarm:snoozeCount:)` требует валидный `Alarm`-fixture, что разрастает scope. TODO оставлен в issue thread'е, не в коде.

## No-touch

entitlements / Info.plist / project.pbxproj / SPM не тронуты.