### PR TITLE
[refactor] Domain types: Money, TimeOfDay, Weekday (phase 1 of #31)

### DIFF
--- a/SnoozePay/SnoozePay/Models/Alarm.swift
+++ b/SnoozePay/SnoozePay/Models/Alarm.swift
@@ -69,6 +69,32 @@ struct Alarm: Identifiable, Equatable, Codable {
         let multiplier = pow(2.0, Double(count - 1))
         return penaltyAmount * multiplier
     }
+
+    // MARK: - Typed views (phase 1 of #31)
+    //
+    // The fields below are the typed-domain projections of the underlying
+    // primitive storage. They never mutate state — they're read-only views.
+    // Phase 2 will migrate the storage itself; until then, callers can adopt
+    // the typed view incrementally without invalidating persisted JSON.
+
+    /// Wall-clock time-of-day projection of `time`. `nil` only if the
+    /// calendar refuses to extract hour/minute, which doesn't happen for
+    /// real `Date` values + `Calendar.current`.
+    var timeOfDay: TimeOfDay? {
+        TimeOfDay(from: time)
+    }
+
+    /// Typed view over `repeatDays`. Out-of-range integers in legacy storage
+    /// are silently skipped (existing data may contain them).
+    var weekdays: Set<Weekday> {
+        Set<Weekday>(legacyMondayFirstIndices: repeatDays)
+    }
+
+    /// Typed view of `penaltyAmount`. `nil` if the legacy `Double` is
+    /// negative or non-finite, which a typed setter would have refused.
+    var penaltyMoney: Money? {
+        Money(penaltyAmount)
+    }
 }
 
 // MARK: - Safe array subscript

--- a/SnoozePay/SnoozePay/Models/Money.swift
+++ b/SnoozePay/SnoozePay/Models/Money.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Value type for monetary amounts.
+///
+/// Wraps `Decimal` (not `Double`) because money in floating-point accumulates
+/// precision errors (`0.1 + 0.2 != 0.3`). All arithmetic here is exact within
+/// `Decimal`'s 38-digit mantissa.
+///
+/// Invariants:
+/// - amount is non-negative (negative money is never a valid balance/penalty
+///   in this app — debits/credits are encoded by `Transaction.type`, not sign).
+/// - amount is finite (no NaN/infinity sneak-ins from `Double` bridges).
+///
+/// Phase 1 of #31: introduced as a parallel API alongside the existing
+/// `Double`-based API on `BalanceService` / `Alarm` / `Transaction`. Callers
+/// will be migrated over a follow-up PR (phase 2).
+struct Money: Equatable, Hashable, Codable {
+
+    /// The non-negative monetary amount, in the app's single base currency (RUB).
+    let amount: Decimal
+
+    // MARK: - Construction
+
+    /// Failable init that enforces invariants:
+    /// - rejects negative values
+    /// - rejects NaN (Decimal has its own NaN representation, separate from Double)
+    init?(_ amount: Decimal) {
+        guard !amount.isNaN, amount >= 0 else { return nil }
+        self.amount = amount
+    }
+
+    /// Convenience bridge from `Double`. Rejects NaN / infinite / negative
+    /// before the conversion can silently round-trip into `Decimal`.
+    init?(_ amount: Double) {
+        guard amount.isFinite, amount >= 0 else { return nil }
+        self.init(Decimal(amount))
+    }
+
+    /// Convenience for integer literals — always valid for non-negative.
+    init?(_ amount: Int) {
+        guard amount >= 0 else { return nil }
+        self.init(Decimal(amount))
+    }
+
+    /// The additive identity. Useful as a starting accumulator.
+    static let zero: Money = Money(Decimal(0))!
+
+    // MARK: - Bridges
+
+    /// Lossy bridge for legacy Double-based APIs (`BalanceService.balance: Double`,
+    /// `Alarm.penaltyAmount: Double`). Removed once phase 2 migrates callers.
+    func toDouble() -> Double {
+        NSDecimalNumber(decimal: amount).doubleValue
+    }
+
+    // MARK: - Arithmetic
+
+    /// Sum of two monetary amounts. Always non-negative since both operands are.
+    static func + (lhs: Money, rhs: Money) -> Money {
+        // Forced unwrap is safe: the sum of two non-negative non-NaN Decimals
+        // is itself a non-negative non-NaN Decimal.
+        Money(lhs.amount + rhs.amount)!
+    }
+
+    /// Subtraction with saturating semantics — returns `nil` if the result
+    /// would be negative (i.e. would violate the invariant). Callers explicitly
+    /// surface "insufficient funds" via the `nil` return rather than discovering
+    /// it via a runtime trap.
+    static func - (lhs: Money, rhs: Money) -> Money? {
+        Money(lhs.amount - rhs.amount)
+    }
+
+    /// Multiplication by a non-negative scalar (e.g. progressive penalty
+    /// doubling). Returns `nil` if the multiplier is negative or NaN.
+    func multiplied(by multiplier: Decimal) -> Money? {
+        guard !multiplier.isNaN, multiplier >= 0 else { return nil }
+        return Money(amount * multiplier)
+    }
+
+    // MARK: - Ordering
+
+    static func < (lhs: Money, rhs: Money) -> Bool {
+        lhs.amount < rhs.amount
+    }
+
+    static func <= (lhs: Money, rhs: Money) -> Bool {
+        lhs.amount <= rhs.amount
+    }
+
+    static func > (lhs: Money, rhs: Money) -> Bool {
+        lhs.amount > rhs.amount
+    }
+
+    static func >= (lhs: Money, rhs: Money) -> Bool {
+        lhs.amount >= rhs.amount
+    }
+
+    // MARK: - Formatting
+
+    /// Localized formatted representation, e.g. "150 ₽" for `currencyCode = "RUB"`
+    /// in a Russian locale. Default rounds to whole units (the app currently
+    /// transacts only integer rubles).
+    func formatted(
+        currencyCode: String = "RUB",
+        locale: Locale = Locale(identifier: "ru_RU"),
+        fractionDigits: Int = 0
+    ) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = currencyCode
+        formatter.locale = locale
+        formatter.minimumFractionDigits = fractionDigits
+        formatter.maximumFractionDigits = fractionDigits
+        let number = NSDecimalNumber(decimal: amount)
+        return formatter.string(from: number) ?? "\(amount) \(currencyCode)"
+    }
+}

