### PR TITLE
[ui] Replace dollar icon with rublesign on TopUp packages (#57)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Settings/TopUpViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/TopUpViewController.swift
@@ -330,7 +330,7 @@ final class TopUpPackageCell: UITableViewCell {
 
     private let coinIcon: UIImageView = {
         let imageView = UIImageView()
-        imageView.image = UIImage(systemName: "dollarsign.circle.fill")?.withConfiguration(
+        imageView.image = UIImage(systemName: "rublesign.circle.fill")?.withConfiguration(
             UIImage.SymbolConfiguration(pointSize: 28, weight: .medium)
         )
         imageView.tintColor = AppColors.accentOrange


### PR DESCRIPTION
Fixes #57

## What changed
- `TopUpViewController.swift` — заменён SF Symbol `dollarsign.circle.fill` на `rublesign.circle.fill` в `coinIcon` пакетов TopUp. Иконка теперь визуально соответствует валюте (₽).

## Verify
- swiftlint: 0 errors (только pre-existing warning `file_length`, не относится к правке)
- build_sim: succeeded (simulator: iPhone 16e)
- test_sim: skipped (UI-only one-line change, gate отключён)
- screenshot: skipped (gate отключён)

## Notes
Найдено ещё одно место с `dollarsign.circle` — `SettingsViewController.swift:165`. Не правил в этом PR (вне scope #57). Если PM хочет — отдельный issue.

`UIImage(systemName: "rublesign.circle.fill")` доступен начиная с iOS 13 / SF Symbols 1, target iOS 26.3 — OK.