### PR TITLE
[refactor] Multi-observer pattern via NotificationCenter (#22)

### DIFF
--- a/SnoozePay/SnoozePay/Services/BalanceService.swift
+++ b/SnoozePay/SnoozePay/Services/BalanceService.swift
@@ -9,13 +9,19 @@ final class BalanceService {
 
     static let shared = BalanceService()
 
+    /// Broadcast on every successful balance mutation (charge / topUp).
+    /// Multiple observers may subscribe simultaneously — each is independent
+    /// and must remove its own observer in `deinit` (or rely on
+    /// `NotificationCenter`'s automatic cleanup of dealloc'd weak observers).
+    /// `userInfo[Self.balanceUserInfoKey]` carries the new balance as `Double`.
+    static let balanceChangedNotification = Notification.Name("snoozepay.balance.changed")
+    static let balanceUserInfoKey = "balance"
+
     private let defaults: UserDefaults
     private let balanceKey = "user_balance"
     private let transactionRepository: TransactionRepository
     private let queue = DispatchQueue(label: "com.snoozepay.balance.serial")
-
-    // Observers can subscribe to balance changes
-    var onBalanceChanged: ((Double) -> Void)?
+    private let notificationCenter: NotificationCenter
 
     /// Production code MUST use `BalanceService.shared`.
     /// Direct construction creates an isolated instance with its own serial queue —
@@ -24,18 +30,22 @@ final class BalanceService {
     #if DEBUG
     init(
         defaults: UserDefaults = .standard,
-        transactionRepository: TransactionRepository = TransactionRepository()
+        transactionRepository: TransactionRepository = TransactionRepository(),
+        notificationCenter: NotificationCenter = .default
     ) {
         self.defaults = defaults
         self.transactionRepository = transactionRepository
+        self.notificationCenter = notificationCenter
     }
     #else
     private init(
         defaults: UserDefaults = .standard,
-        transactionRepository: TransactionRepository = TransactionRepository()
+        transactionRepository: TransactionRepository = TransactionRepository(),
+        notificationCenter: NotificationCenter = .default
     ) {
         self.defaults = defaults
         self.transactionRepository = transactionRepository
+        self.notificationCenter = notificationCenter
     }
     #endif
 
@@ -101,14 +111,24 @@ final class BalanceService {
     }
 
     /// Hop to main since `charge`/`topUp` may be called from a background queue
-    /// (notification action handler) and listeners drive UIKit.
+    /// (notification action handler) and observers drive UIKit. NotificationCenter
+    /// delivers synchronously on the posting thread, so we explicitly hop here
+    /// rather than push that responsibility onto every observer.
     private func notifyBalanceChanged(_ newBalance: Double) {
         if Thread.isMainThread {
-            onBalanceChanged?(newBalance)
+            postBalanceChanged(newBalance)
         } else {
             DispatchQueue.main.async { [weak self] in
-                self?.onBalanceChanged?(newBalance)
+                self?.postBalanceChanged(newBalance)
             }
         }
+    }
+
+    private func postBalanceChanged(_ newBalance: Double) {
+        notificationCenter.post(
+            name: Self.balanceChangedNotification,
+            object: self,
+            userInfo: [Self.balanceUserInfoKey: newBalance]
+        )
     }
 }

--- a/SnoozePay/SnoozePay/Services/StoreKitService.swift
+++ b/SnoozePay/SnoozePay/Services/StoreKitService.swift
@@ -26,13 +26,29 @@ final class StoreKitService {
         "com.snooze_pay.balance.999": 999
     ]
 
-    private(set) var products: [Product] = []
-    var onProductsLoaded: (([Product]) -> Void)?
-    var onPurchaseCompleted: ((Double) -> Void)?
-    var onPurchaseFailed: ((String) -> Void)?
+    // MARK: - Notification names
+    //
+    // Multi-observer broadcast replaces the old single-slot closure properties.
+    // Each observer registers via `NotificationCenter.default.addObserver(...)`,
+    // stores its token, and removes it in `deinit`.
+
+    /// userInfo[`productsUserInfoKey`]: `[Product]`
+    static let productsLoadedNotification = Notification.Name("snoozepay.storekit.productsLoaded")
+    static let productsUserInfoKey = "products"
+
+    /// userInfo[`amountUserInfoKey`]: `Double` — RUB credited to the balance.
+    static let purchaseCompletedNotification = Notification.Name("snoozepay.storekit.purchaseCompleted")
+    static let amountUserInfoKey = "amount"
+
+    /// userInfo[`messageUserInfoKey`]: `String` — user-facing error description.
+    static let purchaseFailedNotification = Notification.Name("snoozepay.storekit.purchaseFailed")
+    static let messageUserInfoKey = "message"
+
     /// Fired when a purchase enters Ask-to-Buy / SCA verification.
-    /// Resolves later via `Transaction.updates` once parent approves.
-    var onPurchasePending: (() -> Void)?
+    /// Resolves later via `Transaction.updates` once parent approves. No userInfo.
+    static let purchasePendingNotification = Notification.Name("snoozepay.storekit.purchasePending")
+
+    private(set) var products: [Product] = []
 
     /// Background listener for `Transaction.updates`. Required by StoreKit 2 to
     /// receive deferred transactions: Ask-to-Buy approvals, refunds, restores
@@ -70,10 +86,10 @@ final class StoreKitService {
         do {
             let loaded = try await Product.products(for: Set(StoreKitService.productIDs))
             products = loaded.sorted { $0.price < $1.price }
-            onProductsLoaded?(products)
+            postProductsLoaded(products)
         } catch {
             print("[StoreKit] product load failed: \(error)")
-            onPurchaseFailed?("Не удалось загрузить пакеты пополнения. Проверь интернет-соединение.")
+            postPurchaseFailed("Не удалось загрузить пакеты пополнения. Проверь интернет-соединение.")
         }
     }
 
@@ -92,21 +108,21 @@ final class StoreKitService {
                 }
                 let amount = creditBalance(for: transaction.productID, fallbackPrice: product.price)
                 await transaction.finish()
-                onPurchaseCompleted?(amount)
+                postPurchaseCompleted(amount)
 
             case .userCancelled:
                 break
 
             case .pending:
                 // Ask-to-Buy or SCA — resolved later via Transaction.updates listener.
-                onPurchasePending?()
+                postPurchasePending()
 
             @unknown default:
                 print("[StoreKit] unknown PurchaseResult case — likely future StoreKit addition")
-                onPurchaseFailed?("Покупка не выполнена. Обнови приложение и попробуй ещё раз.")
+                postPurchaseFailed("Покупка не выполнена. Обнови приложение и попробуй ещё раз.")
             }
         } catch {
-            onPurchaseFailed?(error.localizedDescription)
+            postPurchaseFailed(error.localizedDescription)
         }
     }
 
