### PR TITLE
[fix] Surface AudioService failures and stop audio on missing alarm (#29)

### DIFF
--- a/SnoozePay/SnoozePay/AppDelegate.swift
+++ b/SnoozePay/SnoozePay/AppDelegate.swift
@@ -159,10 +159,20 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         guard
             let alarmIDString = userInfo["alarmID"] as? String,
             let alarmID = UUID(uuidString: alarmIDString)
-        else { return }
+        else {
+            // Audio may already be playing from willPresent — stop it so the user
+            // is not stuck with a silent-screen + sounding alarm we can't dismiss.
+            print("[AppDelegate] alarm not found (missing/invalid alarmID), stopping audio")
+            AudioService.shared.stopAlarmSound()
+            return
+        }
 
         let repo = AlarmRepository()
-        guard let alarm = repo.fetch(id: alarmID) else { return }
+        guard let alarm = repo.fetch(id: alarmID) else {
+            print("[AppDelegate] alarm not found (repo returned nil for \(alarmID)), stopping audio")
+            AudioService.shared.stopAlarmSound()
+            return
+        }
 
         DispatchQueue.main.async {
             let firingVC = AlarmFiringViewController(alarm: alarm, snoozeCount: userInfo["snoozeCount"] as? Int ?? 0)
@@ -174,7 +184,11 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
                     .compactMap({ $0 as? UIWindowScene })
                     .first,
                 let rootVC = windowScene.windows.first?.rootViewController
-            else { return }
+            else {
+                print("[AppDelegate] no window scene, stopping audio")
+                AudioService.shared.stopAlarmSound()
+                return
+            }
 
             var topVC = rootVC
             while let presented = topVC.presentedViewController {

--- a/SnoozePay/SnoozePay/Services/AudioService.swift
+++ b/SnoozePay/SnoozePay/Services/AudioService.swift
@@ -19,13 +19,16 @@ final class AudioService {
 
     /// Configure the audio session for alarm playback.
     /// Uses `.playback` category so audio continues when screen is locked.
-    private func configureAudioSession() {
+    /// - Returns: `true` if the session is active and ready, `false` otherwise.
+    private func configureAudioSession() -> Bool {
         do {
             let session = AVAudioSession.sharedInstance()
             try session.setCategory(.playback, options: [.duckOthers])
             try session.setActive(true, options: [])
+            return true
         } catch {
-            print("Failed to configure audio session: \(error)")
+            print("[AudioService] Failed to configure audio session: \(error)")
+            return false
         }
     }
 
@@ -46,7 +49,14 @@ final class AudioService {
     func startAlarmSound(soundID: String) {
         guard !isPlaying else { return }
 
-        configureAudioSession()
+        guard configureAudioSession() else {
+            // Audio session unavailable (e.g. another app holds it).
+            // Surface explicitly via isPlaying = false so the UI / caller can react.
+            // Skip vibration too — without an active session we cannot guarantee playback.
+            print("[AudioService] startAlarmSound aborted: audio session unavailable")
+            isPlaying = false
+            return
+        }
 
         // Try to find the sound file in the bundle
         let url: URL? = Bundle.main.url(forResource: soundID, withExtension: "caf")
@@ -56,11 +66,17 @@ final class AudioService {
             ?? Bundle.main.url(forResource: "default_alarm", withExtension: "caf")
             ?? Bundle.main.url(forResource: "default_alarm", withExtension: "m4a")
 
-        let player: AVAudioPlayer?
+        // Try the bundled file first; fall back to synthetic tone if the file
+        // is missing or corrupt (AVAudioPlayer init returns nil).
+        var player: AVAudioPlayer?
         if let soundURL = url {
             player = try? AVAudioPlayer(contentsOf: soundURL)
-        } else {
-            // No sound file found — generate a synthetic alarm tone
+            if player == nil {
+                let name = soundURL.lastPathComponent
+                print("[AudioService] AVAudioPlayer init failed for \(name), using synthetic tone")
+            }
+        }
+        if player == nil {
             player = Self.generateAlarmTone()
         }
 
@@ -71,12 +87,14 @@ final class AudioService {
             player.prepareToPlay()
             player.play()
             isPlaying = true
+            startVibration()
         } else {
-            // Last resort: vibration only
-            isPlaying = true
+            // Neither bundled file nor synthetic tone available — refuse to claim playback.
+            // We still vibrate, but isPlaying stays false to signal silent failure.
+            print("[AudioService] startAlarmSound: no audio source available, vibration only")
+            isPlaying = false
+            startVibration()
         }
-
-        startVibration()
     }
 
     /// Stop alarm sound and vibration immediately.

--- a/SnoozePay/SnoozePayTests/AudioServiceTests.swift
+++ b/SnoozePay/SnoozePayTests/AudioServiceTests.swift
@@ -13,13 +13,41 @@ final class AudioServiceTests: XCTestCase {
         XCTAssertFalse(service.isPlaying)
 
         service.startAlarmSound(soundID: "nonexistent_test_sound")
-        // Even when the sound file is missing, isPlaying should be set
-        // because AudioService starts vibration as fallback
+        // Missing bundle file → AudioService falls back to a synthetic tone
+        // (generateAlarmTone). isPlaying must be true to reflect that real audio
+        // is being produced, not just vibration.
         XCTAssertTrue(service.isPlaying)
 
         // Cleanup
         service.stopAlarmSound()
     }
+
+    /// IOS-037 — silent failure regression guard.
+    /// When the bundle does not contain the requested sound file, AudioService
+    /// must fall back to the synthetic tone instead of silently going
+    /// vibration-only with isPlaying = true.
+    func testStartAlarmSound_withMissingFile_fallsBackToSynthetic() {
+        let service = AudioService.shared
+        service.stopAlarmSound()
+        XCTAssertFalse(service.isPlaying)
+
+        service.startAlarmSound(soundID: "definitely_not_a_real_sound_file_xyz")
+        // Synthetic tone generation is deterministic and does not depend on
+        // audio session state for unit-test correctness — isPlaying reflects
+        // the in-memory player being created and started.
+        XCTAssertTrue(
+            service.isPlaying,
+            "Missing bundle file should fall back to synthetic tone, not silent vibration"
+        )
+
+        service.stopAlarmSound()
+        XCTAssertFalse(service.isPlaying)
+    }
+
+    // NOTE: We cannot easily simulate AVAudioSession.setActive failure without
+    // a DI refactor (AVAudioSession is a hard-coded singleton inside AudioService).
+    // A follow-up could introduce a session-providing protocol so the
+    // setActive-throws path can be exercised in unit tests.
 
     func testStartAlarmSound_whenAlreadyPlaying_doesNotRestart() {
         let service = AudioService.shared


### PR DESCRIPTION
Fixes #29

## Что сделано
- `AudioService.startAlarmSound`: при сбое `AVAudioSession.setActive` теперь выходим раньше с `isPlaying = false` вместо тихого `player.play()` no-op.
- При nil от `AVAudioPlayer(contentsOf:)` (битый/отсутствующий файл) делаем fallback на synthetic tone, а не остаёмся с одной вибрацией под видом «играет».
- `isPlaying = true` теперь означает, что реально есть активный audio source (bundled player ИЛИ synthetic tone). Если ничего не получилось — `isPlaying = false`, и это видно вызывающей стороне.
- `AppDelegate.presentAlarmFiringScreen`: на ранних `return`'ах (невалидный `alarmID`, alarm удалён из репо, нет window scene) теперь вызывается `AudioService.shared.stopAlarmSound()`, иначе уже запущенный (в `willPresent`) звук остаётся играть без UI, чтобы его выключить.
- Добавлен регрессионный тест `testStartAlarmSound_withMissingFile_fallsBackToSynthetic`.

## No-touch
- entitlements / Info.plist / project.pbxproj signing — не трогал.

## Verify
- swiftlint: 0 violations в изменённых строках (2 pre-existing нарушения `i`/`t` в `generateAlarmTone` остались, не вводились этим PR).
- `xcodebuild build -destination 'platform=iOS Simulator,name=iPhone 16e'`: BUILD SUCCEEDED.
- Тесты `AudioServiceTests` обновлены, добавлен новый case под IOS-037.