### PR TITLE
[fix] AlarmRepository.setEnabled signals missing UUID (#35)

### DIFF
--- a/SnoozePay/SnoozePay/Services/AlarmRepository.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmRepository.swift
@@ -67,7 +67,13 @@ final class AlarmRepository {
         AlarmScheduler.shared.cancel(id)
     }
 
-    func setEnabled(_ enabled: Bool, id: UUID) {
+    /// Toggles `enabled` on the alarm with the given id.
+    /// - Returns: `true` if the alarm existed and was updated; `false` if no alarm
+    ///   matched the id. Callers (e.g. `AlarmsListViewModel`) rely on the boolean
+    ///   to roll back optimistic UI flips when the underlying alarm has been
+    ///   deleted from another path (issue #35).
+    @discardableResult
+    func setEnabled(_ enabled: Bool, id: UUID) -> Bool {
         let updated: Alarm? = queue.sync {
             var alarms = readAll()
             guard let idx = alarms.firstIndex(where: { $0.id == id }) else { return nil }
@@ -76,11 +82,18 @@ final class AlarmRepository {
             return alarms[idx]
         }
 
-        guard let alarm = updated else { return }
+        guard let alarm = updated else {
+            os_log(
+                "setEnabled: no alarm with id %{public}@",
+                log: Self.log, type: .info, id.uuidString
+            )
+            return false
+        }
         AlarmScheduler.shared.cancel(alarm.id)
         if alarm.enabled {
             AlarmScheduler.shared.schedule(alarm)
         }
+        return true
     }
 
     // MARK: - Private (must be called inside queue.sync)

--- a/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
@@ -81,7 +81,18 @@ final class AlarmsListViewModel {
             onAlarmsUpdated?()
             return
         }
-        alarmRepository.setEnabled(enabled, id: id)
+
+        let didUpdate = alarmRepository.setEnabled(enabled, id: id)
+        guard didUpdate else {
+            // Repository no longer has this alarm (deleted from another path).
+            // The cell already optimistically flipped its switch in setEnabledAppearance —
+            // resync from the source of truth and re-bind so the UI rolls back (issue #35).
+            print("[AlarmsListViewModel] setEnabled returned false; rolling back UI for id=\(id)")
+            alarms = alarmRepository.fetchAll()
+            onAlarmsUpdated?()
+            return
+        }
+
         alarms[index] = Alarm(
             id: alarms[index].id,
             time: alarms[index].time,

--- a/SnoozePay/SnoozePayTests/AlarmRepositoryTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmRepositoryTests.swift
@@ -68,8 +68,19 @@ final class AlarmRepositoryTests: XCTestCase {
     }
 
     func testSetEnabled_unknownIDIsNoOp() {
-        repo.setEnabled(false, id: UUID())
+        let didUpdate = repo.setEnabled(false, id: UUID())
+        XCTAssertFalse(didUpdate, "setEnabled must report failure when no alarm matches the id")
         XCTAssertEqual(repo.fetchAll().count, 0)
+    }
+
+    func testSetEnabled_existingIDReturnsTrueAndPersists() {
+        let alarm = makeAlarm()
+        repo.save(alarm)
+
+        let didUpdate = repo.setEnabled(false, id: alarm.id)
+
+        XCTAssertTrue(didUpdate, "setEnabled must report success when the alarm exists")
+        XCTAssertEqual(repo.fetch(id: alarm.id)?.enabled, false, "Persistence must reflect the new flag")
     }
 
     // MARK: - Concurrency

--- a/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
@@ -127,6 +127,31 @@ final class AlarmsListViewModelTests: XCTestCase {
 
     // MARK: - toggleAlarm(id:enabled:)
 
+    /// Regression for issue #35: when the alarm exists in the VM's in-memory snapshot
+    /// but has been deleted from the repository (e.g. via another tab/path), `setEnabled`
+    /// must report failure and the VM must resync from the repo + trigger a re-bind so
+    /// the optimistic switch flip in the cell rolls back.
+    func testToggleAlarm_repoMissingTriggersResyncAndRebind() {
+        let alarm = Alarm(penaltyAmount: 50, enabled: true)
+        repo.save(alarm)
+
+        let vm = makeViewModel()
+        vm.loadData()
+        XCTAssertEqual(vm.alarms.count, 1)
+
+        // Simulate a parallel delete that bypassed the VM (the VM still has the
+        // alarm in its in-memory snapshot, but the repository no longer does).
+        repo.delete(id: alarm.id)
+
+        var rebindFired = false
+        vm.onAlarmsUpdated = { rebindFired = true }
+
+        vm.toggleAlarm(id: alarm.id, enabled: false)
+
+        XCTAssertTrue(rebindFired, "VM must trigger a UI re-bind so the cell switch rolls back")
+        XCTAssertTrue(vm.alarms.isEmpty, "VM must resync from the repository after a missing-id failure")
+    }
+
     /// Regression for tag-based identity bug: when middle alarm is removed and the
     /// caller toggles the *first* alarm, only that alarm — resolved by id — must flip,
     /// not whichever alarm currently lives at the captured row index.


### PR DESCRIPTION
Fixes #35

## Что сделано
- `AlarmRepository.setEnabled(_:id:)` теперь `@discardableResult ... -> Bool`. Возвращает `true` если alarm найден и обновлён, `false` если UUID не найден (тихий no-op заменён на явный сигнал caller'у).
- `AlarmsListViewModel.toggleAlarm(id:enabled:)` обрабатывает `false`: пересинхронизирует `alarms` из репозитория и зовёт `onAlarmsUpdated?()`, чтобы cell с уже оптимистично перевёрнутым switch'ем откатился к источнику правды.
- Сценарий-источник бага: alarm удалён в одном пути (cross-tab или внешний trigger), пользователь успевает дёрнуть toggle — раньше switch визуально летал, persistence нет; теперь UI видит правду.

## Verify
- swiftlint: 0 errors в тронутых файлах (10 pre-existing warnings про `vm` идентификатор в существующих тестах — не трогал)
- build_sim: succeeded (iPhone 17 Pro, scheme SnoozePay)
- test_sim: skipped (gate отключён, см. CLAUDE.md memory)

## Тесты добавлены
- `AlarmRepositoryTests.testSetEnabled_unknownIDIsNoOp` — расширен на `XCTAssertFalse(didUpdate)`
- `AlarmRepositoryTests.testSetEnabled_existingIDReturnsTrueAndPersists` — новый
- `AlarmsListViewModelTests.testToggleAlarm_repoMissingTriggersResyncAndRebind` — новый, проверяет rollback при удалённом alarm