@@ -135,7 +151,7 @@ final class StoreKitService {
             let amount = Self.creditAmount(for: transaction.productID, fallbackPrice: nil)
             guard amount > 0 else {
                 print("[StoreKit] unknown productID \(transaction.productID) tx=\(transaction.id) — not finishing")
-                onPurchaseFailed?("Неизвестный пакет пополнения. Обнови приложение.")
+                postPurchaseFailed("Неизвестный пакет пополнения. Обнови приложение.")
                 return
             }
             // Idempotency — guard against StoreKit replaying a transaction we already
@@ -147,15 +163,48 @@ final class StoreKitService {
             }
             BalanceService.shared.topUp(amount: amount)
             await transaction.finish()
-            onPurchaseCompleted?(amount)
+            postPurchaseCompleted(amount)
 
         case .unverified(let transaction, let error):
             // Don't finish — let Apple retry next launch. Verification can fail temporarily
             // (clock drift, cert refresh). Finishing here would discard a potentially valid
             // purchase. WWDC sample code (Fruta, Backyard Birds) follows this pattern too.
             print("[StoreKit] unverified tx=\(transaction.id) productID=\(transaction.productID) error=\(error)")
-            onPurchaseFailed?("Не удалось проверить чек покупки. Если деньги списаны — напиши в поддержку.")
+            postPurchaseFailed("Не удалось проверить чек покупки. Если деньги списаны — напиши в поддержку.")
         }