--- a/SnoozePay/SnoozePay/Models/TimeOfDay.swift
+++ b/SnoozePay/SnoozePay/Models/TimeOfDay.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Wall-clock time-of-day, decoupled from any specific calendar date.
+///
+/// `Alarm.time` historically stored a `Date` whose date components were
+/// meaningless — only `(hour, minute)` was ever read. This invited bugs where
+/// the date portion leaked into scheduling logic. `TimeOfDay` makes the
+/// "only hour/minute" intent explicit and validates ranges at construction.
+///
+/// Phase 1 of #31: introduced as a parallel API; `Alarm.time: Date` remains
+/// the storage primary so existing UserDefaults JSON keeps decoding. Callers
+/// that want validated semantics can read `Alarm.timeOfDay`.
+struct TimeOfDay: Equatable, Hashable, Codable {
+
+    let hour: Int    // 0...23
+    let minute: Int  // 0...59
+
+    /// Failable init that enforces hour/minute ranges. Returns `nil` for
+    /// any out-of-range input rather than clamping silently — silent clamp
+    /// would mask programmer errors at construction time.
+    init?(hour: Int, minute: Int) {
+        guard (0...23).contains(hour), (0...59).contains(minute) else { return nil }
+        self.hour = hour
+        self.minute = minute
+    }
+
+    /// Build from a `Date` by extracting wall-clock components in the given
+    /// calendar. Returns `nil` only if the calendar refuses to provide both
+    /// components (in practice, never for `Calendar.current` + a real date).
+    init?(from date: Date, calendar: Calendar = .current) {
+        let components = calendar.dateComponents([.hour, .minute], from: date)
+        guard let hour = components.hour, let minute = components.minute else { return nil }
+        self.init(hour: hour, minute: minute)
+    }
+
+    /// Project this time-of-day onto the same calendar day as `referenceDate`.
+    /// Returns the computed `Date` or `nil` if the calendar refuses
+    /// (DST gaps, unusual calendars) — callers must handle that edge.
+    func toDate(on referenceDate: Date, calendar: Calendar = .current) -> Date? {
+        var components = calendar.dateComponents([.year, .month, .day], from: referenceDate)
+        components.hour = hour
+        components.minute = minute
+        components.second = 0
+        return calendar.date(from: components)
+    }
+}

--- a/SnoozePay/SnoozePay/Models/Transaction.swift
+++ b/SnoozePay/SnoozePay/Models/Transaction.swift
@@ -32,4 +32,13 @@ struct Transaction: Identifiable, Codable {
         let prefix = type == .charge ? "-" : "+"
         return "\(prefix)\(Int(amount)) ₽"
     }
+
+    // MARK: - Typed views (phase 1 of #31)
+
+    /// Typed view of the transaction amount. `nil` if the legacy `Double`
+    /// is negative or non-finite — old data may have leaked such values
+    /// since the primitive API never validated.
+    var money: Money? {
+        Money(amount)
+    }
 }

