### PR TITLE
[fix] Listen to StoreKit Transaction.updates for deferred purchases (#24)

### DIFF
--- a/SnoozePay/SnoozePay/AppDelegate.swift
+++ b/SnoozePay/SnoozePay/AppDelegate.swift
@@ -22,6 +22,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         }
 
+        // Eagerly construct StoreKitService so its Transaction.updates listener
+        // starts at app launch — otherwise deferred Ask-to-Buy approvals / refunds
+        // pile up unprocessed until the user opens TopUp.
+        _ = StoreKitService.shared
+
         // Handle notification responses
         UNUserNotificationCenter.current().delegate = self
 

--- a/SnoozePay/SnoozePay/Services/StoreKitService.swift
+++ b/SnoozePay/SnoozePay/Services/StoreKitService.swift
@@ -41,7 +41,12 @@ final class StoreKitService {
 
     /// Persisted set of transaction IDs that have already been credited. Prevents
     /// double-credit when StoreKit replays an unfinished transaction on next launch.
+    /// Stored as `[String]` because UserDefaults does not round-trip `UInt64` cleanly
+    /// (plist normalises numerics; `as? [UInt64]` can fail silently and re-enable
+    /// double-crediting). Bounded — keeps the most recent N IDs to prevent unbounded
+    /// growth in UserDefaults across the lifetime of the install.
     private static let processedTxKey = "storekit.processed_tx_ids"
+    private static let processedTxCap = 200
 
     private init() {
         transactionListener = Self.makeTransactionListener()
@@ -153,12 +158,23 @@ final class StoreKitService {
 
     /// Returns true if this transaction is new (recorded for the first time);
     /// false if it was already processed in a previous app session.
+    ///
+    /// Storage is `[String]` (not `[UInt64]`) because UserDefaults plist storage
+    /// silently fails the `as? [UInt64]` cast in some cases — a nil cast result
+    /// would reset the set and re-enable double-crediting. Strings round-trip safely.
+    /// We keep insertion order (Array, not Set) so we can trim the oldest IDs once
+    /// the cap is exceeded, keeping UserDefaults bounded.
     private func markProcessed(transactionID: UInt64) -> Bool {
         let defaults = UserDefaults.standard
-        var processed = Set(defaults.array(forKey: Self.processedTxKey) as? [UInt64] ?? [])
-        guard !processed.contains(transactionID) else { return false }
-        processed.insert(transactionID)
-        defaults.set(Array(processed), forKey: Self.processedTxKey)
+        let key = Self.processedTxKey
+        let idString = String(transactionID)
+        var processed = (defaults.array(forKey: key) as? [String]) ?? []
+        guard !processed.contains(idString) else { return false }
+        processed.append(idString)
+        if processed.count > Self.processedTxCap {
+            processed = Array(processed.suffix(Self.processedTxCap))
+        }
+        defaults.set(processed, forKey: key)
         return true
     }
 

--- a/SnoozePay/SnoozePay/Services/StoreKitService.swift
+++ b/SnoozePay/SnoozePay/Services/StoreKitService.swift
@@ -30,8 +30,30 @@ final class StoreKitService {
     var onProductsLoaded: (([Product]) -> Void)?
     var onPurchaseCompleted: ((Double) -> Void)?
     var onPurchaseFailed: ((String) -> Void)?
+    /// Fired when a purchase enters Ask-to-Buy / SCA verification.
+    /// Resolves later via `Transaction.updates` once parent approves.
+    var onPurchasePending: (() -> Void)?
 
-    private init() {}
+    /// Background listener for `Transaction.updates`. Required by StoreKit 2 to
+    /// receive deferred transactions: Ask-to-Buy approvals, refunds, restores
+    /// and purchases that completed while the app was not running.
+    private var transactionListener: Task<Void, Never>?
+
+    private init() {
+        transactionListener = Self.makeTransactionListener()
+    }
+
+    deinit {
+        transactionListener?.cancel()
+    }
+
+    private static func makeTransactionListener() -> Task<Void, Never> {
+        Task.detached {
+            for await result in StoreKit.Transaction.updates {
+                await StoreKitService.shared.handle(transactionResult: result)
+            }
+        }
+    }
 
     // MARK: - Load products
 
@@ -54,9 +76,7 @@ final class StoreKitService {
             switch result {
             case .success(let verification):
                 let transaction = try checkVerified(verification)
-                // Credit balance
-                let amount = StoreKitService.productAmounts[product.id] ?? product.price.doubleValue
-                BalanceService.shared.topUp(amount: amount)
+                let amount = creditBalance(for: transaction.productID, fallbackPrice: product.price)
                 await transaction.finish()
                 onPurchaseCompleted?(amount)
 
@@ -64,14 +84,41 @@ final class StoreKitService {
                 break
 
             case .pending:
-                // Transaction is pending (e.g., Ask to Buy). Handle later.
-                break
+                // Ask-to-Buy or SCA — resolved later via Transaction.updates listener.
+                onPurchasePending?()
 
             @unknown default:
                 break
             }
         } catch {
             onPurchaseFailed?(error.localizedDescription)
+        }
+    }
+
+    // MARK: - Transaction.updates handling
+
+    /// Called for every transaction update delivered out-of-band:
+    /// deferred Ask-to-Buy approvals, refunds, restores, and purchases
+    /// that completed while the app was suspended.
+    private func handle(transactionResult: VerificationResult<StoreKit.Transaction>) async {
+        switch transactionResult {
+        case .verified(let transaction):
+            // Skip revoked transactions (refunds / family-share removal):
+            // Apple delivers them so we can revoke entitlements, but for
+            // consumables we simply finish them — the balance was already spent.
+            if transaction.revocationDate == nil {
+                let amount = creditBalance(for: transaction.productID, fallbackPrice: nil)
+                if amount > 0 {
+                    onPurchaseCompleted?(amount)
+                }
+            }
+            await transaction.finish()
+
+        case .unverified(let transaction, let error):
+            // Per Apple docs: still finish unverified transactions to drain the queue,
+            // but do not credit balance.
+            print("StoreKit unverified transaction \(transaction.id): \(error)")
+            await transaction.finish()
         }
     }
 
@@ -84,6 +131,25 @@ final class StoreKitService {
         case .verified(let safe):
             return safe
         }
+    }
+
+    // MARK: - Helpers
+
+    /// Credits the user's balance for the given product. Returns the credited amount
+    /// (0 if the product is unknown and no fallback was provided).
+    @discardableResult
+    private func creditBalance(for productID: String, fallbackPrice: Decimal?) -> Double {
+        let amount = Self.creditAmount(for: productID, fallbackPrice: fallbackPrice)
+        guard amount > 0 else { return 0 }
+        BalanceService.shared.topUp(amount: amount)
+        return amount
+    }
+
+    private static func creditAmount(for productID: String, fallbackPrice: Decimal?) -> Double {
+        if let mapped = productAmounts[productID] {
+            return mapped
+        }
+        return fallbackPrice?.doubleValue ?? 0
     }
 
     enum StoreError: Error {

--- a/SnoozePay/SnoozePay/Services/StoreKitService.swift
+++ b/SnoozePay/SnoozePay/Services/StoreKitService.swift
@@ -126,19 +126,23 @@ final class StoreKitService {
                 await transaction.finish()
                 return
             }
+            // Unknown productID in background listener: do NOT finish AND do NOT mark
+            // as processed — leave for retry after app update. Finishing would silently
+            // lose the user's money since fallbackPrice is nil here. Marking processed
+            // would poison the dedup table: on next launch the replay would be matched
+            // by the idempotency guard and finish() called below, also losing the money.
+            // Order matters — check amount before markProcessed.
+            let amount = Self.creditAmount(for: transaction.productID, fallbackPrice: nil)
+            guard amount > 0 else {
+                print("[StoreKit] unknown productID \(transaction.productID) tx=\(transaction.id) — not finishing")
+                onPurchaseFailed?("Неизвестный пакет пополнения. Обнови приложение.")
+                return
+            }
             // Idempotency — guard against StoreKit replaying a transaction we already
             // credited (e.g. if the previous run crashed between topUp and finish()).
             guard markProcessed(transactionID: transaction.id) else {
                 print("[StoreKit] tx \(transaction.id) already processed — finishing without re-credit")
                 await transaction.finish()
-                return
-            }
-            // Unknown productID in background listener: do NOT finish — leave for retry.
-            // Finishing would silently lose the user's money since fallbackPrice is nil here.
-            let amount = Self.creditAmount(for: transaction.productID, fallbackPrice: nil)
-            guard amount > 0 else {
-                print("[StoreKit] unknown productID \(transaction.productID) tx=\(transaction.id) — not finishing")
-                onPurchaseFailed?("Неизвестный пакет пополнения. Обнови приложение.")
                 return
             }
             BalanceService.shared.topUp(amount: amount)

--- a/SnoozePay/SnoozePay/Services/StoreKitService.swift
+++ b/SnoozePay/SnoozePay/Services/StoreKitService.swift
@@ -39,6 +39,10 @@ final class StoreKitService {
     /// and purchases that completed while the app was not running.
     private var transactionListener: Task<Void, Never>?
 
+    /// Persisted set of transaction IDs that have already been credited. Prevents
+    /// double-credit when StoreKit replays an unfinished transaction on next launch.
+    private static let processedTxKey = "storekit.processed_tx_ids"
+
     private init() {
         transactionListener = Self.makeTransactionListener()
     }
@@ -60,11 +64,11 @@ final class StoreKitService {
     func loadProducts() async {
         do {
             let loaded = try await Product.products(for: Set(StoreKitService.productIDs))
-            // Sort by price ascending
             products = loaded.sorted { $0.price < $1.price }
             onProductsLoaded?(products)
         } catch {
-            print("StoreKit product load error: \(error)")
+            print("[StoreKit] product load failed: \(error)")
+            onPurchaseFailed?("Не удалось загрузить пакеты пополнения. Проверь интернет-соединение.")
         }
     }
 
@@ -76,6 +80,11 @@ final class StoreKitService {
             switch result {
             case .success(let verification):
                 let transaction = try checkVerified(verification)
+                guard markProcessed(transactionID: transaction.id) else {
+                    print("[StoreKit] tx \(transaction.id) already processed — skipping double credit")
+                    await transaction.finish()
+                    return
+                }
                 let amount = creditBalance(for: transaction.productID, fallbackPrice: product.price)
                 await transaction.finish()
                 onPurchaseCompleted?(amount)
@@ -88,7 +97,8 @@ final class StoreKitService {
                 onPurchasePending?()
 
             @unknown default:
-                break
+                print("[StoreKit] unknown PurchaseResult case — likely future StoreKit addition")
+                onPurchaseFailed?("Покупка не выполнена. Обнови приложение и попробуй ещё раз.")
             }
         } catch {
             onPurchaseFailed?(error.localizedDescription)
@@ -103,23 +113,53 @@ final class StoreKitService {
     private func handle(transactionResult: VerificationResult<StoreKit.Transaction>) async {
         switch transactionResult {
         case .verified(let transaction):
-            // Skip revoked transactions (refunds / family-share removal):
-            // Apple delivers them so we can revoke entitlements, but for
-            // consumables we simply finish them — the balance was already spent.
-            if transaction.revocationDate == nil {
-                let amount = creditBalance(for: transaction.productID, fallbackPrice: nil)
-                if amount > 0 {
-                    onPurchaseCompleted?(amount)
-                }
+            // Revoked (refund / family-share removal): log audit trail, don't re-credit,
+            // do finish so it stops being delivered. For consumables we cannot reverse
+            // a spent balance — track this as a known limitation (see #22-style follow-up).
+            guard transaction.revocationDate == nil else {
+                print("[StoreKit] revoked tx \(transaction.id) productID=\(transaction.productID)")
+                await transaction.finish()
+                return
             }
+            // Idempotency — guard against StoreKit replaying a transaction we already
+            // credited (e.g. if the previous run crashed between topUp and finish()).
+            guard markProcessed(transactionID: transaction.id) else {
+                print("[StoreKit] tx \(transaction.id) already processed — finishing without re-credit")
+                await transaction.finish()
+                return
+            }
+            // Unknown productID in background listener: do NOT finish — leave for retry.
+            // Finishing would silently lose the user's money since fallbackPrice is nil here.
+            let amount = Self.creditAmount(for: transaction.productID, fallbackPrice: nil)
+            guard amount > 0 else {
+                print("[StoreKit] unknown productID \(transaction.productID) tx=\(transaction.id) — not finishing")
+                onPurchaseFailed?("Неизвестный пакет пополнения. Обнови приложение.")
+                return
+            }
+            BalanceService.shared.topUp(amount: amount)
             await transaction.finish()
+            onPurchaseCompleted?(amount)
 
         case .unverified(let transaction, let error):
-            // Per Apple docs: still finish unverified transactions to drain the queue,
-            // but do not credit balance.
-            print("StoreKit unverified transaction \(transaction.id): \(error)")
-            await transaction.finish()
+            // Don't finish — let Apple retry next launch. Verification can fail temporarily
+            // (clock drift, cert refresh). Finishing here would discard a potentially valid
+            // purchase. WWDC sample code (Fruta, Backyard Birds) follows this pattern too.
+            print("[StoreKit] unverified tx=\(transaction.id) productID=\(transaction.productID) error=\(error)")
+            onPurchaseFailed?("Не удалось проверить чек покупки. Если деньги списаны — напиши в поддержку.")
         }
+    }
+
+    // MARK: - Idempotency
+
+    /// Returns true if this transaction is new (recorded for the first time);
+    /// false if it was already processed in a previous app session.
+    private func markProcessed(transactionID: UInt64) -> Bool {
+        let defaults = UserDefaults.standard
+        var processed = Set(defaults.array(forKey: Self.processedTxKey) as? [UInt64] ?? [])
+        guard !processed.contains(transactionID) else { return false }
+        processed.insert(transactionID)
+        defaults.set(Array(processed), forKey: Self.processedTxKey)
+        return true
     }
 
     // MARK: - Verify transaction

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/TopUpViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/TopUpViewController.swift
@@ -146,6 +146,12 @@ class TopUpViewController: UIViewController {
         }
 
         let product = products[index]
+        var pendingShown = false
+        storeService.onPurchasePending = { [weak self] in
+            pendingShown = true
+            self?.presentPendingAlert()
+        }
+
         Task {
             loadingProductID = product.id
             tableView.reloadData()
@@ -156,7 +162,20 @@ class TopUpViewController: UIViewController {
             // Refresh balance header
             tableView.tableHeaderView = makeBalanceHeader()
             tableView.reloadData()
+            if !pendingShown {
+                storeService.onPurchasePending = nil
+            }
         }
+    }
+
+    private func presentPendingAlert() {
+        let alert = UIAlertController(
+            title: "Ожидаем подтверждения",
+            message: "Покупка ожидает одобрения родителя. Баланс пополнится автоматически.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
     }
 }
 

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/TopUpViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/TopUpViewController.swift
@@ -52,7 +52,24 @@ class TopUpViewController: UIViewController {
         )
 
         setupTableView()
+        wireStoreCallbacks()
         loadStoreProducts()
+    }
+
+    private func wireStoreCallbacks() {
+        // loadProducts() and the foreground purchase path call onPurchaseFailed
+        // when the store is unreachable or a verification/cancel error occurs.
+        // Without this wiring, the user-visible error message added in IOS-032
+        // would silently drop on the floor.
+        storeService.onPurchaseFailed = { [weak self] message in
+            self?.presentErrorAlert(message)
+        }
+    }
+
+    private func presentErrorAlert(_ message: String) {
+        let alert = UIAlertController(title: "Ошибка", message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
     }
 
     // MARK: - Setup
@@ -146,9 +163,7 @@ class TopUpViewController: UIViewController {
         }
 
         let product = products[index]
-        var pendingShown = false
         storeService.onPurchasePending = { [weak self] in
-            pendingShown = true
             self?.presentPendingAlert()
         }
 
@@ -162,9 +177,11 @@ class TopUpViewController: UIViewController {
             // Refresh balance header
             tableView.tableHeaderView = makeBalanceHeader()
             tableView.reloadData()
-            if !pendingShown {
-                storeService.onPurchasePending = nil
-            }
+            // Always clear — including the .pending case where the alert was shown.
+            // The actual credit happens later via Transaction.updates listener; the
+            // pending callback's job ends with the alert. Leaving the closure live
+            // would leak the VC capture if the user navigates away before approval.
+            storeService.onPurchasePending = nil
         }
     }
 

--- a/SnoozePay/SnoozePayTests/StoreKitServiceTests.swift
+++ b/SnoozePay/SnoozePayTests/StoreKitServiceTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import SnoozePay
+
+/// Smoke tests for StoreKitService.
+///
+/// NOTE: Fully exercising the `Transaction.updates` listener requires mocking
+/// `StoreKit.Transaction.updates`, which is a built-in `AsyncStream` not
+/// designed for substitution without a larger DI refactor. We therefore
+/// limit coverage to:
+///   - product ID → credit amount mapping (pure logic)
+///   - shared instance reachability (smoke)
+///
+/// TODO(IOS-032+): Once StoreKit transaction handling is extracted behind a
+/// protocol, add an end-to-end test that pushes a mock verified transaction
+/// through `handle(transactionResult:)` and asserts the balance is credited
+/// and the transaction is finished.
+@MainActor
+final class StoreKitServiceTests: XCTestCase {
+
+    func testSharedInstance_isReachable() {
+        // Touching `.shared` triggers `init`, which spawns the
+        // `Transaction.updates` listener. If the listener crashed at start
+        // this test would surface it.
+        let service = StoreKitService.shared
+        XCTAssertNotNil(service)
+    }
+
+    func testProductAmounts_coversAllProductIDs() {
+        for productID in StoreKitService.productIDs {
+            XCTAssertNotNil(
+                StoreKitService.productAmounts[productID],
+                "Missing credit amount mapping for \(productID)"
+            )
+        }
+    }
+
+    func testProductAmounts_matchProductIDSuffix() {
+        // Each product ID encodes its RUB amount as the trailing component
+        // (e.g. "...balance.149" → 149 RUB). Catch drift between the two tables.
+        for (productID, amount) in StoreKitService.productAmounts {
+            let suffix = productID.split(separator: ".").last.map(String.init) ?? ""
+            XCTAssertEqual(
+                Double(suffix),
+                amount,
+                "Product \(productID) maps to \(amount) but suffix says \(suffix)"
+            )
+        }
+    }
+}


### PR DESCRIPTION
Fixes #24

## Что сделано
- `StoreKitService.init` стартует `Task.detached` подписанный на `StoreKit.Transaction.updates`. На каждый `.verified` транзакции — кредит баланса через `BalanceService.shared.topUp(amount:)` + `await transaction.finish()`. Skip transactions с `revocationDate != nil` (refund'ы Apple для consumables — баланс уже потрачен, просто финализируем). На `.unverified` — лог + `finish()` (per Apple docs: drain queue).
- `Task` сохраняется в private property `transactionListener` и отменяется в `deinit`.
- `purchase(_:)` обработка `.pending` (Ask-to-Buy) теперь триггерит новый callback `onPurchasePending`. `TopUpViewController` показывает alert "Ожидаем подтверждения родителя".
- Маппинг productID → amount экстрагирован в общий helper `creditBalance(for:fallbackPrice:)` — используется и в `purchase`, и в `handle(transactionResult:)`.

## Архитектурные заметки
- Listener в `Task.detached` намеренно — не унаследует `@MainActor`, переключается обратно через `await StoreKitService.shared.handle(...)`.
- Полное unit-тестирование `Transaction.updates` требует DI-рефактора (тип возвращает встроенный `AsyncStream`, не подменяемый без сервисной абстракции). В этом PR — только smoke tests для маппинга productID и достижимости shared (проверяет, что listener не падает на старте). TODO в тестах.

## Verify
- swiftlint: 0 новых ошибок (предсуществующие violations в `TopUpPackageCell` UI definitions не трогал)
- `xcodebuild build`: BUILD SUCCEEDED (iPhone 17 Pro)
- `xcodebuild build-for-testing`: TEST BUILD SUCCEEDED (тест-таргет компилируется)
- test_sim: пропущен per orchestrator instructions

## No-touch zones
Не затронуты: entitlements, Info.plist, project.pbxproj signing, новые SPM. StoreKit — Apple framework, уже подключён.