### PR TITLE
[fix] Cancel one-off alarm notification on delete (#70)

### DIFF
--- a/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
@@ -116,11 +116,27 @@ final class AlarmScheduler {
 
     // MARK: - Cancel
 
+    /// Cancel every notification scheduled for the given alarm, regardless of trigger label
+    /// (e.g. `day0`-`day6`, `once`, future labels) and the snooze follow-up.
+    ///
+    /// We fetch pending requests and filter by `alarmID` prefix instead of hard-coding the
+    /// label list — this prevents regressions like IOS-070 where a one-off (`once`) alarm
+    /// kept ringing after deletion because its identifier was missing from the cancel set.
     func cancel(_ alarmID: UUID) {
-        let allIDs = (0...6).map { notificationID(for: alarmID, trigger: "day\($0)") }
-            + [snoozeNotificationID(for: alarmID)]
-        notificationCenter.removePendingNotificationRequests(withIdentifiers: allIDs)
-        notificationCenter.removeDeliveredNotifications(withIdentifiers: allIDs)
+        let prefix = notificationIDPrefix(for: alarmID)
+        let snoozeID = snoozeNotificationID(for: alarmID)
+        let belongsToAlarm: (String) -> Bool = { $0.hasPrefix(prefix) || $0 == snoozeID }
+
+        notificationCenter.getPendingNotificationRequests { [notificationCenter] requests in
+            let ids = requests.map { $0.identifier }.filter(belongsToAlarm)
+            guard !ids.isEmpty else { return }
+            notificationCenter.removePendingNotificationRequests(withIdentifiers: ids)
+        }
+        notificationCenter.getDeliveredNotifications { [notificationCenter] notifications in
+            let ids = notifications.map { $0.request.identifier }.filter(belongsToAlarm)
+            guard !ids.isEmpty else { return }
+            notificationCenter.removeDeliveredNotifications(withIdentifiers: ids)
+        }
     }
 
     func cancelAll() {
@@ -200,7 +216,13 @@ final class AlarmScheduler {
     }
 
     private func notificationID(for alarmID: UUID, trigger: String) -> String {
-        "alarm_\(alarmID.uuidString)_\(trigger)"
+        "\(notificationIDPrefix(for: alarmID))\(trigger)"
+    }
+
+    /// Shared prefix for every per-trigger notification belonging to an alarm.
+    /// Used by `cancel(_:)` to remove pending requests for any trigger label.
+    private func notificationIDPrefix(for alarmID: UUID) -> String {
+        "alarm_\(alarmID.uuidString)_"
     }
 
     private func snoozeNotificationID(for alarmID: UUID) -> String {

--- a/SnoozePay/SnoozePayTests/AlarmSchedulerTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmSchedulerTests.swift
@@ -161,4 +161,76 @@ final class AlarmSchedulerTests: XCTestCase {
         }
         wait(for: [expectation], timeout: 5.0)
     }
+
+    // MARK: - Cancel covers all trigger variants (regression for IOS-070)
+    //
+    // We add raw pending requests directly to UNUserNotificationCenter using the same
+    // identifier scheme AlarmScheduler.schedule() uses, then call cancel(_:) and verify
+    // that *every* variant — including the one-off "once" label that previously leaked —
+    // is removed. We can't go through schedule() in the test process because that
+    // requires notification permission and a real future trigger date.
+
+    func testCancel_removesAllVariantsIncludingOnce() {
+        let alarmID = UUID()
+        let center = UNUserNotificationCenter.current()
+        let prefix = "alarm_\(alarmID.uuidString)_"
+        let snoozePrefix = "snooze_\(alarmID.uuidString)"
+
+        // Identifiers that schedule() can produce: every weekday + once + snooze.
+        let labels = ["day0", "day1", "day2", "day3", "day4", "day5", "day6", "once"]
+        let scheduledIDs = labels.map { "\(prefix)\($0)" } + [snoozePrefix]
+
+        // Use a far-future trigger so requests are accepted as pending.
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 60 * 60 * 24, repeats: false)
+        let content = UNMutableNotificationContent()
+        content.title = "test"
+
+        let added = expectation(description: "all requests added")
+        added.expectedFulfillmentCount = scheduledIDs.count
+        for id in scheduledIDs {
+            let request = UNNotificationRequest(identifier: id, content: content, trigger: trigger)
+            center.add(request) { _ in added.fulfill() }
+        }
+        wait(for: [added], timeout: 5.0)
+
+        // Sanity: confirm at least one of our IDs landed in pending before we cancel.
+        let beforeCancel = expectation(description: "pending fetched before cancel")
+        var beforeIDs: Set<String> = []
+        center.getPendingNotificationRequests { requests in
+            beforeIDs = Set(requests.map { $0.identifier })
+            beforeCancel.fulfill()
+        }
+        wait(for: [beforeCancel], timeout: 5.0)
+
+        // If permission denied or scheduling silently dropped them, skip — the cancel
+        // logic is what we're testing, not UN's pre-permission scheduling behaviour.
+        let landedIDs = beforeIDs.intersection(scheduledIDs)
+        try XCTSkipIf(landedIDs.isEmpty,
+                      "UNUserNotificationCenter did not accept test requests in this environment")
+
+        // Act
+        scheduler.cancel(alarmID)
+
+        // Assert: poll up to 5s — cancel() goes through getPendingNotificationRequests
+        // which is async, so we need to give it time to complete.
+        let cancelled = expectation(description: "all variants cancelled")
+        var remainingIDs: Set<String> = []
+        let deadline = Date().addingTimeInterval(5.0)
+
+        func poll() {
+            center.getPendingNotificationRequests { requests in
+                remainingIDs = Set(requests.map { $0.identifier }).intersection(scheduledIDs)
+                if remainingIDs.isEmpty || Date() >= deadline {
+                    cancelled.fulfill()
+                } else {
+                    DispatchQueue.global().asyncAfter(deadline: .now() + 0.2) { poll() }
+                }
+            }
+        }
+        poll()
+        wait(for: [cancelled], timeout: 6.0)
+
+        XCTAssertTrue(remainingIDs.isEmpty,
+                      "cancel(_:) must remove every notification for the alarm — leaked: \(remainingIDs)")
+    }
 }


### PR DESCRIPTION
Fixes #70

## Что сделано
- `AlarmScheduler.cancel(_:)` теперь снимает любые pending/delivered нотификации для alarmID — fetch + filter по prefix `alarm_<id>_`, плюс отдельный snooze ID. Раньше hard-coded set покрывал только `day0..day6 + snooze`, поэтому one-off (`once`) будильник продолжал звонить после удаления.
- Извлечён helper `notificationIDPrefix(for:)` чтобы один источник правды для prefix у `schedule` и `cancel`.
- Добавлен regression test `testCancel_removesAllVariantsIncludingOnce`: добавляет сырые requests для всех label вариантов (day0..day6, once, snooze), вызывает cancel, проверяет что pending очищен.

## Verify
- swiftlint: 0 errors (только pre-existing for_where warnings в нетронутых строках)
- build_sim: succeeded (simulator: iPhone 17 Pro)
- test_sim: пропущен (test gate disabled per CLAUDE.md)

## No-touch zones
Не затронуты: entitlements, Info.plist, signing, новые SPM пакеты.