### PR TITLE
[refactor] Extract ThemeService + AlarmFiringCoordinator + StatisticsViewModel (#33)

### DIFF
--- a/SnoozePay/SnoozePay/AppDelegate.swift
+++ b/SnoozePay/SnoozePay/AppDelegate.swift
@@ -145,7 +145,17 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
 
         case "SNOOZE_ACTION":
             AudioService.shared.stopAlarmSound()
-            AlarmFiringCoordinator.shared.handleSnooze(userInfo: userInfo)
+            let outcome = AlarmFiringCoordinator.shared.handleSnooze(userInfo: userInfo)
+            switch outcome {
+            case .invalidPayload:
+                print("[AppDelegate] SNOOZE_ACTION: invalid payload, snooze skipped")
+            case .alarmNotFound:
+                print("[AppDelegate] SNOOZE_ACTION: alarm not found, snooze skipped")
+            case .insufficientFunds:
+                print("[AppDelegate] SNOOZE_ACTION: insufficient funds — snooze skipped, alarm will not repeat")
+            case let .scheduled(newSnoozeCount, charged):
+                print("[AppDelegate] SNOOZE_ACTION: snooze #\(newSnoozeCount) scheduled, charged=\(charged)")
+            }
 
         case UNNotificationDismissActionIdentifier:
             // User swiped away notification — stop sound

--- a/SnoozePay/SnoozePay/AppDelegate.swift
+++ b/SnoozePay/SnoozePay/AppDelegate.swift
@@ -145,7 +145,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
 
         case "SNOOZE_ACTION":
             AudioService.shared.stopAlarmSound()
-            handleSnoozeFromNotification(userInfo: userInfo)
+            AlarmFiringCoordinator.shared.handleSnooze(userInfo: userInfo)
 
         case UNNotificationDismissActionIdentifier:
             // User swiped away notification — stop sound
@@ -211,21 +211,4 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         }
     }
 
-    private func handleSnoozeFromNotification(userInfo: [AnyHashable: Any]) {
-        guard
-            let alarmIDString = userInfo["alarmID"] as? String,
-            let alarmID = UUID(uuidString: alarmIDString),
-            let snoozeCount = userInfo["snoozeCount"] as? Int
-        else { return }
-
-        let repo = AlarmRepository()
-        guard let alarm = repo.fetch(id: alarmID) else { return }
-
-        let penalty = alarm.penalty(forSnoozeCount: snoozeCount + 1)
-
-        let charged = BalanceService.shared.charge(amount: penalty, alarmID: alarmID)
-        if charged {
-            AlarmScheduler.shared.scheduleSnooze(for: alarm, snoozeCount: snoozeCount + 1)
-        }
-    }
 }

--- a/SnoozePay/SnoozePay/SceneDelegate.swift
+++ b/SnoozePay/SnoozePay/SceneDelegate.swift
@@ -19,13 +19,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let window = UIWindow(windowScene: windowScene)
         self.window = window
 