--- a/SnoozePay/SnoozePay/Models/Weekday.swift
+++ b/SnoozePay/SnoozePay/Models/Weekday.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// Day of the week, aligned with `Calendar.weekday` (1 = Sunday … 7 = Saturday).
+///
+/// This matches `DateComponents.weekday` and `UNCalendarNotificationTrigger`'s
+/// expected values directly, so scheduling code can pass `rawValue` without
+/// any off-by-one bridging.
+///
+/// The legacy storage on `Alarm.repeatDays: [Int]` uses a *different*
+/// convention (0 = Monday … 6 = Sunday). The `init?(legacyMondayFirstIndex:)`
+/// initializer and the `legacyMondayFirstIndex` property bridge between the
+/// two so we can introduce typed access without rewriting persisted JSON.
+enum Weekday: Int, CaseIterable, Codable, Hashable {
+    case sunday = 1
+    case monday = 2
+    case tuesday = 3
+    case wednesday = 4
+    case thursday = 5
+    case friday = 6
+    case saturday = 7
+
+    // MARK: - Legacy bridge (Mon=0 … Sun=6)
+
+    /// Build from the project's legacy `repeatDays` integer convention
+    /// (0 = Monday … 6 = Sunday). Returns `nil` for any value outside `0...6`,
+    /// which were silently allowed before this type existed.
+    init?(legacyMondayFirstIndex index: Int) {
+        switch index {
+        case 0: self = .monday
+        case 1: self = .tuesday
+        case 2: self = .wednesday
+        case 3: self = .thursday
+        case 4: self = .friday
+        case 5: self = .saturday
+        case 6: self = .sunday
+        default: return nil
+        }
+    }
+
+    /// The legacy index (0 = Monday … 6 = Sunday) for round-tripping
+    /// back into the existing `[Int]` storage.
+    var legacyMondayFirstIndex: Int {
+        switch self {
+        case .monday: return 0
+        case .tuesday: return 1
+        case .wednesday: return 2
+        case .thursday: return 3
+        case .friday: return 4
+        case .saturday: return 5
+        case .sunday: return 6
+        }
+    }
+
+    // MARK: - Display
+
+    /// Russian short label, matching the existing UI strings on
+    /// `Alarm.repeatDaysDescription` ("Пн, Вт, …").
+    var localizedShortName: String {
+        switch self {
+        case .monday: return "Пн"
+        case .tuesday: return "Вт"
+        case .wednesday: return "Ср"
+        case .thursday: return "Чт"
+        case .friday: return "Пт"
+        case .saturday: return "Сб"
+        case .sunday: return "Вс"
+        }
+    }
+}
+
+// MARK: - Convenience: convert a legacy `[Int]` set into a typed `Set<Weekday>`
+
+extension Set where Element == Weekday {
+
+    /// Convert from the project's legacy `repeatDays: [Int]` storage. Silently
+    /// drops any out-of-range integers (the legacy storage allowed them; the
+    /// typed view skips them rather than crashing existing user data).
+    init(legacyMondayFirstIndices indices: [Int]) {
+        self.init(indices.compactMap { Weekday(legacyMondayFirstIndex: $0) })
+    }
+
+    /// Round-trip back to the legacy `[Int]` storage, sorted Mon→Sun.
+    var legacyMondayFirstIndices: [Int] {
+        map(\.legacyMondayFirstIndex).sorted()
+    }
+}

--- a/SnoozePay/SnoozePay/Services/BalanceService.swift
+++ b/SnoozePay/SnoozePay/Services/BalanceService.swift
@@ -110,6 +110,38 @@ final class BalanceService {
         queue.sync { defaults.double(forKey: balanceKey) >= amount }
     }
 
+    // MARK: - Typed API (phase 1 of #31)
+    //
+    // Money-based wrappers around the existing Double API. Storage stays
+    // Double for backward compatibility with persisted UserDefaults until
+    // phase 2 migrates it. These wrappers reject invalid amounts (negative,
+    // NaN, infinite) at the type-system level rather than allowing them
+    // through and corrupting the ledger.
+
+    /// Current balance as a `Money` value. Always non-nil — `Double` from
+    /// `UserDefaults.double(forKey:)` defaults to `0` (which is valid).
+    /// If a corrupt negative value somehow exists, falls back to `.zero`.
+    var balanceMoney: Money {
+        Money(balance) ?? .zero
+    }
+
+    /// Money-typed charge. Returns `false` when funds are insufficient,
+    /// matching the legacy `charge(amount:alarmID:)` contract.
+    @discardableResult
+    func charge(_ amount: Money, alarmID: UUID?) -> Bool {
+        charge(amount: amount.toDouble(), alarmID: alarmID)
+    }
+
+    /// Money-typed top-up. The `Money` invariant guarantees non-negative,
+    /// finite — replacing the loose `Double` precondition.
+    func topUp(_ amount: Money) {
+        topUp(amount: amount.toDouble())
+    }
+
+    func canAfford(_ amount: Money) -> Bool {
+        canAfford(amount.toDouble())
+    }
+
     /// Hop to main since `charge`/`topUp` may be called from a background queue
     /// (notification action handler) and observers drive UIKit. NotificationCenter
     /// delivers synchronously on the posting thread, so we explicitly hop here

