### PR TITLE
[ui] Add delete button to CreateAlarmVC + harden swipe-to-delete (#50)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
@@ -317,14 +317,23 @@ extension AlarmsListViewController: UITableViewDelegate {
                 completion(false)
                 return
             }
-            // Guard against stale indexPath: the table may have already mutated
-            // (delete from detail screen, programmatic reload) since the swipe
-            // gesture began. Without this check we'd index past `alarms.count`.
+            // Capture the alarm id before the action fires so a concurrent mutation
+            // that re-orders rows (delete from detail, programmatic reload) cannot
+            // make us delete the wrong alarm. Index-based delete would silently
+            // drop whichever alarm now sits at the swiped row, with no feedback
+            // to the user. Identity-based delete short-circuits if the alarm has
+            // already been removed and triggers a full reload to resync the UI.
             guard indexPath.row < self.viewModel.alarms.count else {
+                self.viewModel.loadData()
                 completion(false)
                 return
             }
-            self.viewModel.deleteAlarm(at: indexPath.row)
+            let alarmID = self.viewModel.alarms[indexPath.row].id
+            guard self.viewModel.deleteAlarm(id: alarmID) else {
+                self.viewModel.loadData()
+                completion(false)
+                return
+            }
             tableView.deleteRows(at: [indexPath], with: .automatic)
             completion(true)
         }

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
@@ -292,9 +292,16 @@ extension AlarmsListViewController: UITableViewDataSource {
 extension AlarmsListViewController: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
         let alarm = viewModel.alarms[indexPath.row]
         let editVC = CreateAlarmViewController(alarm: alarm)
         editVC.onSave = { [weak self] in
+            self?.viewModel.loadData()
+        }
+        // Re-fetch from the source of truth instead of mutating by row index —
+        // the row that was tapped may have shifted after another in-flight
+        // delete (e.g. swipe + detail open near-simultaneously).
+        editVC.onDelete = { [weak self] in
             self?.viewModel.loadData()
         }
         let nav = UINavigationController(rootViewController: editVC)
@@ -306,10 +313,26 @@ extension AlarmsListViewController: UITableViewDelegate {
         trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath
     ) -> UISwipeActionsConfiguration? {
         let delete = UIContextualAction(style: .destructive, title: "Удалить") { [weak self] _, _, completion in
-            self?.viewModel.deleteAlarm(at: indexPath.row)
+            guard let self else {
+                completion(false)
+                return
+            }
+            // Guard against stale indexPath: the table may have already mutated
+            // (delete from detail screen, programmatic reload) since the swipe
+            // gesture began. Without this check we'd index past `alarms.count`.
+            guard indexPath.row < self.viewModel.alarms.count else {
+                completion(false)
+                return
+            }
+            self.viewModel.deleteAlarm(at: indexPath.row)
             tableView.deleteRows(at: [indexPath], with: .automatic)
             completion(true)
         }
+        // SF Symbol gives the action a recognisable affordance even before the
+        // user has read the title — addresses the PM feedback that the swipe
+        // gesture was not obvious.
+        delete.image = UIImage(systemName: "trash")
+        delete.backgroundColor = .systemRed
         return UISwipeActionsConfiguration(actions: [delete])
     }
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
@@ -8,6 +8,10 @@ class CreateAlarmViewController: UIViewController {
     // MARK: - Properties
 
     var onSave: (() -> Void)?
+    /// Invoked after the user confirms deletion of the alarm being edited so the
+    /// presenter can refresh its list. Defaults to nil for new alarms (delete row
+    /// is hidden in create mode).
+    var onDelete: (() -> Void)?
     private let viewModel: CreateAlarmViewModel
 
     // MARK: - UI
@@ -104,6 +108,10 @@ class CreateAlarmViewController: UIViewController {
         case penalty
         case progressiveScale
         case snoozeTime
+        /// Destructive "Удалить будильник" row — only visible in edit mode.
+        /// In create mode `numberOfRowsInSection` returns 0, hiding the section
+        /// entirely (including its background pill).
+        case deleteAction
     }
 
     // MARK: - Init
@@ -298,6 +306,10 @@ extension CreateAlarmViewController: UITableViewDataSource {
         switch sec {
         case .progressiveScale:
             return viewModel.progressiveScale ? 2 : 1
+        case .deleteAction:
+            // Hide the destructive row entirely when creating a new alarm —
+            // there's nothing to delete yet.
+            return viewModel.isEditing ? 1 : 0
         default:
             return 1
         }
@@ -314,6 +326,7 @@ extension CreateAlarmViewController: UITableViewDataSource {
         case .penalty: return "ШТРАФ ЗА ОТКЛАДЫВАНИЕ"
         case .progressiveScale: return nil
         case .snoozeTime: return "ВРЕМЯ ОТКЛАДЫВАНИЯ"
+        case .deleteAction: return nil
         }
     }
 
@@ -409,6 +422,16 @@ extension CreateAlarmViewController: UITableViewDataSource {
             cell.detailTextLabel?.text = snoozeMinutesText
             cell.detailTextLabel?.textColor = .label
             cell.accessoryView = snoozeStepper
+
+        case .deleteAction:
+            // Centered red text mimics iOS Settings' destructive row pattern
+            // (see Calendar.app "Delete Event"). selectionStyle=.default to give
+            // the user tactile feedback before the confirmation alert appears.
+            cell.textLabel?.text = "Удалить будильник"
+            cell.textLabel?.textColor = .systemRed
+            cell.textLabel?.textAlignment = .center
+            cell.textLabel?.font = UIFont.systemFont(ofSize: 17, weight: .regular)
+            cell.selectionStyle = .default
         }
 
         return cell
@@ -502,9 +525,40 @@ extension CreateAlarmViewController: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        guard let section = Section(rawValue: indexPath.section), section == .sound else { return }
-        // Sound picker navigation — simple action sheet for MVP
-        showSoundPicker()
+        guard let section = Section(rawValue: indexPath.section) else { return }
+        switch section {
+        case .sound:
+            // Sound picker navigation — simple action sheet for MVP
+            showSoundPicker()
+        case .deleteAction:
+            confirmDelete()
+        default:
+            return
+        }
+    }
+
+    private func confirmDelete() {
+        let alert = UIAlertController(
+            title: "Удалить будильник?",
+            message: "Это действие нельзя отменить.",
+            preferredStyle: .actionSheet
+        )
+        alert.addAction(UIAlertAction(title: "Удалить", style: .destructive) { [weak self] _ in
+            guard let self else { return }
+            // ViewModel.delete forwards to AlarmRepository.delete, which itself
+            // cancels the scheduled UNNotificationRequests via AlarmScheduler.
+            self.viewModel.delete()
+            self.onDelete?()
+            self.dismiss(animated: true)
+        })
+        alert.addAction(UIAlertAction(title: "Отмена", style: .cancel))
+        // Without a sourceView the action sheet crashes on iPad popovers.
+        if let popover = alert.popoverPresentationController {
+            popover.sourceView = view
+            popover.sourceRect = CGRect(x: view.bounds.midX, y: view.bounds.midY, width: 0, height: 0)
+            popover.permittedArrowDirections = []
+        }
+        present(alert, animated: true)
     }
 
     private func showSoundPicker() {

--- a/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
@@ -111,8 +111,21 @@ final class AlarmsListViewModel {
 
     func deleteAlarm(at index: Int) {
         guard index < alarms.count else { return }
-        alarmRepository.delete(id: alarms[index].id)
+        deleteAlarm(id: alarms[index].id)
+    }
+
+    /// Identity-based delete — preferred over index-based when triggered by
+    /// async UI events (swipe handlers) where the visible index may have
+    /// drifted from the data-source row by the time the action fires.
+    @discardableResult
+    func deleteAlarm(id: UUID) -> Bool {
+        guard let index = alarms.firstIndex(where: { $0.id == id }) else {
+            print("[AlarmsListViewModel] deleteAlarm: id \(id) not in current snapshot")
+            return false
+        }
+        alarmRepository.delete(id: id)
         alarms.remove(at: index)
+        return true
     }
 
     // MARK: - Formatted balance

--- a/SnoozePay/SnoozePay/ViewModels/CreateAlarmViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/CreateAlarmViewModel.swift
@@ -61,6 +61,19 @@ final class CreateAlarmViewModel {
         return alarmRepository.save(alarm)
     }
 
+    // MARK: - Delete
+
+    /// Removes the alarm being edited. Returns `false` for new (unsaved) alarms,
+    /// where there is nothing to delete — the caller should treat this case as a
+    /// no-op (the user can simply cancel out of the create screen instead).
+    /// Cancelling the scheduled notification is handled by `AlarmRepository.delete`.
+    @discardableResult
+    func delete() -> Bool {
+        guard let id = existingID else { return false }
+        alarmRepository.delete(id: id)
+        return true
+    }
+
     // MARK: - Day toggle helpers
 
     func toggleDay(_ day: Int) {

--- a/SnoozePay/SnoozePayTests/CreateAlarmViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/CreateAlarmViewModelTests.swift
@@ -230,6 +230,49 @@ final class CreateAlarmViewModelSoundTests: XCTestCase {
         XCTAssertEqual(alarms.first?.penaltyAmount, 200)
     }
 
+    // MARK: - Delete (issue #50)
+
+    func testDelete_existingAlarm_removesFromRepository() {
+        // Persist an alarm directly so the VM thinks it's editing an existing one.
+        let original = Alarm(name: "Утро", penaltyAmount: 100)
+        repo.save(original)
+        XCTAssertEqual(repo.fetchAll().count, 1)
+
+        let vm = CreateAlarmViewModel(alarm: original, repository: repo)
+        XCTAssertTrue(vm.isEditing)
+
+        let didDelete = vm.delete()
+        XCTAssertTrue(didDelete)
+        XCTAssertEqual(repo.fetchAll().count, 0)
+    }
+
+    func testDelete_newAlarm_isNoOp() {
+        // No existingID → there's nothing to delete. The VM should refuse and
+        // return false so the VC can short-circuit (no alert dismiss, etc.).
+        let vm = CreateAlarmViewModel(repository: repo)
+        XCTAssertFalse(vm.isEditing)
+
+        let didDelete = vm.delete()
+        XCTAssertFalse(didDelete)
+        XCTAssertEqual(repo.fetchAll().count, 0)
+    }
+
+    func testDelete_existingAlarm_doesNotAffectOtherAlarms() {
+        // Two alarms, delete one — the other must survive.
+        let alpha = Alarm(name: "Альфа")
+        let beta = Alarm(name: "Бета")
+        repo.save(alpha)
+        repo.save(beta)
+        XCTAssertEqual(repo.fetchAll().count, 2)
+
+        let vm = CreateAlarmViewModel(alarm: alpha, repository: repo)
+        vm.delete()
+
+        let remaining = repo.fetchAll()
+        XCTAssertEqual(remaining.count, 1)
+        XCTAssertEqual(remaining.first?.name, "Бета")
+    }
+
     func testInit_fromExistingAlarm_loadsValues() {
         let alarm = Alarm(
             repeatDays: [0, 2, 4],


### PR DESCRIPTION
Fixes #50

## Что сделано

**A. Кнопка "Удалить будильник" в детальном экране (edit-режим)**
- Новая секция `Section.deleteAction` в `CreateAlarmViewController` — рендерит красную центрированную ячейку, видна только когда `viewModel.isEditing == true` (для нового будильника `numberOfRowsInSection` возвращает 0, секция полностью скрыта).
- Тап → `UIAlertController` (.actionSheet) с подтверждением "Удалить будильник? Это действие нельзя отменить." Кнопки `Удалить` (destructive) / `Отмена` (cancel).
- На подтверждение → `viewModel.delete()` → `onDelete` callback → `dismiss`. Список обновляется через `loadData()` в callback'е.
- Popover sourceView выставлен на случай iPad (без него action sheet крашит).

**B. `CreateAlarmViewModel.delete()`**
- Делегирует `AlarmRepository.delete(id:)`, который сам отменяет запланированные `UNNotificationRequest` через `AlarmScheduler.cancel`. Возвращает `false` для нового (не сохранённого) аларма — там удалять нечего.

**C. Hardening swipe-to-delete в списке**
- Добавлена `delete.image = UIImage(systemName: "trash")` — иконка корзины делает swipe action узнаваемым ещё до того как пользователь прочитает текст (PM-фидбэк: "swipe не очевиден").
- Guard против устаревшего `indexPath` в swipe handler — если row уже удалён через детальный экран до завершения свайпа, completion возвращает `false` вместо краша индексом за пределами `alarms.count`.
- `tableView.deselectRow` в `didSelectRowAt` чтобы row не оставался подсвеченным после возврата из детального экрана.

## Verify
- swiftlint: 0 new errors в моих файлах (4 pre-existing errors в идентификаторах `s`/`l` — не трогал)
- build_sim (iPhone 17 Pro): succeeded
- Новые тесты в `CreateAlarmViewModelTests.swift`:
  - `testDelete_existingAlarm_removesFromRepository` — удаление снимает alarm из repository
  - `testDelete_newAlarm_isNoOp` — для не-edit VM возвращает false, ничего не трогает
  - `testDelete_existingAlarm_doesNotAffectOtherAlarms` — удаляется только нужный alarm

## Acceptance (из issue)
- [x] Swipe-to-delete виден и удаляет (теперь с иконкой trash)
- [x] Кнопка видна только при редактировании существующего
- [x] Confirmation alert перед удалением
- [x] После удаления экран закрывается, список обновляется
- [x] Уведомление снимается из системы (через `AlarmRepository.delete` → `AlarmScheduler.cancel`)
- [x] Локализация на русском: "Удалить будильник", "Удалить", "Отмена", "Это действие нельзя отменить."

🤖 Generated with [Claude Code](https://claude.com/claude-code)