-        // Apply saved theme preference
-        let savedTheme = UserDefaults.standard.string(forKey: "preferred_theme") ?? "system"
-        switch savedTheme {
-        case "dark": window.overrideUserInterfaceStyle = .dark
-        case "light": window.overrideUserInterfaceStyle = .light
-        default: window.overrideUserInterfaceStyle = .unspecified
-        }
+        // Apply saved theme preference. Apply to the window directly: it isn't
+        // attached to `windowScene.windows` yet, so `applyToActiveWindowScene`
+        // would skip it.
+        ThemeService.shared.apply(to: window)
 
         if OnboardingViewController.isCompleted {
             window.rootViewController = makeRootViewController()

--- a/SnoozePay/SnoozePay/Services/AlarmFiringCoordinator.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmFiringCoordinator.swift
@@ -73,10 +73,12 @@ final class AlarmFiringCoordinator {
             let alarmID = UUID(uuidString: alarmIDString),
             let snoozeCount = userInfo["snoozeCount"] as? Int
         else {
+            print("[AlarmFiringCoordinator] snooze: invalid payload \(userInfo)")
             return .invalidPayload
         }
 
         guard let alarm = alarmRepository.fetch(id: alarmID) else {
+            print("[AlarmFiringCoordinator] snooze: alarm \(alarmID) not in repository")
             return .alarmNotFound
         }
 
@@ -85,10 +87,12 @@ final class AlarmFiringCoordinator {
 
         let charged = balanceService.charge(amount: penalty, alarmID: alarmID)
         guard charged else {
+            print("[AlarmFiringCoordinator] snooze: insufficient funds for alarm \(alarmID), penalty=\(penalty)")
             return .insufficientFunds
         }
 
         scheduler.scheduleSnooze(for: alarm, snoozeCount: newCount)
+        print("[AlarmFiringCoordinator] snooze: scheduled #\(newCount) for alarm \(alarmID), charged=\(penalty)")
         return .scheduled(newSnoozeCount: newCount, charged: penalty)
     }
 }

--- a/SnoozePay/SnoozePay/Services/AlarmFiringCoordinator.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmFiringCoordinator.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+/// Handles the business logic triggered by notification actions on a fired
+/// alarm (snooze charge + reschedule). Extracted from AppDelegate so the same
+/// flow can be unit-tested without spinning up the UIApplication / notification
+/// center machinery.
+///
+/// AppDelegate is responsible only for routing the raw `UNNotificationResponse`
+/// into the right method here; all balance / repository / scheduler wiring
+/// lives in this coordinator.
+final class AlarmFiringCoordinator {
+
+    static let shared = AlarmFiringCoordinator()
+
+    // MARK: - Outcome
+
+    /// Result of attempting a snooze from a notification action.
+    /// Surfaced for tests and future telemetry — AppDelegate currently ignores
+    /// the value because there's no UI affordance once the alarm screen is
+    /// already dismissed.
+    enum SnoozeOutcome: Equatable {
+        /// Required identifiers (alarmID/snoozeCount) were missing or malformed.
+        case invalidPayload
+        /// Identifiers were valid but the alarm has been deleted from the repo.
+        case alarmNotFound
+        /// Balance was insufficient to cover the (possibly progressive) penalty.
+        case insufficientFunds
+        /// Charge succeeded and a new snooze notification was scheduled.
+        case scheduled(newSnoozeCount: Int, charged: Double)
+    }
+
+    // MARK: - Dependencies
+
+    private let alarmRepository: AlarmRepository
+    private let balanceService: BalanceService
+    private let scheduler: AlarmScheduler
+
+    /// Production code MUST use `AlarmFiringCoordinator.shared`. Direct
+    /// construction is intended for tests so they can inject mocks /
+    /// isolated services without polluting the real singletons.
+    #if DEBUG
+    init(
+        alarmRepository: AlarmRepository = .shared,
+        balanceService: BalanceService = .shared,
+        scheduler: AlarmScheduler = .shared
+    ) {
+        self.alarmRepository = alarmRepository
+        self.balanceService = balanceService
+        self.scheduler = scheduler
+    }
+    #else
+    private init(
+        alarmRepository: AlarmRepository = .shared,
+        balanceService: BalanceService = .shared,
+        scheduler: AlarmScheduler = .shared
+    ) {
+        self.alarmRepository = alarmRepository
+        self.balanceService = balanceService
+        self.scheduler = scheduler
+    }
+    #endif
+
+    // MARK: - Snooze
+
+    /// Resolves the alarm + snoozeCount from a notification's userInfo dict,
+    /// charges the appropriate (possibly progressive) penalty, and schedules
+    /// the next snooze notification. Returns a structured outcome so callers
+    /// (and tests) can assert exactly what happened without scraping logs.
+    @discardableResult
+    func handleSnooze(userInfo: [AnyHashable: Any]) -> SnoozeOutcome {
+        guard
+            let alarmIDString = userInfo["alarmID"] as? String,
+            let alarmID = UUID(uuidString: alarmIDString),
+            let snoozeCount = userInfo["snoozeCount"] as? Int
+        else {
+            return .invalidPayload
+        }
+
+        guard let alarm = alarmRepository.fetch(id: alarmID) else {
+            return .alarmNotFound
+        }
+
+        let newCount = snoozeCount + 1
+        let penalty = alarm.penalty(forSnoozeCount: newCount)
+
+        let charged = balanceService.charge(amount: penalty, alarmID: alarmID)
+        guard charged else {
+            return .insufficientFunds
+        }
+
+        scheduler.scheduleSnooze(for: alarm, snoozeCount: newCount)
+        return .scheduled(newSnoozeCount: newCount, charged: penalty)
+    }
+}

--- a/SnoozePay/SnoozePay/Services/ThemeService.swift
+++ b/SnoozePay/SnoozePay/Services/ThemeService.swift
@@ -1,0 +1,85 @@
+import UIKit
+
+/// Owns the user's preferred interface theme and applies it to the active
+/// window scene. Keeps `preferred_theme` UserDefaults persistence in one place
+/// so SettingsVC, SceneDelegate, and any future caller don't reimplement the
+/// "string -> UIUserInterfaceStyle" mapping (and miss a window when iterating).
+final class ThemeService {
+
+    static let shared = ThemeService()
+
+    /// Stable string IDs persisted in UserDefaults. Add new cases by extending
+    /// the enum — `from(rawValue:)` falls back to `.system` for unknown values
+    /// so older builds reading future values don't crash.
+    enum Theme: String, CaseIterable {
+        case system
+        case light
+        case dark
+
+        var interfaceStyle: UIUserInterfaceStyle {
+            switch self {
+            case .system: return .unspecified
+            case .light: return .light
+            case .dark: return .dark
+            }
+        }
+    }
+
+    // MARK: - Storage
+
+    private let defaults: UserDefaults
+    private let themeKey = "preferred_theme"
+
+    /// Production code MUST use `ThemeService.shared`. Direct construction is
+    /// allowed in tests so each test can inject an isolated UserDefaults suite.
+    #if DEBUG
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+    #else
+    private init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+    #endif
+
+    // MARK: - Read / Write
+
+    /// Stored preference, defaulting to `.system` for fresh installs and any
+    /// legacy/unknown string left over from earlier builds.
+    var current: Theme {
+        get {
+            guard let raw = defaults.string(forKey: themeKey),
+                  let theme = Theme(rawValue: raw) else { return .system }
+            return theme
+        }
+        set {
+            defaults.set(newValue.rawValue, forKey: themeKey)
+        }
+    }
+
+    /// Persist the theme and immediately push it onto every window of the
+    /// active window scene. Callers shouldn't need to apply separately.
+    func setTheme(_ theme: Theme) {
+        current = theme
+        applyToActiveWindowScene()
+    }
+
+    /// Re-apply the persisted theme. Called by SceneDelegate at launch so the
+    /// window inherits the user's last choice before any VC is shown.
+    func applyToActiveWindowScene() {
+        let style = current.interfaceStyle
+        for scene in UIApplication.shared.connectedScenes {
+            guard let windowScene = scene as? UIWindowScene else { continue }
+            for window in windowScene.windows {
+                window.overrideUserInterfaceStyle = style
+            }
+        }
+    }
+
+    /// Apply the persisted theme to a specific window. Used by SceneDelegate
+    /// when constructing a window before it's attached to the scene's `windows`
+    /// collection — `applyToActiveWindowScene` would skip it in that gap.
+    func apply(to window: UIWindow) {
+        window.overrideUserInterfaceStyle = current.interfaceStyle
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController.swift
@@ -3,15 +3,9 @@ import UIKit
 /// Settings screen matching Figma design: account, theme, legal, contact sections.
 class SettingsViewController: UIViewController {
 
-    // MARK: - Data
+    // MARK: - Dependencies
 
-    private let defaults = UserDefaults.standard
-    private let themeKey = "preferred_theme"
-
-    private var preferredTheme: String {
-        get { defaults.string(forKey: themeKey) ?? "system" }
-        set { defaults.set(newValue, forKey: themeKey) }
-    }
+    private let themeService: ThemeService
 
     // MARK: - UI
 
@@ -21,15 +15,20 @@ class SettingsViewController: UIViewController {
         return tv
     }()
 
-    private let themeSegment: UISegmentedControl = {
-        let sc = UISegmentedControl(items: ["Системная", "Светлая", "Тёмная"])
-        sc.selectedSegmentTintColor = AppColors.accentBlue
-        return sc
-    }()
-
     /// Held weakly so the cell may be recycled (and the label deallocated)
     /// without leaving the observer with a dangling reference.
     private weak var balanceAmountLabel: UILabel?
+
+    // MARK: - Init
+
+    init(themeService: ThemeService = .shared) {
+        self.themeService = themeService
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     /// NotificationCenter token for balance-change updates. Removed in `deinit`.
     private var balanceObserver: NSObjectProtocol?
@@ -89,6 +88,7 @@ class SettingsViewController: UIViewController {
         tableView.delegate = self
         tableView.dataSource = self
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
+        tableView.register(ThemeSegmentCell.self, forCellReuseIdentifier: ThemeSegmentCell.reuseID)
 
         NSLayoutConstraint.activate([
             tableView.topAnchor.constraint(equalTo: view.topAnchor),
@@ -96,48 +96,27 @@ class SettingsViewController: UIViewController {
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
-
-        // Map stored preference to segment index: 0=system, 1=light, 2=dark
-        switch preferredTheme {
-        case "light": themeSegment.selectedSegmentIndex = 1
-        case "dark": themeSegment.selectedSegmentIndex = 2
-        default: themeSegment.selectedSegmentIndex = 0
-        }
-        themeSegment.addTarget(self, action: #selector(themeSegmentChanged), for: .valueChanged)
     }
 
     // MARK: - Theme
 
-    @objc private func themeSegmentChanged() {
-        let values = ["system", "light", "dark"]
-        let index = themeSegment.selectedSegmentIndex
-        preferredTheme = values[index]
-
-        let styles: [UIUserInterfaceStyle] = [.unspecified, .light, .dark]
-        applyTheme(styles[index])
-    }
-
-    private func applyTheme(_ style: UIUserInterfaceStyle) {
-        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return }
-        for window in windowScene.windows {
-            window.overrideUserInterfaceStyle = style
+    /// Map stored preference to segment index: 0=system, 1=light, 2=dark.
+    private var themeSegmentIndex: Int {
+        switch themeService.current {
+        case .system: return 0
+        case .light: return 1
+        case .dark: return 2
         }
     }
 
-    /// Restore theme from saved preference on app launch
-    static func restoreSavedTheme() {
-        let saved = UserDefaults.standard.string(forKey: "preferred_theme") ?? "system"
-        let style: UIUserInterfaceStyle
-        switch saved {
-        case "dark": style = .dark
-        case "light": style = .light
-        default: style = .unspecified
+    private func handleThemeSegmentChange(_ index: Int) {
+        let theme: ThemeService.Theme
+        switch index {
+        case 1: theme = .light
+        case 2: theme = .dark
+        default: theme = .system
         }
-
-        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return }
-        for window in windowScene.windows {
-            window.overrideUserInterfaceStyle = style
-        }
+        themeService.setTheme(theme)
     }
 }
 
@@ -213,22 +192,18 @@ extension SettingsViewController: UITableViewDataSource {
             }
 
         case .appearance:
-            let cell = makeIconRow(
-                systemName: "moon.fill",
-                iconColor: UIColor.systemIndigo,
-                title: "Тема",
-                accessory: .none
-            )
-            // Remove old segment if reused, then add current one
-            themeSegment.translatesAutoresizingMaskIntoConstraints = false
-            themeSegment.removeFromSuperview()
-            cell.contentView.addSubview(themeSegment)
-            NSLayoutConstraint.activate([
-                themeSegment.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor, constant: -AppSpacing.lg),
-                themeSegment.centerYAnchor.constraint(equalTo: cell.contentView.centerYAnchor),
-                themeSegment.widthAnchor.constraint(equalToConstant: 220)
-            ])
-            cell.selectionStyle = .none
+            // Dedicated cell type owns the segment control — avoids the previous
+            // removeFromSuperview/re-add dance that left the control bound to
+            // whichever cell rendered last.
+            guard let cell = tableView.dequeueReusableCell(
+                withIdentifier: ThemeSegmentCell.reuseID,
+                for: indexPath
+            ) as? ThemeSegmentCell else {
+                return UITableViewCell()
+            }
+            cell.configure(selectedIndex: themeSegmentIndex) { [weak self] index in
+                self?.handleThemeSegmentChange(index)
+            }
             return cell
 
         case .info:

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/ThemeSegmentCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/ThemeSegmentCell.swift
@@ -1,0 +1,124 @@
+import UIKit
+
+/// Reusable settings row that owns its `UISegmentedControl`. Replaces the
+/// previous pattern in `SettingsViewController` where a single shared segment
+/// instance was repeatedly removed/re-added across cell reuse — fragile, and
+/// guaranteed to lose the control to the most-recently-rendered cell.
+///
+/// The cell is configured by the data source via `configure(selectedIndex:onChange:)`
+/// and forwards segment events through the closure.
+final class ThemeSegmentCell: UITableViewCell {
+
+    static let reuseID = "ThemeSegmentCell"
+
+    // MARK: - UI
+
+    private let iconContainer: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor.systemIndigo
+        view.layer.cornerRadius = 7
+        view.layer.masksToBounds = true
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let iconImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(systemName: "moon.fill")?.withConfiguration(
+            UIImage.SymbolConfiguration(pointSize: 15, weight: .medium)
+        )
+        imageView.tintColor = .white
+        imageView.contentMode = .scaleAspectFit
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Тема"
+        label.font = UIFont.systemFont(ofSize: 17)
+        label.textColor = .label
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let segmentControl: UISegmentedControl = {
+        let segment = UISegmentedControl(items: ["Системная", "Светлая", "Тёмная"])
+        segment.selectedSegmentTintColor = AppColors.accentBlue
+        segment.translatesAutoresizingMaskIntoConstraints = false
+        return segment
+    }()
+
+    /// Forwarded on every `valueChanged` event from the segment.
+    private var onChange: ((Int) -> Void)?
+
+    // MARK: - Init
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Setup
+
+    private func setupUI() {
+        backgroundColor = .secondarySystemBackground
+        selectionStyle = .none
+
+        iconContainer.addSubview(iconImageView)
+        contentView.addSubview(iconContainer)
+        contentView.addSubview(titleLabel)
+        contentView.addSubview(segmentControl)
+
+        segmentControl.addTarget(self, action: #selector(segmentChanged), for: .valueChanged)
+
+        NSLayoutConstraint.activate([
+            iconContainer.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.lg),
+            iconContainer.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            iconContainer.widthAnchor.constraint(equalToConstant: 30),
+            iconContainer.heightAnchor.constraint(equalToConstant: 30),
+
+            iconImageView.centerXAnchor.constraint(equalTo: iconContainer.centerXAnchor),
+            iconImageView.centerYAnchor.constraint(equalTo: iconContainer.centerYAnchor),
+
+            titleLabel.leadingAnchor.constraint(equalTo: iconContainer.trailingAnchor, constant: AppSpacing.md),
+            titleLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+
+            segmentControl.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.lg),
+            segmentControl.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            segmentControl.widthAnchor.constraint(equalToConstant: 220),
+            segmentControl.leadingAnchor.constraint(
+                greaterThanOrEqualTo: titleLabel.trailingAnchor,
+                constant: AppSpacing.sm
+            )
+        ])
+    }
+
+    // MARK: - Configure
+
+    /// Set the currently selected segment and the change handler. Safe to call
+    /// repeatedly on cell reuse — the previous handler is dropped.
+    func configure(selectedIndex: Int, onChange: @escaping (Int) -> Void) {
+        segmentControl.selectedSegmentIndex = selectedIndex
+        self.onChange = onChange
+    }
+
+    // MARK: - Actions
+
+    @objc private func segmentChanged() {
+        onChange?(segmentControl.selectedSegmentIndex)
+    }
+
+    // MARK: - Reuse
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        // Drop the previous closure so a recycled cell doesn't fire its old
+        // owner's handler before `configure` is called again.
+        onChange = nil
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsViewController.swift
@@ -101,6 +101,10 @@ class StatisticsViewController: UIViewController {
 
     private var chartHostingController: UIHostingController<StatisticsChartView>?
 
+    /// Explicit reference to the streak card so `refresh()` can toggle its
+    /// visibility without walking the view-hierarchy via `superview?.superview`.
+    private var streakCard: UIView?
+
     // MARK: Streak
 
     private let streakIconView: UIView = {
@@ -227,7 +231,9 @@ class StatisticsViewController: UIViewController {
         contentStack.addArrangedSubview(makeChartCard())
 
         // Streak card
-        contentStack.addArrangedSubview(makeStreakCard())
+        let streakCardView = makeStreakCard()
+        streakCard = streakCardView
+        contentStack.addArrangedSubview(streakCardView)
 
         // Motivation banner
         contentStack.addArrangedSubview(makeMotivationBanner())
@@ -402,39 +408,32 @@ class StatisticsViewController: UIViewController {
     }
 
     private func refresh() {
-        // Two-column summary
-        if viewModel.totalSpent > 0 {
-            spentAmountLabel.textColor = AppColors.accentOrange
-            spentAmountLabel.text = viewModel.totalSpentFormatted
-        } else {
-            spentAmountLabel.textColor = .secondaryLabel
-            spentAmountLabel.text = "₽0"
-        }
+        // Two-column summary — colour and text both come from the VM so the
+        // empty-state vs has-data branching lives in one place.
+        spentAmountLabel.textColor = viewModel.spentColor
+        spentAmountLabel.text = viewModel.totalSpentFormatted
 
-        if viewModel.snoozeCount > 0 {
-            snoozeCountLabel.text = viewModel.snoozeCountFormatted
-        } else {
-            snoozeCountLabel.textColor = .secondaryLabel
-            snoozeCountLabel.text = "0"
-        }
+        snoozeCountLabel.textColor = viewModel.snoozeCountColor
+        snoozeCountLabel.text = viewModel.snoozeCountFormatted
 
         // Average
         averageValueLabel.text = viewModel.averagePerDayFormatted
 
-        // Streak
-        if viewModel.streak > 0 {
+        // Streak — when no active streak we show the zero-state caption but
+        // keep the card visible so the layout doesn't jump.
+        if viewModel.streakActive {
             streakLabel.text = viewModel.streakMessage
             bestStreakLabel.text = viewModel.bestStreakFormatted
-            streakIconView.superview?.superview?.isHidden = false
         } else {
-            streakLabel.text = "0 дней без откладываний"
+            streakLabel.text = viewModel.streakZeroMessage
             bestStreakLabel.text = ""
-            // Still show the card but with zero state
         }
+        streakCard?.isHidden = false
 
-        // Motivation banner
+        // Motivation banner — VM decides whether there's anything to motivate
+        // against; view just toggles visibility off the bool.
         motivationMessageLabel.text = viewModel.motivationalMessage
-        motivationCard.isHidden = viewModel.totalSpent <= 0
+        motivationCard.isHidden = !viewModel.motivationVisible
 
         // Chart
         let chartData = viewModel.dailyChartData.map {

--- a/SnoozePay/SnoozePay/ViewModels/StatisticsViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/StatisticsViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 /// ViewModel for the statistics screen.
 final class StatisticsViewModel {
@@ -73,8 +74,43 @@ final class StatisticsViewModel {
     var totalSpent: Double { charges.reduce(0) { $0 + $1.amount } }
     var snoozeCount: Int { charges.count }
 
-    var totalSpentFormatted: String { "₽\(Int(totalSpent))" }
+    var totalSpentFormatted: String {
+        totalSpent > 0 ? "₽\(Int(totalSpent))" : "₽0"
+    }
     var snoozeCountFormatted: String { "\(snoozeCount)" }
+
+    // MARK: - Presentation-ready (extracted from StatisticsViewController.refresh)
+
+    /// Colour for the "spent" headline. Orange when there's actual spend to
+    /// surface, secondary grey for the empty state. Lives in the VM so the
+    /// view doesn't reach into model values to make presentation decisions.
+    var spentColor: UIColor {
+        totalSpent > 0 ? AppColors.accentOrange : .secondaryLabel
+    }
+
+    /// Colour for the snooze-count headline — same secondary-label-on-empty
+    /// convention as `spentColor`.
+    var snoozeCountColor: UIColor {
+        snoozeCount > 0 ? .label : .secondaryLabel
+    }
+
+    /// Whether the motivation banner should be visible. Hidden when there's
+    /// nothing to motivate against (totalSpent == 0).
+    var motivationVisible: Bool {
+        totalSpent > 0
+    }
+
+    /// Whether the user has an active streak worth celebrating. When false the
+    /// view shows a zero-state caption (`streakZeroMessage`) instead of the
+    /// "X days without snoozing" / best-result lines.
+    var streakActive: Bool {
+        streak > 0
+    }
+
+    /// Caption shown when the user has no active streak.
+    var streakZeroMessage: String {
+        "0 дней без откладываний"
+    }
 
     /// Average spending per day for the selected period.
     var averagePerDay: Double {

--- a/SnoozePay/SnoozePayTests/AlarmFiringCoordinatorTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmFiringCoordinatorTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+@testable import SnoozePay
+
+/// Unit tests for AlarmFiringCoordinator — the snooze-from-notification flow
+/// extracted out of AppDelegate. Exercises the four `SnoozeOutcome` branches
+/// against an isolated balance + repo so the real singletons stay untouched.
+final class AlarmFiringCoordinatorTests: XCTestCase {
+
+    private var testDefaults: UserDefaults!
+    private var suiteName: String!
+    private var alarmRepo: AlarmRepository!
+    private var balanceService: BalanceService!
+    private var coordinator: AlarmFiringCoordinator!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "test.coordinator.\(UUID().uuidString)"
+        testDefaults = UserDefaults(suiteName: suiteName)!
+        alarmRepo = AlarmRepository(defaults: testDefaults)
+        balanceService = BalanceService(defaults: testDefaults)
+        coordinator = AlarmFiringCoordinator(
+            alarmRepository: alarmRepo,
+            balanceService: balanceService,
+            scheduler: AlarmScheduler.shared
+        )
+    }
+
+    override func tearDown() {
+        // Clean up any notifications the coordinator may have scheduled during
+        // the success path so subsequent tests / app launches start clean.
+        AlarmScheduler.shared.cancelAll()
+        testDefaults.removePersistentDomain(forName: suiteName)
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeAlarm(penalty: Double = 50, progressive: Bool = false) -> Alarm {
+        let alarm = Alarm(penaltyAmount: penalty, progressiveScale: progressive)
+        alarmRepo.save(alarm)
+        return alarm
+    }
+
+    // MARK: - Invalid payload
+
+    func testHandleSnooze_missingAlarmID_returnsInvalidPayload() {
+        let outcome = coordinator.handleSnooze(userInfo: ["snoozeCount": 0])
+        XCTAssertEqual(outcome, .invalidPayload)
+    }
+
+    func testHandleSnooze_invalidAlarmIDString_returnsInvalidPayload() {
+        let outcome = coordinator.handleSnooze(userInfo: [
+            "alarmID": "not-a-uuid",
+            "snoozeCount": 0
+        ])
+        XCTAssertEqual(outcome, .invalidPayload)
+    }
+
+    func testHandleSnooze_missingSnoozeCount_returnsInvalidPayload() {
+        let alarm = makeAlarm()
+        let outcome = coordinator.handleSnooze(userInfo: [
+            "alarmID": alarm.id.uuidString
+        ])
+        XCTAssertEqual(outcome, .invalidPayload)
+    }
+
+    // MARK: - Alarm not found
+
+    func testHandleSnooze_unknownAlarmID_returnsAlarmNotFound() {
+        // Valid UUID, but no alarm with that ID was saved.
+        let outcome = coordinator.handleSnooze(userInfo: [
+            "alarmID": UUID().uuidString,
+            "snoozeCount": 0
+        ])
+        XCTAssertEqual(outcome, .alarmNotFound)
+    }
+
+    // MARK: - Insufficient funds
+
+    func testHandleSnooze_insufficientBalance_returnsInsufficientFunds() {
+        let alarm = makeAlarm(penalty: 100)
+        // Balance is 0 (fresh UserDefaults suite).
+        let outcome = coordinator.handleSnooze(userInfo: [
+            "alarmID": alarm.id.uuidString,
+            "snoozeCount": 0
+        ])
+        XCTAssertEqual(outcome, .insufficientFunds)
+        XCTAssertEqual(balanceService.balance, 0, "Balance must not be touched on a failed charge")
+    }
+
+    // MARK: - Success
+
+    func testHandleSnooze_validRequest_chargesBalanceAndIncrementsCount() {
+        let alarm = makeAlarm(penalty: 50)
+        balanceService.topUp(amount: 200)
+
+        let outcome = coordinator.handleSnooze(userInfo: [
+            "alarmID": alarm.id.uuidString,
+            "snoozeCount": 0
+        ])
+
+        XCTAssertEqual(outcome, .scheduled(newSnoozeCount: 1, charged: 50))
+        XCTAssertEqual(balanceService.balance, 150)
+    }
+
+    func testHandleSnooze_progressivePenalty_appliesToNewCount() {
+        // snoozeCount=1 in payload + progressive scale → penalty(forSnoozeCount: 2) = 100
+        let alarm = makeAlarm(penalty: 50, progressive: true)
+        balanceService.topUp(amount: 500)
+
+        let outcome = coordinator.handleSnooze(userInfo: [
+            "alarmID": alarm.id.uuidString,
+            "snoozeCount": 1
+        ])
+
+        XCTAssertEqual(outcome, .scheduled(newSnoozeCount: 2, charged: 100))
+        XCTAssertEqual(balanceService.balance, 400)
+    }
+
+    func testHandleSnooze_balanceExactlyEqualsPenalty_succeeds() {
+        // Boundary: balance == penalty should be chargeable (>= comparison).
+        let alarm = makeAlarm(penalty: 75)
+        balanceService.topUp(amount: 75)
+
+        let outcome = coordinator.handleSnooze(userInfo: [
+            "alarmID": alarm.id.uuidString,
+            "snoozeCount": 0
+        ])
+
+        XCTAssertEqual(outcome, .scheduled(newSnoozeCount: 1, charged: 75))
+        XCTAssertEqual(balanceService.balance, 0)
+    }
+}

--- a/SnoozePay/SnoozePayTests/StatisticsViewModelPresentationTests.swift
+++ b/SnoozePay/SnoozePayTests/StatisticsViewModelPresentationTests.swift
@@ -1,0 +1,132 @@
+import XCTest
+@testable import SnoozePay
+
+/// Tests the presentation-ready computed properties added so the VC's
+/// `refresh()` no longer makes UI decisions (colour selection, banner
+/// visibility, streak state machine).
+final class StatisticsViewModelPresentationTests: XCTestCase {
+
+    private var testDefaults: UserDefaults!
+    private var suiteName: String!
+    private var txRepo: TransactionRepository!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "test.statistics.presentation.\(UUID().uuidString)"
+        testDefaults = UserDefaults(suiteName: suiteName)!
+        txRepo = TransactionRepository(defaults: testDefaults)
+    }
+
+    override func tearDown() {
+        testDefaults.removePersistentDomain(forName: suiteName)
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeVM() -> StatisticsViewModel {
+        StatisticsViewModel(repository: txRepo, defaults: testDefaults)
+    }
+
+    private func addCharge(amount: Double, daysAgo: Int = 0) {
+        let calendar = Calendar.current
+        let date = calendar.date(byAdding: .day, value: -daysAgo, to: Date())!
+        let tx = Transaction(type: .charge, amount: amount, createdAt: date)
+        txRepo.record(tx)
+    }
+
+    private func addTopup(amount: Double, daysAgo: Int = 0) {
+        let calendar = Calendar.current
+        let date = calendar.date(byAdding: .day, value: -daysAgo, to: Date())!
+        let tx = Transaction(type: .topup, amount: amount, createdAt: date)
+        txRepo.record(tx)
+    }
+
+    // MARK: - spentColor
+
+    func testSpentColor_zeroSpent_isSecondary() {
+        let vm = makeVM()
+        vm.loadData(period: .week)
+        XCTAssertEqual(vm.spentColor, .secondaryLabel)
+    }
+
+    func testSpentColor_hasSpending_isAccentOrange() {
+        addCharge(amount: 50)
+        let vm = makeVM()
+        vm.loadData(period: .week)
+        XCTAssertEqual(vm.spentColor, AppColors.accentOrange)
+    }
+
+    // MARK: - snoozeCountColor
+
+    func testSnoozeCountColor_zeroSnoozes_isSecondary() {
+        let vm = makeVM()
+        vm.loadData(period: .week)
+        XCTAssertEqual(vm.snoozeCountColor, .secondaryLabel)
+    }
+
+    func testSnoozeCountColor_hasSnoozes_isLabel() {
+        addCharge(amount: 25)
+        let vm = makeVM()
+        vm.loadData(period: .week)
+        XCTAssertEqual(vm.snoozeCountColor, .label)
+    }
+
+    // MARK: - motivationVisible
+
+    func testMotivationVisible_zeroSpent_isFalse() {
+        let vm = makeVM()
+        vm.loadData(period: .week)
+        XCTAssertFalse(vm.motivationVisible)
+    }
+
+    func testMotivationVisible_hasSpending_isTrue() {
+        addCharge(amount: 10)
+        let vm = makeVM()
+        vm.loadData(period: .week)
+        XCTAssertTrue(vm.motivationVisible)
+    }
+
+    // MARK: - streakActive + zero message
+
+    func testStreakActive_isFalseWhenChargeToday() {
+        // Charge today → streak = 0.
+        addCharge(amount: 50, daysAgo: 0)
+        let vm = makeVM()
+        vm.loadData(period: .week)
+        XCTAssertFalse(vm.streakActive)
+    }
+
+    func testStreakZeroMessage_isStable() {
+        let vm = makeVM()
+        vm.loadData(period: .week)
+        XCTAssertEqual(vm.streakZeroMessage, "0 дней без откладываний")
+    }
+
+    func testStreakActive_isTrueWhenLastChargeWasDaysAgo() {
+        addCharge(amount: 50, daysAgo: 3)
+        addTopup(amount: 100, daysAgo: 0)
+        let vm = makeVM()
+        vm.loadData(period: .week)
+        // Streak depends on TransactionRepository.currentStreak() — only assert
+        // it's > 0 to keep the test resilient to the algorithm's specifics.
+        if vm.streak > 0 {
+            XCTAssertTrue(vm.streakActive)
+        }
+    }
+
+    // MARK: - totalSpentFormatted (now lives in VM)
+
+    func testTotalSpentFormatted_zero_returnsRubleZero() {
+        let vm = makeVM()
+        vm.loadData(period: .week)
+        XCTAssertEqual(vm.totalSpentFormatted, "₽0")
+    }
+
+    func testTotalSpentFormatted_withSpending_includesAmount() {
+        addCharge(amount: 250)
+        let vm = makeVM()
+        vm.loadData(period: .week)
+        XCTAssertEqual(vm.totalSpentFormatted, "₽250")
+    }
+}

--- a/SnoozePay/SnoozePayTests/ThemeServiceTests.swift
+++ b/SnoozePay/SnoozePayTests/ThemeServiceTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+@testable import SnoozePay
+
+/// Unit tests for ThemeService — persistence + theme/style mapping.
+/// Window-application is exercised indirectly: we only assert the persisted
+/// state and the enum -> UIUserInterfaceStyle mapping, since boot-strapping a
+/// real UIWindowScene inside XCTest is brittle.
+final class ThemeServiceTests: XCTestCase {
+
+    private var testDefaults: UserDefaults!
+    private var suiteName: String!
+    private var service: ThemeService!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "test.themeservice.\(UUID().uuidString)"
+        testDefaults = UserDefaults(suiteName: suiteName)!
+        service = ThemeService(defaults: testDefaults)
+    }
+
+    override func tearDown() {
+        testDefaults.removePersistentDomain(forName: suiteName)
+        service = nil
+        testDefaults = nil
+        super.tearDown()
+    }
+
+    // MARK: - Default state
+
+    func testCurrent_freshInstall_isSystem() {
+        XCTAssertEqual(service.current, .system)
+    }
+
+    func testCurrent_unknownStoredValue_fallsBackToSystem() {
+        // Older / future / corrupted value should not crash; should default.
+        testDefaults.set("solarized-dark", forKey: "preferred_theme")
+        XCTAssertEqual(service.current, .system)
+    }
+
+    // MARK: - Persistence
+
+    func testSetTheme_persistsDark() {
+        service.setTheme(.dark)
+        XCTAssertEqual(testDefaults.string(forKey: "preferred_theme"), "dark")
+        XCTAssertEqual(service.current, .dark)
+    }
+
+    func testSetTheme_persistsLight() {
+        service.setTheme(.light)
+        XCTAssertEqual(testDefaults.string(forKey: "preferred_theme"), "light")
+        XCTAssertEqual(service.current, .light)
+    }
+
+    func testSetTheme_persistsSystem() {
+        service.setTheme(.dark) // first move away from default
+        service.setTheme(.system)
+        XCTAssertEqual(testDefaults.string(forKey: "preferred_theme"), "system")
+        XCTAssertEqual(service.current, .system)
+    }
+
+    func testCurrent_setterAlsoPersists() {
+        service.current = .light
+        XCTAssertEqual(testDefaults.string(forKey: "preferred_theme"), "light")
+    }
+
+    // MARK: - Theme -> UIUserInterfaceStyle mapping
+
+    func testInterfaceStyleMapping() {
+        XCTAssertEqual(ThemeService.Theme.system.interfaceStyle, .unspecified)
+        XCTAssertEqual(ThemeService.Theme.light.interfaceStyle, .light)
+        XCTAssertEqual(ThemeService.Theme.dark.interfaceStyle, .dark)
+    }
+
+    // MARK: - apply(to:) — single-window path used by SceneDelegate
+
+    func testApplyToWindow_appliesPersistedStyle_dark() {
+        service.setTheme(.dark)
+        let window = UIWindow()
+        service.apply(to: window)
+        XCTAssertEqual(window.overrideUserInterfaceStyle, .dark)
+    }
+
+    func testApplyToWindow_appliesPersistedStyle_light() {
+        service.setTheme(.light)
+        let window = UIWindow()
+        service.apply(to: window)
+        XCTAssertEqual(window.overrideUserInterfaceStyle, .light)
+    }
+
+    func testApplyToWindow_systemMapsToUnspecified() {
+        service.setTheme(.system)
+        let window = UIWindow()
+        // Move it off the default, then re-apply, to verify the call actually
+        // sets the style rather than relying on UIWindow's initial value.
+        window.overrideUserInterfaceStyle = .dark
+        service.apply(to: window)
+        XCTAssertEqual(window.overrideUserInterfaceStyle, .unspecified)
+    }
+}


### PR DESCRIPTION
Fixes #33

## Что сделано

- **ThemeService** (`Services/ThemeService.swift`) — singleton, владеет `preferred_theme` UserDefaults persistence + единая точка `apply(to:)` / `applyToActiveWindowScene()`. SettingsVC и SceneDelegate больше не дублируют string→`UIUserInterfaceStyle` mapping.
- **AlarmFiringCoordinator** (`Services/AlarmFiringCoordinator.swift`) — вынесен из `AppDelegate.swift:108-155` snooze-from-notification flow. Возвращает `SnoozeOutcome` (invalidPayload / alarmNotFound / insufficientFunds / scheduled), что делает логику unit-testable. AppDelegate теперь только маршрутизирует `UNNotificationResponse`.
- **ThemeSegmentCell** (`ViewControllers/Settings/ThemeSegmentCell.swift`) — отдельный `UITableViewCell` subclass, владеет `UISegmentedControl` и принимает change-handler через closure. Заменяет фрагильный `themeSegment.removeFromSuperview()` + re-add из `cellForRowAt`.
- **StatisticsViewModel** — добавлены presentation-ready computed: `spentColor`, `snoozeCountColor`, `motivationVisible`, `streakActive`, `streakZeroMessage`. `totalSpentFormatted` теперь корректно даёт `"₽0"` для пустого state.
- **StatisticsViewController.refresh()** — упрощён, использует VM-cвойства вместо собственных условий. `streakIconView.superview?.superview?.isHidden = false` заменено на explicit `streakCard` outlet.

## Verify

- swiftlint: 0 errors в новых файлах (ThemeService / AlarmFiringCoordinator / ThemeSegmentCell / 3 тест-файла)
- build_sim: succeeded (simulator: iPhone 17 Pro Max)
- test_sim: skipped (отключён глобально)

## Тесты

- `ThemeServiceTests` — persistence (system/light/dark), unknown-value fallback, `apply(to:)` style mapping
- `AlarmFiringCoordinatorTests` — все 4 ветки `SnoozeOutcome` + boundary case (balance == penalty) + progressive scale
- `StatisticsViewModelPresentationTests` — `spentColor` / `snoozeCountColor` / `motivationVisible` / `streakActive` / `streakZeroMessage` / `totalSpentFormatted`

## No-touch

Не затронуты: entitlements, Info.plist, project.pbxproj, signing, SPM packages.