--- a/SnoozePay/SnoozePayTests/AlarmTransactionTypedViewsTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmTransactionTypedViewsTests.swift
@@ -1,0 +1,101 @@
+import XCTest
+@testable import SnoozePay
+
+/// Integration tests for the phase-1 typed views layered onto the legacy
+/// `Alarm` and `Transaction` primitives (issue #31). These pin the bridge
+/// contracts that phase-2 migration will rely on — off-by-one in `weekdays`
+/// would silently fire alarms on the wrong day, `Money?` returning `nil` for
+/// corrupt legacy data would silently drop charges in the UI.
+final class AlarmTransactionTypedViewsTests: XCTestCase {
+
+    // MARK: - Alarm.timeOfDay
+
+    func testAlarmTimeOfDay_extractsHourAndMinuteFromCurrentCalendar() {
+        let calendar = Calendar.current
+        let date = calendar.date(from: DateComponents(hour: 7, minute: 30))!
+        let alarm = Alarm(time: date)
+
+        let timeOfDay = alarm.timeOfDay
+        XCTAssertNotNil(timeOfDay)
+        XCTAssertEqual(timeOfDay?.hour, 7)
+        XCTAssertEqual(timeOfDay?.minute, 30)
+    }
+
+    // MARK: - Alarm.weekdays (off-by-one regression fence)
+
+    func testAlarmWeekdays_legacyZeroIsMondayNotSunday() {
+        // Legacy storage convention: 0 = Monday. Calendar.weekday convention:
+        // 1 = Sunday. Bridge must NOT shift the origin — testing both endpoints.
+        let alarm = Alarm(repeatDays: [0])
+        XCTAssertEqual(alarm.weekdays, [.monday])
+    }
+
+    func testAlarmWeekdays_legacySixIsSunday() {
+        let alarm = Alarm(repeatDays: [6])
+        XCTAssertEqual(alarm.weekdays, [.sunday])
+    }
+
+    func testAlarmWeekdays_emptyRepeatDaysProducesEmptySet() {
+        let alarm = Alarm(repeatDays: [])
+        XCTAssertTrue(alarm.weekdays.isEmpty)
+    }
+
+    func testAlarmWeekdays_dropsOutOfRangeLegacyIntegers() {
+        // Corrupted legacy data (`-1`, `8`, `99`) must not crash; the bridge
+        // silently drops invalid indices, mirroring `repeatDaysDescription`.
+        let alarm = Alarm(repeatDays: [-1, 0, 8, 99, 6])
+        XCTAssertEqual(alarm.weekdays, [.monday, .sunday])
+    }
+
+    func testAlarmWeekdays_deduplicatesSetSemantics() {
+        let alarm = Alarm(repeatDays: [0, 0, 1])
+        XCTAssertEqual(alarm.weekdays, [.monday, .tuesday])
+    }
+
+    // MARK: - Alarm.penaltyMoney
+
+    func testAlarmPenaltyMoney_positiveAmountWraps() {
+        let alarm = Alarm(penaltyAmount: 50)
+        XCTAssertEqual(alarm.penaltyMoney, Money(50))
+    }
+
+    func testAlarmPenaltyMoney_zeroIsValidMoneyZero() {
+        let alarm = Alarm(penaltyAmount: 0)
+        XCTAssertEqual(alarm.penaltyMoney, .zero)
+    }
+
+    func testAlarmPenaltyMoney_negativeLegacyValueReturnsNil() {
+        // The primitive setter never validated, so corrupt persisted alarms
+        // could carry a negative `penaltyAmount`. The typed view surfaces this
+        // as `nil` so phase-2 callers must explicitly handle it.
+        let alarm = Alarm(penaltyAmount: -50)
+        XCTAssertNil(alarm.penaltyMoney)
+    }
+
+    func testAlarmPenaltyMoney_nanReturnsNil() {
+        let alarm = Alarm(penaltyAmount: .nan)
+        XCTAssertNil(alarm.penaltyMoney)
+    }
+
+    // MARK: - Transaction.money
+
+    func testTransactionMoney_positiveAmountWraps() {
+        let transaction = Transaction(type: .topup, amount: 100)
+        XCTAssertEqual(transaction.money, Money(100))
+    }
+
+    func testTransactionMoney_zeroIsValid() {
+        let transaction = Transaction(type: .charge, amount: 0)
+        XCTAssertEqual(transaction.money, .zero)
+    }
+
+    func testTransactionMoney_negativeLegacyValueReturnsNil() {
+        let transaction = Transaction(type: .charge, amount: -10)
+        XCTAssertNil(transaction.money)
+    }
+
+    func testTransactionMoney_nanReturnsNil() {
+        let transaction = Transaction(type: .topup, amount: .nan)
+        XCTAssertNil(transaction.money)
+    }
+}

