### PR TITLE
[fix] Don't wipe user data on JSON encode/decode failures (#23)

### DIFF
--- a/SnoozePay/SnoozePay/Services/AlarmRepository.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmRepository.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os.log
 
 /// Persists alarms in UserDefaults with a serial queue protecting all reads and writes.
 /// Without serialization, concurrent callers (UI edits + notification action handlers)
@@ -10,6 +11,7 @@ final class AlarmRepository {
     private let key = "stored_alarms"
     private let defaults: UserDefaults
     private let queue = DispatchQueue(label: "com.snoozepay.alarms.serial")
+    private static let log = OSLog(subsystem: "Ivan-Emelyanov.SnoozePay", category: "AlarmRepository")
 
     /// Production code MUST use `AlarmRepository.shared`.
     /// Direct construction creates an isolated instance with its own serial queue —
@@ -83,11 +85,32 @@ final class AlarmRepository {
 
     // MARK: - Private (must be called inside queue.sync)
 
+    /// Returns persisted alarms.
+    ///
+    /// Differentiates three states (issue #23):
+    ///   1. Key absent — new user, returns `[]` (legitimate empty state).
+    ///   2. Key present, decode succeeds — returns sorted alarms.
+    ///   3. Key present, decode fails — logs the error and returns `[]` for this read,
+    ///      but the corrupted JSON stays on disk untouched. The next `persist()`
+    ///      from a healthy in-memory state will overwrite it. Until then, the raw
+    ///      bytes remain available for debugging instead of being silently wiped.
     private func readAll() -> [Alarm] {
-        guard let data = defaults.data(forKey: key),
-              let alarms = try? JSONDecoder().decode([Alarm].self, from: data)
-        else { return [] }
-        return alarms.sorted { $0.time < $1.time }
+        guard let data = defaults.data(forKey: key) else {
+            // Case 1: brand-new install — no stored alarms yet.
+            return []
+        }
+        do {
+            let alarms = try JSONDecoder().decode([Alarm].self, from: data)
+            return alarms.sorted { $0.time < $1.time }
+        } catch {
+            // Case 3: stored bytes can't be decoded. Surface the failure but DO NOT
+            // overwrite the corrupted blob — preserve it for diagnosis.
+            os_log(
+                "Decode failed (%{public}d bytes preserved on disk): %{public}@",
+                log: Self.log, type: .error, data.count, String(describing: error)
+            )
+            return []
+        }
     }
 
     private func persist(_ alarms: [Alarm]) {
@@ -96,9 +119,12 @@ final class AlarmRepository {
             defaults.set(data, forKey: key)
         } catch {
             // Don't write nil — that wipes the entire alarm list silently.
-            // Issue #23 tracks proper logging+UI surfacing; this guard at least preserves data.
+            // If encode fails the previous JSON on disk stays intact (issue #23).
+            os_log(
+                "Encode failed, previous state preserved on disk: %{public}@",
+                log: Self.log, type: .error, String(describing: error)
+            )
             assertionFailure("AlarmRepository encode failed: \(error)")
-            print("[AlarmRepository] encode failed, preserving previous state: \(error)")
         }
     }
 }

--- a/SnoozePay/SnoozePay/Services/TransactionRepository.swift
+++ b/SnoozePay/SnoozePay/Services/TransactionRepository.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os.log
 
 /// Persists transactions in UserDefaults with a serial queue protecting all reads and writes.
 /// Transactions are a financial ledger — losing entries due to a read-modify-write race
@@ -11,6 +12,10 @@ final class TransactionRepository {
     private let key = "stored_transactions"
     private let defaults: UserDefaults
     private let queue = DispatchQueue(label: "com.snoozepay.transactions.serial")
+    private static let log = OSLog(
+        subsystem: "Ivan-Emelyanov.SnoozePay",
+        category: "TransactionRepository"
+    )
 
     /// Production code MUST use `TransactionRepository.shared`.
     /// Direct construction creates an isolated instance with its own serial queue —
@@ -45,15 +50,7 @@ final class TransactionRepository {
         queue.sync {
             var txs = readAll()
             txs.append(transaction)
-            do {
-                let data = try JSONEncoder().encode(txs)
-                defaults.set(data, forKey: key)
-            } catch {
-                // Don't write nil — that wipes the financial ledger silently.
-                // Issue #23 tracks proper logging+UI surfacing.
-                assertionFailure("TransactionRepository encode failed: \(error)")
-                print("[TransactionRepository] encode failed, preserving previous state: \(error)")
-            }
+            persist(txs)
         }
         return true
     }
@@ -87,10 +84,46 @@ final class TransactionRepository {
 
     // MARK: - Private (must be called inside queue.sync)
 
+    /// Returns persisted transactions.
+    ///
+    /// Differentiates three states (issue #23):
+    ///   1. Key absent — new user, returns `[]` (legitimate empty state).
+    ///   2. Key present, decode succeeds — returns sorted transactions.
+    ///   3. Key present, decode fails — logs the error and returns `[]` for this read,
+    ///      but the corrupted JSON stays on disk untouched. The next `persist()`
+    ///      from a healthy in-memory state will overwrite it. Until then, the raw
+    ///      bytes remain available for debugging instead of being silently wiped.
     private func readAll() -> [Transaction] {
-        guard let data = defaults.data(forKey: key),
-              let txs = try? JSONDecoder().decode([Transaction].self, from: data)
-        else { return [] }
-        return txs.sorted { $0.createdAt > $1.createdAt }
+        guard let data = defaults.data(forKey: key) else {
+            // Case 1: brand-new install — no recorded transactions yet.
+            return []
+        }
+        do {
+            let txs = try JSONDecoder().decode([Transaction].self, from: data)
+            return txs.sorted { $0.createdAt > $1.createdAt }
+        } catch {
+            // Case 3: stored bytes can't be decoded. Surface the failure but DO NOT
+            // overwrite the corrupted blob — preserve it for diagnosis.
+            os_log(
+                "Decode failed (%{public}d bytes preserved on disk): %{public}@",
+                log: Self.log, type: .error, data.count, String(describing: error)
+            )
+            return []
+        }
+    }
+
+    private func persist(_ transactions: [Transaction]) {
+        do {
+            let data = try JSONEncoder().encode(transactions)
+            defaults.set(data, forKey: key)
+        } catch {
+            // Don't write nil — that wipes the financial ledger silently.
+            // If encode fails the previous JSON on disk stays intact (issue #23).
+            os_log(
+                "Encode failed, previous state preserved on disk: %{public}@",
+                log: Self.log, type: .error, String(describing: error)
+            )
+            assertionFailure("TransactionRepository encode failed: \(error)")
+        }
     }
 }

--- a/SnoozePay/SnoozePayTests/AlarmRepositoryTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmRepositoryTests.swift
@@ -117,6 +117,58 @@ final class AlarmRepositoryTests: XCTestCase {
                       "All added alarms must be persisted")
     }
 
+    // MARK: - Corrupted persistence (issue #23)
+
+    /// When the stored JSON can't be decoded, the read must return `[]`
+    /// without silently overwriting the corrupted blob — the raw bytes stay
+    /// on disk so we can diagnose what got broken.
+    func testFetchAll_corruptedJSON_returnsEmptyAndPreservesRawData() {
+        let corruptBytes = Data("{ this is not valid json".utf8)
+        testDefaults.set(corruptBytes, forKey: "stored_alarms")
+
+        XCTAssertEqual(repo.fetchAll(), [], "Decode failure should yield empty list to caller")
+
+        let onDisk = testDefaults.data(forKey: "stored_alarms")
+        XCTAssertEqual(onDisk, corruptBytes,
+                       "Corrupt JSON must remain untouched on disk for debugging")
+    }
+
+    /// fetchAll() called twice on corrupted data must NOT have overwritten
+    /// the stored blob between calls — the second fetch sees the same raw bytes.
+    func testFetchAll_corruptedJSON_repeatedReadDoesNotMutateStorage() {
+        let corruptBytes = Data("not json".utf8)
+        testDefaults.set(corruptBytes, forKey: "stored_alarms")
+
+        _ = repo.fetchAll()
+        _ = repo.fetchAll()
+
+        XCTAssertEqual(testDefaults.data(forKey: "stored_alarms"), corruptBytes,
+                       "Reading corrupt data must never write back")
+    }
+
+    /// Absent key (brand-new install) is the legitimate empty state.
+    func testFetchAll_keyAbsent_returnsEmptyAndDoesNotCreateKey() {
+        testDefaults.removeObject(forKey: "stored_alarms")
+
+        XCTAssertEqual(repo.fetchAll(), [])
+        XCTAssertNil(testDefaults.data(forKey: "stored_alarms"),
+                     "Read on missing key must not materialize an empty value")
+    }
+
+    /// After a successful save the previously-corrupted bytes are replaced
+    /// with valid JSON — proves persist() is the only path that can clobber
+    /// corrupt data, and only with a healthy snapshot.
+    func testSaveAfterCorruption_overwritesWithValidData() {
+        testDefaults.set(Data("garbage".utf8), forKey: "stored_alarms")
+
+        let alarm = makeAlarm(name: "Recovery")
+        repo.save(alarm)
+
+        let stored = repo.fetchAll()
+        XCTAssertEqual(stored.count, 1)
+        XCTAssertEqual(stored.first?.name, "Recovery")
+    }
+
     func testConcurrentToggleVsSave_finalStateIsConsistent() {
         // Race a setEnabled(true) loop against save(disabledClone) on the same id.
         // On the buggy code, save() does fetch+upsert without serialization — the

--- a/SnoozePay/SnoozePayTests/TransactionRepositoryTests.swift
+++ b/SnoozePay/SnoozePayTests/TransactionRepositoryTests.swift
@@ -181,6 +181,63 @@ final class TransactionRepositoryTests: XCTestCase {
         otherDefaults.removePersistentDomain(forName: otherSuiteName)
     }
 
+    // MARK: - Corrupted persistence (issue #23)
+
+    /// When stored JSON can't be decoded, the read must return `[]`
+    /// without silently overwriting the corrupted blob — the raw bytes stay
+    /// on disk so we can diagnose what got broken.
+    func testFetchAll_corruptedJSON_returnsEmptyAndPreservesRawData() {
+        let corruptBytes = Data("{ this is not valid json".utf8)
+        testDefaults.set(corruptBytes, forKey: "stored_transactions")
+
+        XCTAssertTrue(repo.fetchAll().isEmpty, "Decode failure yields empty list to caller")
+
+        let onDisk = testDefaults.data(forKey: "stored_transactions")
+        XCTAssertEqual(onDisk, corruptBytes,
+                       "Corrupt JSON must remain untouched on disk for debugging")
+    }
+
+    func testFetchAll_corruptedJSON_repeatedReadDoesNotMutateStorage() {
+        let corruptBytes = Data("not json".utf8)
+        testDefaults.set(corruptBytes, forKey: "stored_transactions")
+
+        _ = repo.fetchAll()
+        _ = repo.fetchAll()
+        _ = repo.fetchCharges(since: Date.distantPast)
+
+        XCTAssertEqual(testDefaults.data(forKey: "stored_transactions"), corruptBytes,
+                       "Reading corrupt data must never write back")
+    }
+
+    func testFetchAll_keyAbsent_returnsEmptyAndDoesNotCreateKey() {
+        testDefaults.removeObject(forKey: "stored_transactions")
+
+        XCTAssertTrue(repo.fetchAll().isEmpty)
+        XCTAssertNil(testDefaults.data(forKey: "stored_transactions"),
+                     "Read on missing key must not materialize an empty value")
+    }
+
+    /// A subsequent valid `record()` call replaces the corrupt blob with healthy JSON.
+    /// This is the only path that may overwrite corrupted data — and only with a
+    /// known-good in-memory snapshot.
+    func testRecordAfterCorruption_overwritesWithValidData() {
+        testDefaults.set(Data("garbage".utf8), forKey: "stored_transactions")
+
+        repo.record(charge(amount: 99))
+
+        let all = repo.fetchAll()
+        XCTAssertEqual(all.count, 1)
+        XCTAssertEqual(all.first?.amount, 99)
+    }
+
+    /// On corrupted data, currentStreak() must not crash and must report 0
+    /// (matching the new-user fallback) rather than returning a misleading value.
+    func testCurrentStreak_corruptedJSON_returnsZero() {
+        testDefaults.set(Data("nope".utf8), forKey: "stored_transactions")
+
+        XCTAssertEqual(repo.currentStreak(), 0)
+    }
+
     // MARK: - Concurrency
 
     func testConcurrentRecord_allTransactionsLanded() {


### PR DESCRIPTION
Fixes #23

## Summary

`AlarmRepository` and `TransactionRepository` used `try?` on JSON encode/decode. Two silent failure modes:

- **encode fail** → `defaults.set(nil, ...)` → wipes the entire alarm list / financial ledger.
- **decode fail** → returns `[]` indistinguishably from a brand-new install.

This PR reworks both so user data survives Codable mishaps.

## Changes

### `Services/AlarmRepository.swift`, `Services/TransactionRepository.swift`
- `readAll()` differentiates three states:
  1. **Key absent** — new user, returns `[]` (legitimate empty state).
  2. **Key present, decode succeeds** — returns sorted items.
  3. **Key present, decode fails** — logs via `os_log` and returns `[]` for this read, but the corrupted JSON stays on disk untouched. The next `persist()` from a healthy in-memory state overwrites it.
- `persist()` catches encode errors via `do/catch` + `os_log`; previous bytes on disk remain intact (no `nil` write).
- `TransactionRepository`: extracted a private `persist()` mirroring `AlarmRepository`.

### Tests
- `AlarmRepositoryTests` / `TransactionRepositoryTests`:
  - Corrupt JSON → `fetchAll()` returns `[]` AND raw bytes preserved.
  - Repeated reads on corrupt data don't mutate storage.
  - Absent key returns `[]` without materializing the key.
  - Successful `save()`/`record()` after corruption replaces bytes with valid JSON.
  - `currentStreak()` on corrupt data returns 0 without crashing.

## Verify

- swiftlint: 0 errors on changed files (4 pre-existing `tx` identifier warnings — not introduced here).
- xcodebuild build (iPhone 17 Pro Max simulator): **BUILD SUCCEEDED**.
- Tests: ran via `xcodebuild build` only (test_sim disabled per environment config). Test code compiles cleanly as part of the build.

## Out of scope (follow-up candidates)

- UI banner / alert when `decodeFailed` is detected (the issue body mentions this; it requires UX decision so I left it for a separate `status:proposed` issue if desired).
- Versioned payload (`{ "v": 1, "items": [...] }`) for future Codable migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)