+    }
+
+    // MARK: - Notification posting helpers
+
+    private func postProductsLoaded(_ products: [Product]) {
+        NotificationCenter.default.post(
+            name: Self.productsLoadedNotification,
+            object: self,
+            userInfo: [Self.productsUserInfoKey: products]
+        )
+    }
+
+    private func postPurchaseCompleted(_ amount: Double) {
+        NotificationCenter.default.post(
+            name: Self.purchaseCompletedNotification,
+            object: self,
+            userInfo: [Self.amountUserInfoKey: amount]
+        )
+    }
+
+    private func postPurchaseFailed(_ message: String) {
+        NotificationCenter.default.post(
+            name: Self.purchaseFailedNotification,
+            object: self,
+            userInfo: [Self.messageUserInfoKey: message]
+        )
+    }
+
+    private func postPurchasePending() {
+        NotificationCenter.default.post(
+            name: Self.purchasePendingNotification,
+            object: self
+        )
     }
 
     // MARK: - Idempotency

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController.swift
@@ -27,6 +27,13 @@ class SettingsViewController: UIViewController {
         return sc
     }()
 
+    /// Held weakly so the cell may be recycled (and the label deallocated)
+    /// without leaving the observer with a dangling reference.
+    private weak var balanceAmountLabel: UILabel?
+
+    /// NotificationCenter token for balance-change updates. Removed in `deinit`.
+    private var balanceObserver: NSObjectProtocol?
+
     // MARK: - Sections
 
     private enum Section: Int, CaseIterable {
@@ -44,11 +51,35 @@ class SettingsViewController: UIViewController {
         navigationController?.navigationBar.prefersLargeTitles = true
         view.backgroundColor = .systemGroupedBackground
         setupUI()
+        observeBalanceChanges()
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         tableView.reloadData()
+    }
+
+    deinit {
+        if let token = balanceObserver {
+            NotificationCenter.default.removeObserver(token)
+        }
+    }
+
+    // MARK: - Balance live-update
+
+    /// Subscribe to balance changes so the row updates immediately after a
+    /// top-up that happens while Settings is on-screen (e.g. another tab posts
+    /// a change). Without this, the balance only refreshes on `viewWillAppear`.
+    private func observeBalanceChanges() {
+        balanceObserver = NotificationCenter.default.addObserver(
+            forName: BalanceService.balanceChangedNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            guard let self,
+                  let newBalance = note.userInfo?[BalanceService.balanceUserInfoKey] as? Double else { return }
+            self.balanceAmountLabel?.text = "₽\(Int(newBalance))"
+        }
     }
 
     // MARK: - Setup
@@ -170,6 +201,12 @@ extension SettingsViewController: UITableViewDataSource {
                     balanceAmount.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor, constant: -AppSpacing.lg),
                     balanceAmount.centerYAnchor.constraint(equalTo: cell.contentView.centerYAnchor)
                 ])