--- a/SnoozePay/SnoozePayTests/BalanceServiceMoneyAPITests.swift
+++ b/SnoozePay/SnoozePayTests/BalanceServiceMoneyAPITests.swift
@@ -1,0 +1,84 @@
+import XCTest
+@testable import SnoozePay
+
+/// Tests for the phase-1 Money-typed wrappers on `BalanceService` (issue #31).
+/// The wrappers bridge through `toDouble()` to the legacy `Double` storage
+/// until phase 2; these tests pin the input-validation contract and the
+/// corruption-fallback semantics of `balanceMoney`.
+final class BalanceServiceMoneyAPITests: XCTestCase {
+
+    private var testDefaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "test_\(UUID().uuidString)"
+        testDefaults = UserDefaults(suiteName: suiteName)!
+    }
+
+    override func tearDown() {
+        testDefaults.removePersistentDomain(forName: suiteName)
+        super.tearDown()
+    }
+
+    private func makeService(balance: Double = 0) -> BalanceService {
+        testDefaults.set(balance, forKey: "user_balance")
+        return BalanceService(defaults: testDefaults, notificationCenter: NotificationCenter())
+    }
+
+    // MARK: - balanceMoney
+
+    func testBalanceMoney_freshServiceIsZero() {
+        let service = makeService(balance: 0)
+        XCTAssertEqual(service.balanceMoney, .zero)
+    }
+
+    func testBalanceMoney_reflectsPersistedDouble() {
+        let service = makeService(balance: 250)
+        XCTAssertEqual(service.balanceMoney, Money(250))
+    }
+
+    func testBalanceMoney_corruptNegativeFallsBackToZero() {
+        // Documented contract: a corrupted negative balance (e.g. from a
+        // hypothetical migration bug) must NOT crash. The typed view falls
+        // back to `.zero` instead of trapping on `Money(negative) -> nil`.
+        let service = makeService(balance: -100)
+        XCTAssertEqual(service.balanceMoney, .zero)
+    }
+
+    // MARK: - charge(_ Money, alarmID:)
+
+    func testCharge_money_succeedsWhenFundsAvailable() {
+        let service = makeService(balance: 100)
+        let didCharge = service.charge(Money(50)!, alarmID: nil)
+        XCTAssertTrue(didCharge)
+        XCTAssertEqual(service.balanceMoney, Money(50))
+    }
+
+    func testCharge_money_failsAndLeavesBalanceWhenInsufficient() {
+        let service = makeService(balance: 30)
+        let didCharge = service.charge(Money(50)!, alarmID: nil)
+        XCTAssertFalse(didCharge)
+        XCTAssertEqual(service.balanceMoney, Money(30))
+    }
+
+    // MARK: - topUp(_ Money)
+
+    func testTopUp_money_increasesBalanceByExactAmount() {
+        let service = makeService(balance: 100)
+        service.topUp(Money(50)!)
+        XCTAssertEqual(service.balanceMoney, Money(150))
+    }
+
+    // MARK: - canAfford(_ Money)
+
+    func testCanAfford_money_trueAtExactEquality() {
+        let service = makeService(balance: 50)
+        XCTAssertTrue(service.canAfford(Money(50)!))
+    }
+
+    func testCanAfford_money_falseWhenAboveBalance() {
+        let service = makeService(balance: 50)
+        XCTAssertFalse(service.canAfford(Money(50.01)!))
+    }
+}

