### PR TITLE
[test] Cover AlarmRepository / BalanceService.charge / StoreKit / ALVM gaps (#32)

### DIFF
--- a/SnoozePay/SnoozePayTests/AlarmRepositoryTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmRepositoryTests.swift
@@ -26,6 +26,14 @@ final class AlarmRepositoryTests: XCTestCase {
         Alarm(name: name, penaltyAmount: 50)
     }
 
+    /// Build an alarm at a deterministic time-of-day so sort/upsert tests
+    /// don't accidentally rely on `Date()` resolution within `setUp`.
+    private func makeAlarm(hour: Int, minute: Int = 0, name: String) -> Alarm {
+        let calendar = Calendar(identifier: .gregorian)
+        let date = calendar.date(from: DateComponents(hour: hour, minute: minute))!
+        return Alarm(time: date, name: name, penaltyAmount: 50)
+    }
+
     // MARK: - Basic CRUD
 
     func testSave_persistsAlarm() {
@@ -178,6 +186,52 @@ final class AlarmRepositoryTests: XCTestCase {
         let stored = repo.fetchAll()
         XCTAssertEqual(stored.count, 1)
         XCTAssertEqual(stored.first?.name, "Recovery")
+    }
+
+    // MARK: - Coverage gaps surfaced by pr-test-analyzer (#32)
+
+    /// `save` is upsert: re-saving the same id MUST replace in place rather
+    /// than appending a duplicate. The previous `testSave_updatesExistingAlarm`
+    /// covers data-replacement; this one specifically pins down the array-shape
+    /// invariant so a future regression that switched to "always append" would
+    /// fail loudly here even if the last-write-wins on the field comparison.
+    func testSave_upsertsExistingAlarmInPlace() {
+        var alarm = makeAlarm(name: "v1")
+        repo.save(alarm)
+        repo.save(alarm) // same id, second time
+        alarm.name = "v2"
+        repo.save(alarm) // mutated, same id
+
+        let stored = repo.fetchAll()
+        XCTAssertEqual(stored.count, 1, "Repeated saves of the same id must NOT duplicate the alarm")
+        XCTAssertEqual(stored.first?.name, "v2")
+    }
+
+    /// `fetchAll()` must return alarms sorted by `time` ascending so the list UI
+    /// renders earliest-first. Without an explicit assertion the natural insert
+    /// order would mask a regression that dropped the `sorted` call in `readAll`.
+    func testFetchAll_sortsByTime() {
+        let late = makeAlarm(hour: 22, name: "Late")
+        let early = makeAlarm(hour: 6, name: "Early")
+        let mid = makeAlarm(hour: 12, name: "Mid")
+
+        // Insert out of order to ensure result depends on sort, not insertion order.
+        repo.save(late)
+        repo.save(early)
+        repo.save(mid)
+
+        let names = repo.fetchAll().map(\.name)
+        XCTAssertEqual(names, ["Early", "Mid", "Late"],
+                       "fetchAll must order alarms by time ascending")
+    }
+
+    /// Earlier tests cover preservation of corrupt bytes on disk. This one nails
+    /// the caller-visible contract: a single `fetchAll()` against syntactically
+    /// invalid JSON returns `[]` silently — no crash, no rethrow, no partial list.
+    /// Listed explicitly in #32 as an acceptance-criteria bullet.
+    func testCorruptJSONInDefaults_returnsEmptyArray() {
+        testDefaults.set(Data("totally not json {".utf8), forKey: "stored_alarms")
+        XCTAssertEqual(repo.fetchAll(), [])
     }
 
     func testConcurrentToggleVsSave_finalStateIsConsistent() {

--- a/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
@@ -125,6 +125,79 @@ final class AlarmsListViewModelTests: XCTestCase {
         XCTAssertFalse(stored[0].enabled, "Toggle must persist through the repository")
     }
 
+    // MARK: - Coverage gaps surfaced by pr-test-analyzer (#32)
+
+    /// `toggleAlarm` rebuilds the in-memory cache via the positional `Alarm(...)`
+    /// initializer. Every non-`enabled` field MUST round-trip unchanged — if a
+    /// future model field is added but the rebuild block is not updated, that
+    /// field would silently revert to the default on toggle (the suspected
+    /// root cause of #18). This is a regression fence: any new field plus a
+    /// changed default value will trip the assertion.
+    func testToggleAlarm_persistsAndRebuildsCacheCorrectly() {
+        let calendar = Calendar(identifier: .gregorian)
+        let time = calendar.date(from: DateComponents(hour: 7, minute: 30))!
+        let original = Alarm(
+            time: time,
+            repeatDays: [1, 3, 5],
+            name: "Тренировка",
+            soundID: "marimba",
+            vibrationEnabled: false,
+            snoozeMinutes: 7,
+            penaltyAmount: 250,
+            progressiveScale: true,
+            enabled: true
+        )
+        repo.save(original)
+
+        let vm = makeViewModel()
+        vm.loadData()
+
+        vm.toggleAlarm(at: 0, enabled: false)
+
+        let cached = vm.alarms[0]
+        XCTAssertEqual(cached.id, original.id)
+        XCTAssertEqual(cached.time, original.time)
+        XCTAssertEqual(cached.repeatDays, original.repeatDays)
+        XCTAssertEqual(cached.name, original.name)
+        XCTAssertEqual(cached.soundID, original.soundID)
+        XCTAssertEqual(cached.vibrationEnabled, original.vibrationEnabled)
+        XCTAssertEqual(cached.snoozeMinutes, original.snoozeMinutes)
+        XCTAssertEqual(cached.penaltyAmount, original.penaltyAmount)
+        XCTAssertEqual(cached.progressiveScale, original.progressiveScale)
+        XCTAssertFalse(cached.enabled, "Only `enabled` should change")
+
+        // Repository must mirror the in-memory state.
+        let stored = repo.fetch(id: original.id)!
+        XCTAssertEqual(stored, cached, "In-memory cache must equal persisted state after toggle")
+    }
+
+    /// Happy-path toggle (alarm exists in repo) MUST NOT call `onAlarmsUpdated`.
+    /// The current implementation updates the in-place cache and returns silently
+    /// — the cell already reflects the optimistic state. A regression that fired
+    /// the callback on every toggle would force a full table reload, dropping
+    /// in-flight cell animations and re-running every cellForRow path.
+    func testToggleAlarm_emitsOnAlarmsUpdatedExactlyOnce() {
+        let alarm = Alarm(penaltyAmount: 50, enabled: true)
+        repo.save(alarm)
+
+        let vm = makeViewModel()
+        var emissions = 0
+        vm.onAlarmsUpdated = { emissions += 1 }
+
+        vm.loadData()
+        // loadData() MUST emit once (initial bind). Reset the counter so the
+        // toggle assertion below isolates the toggle's own emissions.
+        XCTAssertEqual(emissions, 1, "loadData must emit onAlarmsUpdated exactly once on initial load")
+        emissions = 0
+
+        vm.toggleAlarm(at: 0, enabled: false)
+
+        XCTAssertEqual(
+            emissions, 0,
+            "Successful toggle must not refire onAlarmsUpdated — the cell already shows the new state"
+        )
+    }
+
     // MARK: - toggleAlarm(id:enabled:)
 
     /// Regression for issue #35: when the alarm exists in the VM's in-memory snapshot

--- a/SnoozePay/SnoozePayTests/BalanceServiceTests.swift
+++ b/SnoozePay/SnoozePayTests/BalanceServiceTests.swift
@@ -112,6 +112,91 @@ final class BalanceServiceTests: XCTestCase {
         wait(for: [exp1, exp2], timeout: 2.0)
     }
 
+    // MARK: - charge / topUp invariants (#32)
+
+    /// Helper: build an isolated TransactionRepository tied to the same
+    /// suite as the BalanceService under test, so we can assert side
+    /// effects on the financial ledger without touching shared state.
+    private func makeServiceWithLedger(
+        balance: Double,
+        notificationCenter: NotificationCenter
+    ) -> (service: BalanceService, ledger: TransactionRepository) {
+        testDefaults.set(balance, forKey: "user_balance")
+        let ledger = TransactionRepository(defaults: testDefaults)
+        let service = BalanceService(
+            defaults: testDefaults,
+            transactionRepository: ledger,
+            notificationCenter: notificationCenter
+        )
+        return (service, ledger)
+    }
+
+    /// Insufficient funds: `charge` MUST NOT mutate balance, MUST NOT record
+    /// a transaction, and MUST NOT broadcast `balanceChangedNotification`.
+    /// Three invariants in one test because they're a single atomic contract —
+    /// any one breaking is a financial bug.
+    func testCharge_insufficientFunds_balanceUnchanged_noTransaction_noNotification() {
+        let center = NotificationCenter()
+        let (service, ledger) = makeServiceWithLedger(balance: 30, notificationCenter: center)
+
+        let didFire = expectation(description: "notification must NOT fire")
+        didFire.isInverted = true
+        let token = center.addObserver(
+            forName: BalanceService.balanceChangedNotification,
+            object: nil,
+            queue: nil
+        ) { _ in didFire.fulfill() }
+        defer { center.removeObserver(token) }
+
+        let charged = service.charge(amount: 50, alarmID: nil)
+
+        XCTAssertFalse(charged, "charge must report failure on insufficient funds")
+        XCTAssertEqual(service.balance, 30, "Balance must be untouched on failed charge")
+        XCTAssertTrue(ledger.fetchAll().isEmpty,
+                      "No transaction may be recorded for a failed charge")
+        wait(for: [didFire], timeout: 0.5)
+    }
+
+    /// Successful charge records exactly one Transaction with type=.charge,
+    /// amount = requested, and alarmID round-tripped through the optional UUID.
+    func testCharge_success_recordsTransactionWithAlarmID() {
+        let alarmID = UUID()
+        let (service, ledger) = makeServiceWithLedger(balance: 200, notificationCenter: NotificationCenter())
+
+        XCTAssertTrue(service.charge(amount: 75, alarmID: alarmID))
+
+        let transactions = ledger.fetchAll()
+        XCTAssertEqual(transactions.count, 1)
+        let transaction = transactions[0]
+        XCTAssertEqual(transaction.type, .charge)
+        XCTAssertEqual(transaction.amount, 75)
+        XCTAssertEqual(transaction.alarmID, alarmID.uuidString,
+                       "alarmID must be persisted as the original UUID's string form")
+    }
+
+    /// `topUp` always succeeds (no insufficient-funds gate) and records a
+    /// `.topup` transaction with the credited amount and `alarmID == nil`.
+    func testTopUp_recordsTransaction() {
+        let (service, ledger) = makeServiceWithLedger(balance: 0, notificationCenter: NotificationCenter())
+
+        service.topUp(amount: 149)
+
+        let transactions = ledger.fetchAll()
+        XCTAssertEqual(transactions.count, 1)
+        XCTAssertEqual(transactions[0].type, .topup)
+        XCTAssertEqual(transactions[0].amount, 149)
+        XCTAssertNil(transactions[0].alarmID, "topUp transactions must not carry an alarmID")
+        XCTAssertEqual(service.balance, 149)
+    }
+
+    /// Boundary: balance == amount must satisfy `canAfford` (>=, not >).
+    /// A subtle off-by-one here would silently disable the user's last snooze.
+    func testCanAfford_boundaryAtExactEquality() {
+        let service = makeService(balance: 50)
+        XCTAssertTrue(service.canAfford(50), "canAfford must return true when balance == amount")
+        XCTAssertFalse(service.canAfford(50.01), "canAfford must return false when balance < amount by any epsilon")
+    }
+
     // MARK: - Concurrency
 
     func testConcurrentCharge_neverGoesNegative() {

--- a/SnoozePay/SnoozePayTests/StoreKitServiceTests.swift
+++ b/SnoozePay/SnoozePayTests/StoreKitServiceTests.swift
@@ -46,4 +46,51 @@ final class StoreKitServiceTests: XCTestCase {
             )
         }
     }
+
+    // MARK: - Coverage gaps surfaced by pr-test-analyzer (#32)
+
+    /// `productIDs` and `productAmounts` are two parallel sources of truth.
+    /// The keysets MUST be identical: an ID present in one but not the other
+    /// would silently miscredit (or no-credit) on purchase.
+    func testProductIDs_andProductAmounts_haveIdenticalKeysets() {
+        let idSet = Set(StoreKitService.productIDs)
+        let amountKeys = Set(StoreKitService.productAmounts.keys)
+        XCTAssertEqual(
+            idSet, amountKeys,
+            "productIDs and productAmounts must declare exactly the same product identifiers"
+        )
+    }
+
+    /// Notification names must include the `snoozepay.storekit.` namespace
+    /// prefix so subscribers across the app match a stable, scoped identifier.
+    /// A rename without this assertion would silently break every subscriber.
+    func testNotificationNames_useStableNamespace() {
+        let prefix = "snoozepay.storekit."
+        XCTAssertTrue(StoreKitService.productsLoadedNotification.rawValue.hasPrefix(prefix))
+        XCTAssertTrue(StoreKitService.purchaseCompletedNotification.rawValue.hasPrefix(prefix))
+        XCTAssertTrue(StoreKitService.purchaseFailedNotification.rawValue.hasPrefix(prefix))
+        XCTAssertTrue(StoreKitService.purchasePendingNotification.rawValue.hasPrefix(prefix))
+    }
+
+    /// userInfo keys are part of the contract with subscribers.
+    /// Renaming a key without updating subscribers would silently drop data.
+    func testUserInfoKeys_areDistinctAndStable() {
+        let keys = [
+            StoreKitService.productsUserInfoKey,
+            StoreKitService.amountUserInfoKey,
+            StoreKitService.messageUserInfoKey
+        ]
+        XCTAssertEqual(Set(keys).count, keys.count, "userInfo keys must be distinct")
+        XCTAssertEqual(StoreKitService.amountUserInfoKey, "amount")
+        XCTAssertEqual(StoreKitService.messageUserInfoKey, "message")
+        XCTAssertEqual(StoreKitService.productsUserInfoKey, "products")
+    }
+
+    // TODO(IOS-032+): The remaining gaps from #32 — `.userCancelled` /
+    // `.pending` / `failedVerification` / double-call dedup — exercise
+    // `Product.purchase()` and `Transaction.updates`, which are StoreKit
+    // built-ins without a substitution seam. Covering them requires lifting
+    // the StoreKit boundary behind a protocol (handle(transactionResult:),
+    // purchaseProduct, transactionUpdates AsyncStream). Tracked as a
+    // follow-up so this PR stays test-only and does not modify production.
 }


### PR DESCRIPTION
Fixes #32

## Что сделано

Расширил existing test files новыми кейсами по топ-4 пробелам из issue. **Только новые тесты, без изменений в production-коде** (для избежания конфликта с #34).

### AlarmRepositoryTests (+3 теста)
- `testSave_upsertsExistingAlarmInPlace` — пин invariant'а: повторный save с тем же id не дублирует, заменяет в массиве.
- `testFetchAll_sortsByTime` — explicit ordering после shuffle insert.
- `testCorruptJSONInDefaults_returnsEmptyArray` — single-call контракт (отдельно от existing preserve-on-disk кейсов).

### BalanceServiceTests (+4 теста + helper)
- `testCharge_insufficientFunds_balanceUnchanged_noTransaction_noNotification` — три инварианта в одном тесте: balance не меняется, transaction не записан, notification НЕ fires (через inverted expectation).
- `testCharge_success_recordsTransactionWithAlarmID` — verifies type=.charge, amount, alarmID round-trip через UUID.uuidString.
- `testTopUp_recordsTransaction` — type=.topup, alarmID==nil.
- `testCanAfford_boundaryAtExactEquality` — balance == amount → true; balance < amount + 0.01 → false.
- Helper: `makeServiceWithLedger(...)` — DI'ит TransactionRepository в isolated UserDefaults suite, чтобы side-effects на ledger были verifiable.

### StoreKitServiceTests (+3 теста)
- `testProductIDs_andProductAmounts_haveIdenticalKeysets` — drift между двумя parallel sources of truth.
- `testNotificationNames_useStableNamespace` — `snoozepay.storekit.` prefix как стабильный subscriber-контракт.
- `testUserInfoKeys_areDistinctAndStable` — keys не collide и не переименовываются молча.
- TODO: `.userCancelled` / `.pending` / `failedVerification` / double-call — требуют DI lift StoreKit.Transaction.updates за protocol; tracked как follow-up чтобы PR оставался test-only.

### AlarmsListViewModelTests (+2 теста)
- `testToggleAlarm_persistsAndRebuildsCacheCorrectly` — все 9 полей Alarm round-trip через positional init после toggle (regression fence для #18-style root cause).
- `testToggleAlarm_emitsOnAlarmsUpdatedExactlyOnce` — happy-path toggle НЕ refires onAlarmsUpdated (cell already shows new state); loadData() emits exactly once.

## Verify
- swiftlint: 0 errors (122 warnings — все pre-existing identifier_name / file_length из других файлов, либо новые TODO-маркеры с issue ref)
- build_sim: succeeded (iPhone 17 Pro Max)
- xcodebuild build-for-testing: TEST BUILD SUCCEEDED — test target компилируется
- test_sim: skipped (отключён per CLAUDE.md)

## Touched files
Только `SnoozePay/SnoozePayTests/*.swift` — никакого production-кода, никакого project.pbxproj (synchronized group авто-инклудит новые файлы), никаких no-touch zones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)