+
+                // Track the latest label instance so the balance observer can
+                // refresh it. When the cell is recycled the weak ref nils out
+                // automatically, so the observer becomes a no-op until the row
+                // is rebuilt — at which point this assignment captures the new label.
+                self.balanceAmountLabel = balanceAmount
 
                 cell.selectionStyle = .none
                 return cell

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/TopUpViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/TopUpViewController.swift
@@ -31,6 +31,10 @@ class TopUpViewController: UIViewController {
     private let storeService = StoreKitService.shared
     private var loadingProductID: String?
 
+    /// NotificationCenter tokens — removed in `deinit`.
+    private var purchaseFailedObserver: NSObjectProtocol?
+    private var purchasePendingObserver: NSObjectProtocol?
+
     // MARK: - Sections
 
     private enum Section: Int, CaseIterable {
@@ -57,12 +61,27 @@ class TopUpViewController: UIViewController {
     }
 
     private func wireStoreCallbacks() {
-        // loadProducts() and the foreground purchase path call onPurchaseFailed
+        // loadProducts() and the foreground purchase path post `purchaseFailedNotification`
         // when the store is unreachable or a verification/cancel error occurs.
         // Without this wiring, the user-visible error message added in IOS-032
         // would silently drop on the floor.
-        storeService.onPurchaseFailed = { [weak self] message in
-            self?.presentErrorAlert(message)
+        purchaseFailedObserver = NotificationCenter.default.addObserver(
+            forName: StoreKitService.purchaseFailedNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            guard let self,
+                  let message = note.userInfo?[StoreKitService.messageUserInfoKey] as? String else { return }
+            self.presentErrorAlert(message)
+        }
+    }
+
+    deinit {
+        if let token = purchaseFailedObserver {
+            NotificationCenter.default.removeObserver(token)
+        }
+        if let token = purchasePendingObserver {
+            NotificationCenter.default.removeObserver(token)
         }
     }
 
@@ -163,7 +182,20 @@ class TopUpViewController: UIViewController {
         }
 
         let product = products[index]
-        storeService.onPurchasePending = { [weak self] in
+
+        // Subscribe per-purchase. Removed at the end of the Task so the observer
+        // does not outlive the purchase attempt that registered it. NotificationCenter
+        // tolerates multiple observers on the same name from the same instance —
+        // we still defensively remove the previous token (if any) to avoid two
+        // alerts for back-to-back taps.
+        if let previousToken = purchasePendingObserver {
+            NotificationCenter.default.removeObserver(previousToken)
+        }
+        purchasePendingObserver = NotificationCenter.default.addObserver(
+            forName: StoreKitService.purchasePendingNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
             self?.presentPendingAlert()
         }
 
@@ -179,9 +211,11 @@ class TopUpViewController: UIViewController {
             tableView.reloadData()
             // Always clear — including the .pending case where the alert was shown.
             // The actual credit happens later via Transaction.updates listener; the
-            // pending callback's job ends with the alert. Leaving the closure live
-            // would leak the VC capture if the user navigates away before approval.
-            storeService.onPurchasePending = nil
+            // pending observer's job ends with the alert.
+            if let token = purchasePendingObserver {
+                NotificationCenter.default.removeObserver(token)
+                purchasePendingObserver = nil
+            }
         }
     }
 

--- a/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
@@ -19,6 +19,13 @@ final class AlarmsListViewModel {
     var onAlarmsUpdated: (() -> Void)?
     var onBalanceUpdated: ((Double) -> Void)?
 
+    // MARK: - Observers
+
+    /// Owned observer token. Removed in `deinit` to prevent the
+    /// NotificationCenter from holding a stale reference after this VM dies
+    /// (the ViewController owning it may outlive the VM in edge cases).
+    private var balanceObserver: NSObjectProtocol?
+
     // MARK: - Init
 
     init(
@@ -28,9 +35,21 @@ final class AlarmsListViewModel {
         self.alarmRepository = alarmRepository
         self.balanceService = balanceService
 
-        balanceService.onBalanceChanged = { [weak self] newBalance in
-            self?.balance = newBalance
-            self?.onBalanceUpdated?(newBalance)
+        balanceObserver = NotificationCenter.default.addObserver(
+            forName: BalanceService.balanceChangedNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            guard let self,
+                  let newBalance = note.userInfo?[BalanceService.balanceUserInfoKey] as? Double else { return }
+            self.balance = newBalance
+            self.onBalanceUpdated?(newBalance)
+        }
+    }
+
+    deinit {
+        if let token = balanceObserver {
+            NotificationCenter.default.removeObserver(token)
         }
     }
 

--- a/SnoozePay/SnoozePayTests/BalanceServiceTests.swift
+++ b/SnoozePay/SnoozePayTests/BalanceServiceTests.swift
@@ -22,9 +22,94 @@ final class BalanceServiceTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func makeService(balance: Double = 0) -> BalanceService {
+    private func makeService(
+        balance: Double = 0,
+        notificationCenter: NotificationCenter = .default
+    ) -> BalanceService {
         testDefaults.set(balance, forKey: "user_balance")
-        return BalanceService(defaults: testDefaults)
+        return BalanceService(defaults: testDefaults, notificationCenter: notificationCenter)
+    }
+
+    // MARK: - Multi-observer broadcast (#22)
+
+    /// Three independent observers must all receive a balance update from a
+    /// single `topUp`. Regression for the single-slot closure pattern that
+    /// previously caused `AlarmsListViewModel` to silently overwrite any
+    /// other subscriber.
+    func testTopUp_notifiesAllObservers() {
+        // Use an isolated NotificationCenter so we don't clash with the real
+        // shared singleton observers running inside the host app.
+        let center = NotificationCenter()
+        let service = makeService(balance: 0, notificationCenter: center)
+
+        let exp1 = expectation(description: "observer 1")
+        let exp2 = expectation(description: "observer 2")
+        let exp3 = expectation(description: "observer 3")
+
+        var received: [Double] = []
+        let lock = NSLock()
+        let record: (Notification) -> Void = { note in
+            guard let amount = note.userInfo?[BalanceService.balanceUserInfoKey] as? Double else { return }
+            lock.lock()
+            received.append(amount)
+            lock.unlock()
+        }
+
+        let token1 = center.addObserver(
+            forName: BalanceService.balanceChangedNotification,
+            object: nil,
+            queue: .main
+        ) { note in record(note); exp1.fulfill() }
+        let token2 = center.addObserver(
+            forName: BalanceService.balanceChangedNotification,
+            object: nil,
+            queue: .main
+        ) { note in record(note); exp2.fulfill() }
+        let token3 = center.addObserver(
+            forName: BalanceService.balanceChangedNotification,
+            object: nil,
+            queue: .main
+        ) { note in record(note); exp3.fulfill() }
+
+        defer {
+            center.removeObserver(token1)
+            center.removeObserver(token2)
+            center.removeObserver(token3)
+        }
+
+        service.topUp(amount: 100)
+
+        wait(for: [exp1, exp2, exp3], timeout: 2.0)
+        XCTAssertEqual(received, [100, 100, 100])
+    }
+
+    /// `charge` (the dual mutator) must also broadcast to all observers.
+    func testCharge_notifiesAllObservers() {
+        let center = NotificationCenter()
+        let service = makeService(balance: 500, notificationCenter: center)
+
+        let exp1 = expectation(description: "observer 1")
+        let exp2 = expectation(description: "observer 2")
+
+        let token1 = center.addObserver(
+            forName: BalanceService.balanceChangedNotification,
+            object: nil,
+            queue: .main
+        ) { _ in exp1.fulfill() }
+        let token2 = center.addObserver(
+            forName: BalanceService.balanceChangedNotification,
+            object: nil,
+            queue: .main
+        ) { _ in exp2.fulfill() }
+
+        defer {
+            center.removeObserver(token1)
+            center.removeObserver(token2)
+        }
+
+        let charged = service.charge(amount: 50, alarmID: nil)
+        XCTAssertTrue(charged)
+        wait(for: [exp1, exp2], timeout: 2.0)
     }
 
     // MARK: - Concurrency


### PR DESCRIPTION
Fixes #22

## Что сделано

Заменён single-slot closure-callback паттерн на `NotificationCenter`-broadcast в `BalanceService` и `StoreKitService`. Теперь несколько экранов могут одновременно подписываться на изменения баланса и события покупки без перезаписи чужих подписок.

### Сервисы (источники)
- **`BalanceService`**: удалён `onBalanceChanged: ((Double) -> Void)?`. Добавлен `static let balanceChangedNotification` с `userInfo["balance": Double]`. Hop на main thread сохранён внутри `notifyBalanceChanged` — observers получают уведомление уже на main.
- **`StoreKitService`**: удалены `onProductsLoaded`, `onPurchaseCompleted`, `onPurchaseFailed`, `onPurchasePending`. Каждый событийный канал получил собственный `Notification.Name` (`productsLoadedNotification`, `purchaseCompletedNotification`, `purchaseFailedNotification`, `purchasePendingNotification`).

### Потребители (подписчики)
- **`AlarmsListViewModel`**: подписывается через `addObserver` в init, сохраняет token в `balanceObserver`, удаляет в `deinit`.
- **`SettingsViewController`**: добавлена подписка на `balanceChangedNotification` — теперь баланс в строке "Баланс" обновляется live, а не только в `viewWillAppear`. Сохраняется `weak var balanceAmountLabel` для безопасного обновления (`weak` обнуляется при recycling cell).
- **`TopUpViewController`**: `onPurchaseFailed` → постоянный observer (на весь lifecycle VC); `onPurchasePending` → per-purchase observer, удаляется после завершения `Task`.

### Тесты
Добавлены два теста в `BalanceServiceTests`:
- `testTopUp_notifiesAllObservers` — три independent наблюдателя получают update от одного `topUp`.
- `testCharge_notifiesAllObservers` — `charge` тоже broadcasts всем подписчикам.

Тесты используют изолированный `NotificationCenter()` (через DI), чтобы не интерферировать с реальными observer'ами хоста.

## Verify

- swiftlint: 0 errors в моих изменениях (все error в swiftlint output — pre-existing baseline в файлах TopUp/Settings, не связаны с diff'ом)
- build: BUILD SUCCEEDED (xcodebuild на iPhone 17 Pro Simulator)
- test_sim: gate отключён согласно проектным заметкам — тесты добавлены, но не запускались автоматически
- screenshot: gate отключён

## No-touch zones

Не затронуты: entitlements, Info.plist, signing, новые SPM пакеты, UIKit→SwiftUI миграция.