--- a/SnoozePay/SnoozePayTests/MoneyTests.swift
+++ b/SnoozePay/SnoozePayTests/MoneyTests.swift
@@ -1,0 +1,123 @@
+import XCTest
+@testable import SnoozePay
+
+/// Unit tests for the `Money` value type — invariants, arithmetic, formatting,
+/// and Codable round-trip.
+final class MoneyTests: XCTestCase {
+
+    // MARK: - Construction & invariants
+
+    func testZeroIsValidAndZero() {
+        XCTAssertEqual(Money.zero.amount, 0)
+        XCTAssertEqual(Money.zero, Money(Decimal(0))!)
+    }
+
+    func testValidPositiveDecimal() {
+        let money = Money(Decimal(150))
+        XCTAssertNotNil(money)
+        XCTAssertEqual(money?.amount, 150)
+    }
+
+    func testNegativeDecimalRejected() {
+        XCTAssertNil(Money(Decimal(-1)))
+        XCTAssertNil(Money(Decimal(-0.01)))
+    }
+
+    func testNaNDecimalRejected() {
+        XCTAssertNil(Money(Decimal.nan))
+    }
+
+    func testNegativeDoubleRejected() {
+        XCTAssertNil(Money(-1.0))
+        XCTAssertNil(Money(-0.0001))
+    }
+
+    func testNaNDoubleRejected() {
+        XCTAssertNil(Money(Double.nan))
+    }
+
+    func testInfiniteDoubleRejected() {
+        XCTAssertNil(Money(Double.infinity))
+        XCTAssertNil(Money(-Double.infinity))
+    }
+
+    func testNegativeIntRejected() {
+        XCTAssertNil(Money(-5))
+    }
+
+    // MARK: - Arithmetic
+
+    func testAdditionExact() {
+        // The classic 0.1 + 0.2 case — Decimal must be exact, unlike Double.
+        let lhs = Money(Decimal(string: "0.1")!)!
+        let rhs = Money(Decimal(string: "0.2")!)!
+        let expected = Money(Decimal(string: "0.3")!)!
+        XCTAssertEqual(lhs + rhs, expected)
+    }
+
+    func testSubtractionWithinRange() {
+        let lhs = Money(100)!
+        let rhs = Money(30)!
+        XCTAssertEqual(lhs - rhs, Money(70)!)
+    }
+
+    func testSubtractionUnderflowReturnsNil() {
+        let lhs = Money(50)!
+        let rhs = Money(75)!
+        XCTAssertNil(lhs - rhs, "Subtraction below zero must return nil, not a negative Money")
+    }
+
+    func testMultipliedByPositive() {
+        let base = Money(50)!
+        XCTAssertEqual(base.multiplied(by: 4)?.amount, 200)
+    }
+
+    func testMultipliedByNegativeRejected() {
+        let base = Money(50)!
+        XCTAssertNil(base.multiplied(by: -1))
+    }
+
+    // MARK: - Ordering
+
+    func testOrdering() {
+        let small = Money(10)!
+        let large = Money(100)!
+        XCTAssertTrue(small < large)
+        XCTAssertTrue(large > small)
+        XCTAssertTrue(small <= small)
+        XCTAssertTrue(small >= small)
+    }
+
+    // MARK: - Equality
+
+    func testEqualityFromDifferentSources() {
+        // Constructed from Int and Decimal must compare equal when amounts match.
+        XCTAssertEqual(Money(100)!, Money(Decimal(100))!)
+    }
+
+    // MARK: - Bridging to Double
+
+    func testToDoubleRoundTrip() {
+        let money = Money(149)!
+        XCTAssertEqual(money.toDouble(), 149)
+    }
+
+    // MARK: - Formatting
+
+    func testFormattedRussianRubles() {
+        let formatted = Money(150)!.formatted()
+        // The exact glyph for ruble + spacing is locale-specific; assert
+        // on the parts that matter rather than the whole string.
+        XCTAssertTrue(formatted.contains("150"), "Formatted output should contain the amount: \(formatted)")
+        XCTAssertTrue(formatted.contains("₽"), "Formatted output should contain the ruble sign: \(formatted)")
+    }
+
+    // MARK: - Codable
+
+    func testCodableRoundTrip() throws {
+        let original = Money(Decimal(string: "12345.67")!)!
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(Money.self, from: data)
+        XCTAssertEqual(decoded, original)
+    }
+}

--- a/SnoozePay/SnoozePayTests/TimeOfDayTests.swift
+++ b/SnoozePay/SnoozePayTests/TimeOfDayTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+@testable import SnoozePay
+
+/// Unit tests for the `TimeOfDay` value type — range validation and date projection.
+final class TimeOfDayTests: XCTestCase {
+
+    // MARK: - Construction
+
+    func testValidBoundaries() {
+        XCTAssertNotNil(TimeOfDay(hour: 0, minute: 0))
+        XCTAssertNotNil(TimeOfDay(hour: 23, minute: 59))
+        XCTAssertNotNil(TimeOfDay(hour: 12, minute: 30))
+    }
+
+    func testHourOutOfRangeRejected() {
+        XCTAssertNil(TimeOfDay(hour: -1, minute: 0))
+        XCTAssertNil(TimeOfDay(hour: 24, minute: 0))
+        XCTAssertNil(TimeOfDay(hour: 99, minute: 0))
+    }
+
+    func testMinuteOutOfRangeRejected() {
+        XCTAssertNil(TimeOfDay(hour: 8, minute: -1))
+        XCTAssertNil(TimeOfDay(hour: 8, minute: 60))
+        XCTAssertNil(TimeOfDay(hour: 8, minute: 99))
+    }
+
+    // MARK: - From Date
+
+    func testFromDateExtractsComponents() {
+        // Build 2026-04-15 09:45 in UTC, extract via UTC calendar — exact components.
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        let components = DateComponents(
+            calendar: calendar,
+            year: 2026, month: 4, day: 15, hour: 9, minute: 45
+        )
+        guard let date = components.date else {
+            XCTFail("Failed to construct fixture date")
+            return
+        }
+        let tod = TimeOfDay(from: date, calendar: calendar)
+        XCTAssertEqual(tod, TimeOfDay(hour: 9, minute: 45))
+    }
+
+    // MARK: - To Date
+
+    func testToDatePreservesHourMinuteOnReferenceDay() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+
+        let referenceComponents = DateComponents(
+            calendar: calendar,
+            year: 2026, month: 4, day: 15, hour: 17, minute: 22
+        )
+        let reference = referenceComponents.date!
+
+        let tod = TimeOfDay(hour: 7, minute: 30)!
+        let projected = tod.toDate(on: reference, calendar: calendar)
+        XCTAssertNotNil(projected)
+
+        let projectedComponents = calendar.dateComponents(
+            [.year, .month, .day, .hour, .minute, .second],
+            from: projected!
+        )
+        XCTAssertEqual(projectedComponents.year, 2026)
+        XCTAssertEqual(projectedComponents.month, 4)
+        XCTAssertEqual(projectedComponents.day, 15)
+        XCTAssertEqual(projectedComponents.hour, 7)
+        XCTAssertEqual(projectedComponents.minute, 30)
+        XCTAssertEqual(projectedComponents.second, 0)
+    }
+
+    // MARK: - Codable
+
+    func testCodableRoundTrip() throws {
+        let original = TimeOfDay(hour: 6, minute: 15)!
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(TimeOfDay.self, from: data)
+        XCTAssertEqual(decoded, original)
+    }
+}

