### PR TITLE
[fix] Remove double ₽ prefix on balance banner (#55)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
@@ -227,7 +227,9 @@ class AlarmsListViewController: UIViewController {
 
         viewModel.onBalanceUpdated = { [weak self] _ in
             guard let self else { return }
-            self.balanceAmountLabel.text = "₽ \(self.viewModel.formattedBalance)"
+            // `formattedBalance` already includes the "₽" suffix (e.g. "0 ₽").
+            // Adding a "₽ " prefix here previously rendered "₽ 0 ₽" (issue #55).
+            self.balanceAmountLabel.text = self.viewModel.formattedBalance
         }
     }
 

--- a/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
@@ -98,6 +98,35 @@ final class AlarmsListViewModelTests: XCTestCase {
         XCTAssertTrue(vm.formattedBalance.contains("₽"))
     }
 
+    /// Regression for issue #55: the balance banner previously showed "₽ 0 ₽" because
+    /// AlarmsListViewController prepended "₽ " to a string that already had a " ₽" suffix.
+    /// `formattedBalance` is the single source of truth for the banner — it MUST contain
+    /// exactly one ruble glyph, and the controller MUST render it verbatim (no extra prefix).
+    func testFormattedBalance_containsExactlyOneRubleSign() {
+        let vm = makeViewModel()
+        let occurrences = vm.formattedBalance.filter { $0 == "₽" }.count
+        XCTAssertEqual(
+            occurrences, 1,
+            "formattedBalance must contain exactly one ₽ symbol — saw \"\(vm.formattedBalance)\""
+        )
+    }
+
+    /// Sibling assertion to `testFormattedBalance_containsExactlyOneRubleSign`:
+    /// the formatted string must end with the ruble suffix (Russian convention is
+    /// "X ₽", not "₽X"). A regression toward prefix style would silently break the
+    /// banner layout; encode the convention explicitly here.
+    func testFormattedBalance_endsWithRubleSuffix() {
+        let vm = makeViewModel()
+        XCTAssertTrue(
+            vm.formattedBalance.hasSuffix("₽"),
+            "formattedBalance must end with ₽ (suffix style); got \"\(vm.formattedBalance)\""
+        )
+        XCTAssertFalse(
+            vm.formattedBalance.hasPrefix("₽"),
+            "formattedBalance must NOT start with ₽; got \"\(vm.formattedBalance)\""
+        )
+    }
+
     // MARK: - toggleAlarm(at:enabled:)
 
     func testToggleAlarm_updatesInMemoryState() {


### PR DESCRIPTION
Fixes #55

## Симптом
Баннер БАЛАНС в AlarmsListVC показывал `₽ 0 ₽` — символ рубля дважды.

## Корневая причина
`AlarmsListViewController.swift:230` префиксил `"₽ "` к строке, которая уже содержит суффикс `" ₽"` (`AlarmsListViewModel.formattedBalance`):
- VC: `"₽ \(viewModel.formattedBalance)"`
- VM: `"\(Int(balance)) ₽"`
- → `"₽ " + "0 ₽" = "₽ 0 ₽"`

## Что сделано
- Убран prefix в VC — рендерится только `viewModel.formattedBalance` (already `"X ₽"` suffix-style, что соответствует русской конвенции).
- Добавлены 2 regression-теста на `AlarmsListViewModel.formattedBalance`:
  - `testFormattedBalance_containsExactlyOneRubleSign` — ровно один `₽`.
  - `testFormattedBalance_endsWithRubleSuffix` — заканчивается на `₽`, не начинается с него.

## Scope (намеренно минимальный)
Полная унификация валютного форматирования (CurrencyFormatter helper для всех 13+ callsites) — отдельный issue/PR. Этот PR фиксит только конкретный баннер, не задевая `CreateAlarmViewController.swift` (параллельный PR Dev-1 #52).

## Verify
- ✅ swiftlint: 0 errors в моих файлах (existing warnings про `vm` identifier и function_body_length — pre-existing, не из этого diff).
- ✅ build_sim: succeeded (simulator: iPhone 17 Pro Max).
- ⏭ test_sim: gate отключён глобально (см. CLAUDE.md memory). Новые tests запустит pr-test-analyzer.
- ⏭ screenshot: gate отключён глобально.

## Файлы
- `SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift` — drop prefix.
- `SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift` — +2 regression tests.