### PR TITLE
[fix] Replace tag-based cell identity and dedup target/action in Alarms (#27)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmCell.swift
@@ -47,11 +47,21 @@ final class AlarmCell: UITableViewCell {
         return sw
     }()
 
+    // MARK: - Callbacks
+
+    /// Invoked when the user flips the toggle. Set by the controller in `cellForRowAt`.
+    /// Capturing the alarm's id (not row index or `tag`) lets the controller resolve
+    /// the right alarm even after deletion or reordering.
+    var onToggle: ((Bool) -> Void)?
+
     // MARK: - Init
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setupUI()
+        // Wire the target once at cell creation so re-configuration in
+        // `cellForRowAt` never accumulates duplicate handlers.
+        toggleSwitch.addTarget(self, action: #selector(toggleSwitchChanged), for: .valueChanged)
     }
 
     required init?(coder: NSCoder) {
@@ -100,6 +110,13 @@ final class AlarmCell: UITableViewCell {
         ])
     }
 
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        // The closure captures the previous row's identity — drop it so the
+        // recycled cell never fires the wrong alarm before the next configure.
+        onToggle = nil
+    }
+
     // MARK: - Configure
 
     func configure(time: String, detail: String, penalty: String, enabled: Bool) {
@@ -117,5 +134,11 @@ final class AlarmCell: UITableViewCell {
         timeLabel.alpha = alpha
         detailLabel.alpha = alpha
         penaltyLabel.alpha = alpha
+    }
+
+    @objc private func toggleSwitchChanged() {
+        let isOn = toggleSwitch.isOn
+        setEnabledAppearance(isOn)
+        onToggle?(isOn)
     }
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
@@ -268,18 +268,14 @@ extension AlarmsListViewController: UITableViewDataSource {
             enabled: alarm.enabled
         )
 
-        cell.toggleSwitch.tag = indexPath.row
-        cell.toggleSwitch.addTarget(self, action: #selector(toggleChanged(_:)), for: .valueChanged)
+        // Capture the alarm's stable UUID rather than the row index — the
+        // index becomes invalid after delete/reorder, but the id never does.
+        let alarmID = alarm.id
+        cell.onToggle = { [weak self] isOn in
+            self?.viewModel.toggleAlarm(id: alarmID, enabled: isOn)
+        }
 
         return cell
-    }
-
-    @objc private func toggleChanged(_ sender: UISwitch) {
-        let index = sender.tag
-        viewModel.toggleAlarm(at: index, enabled: sender.isOn)
-        if let cell = tableView.cellForRow(at: IndexPath(row: index, section: 0)) as? AlarmCell {
-            cell.setEnabledAppearance(sender.isOn)
-        }
     }
 }
 

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
@@ -128,7 +128,17 @@ class CreateAlarmViewController: UIViewController {
         view.backgroundColor = .systemGroupedBackground
         setupNavigationBar()
         setupTableView()
+        // Targets must be wired exactly once on these shared controls.
+        // Wiring them in `cellForRowAt` accumulated duplicate handlers on every
+        // reload, multiplying penalty/snooze updates per single user action.
+        wireControlTargets()
         populateFromViewModel()
+    }
+
+    private func wireControlTargets() {
+        penaltySlider.addTarget(self, action: #selector(sliderChanged(_:)), for: .valueChanged)
+        progressiveToggle.addTarget(self, action: #selector(progressiveToggled(_:)), for: .valueChanged)
+        snoozeStepper.addTarget(self, action: #selector(stepperChanged(_:)), for: .valueChanged)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -360,7 +370,6 @@ extension CreateAlarmViewController: UITableViewDataSource {
             stack.axis = .horizontal
             stack.spacing = AppSpacing.md
             stack.translatesAutoresizingMaskIntoConstraints = false
-            penaltySlider.addTarget(self, action: #selector(sliderChanged(_:)), for: .valueChanged)
             cell.contentView.addSubview(stack)
             NSLayoutConstraint.activate([
                 stack.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor, constant: AppSpacing.lg),
@@ -372,7 +381,6 @@ extension CreateAlarmViewController: UITableViewDataSource {
         case .progressiveScale:
             if indexPath.row == 0 {
                 cell.textLabel?.text = "Прогрессивная шкала"
-                progressiveToggle.addTarget(self, action: #selector(progressiveToggled(_:)), for: .valueChanged)
                 cell.accessoryView = progressiveToggle
             } else {
                 // Preview row
@@ -394,7 +402,6 @@ extension CreateAlarmViewController: UITableViewDataSource {
             stack.axis = .horizontal
             stack.spacing = AppSpacing.sm
             stack.alignment = .center
-            snoozeStepper.addTarget(self, action: #selector(stepperChanged(_:)), for: .valueChanged)
             stack.sizeToFit()
             cell.accessoryView = stack
         }

--- a/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
@@ -47,7 +47,15 @@ final class AlarmsListViewModel {
 
     func toggleAlarm(at index: Int, enabled: Bool) {
         guard index < alarms.count else { return }
-        alarmRepository.setEnabled(enabled, id: alarms[index].id)
+        toggleAlarm(id: alarms[index].id, enabled: enabled)
+    }
+
+    /// Toggle by stable UUID rather than row index. Cells should call this so the
+    /// right alarm flips even after the list has been reordered or items deleted
+    /// since the cell was configured.
+    func toggleAlarm(id: UUID, enabled: Bool) {
+        guard let index = alarms.firstIndex(where: { $0.id == id }) else { return }
+        alarmRepository.setEnabled(enabled, id: id)
         alarms[index] = Alarm(
             id: alarms[index].id,
             time: alarms[index].time,

--- a/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
@@ -54,7 +54,14 @@ final class AlarmsListViewModel {
     /// right alarm flips even after the list has been reordered or items deleted
     /// since the cell was configured.
     func toggleAlarm(id: UUID, enabled: Bool) {
-        guard let index = alarms.firstIndex(where: { $0.id == id }) else { return }
+        guard let index = alarms.firstIndex(where: { $0.id == id }) else {
+            // Stale cell closure or deleted alarm — the cell already flipped its visual
+            // state in setEnabledAppearance. Force a re-bind so the list reverts to truth.
+            assertionFailure("toggleAlarm: id \(id) not found (count=\(alarms.count))")
+            print("[AlarmsListViewModel] toggleAlarm called for missing id=\(id)")
+            onAlarmsUpdated?()
+            return
+        }
         alarmRepository.setEnabled(enabled, id: id)
         alarms[index] = Alarm(
             id: alarms[index].id,

--- a/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
@@ -124,4 +124,43 @@ final class AlarmsListViewModelTests: XCTestCase {
         XCTAssertEqual(stored.count, 1)
         XCTAssertFalse(stored[0].enabled, "Toggle must persist through the repository")
     }
+
+    // MARK: - toggleAlarm(id:enabled:)
+
+    /// Regression for tag-based identity bug: when middle alarm is removed and the
+    /// caller toggles the *first* alarm, only that alarm — resolved by id — must flip,
+    /// not whichever alarm currently lives at the captured row index.
+    func testToggleAlarmByID_correctAlarmTogglesAfterDelete() {
+        // Three alarms with distinct times so sort order is stable: 06:00, 07:00, 08:00.
+        let calendar = Calendar(identifier: .gregorian)
+        let date6 = calendar.date(from: DateComponents(hour: 6, minute: 0))!
+        let date7 = calendar.date(from: DateComponents(hour: 7, minute: 0))!
+        let date8 = calendar.date(from: DateComponents(hour: 8, minute: 0))!
+
+        let first = Alarm(time: date6, name: "Early", penaltyAmount: 50, enabled: true)
+        let middle = Alarm(time: date7, name: "Mid", penaltyAmount: 50, enabled: true)
+        let last = Alarm(time: date8, name: "Late", penaltyAmount: 50, enabled: true)
+        repo.save(first)
+        repo.save(middle)
+        repo.save(last)
+
+        let vm = makeViewModel()
+        vm.loadData()
+        XCTAssertEqual(vm.alarms.map(\.id), [first.id, middle.id, last.id])
+
+        // Capture the first alarm's id BEFORE deletion — this is what an
+        // already-configured cell would have closed over.
+        let firstID = first.id
+
+        vm.deleteAlarm(at: 1) // remove "Mid"
+        XCTAssertEqual(vm.alarms.map(\.id), [first.id, last.id])
+
+        vm.toggleAlarm(id: firstID, enabled: false)
+
+        // Only "Early" should have flipped — "Late" stays enabled.
+        let early = vm.alarms.first { $0.id == first.id }
+        let late = vm.alarms.first { $0.id == last.id }
+        XCTAssertEqual(early?.enabled, false, "The alarm matching the captured id must toggle")
+        XCTAssertEqual(late?.enabled, true, "Sibling alarms must NOT be affected by an id-targeted toggle")
+    }
 }


### PR DESCRIPTION
Fixes #27

## What

Two related UIKit anti-patterns in the alarms screens, both surfaced by `/audit`:

**A) Duplicate target/action accumulation (`CreateAlarmViewController`)** — `cellForRowAt` re-added `addTarget` to shared controls (`penaltySlider`, `progressiveToggle`, `snoozeStepper`) every reload. After a few reloads, one user gesture fired the handler N times → penalty/snooze values jumped multiple steps.

**B) Tag-based identity (`AlarmsListViewController`)** — `cell.toggleSwitch.tag = indexPath.row`. After deleting one alarm, toggling another flipped the wrong row because the captured tag pointed at the new occupant.

## How

- `AlarmCell` now owns its toggle handler: target wired once in `init`, `onToggle: ((Bool) -> Void)?` closure invoked from a private `@objc` hop, reset in `prepareForReuse` so a recycled cell never fires a stale identity.
- `AlarmsListViewController.cellForRowAt` captures `alarm.id` (UUID) into the closure — never the row index or the switch tag.
- `AlarmsListViewModel` gains `toggleAlarm(id:enabled:)`; the existing `toggleAlarm(at:enabled:)` resolves the id and delegates, keeping callers/tests passing.
- `CreateAlarmViewController.viewDidLoad` calls a new `wireControlTargets()` once; the three `addTarget` calls were removed from `cellForRowAt`.

## Tests

- `AlarmsListViewModelTests.testToggleAlarmByID_correctAlarmTogglesAfterDelete` — creates 3 alarms, deletes the middle one, toggles the first by its captured UUID, asserts only that alarm flips.
- Existing `toggleAlarm(at:enabled:)` tests still pass (the index variant now routes through the id variant).

## Verify

- swiftlint: 0 new errors in touched files (preexisting `s`/`l`/`tv` short-ident warnings unchanged)
- xcodebuild build (iPhone 17 Pro Max sim): `** BUILD SUCCEEDED **`

🤖 Generated with [Claude Code](https://claude.com/claude-code)