--- a/SnoozePay/SnoozePayTests/WeekdayTests.swift
+++ b/SnoozePay/SnoozePayTests/WeekdayTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+@testable import SnoozePay
+
+/// Unit tests for the `Weekday` enum — Calendar convention, legacy bridge,
+/// and display labels.
+final class WeekdayTests: XCTestCase {
+
+    // MARK: - Calendar.weekday convention (1 = Sunday … 7 = Saturday)
+
+    func testRawValuesMatchCalendarConvention() {
+        // iOS `DateComponents.weekday` and `UNCalendarNotificationTrigger`
+        // both use 1 = Sunday … 7 = Saturday. Lock that in.
+        XCTAssertEqual(Weekday.sunday.rawValue, 1)
+        XCTAssertEqual(Weekday.monday.rawValue, 2)
+        XCTAssertEqual(Weekday.tuesday.rawValue, 3)
+        XCTAssertEqual(Weekday.wednesday.rawValue, 4)
+        XCTAssertEqual(Weekday.thursday.rawValue, 5)
+        XCTAssertEqual(Weekday.friday.rawValue, 6)
+        XCTAssertEqual(Weekday.saturday.rawValue, 7)
+    }
+
+    func testRawValueMatchesGregorianWeekday() {
+        // Cross-check against an actual Date — 2026-04-12 is a Sunday.
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        let sundayComponents = DateComponents(
+            calendar: calendar,
+            year: 2026, month: 4, day: 12
+        )
+        let sundayDate = sundayComponents.date!
+        let weekdayInt = calendar.component(.weekday, from: sundayDate)
+        XCTAssertEqual(weekdayInt, Weekday.sunday.rawValue)
+    }
+
+    // MARK: - Legacy bridge (Mon=0 … Sun=6)
+
+    func testLegacyIndexRoundTripAllDays() {
+        for weekday in Weekday.allCases {
+            let index = weekday.legacyMondayFirstIndex
+            XCTAssertEqual(Weekday(legacyMondayFirstIndex: index), weekday)
+        }
+    }
+
+    func testLegacyIndexBoundaries() {
+        XCTAssertEqual(Weekday(legacyMondayFirstIndex: 0), .monday)
+        XCTAssertEqual(Weekday(legacyMondayFirstIndex: 6), .sunday)
+    }
+
+    func testLegacyIndexOutOfRangeRejected() {
+        XCTAssertNil(Weekday(legacyMondayFirstIndex: -1))
+        XCTAssertNil(Weekday(legacyMondayFirstIndex: 7))
+        XCTAssertNil(Weekday(legacyMondayFirstIndex: 99))
+    }
+
+    // MARK: - Set<Weekday> bridge
+
+    func testSetFromLegacyIndices() {
+        let set = Set<Weekday>(legacyMondayFirstIndices: [0, 2, 6])
+        XCTAssertEqual(set, [.monday, .wednesday, .sunday])
+    }
+
+    func testSetFromLegacyDropsOutOfRange() {
+        // The legacy storage allowed any Int; the typed view skips invalid ones
+        // rather than crashing existing user data.
+        let set = Set<Weekday>(legacyMondayFirstIndices: [0, 99, 5, -1])
+        XCTAssertEqual(set, [.monday, .saturday])
+    }
+
+    func testSetRoundTripToLegacyIndicesIsSorted() {
+        let set: Set<Weekday> = [.sunday, .monday, .friday]
+        // Round-tripped indices come back sorted Mon→Sun
+        XCTAssertEqual(set.legacyMondayFirstIndices, [0, 4, 6])
+    }
+
+    // MARK: - Display
+
+    func testLocalizedShortNamesMatchExistingUI() {
+        // Must match the labels currently used by `Alarm.repeatDaysDescription`.
+        XCTAssertEqual(Weekday.monday.localizedShortName, "Пн")
+        XCTAssertEqual(Weekday.tuesday.localizedShortName, "Вт")
+        XCTAssertEqual(Weekday.wednesday.localizedShortName, "Ср")
+        XCTAssertEqual(Weekday.thursday.localizedShortName, "Чт")
+        XCTAssertEqual(Weekday.friday.localizedShortName, "Пт")
+        XCTAssertEqual(Weekday.saturday.localizedShortName, "Сб")
+        XCTAssertEqual(Weekday.sunday.localizedShortName, "Вс")
+    }
+}


### PR DESCRIPTION
Partially addresses #31 (phase 1).

## Scope

This PR introduces three value types to address the type-design-analyzer findings on `Alarm`, `Transaction`, `BalanceService` — but **only as a parallel typed API alongside the existing primitives**. Underlying storage and Codable representation are unchanged, so persisted UserDefaults JSON keeps decoding. No existing call site is touched; ViewModels and ViewControllers continue to use the `Double` / `[Int]` / `Date` API.

This split is deliberate: doing the full migration in one PR would touch >20 call sites (`AlarmsListViewModel`, `CreateAlarmViewModel`, `AlarmFiringViewModel`, `StatisticsViewModel`, `SettingsViewController`, `TopUpViewController`, `StoreKitService`, `AlarmScheduler`, ...) and risk merge conflicts with concurrent work. Phase 2 will land separately.

## What's added

**`Models/Money.swift`** — `Decimal`-backed value type for currency.
- Failable inits reject negative, NaN, infinite — invalid amounts can't reach the ledger.
- Saturating subtraction (`Money - Money -> Money?`) — underflow surfaces as `nil`, not a runtime trap.
- Exact arithmetic: `0.1 + 0.2 == 0.3` (the classic `Double` precision bug).
- `formatted(currencyCode:locale:fractionDigits:)` for UI.
- `toDouble()` bridge to legacy callers (removed in phase 2).

**`Models/TimeOfDay.swift`** — wall-clock time decoupled from any date.
- Validated `(0...23, 0...59)` failable init — out-of-range returns `nil` instead of clamping silently.
- `init?(from: Date, calendar:)` and `toDate(on:calendar:)` for bridging.

**`Models/Weekday.swift`** — `enum` aligned with `Calendar.weekday` (1=Sun..7=Sat).
- `rawValue` is directly usable in `UNCalendarNotificationTrigger` — no off-by-one bridging.
- `init?(legacyMondayFirstIndex:)` and `legacyMondayFirstIndex` bridge to/from the project's existing `Alarm.repeatDays: [Int]` convention (0=Mon..6=Sun).
- `Set<Weekday>` extension converts a legacy `[Int]` to a typed set, dropping out-of-range entries (existing storage allows them).
- `localizedShortName` matches the existing UI labels ("Пн", "Вт", ...).

## How it integrates

Three computed properties on `Alarm`:
- `var timeOfDay: TimeOfDay?`
- `var weekdays: Set<Weekday>`
- `var penaltyMoney: Money?`

One on `Transaction`:
- `var money: Money?`

Money-typed overloads on `BalanceService`:
- `var balanceMoney: Money`
- `func charge(_ amount: Money, alarmID: UUID?) -> Bool`
- `func topUp(_ amount: Money)`
- `func canAfford(_ amount: Money) -> Bool`

All thin wrappers over the existing `Double` API. Existing tests and call sites continue to work unchanged.

## Tests added

- `MoneyTests` — invariants (negative/NaN/infinite rejection from `Decimal`, `Double`, `Int`), exact arithmetic, saturating subtraction, ordering, formatting, Codable round-trip.
- `TimeOfDayTests` — boundary validation, `Date <-> TimeOfDay` bridges with explicit UTC calendar fixture, Codable round-trip.
- `WeekdayTests` — `Calendar.weekday` convention cross-checked against an actual Sunday date, legacy index round-trip for all cases, `Set` bridge dropping out-of-range entries, localized labels.

## Verify

- swiftlint: 0 errors on touched files (2 preexisting warnings on `TransactionType` raw values left untouched — out of scope).
- build_sim: succeeded on iPhone 17 Pro.
- TEST BUILD SUCCEEDED via `xcodebuild build-for-testing` — tests compile cleanly into the test target.
- test_sim / screenshot / qa-tester: skipped per project policy (gates currently disabled).

## Phase 2 (deferred to follow-up issue, scoped in #31 body)

- Migrate all callers to the typed API, drop `Double` parameters from `BalanceService`.
- `enum PenaltyPolicy { case flat(Money); case progressive(base: Money) }` collapsing `(penaltyAmount, progressiveScale)`.
- `enum TransactionKind` collapsing `(type, alarmID)`.
- `Identifier<T>` phantom-type wrapper for UUID.
- Lock `Alarm` fields to `let` + `with(...)` mutation API; failable init validating `snoozeMinutes`, dedup `repeatDays`, `soundID` enum.

These each require persisted-JSON migration thought, hence the split.