### PR TITLE
[fix] Switch repositories to shared instance to fix Release build and races (#69)

### DIFF
--- a/SnoozePay/SnoozePay/AppDelegate.swift
+++ b/SnoozePay/SnoozePay/AppDelegate.swift
@@ -182,8 +182,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             return
         }
 
-        let repo = AlarmRepository()
-        guard let alarm = repo.fetch(id: alarmID) else {
+        guard let alarm = AlarmRepository.shared.fetch(id: alarmID) else {
             print("[AppDelegate] alarm not found (repo returned nil for \(alarmID)), stopping audio")
             AudioService.shared.stopAlarmSound()
             return

--- a/SnoozePay/SnoozePay/Services/AlarmRepository.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmRepository.swift
@@ -13,19 +13,22 @@ final class AlarmRepository {
     private let queue = DispatchQueue(label: "com.snoozepay.alarms.serial")
     private static let log = OSLog(subsystem: "Ivan-Emelyanov.SnoozePay", category: "AlarmRepository")
 
-    /// Production code MUST use `AlarmRepository.shared`.
-    /// Direct construction creates an isolated instance with its own serial queue —
-    /// two such instances racing on the same UserDefaults key reintroduce the race
-    /// this class exists to prevent.
-    #if DEBUG
-    init(defaults: UserDefaults = .standard) {
+    /// Production code MUST use `AlarmRepository.shared` to avoid creating
+    /// isolated instances with separate serial queues (which reintroduces the
+    /// race this class exists to prevent).
+    ///
+    /// Tests inject a custom `UserDefaults` suite to stay isolated from app
+    /// state — that's why this initializer is `internal` rather than `private`.
+    /// Production call sites that pass no arguments would create an isolated
+    /// instance backed by `.standard`, defeating the singleton serialization,
+    /// so we deliberately omit the default value: callers must be explicit.
+    init(defaults: UserDefaults) {
         self.defaults = defaults
     }
-    #else
-    private init(defaults: UserDefaults = .standard) {
-        self.defaults = defaults
+
+    private convenience init() {
+        self.init(defaults: .standard)
     }
-    #endif
 
     // MARK: - Read
 

--- a/SnoozePay/SnoozePay/Services/BalanceService.swift
+++ b/SnoozePay/SnoozePay/Services/BalanceService.swift
@@ -23,31 +23,44 @@ final class BalanceService {
     private let queue = DispatchQueue(label: "com.snoozepay.balance.serial")
     private let notificationCenter: NotificationCenter
 
-    /// Production code MUST use `BalanceService.shared`.
-    /// Direct construction creates an isolated instance with its own serial queue —
-    /// two such instances racing on the same UserDefaults key reintroduce the race
-    /// this class exists to prevent.
-    #if DEBUG
+    /// Production code MUST use `BalanceService.shared` to avoid creating
+    /// isolated instances with separate serial queues (which reintroduces the
+    /// race this class exists to prevent).
+    ///
+    /// Tests inject a custom `UserDefaults` suite to stay isolated from app
+    /// state — that's why this initializer is `internal`. The `transactionRepository`
+    /// argument has no default to keep test ledgers explicit; tests that don't
+    /// care about the ledger pass `TransactionRepository(defaults: testDefaults)`.
     init(
-        defaults: UserDefaults = .standard,
-        transactionRepository: TransactionRepository = TransactionRepository(),
+        defaults: UserDefaults,
+        transactionRepository: TransactionRepository,
         notificationCenter: NotificationCenter = .default
     ) {
         self.defaults = defaults
         self.transactionRepository = transactionRepository
         self.notificationCenter = notificationCenter
     }
-    #else
-    private init(
-        defaults: UserDefaults = .standard,
-        transactionRepository: TransactionRepository = TransactionRepository(),
+
+    /// Convenience for tests that supply only `defaults`: builds a matching
+    /// ledger pinned to the same suite so charges land in the test store.
+    convenience init(
+        defaults: UserDefaults,
         notificationCenter: NotificationCenter = .default
     ) {
-        self.defaults = defaults
-        self.transactionRepository = transactionRepository
-        self.notificationCenter = notificationCenter
+        self.init(
+            defaults: defaults,
+            transactionRepository: TransactionRepository(defaults: defaults),
+            notificationCenter: notificationCenter
+        )
     }
-    #endif
+
+    private convenience init() {
+        self.init(
+            defaults: .standard,
+            transactionRepository: .shared,
+            notificationCenter: .default
+        )
+    }
 
     // MARK: - Read
 

--- a/SnoozePay/SnoozePay/Services/TransactionRepository.swift
+++ b/SnoozePay/SnoozePay/Services/TransactionRepository.swift
@@ -17,19 +17,21 @@ final class TransactionRepository {
         category: "TransactionRepository"
     )
 
-    /// Production code MUST use `TransactionRepository.shared`.
-    /// Direct construction creates an isolated instance with its own serial queue —
-    /// two such instances racing on the same UserDefaults key reintroduce the race
-    /// this class exists to prevent.
-    #if DEBUG
-    init(defaults: UserDefaults = .standard) {
+    /// Production code MUST use `TransactionRepository.shared` to avoid
+    /// creating isolated instances with separate serial queues (which
+    /// reintroduces the race this class exists to prevent).
+    ///
+    /// Tests inject a custom `UserDefaults` suite to stay isolated from app
+    /// state — that's why this initializer is `internal` rather than `private`.
+    /// We deliberately omit the default value so a stray `TransactionRepository()`
+    /// call site cannot bypass the singleton.
+    init(defaults: UserDefaults) {
         self.defaults = defaults
     }
-    #else
-    private init(defaults: UserDefaults = .standard) {
-        self.defaults = defaults
+
+    private convenience init() {
+        self.init(defaults: .standard)
     }
-    #endif
 
     // MARK: - Read
 

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController.swift
@@ -375,7 +375,7 @@ final class TransactionHistoryViewController: UIViewController {
     }()
 
     private var transactions: [Transaction] = []
-    private let alarmRepository = AlarmRepository()
+    private let alarmRepository = AlarmRepository.shared
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -399,7 +399,7 @@ final class TransactionHistoryViewController: UIViewController {
     }
 
     private func loadTransactions() {
-        transactions = TransactionRepository().fetchAll()
+        transactions = TransactionRepository.shared.fetchAll()
         tableView.reloadData()
     }
 }

--- a/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
@@ -25,7 +25,7 @@ final class AlarmFiringViewModel {
         alarm: Alarm,
         snoozeCount: Int = 0,
         balanceService: BalanceService = .shared,
-        alarmRepository: AlarmRepository = AlarmRepository(),
+        alarmRepository: AlarmRepository = .shared,
         scheduler: AlarmScheduler = .shared
     ) {
         self.alarm = alarm

--- a/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
@@ -29,7 +29,7 @@ final class AlarmsListViewModel {
     // MARK: - Init
 
     init(
-        alarmRepository: AlarmRepository = AlarmRepository(),
+        alarmRepository: AlarmRepository = .shared,
         balanceService: BalanceService = .shared
     ) {
         self.alarmRepository = alarmRepository

--- a/SnoozePay/SnoozePay/ViewModels/CreateAlarmViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/CreateAlarmViewModel.swift
@@ -26,7 +26,7 @@ final class CreateAlarmViewModel {
 
     // MARK: - Init
 
-    init(alarm: Alarm? = nil, repository: AlarmRepository = AlarmRepository()) {
+    init(alarm: Alarm? = nil, repository: AlarmRepository = .shared) {
         self.alarmRepository = repository
         self.existingID = alarm?.id
 

--- a/SnoozePay/SnoozePay/ViewModels/StatisticsViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/StatisticsViewModel.swift
@@ -41,7 +41,7 @@ final class StatisticsViewModel {
     // MARK: - Init
 
     init(
-        repository: TransactionRepository = TransactionRepository(),
+        repository: TransactionRepository = .shared,
         defaults: UserDefaults = .standard
     ) {
         self.transactionRepository = repository

--- a/SnoozePay/SnoozePayTests/AlarmFiringViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmFiringViewModelTests.swift
@@ -122,7 +122,7 @@ final class AlarmFiringViewModelIOS011Tests: XCTestCase {
     }
 
     func testDismiss_disablesNonRepeatingAlarm() {
-        let repo = AlarmRepository()
+        let repo = AlarmRepository(defaults: .standard)
         var alarm = Alarm(penaltyAmount: 50)
         alarm.repeatDays = []
         alarm.enabled = true
@@ -140,7 +140,7 @@ final class AlarmFiringViewModelIOS011Tests: XCTestCase {
     }
 
     func testDismiss_keepsRepeatingAlarmEnabled() {
-        let repo = AlarmRepository()
+        let repo = AlarmRepository(defaults: .standard)
         var alarm = Alarm(penaltyAmount: 50)
         alarm.repeatDays = [0, 1, 2, 3, 4] // Weekdays
         alarm.enabled = true
@@ -162,7 +162,7 @@ final class AlarmFiringViewModelIOS011Tests: XCTestCase {
     /// must not crash and must not leak any user-facing error — the desired
     /// end-state is already achieved.
     func testDismiss_alarmAlreadyRemoved_doesNotCrash() {
-        let repo = AlarmRepository()
+        let repo = AlarmRepository(defaults: .standard)
         var alarm = Alarm(penaltyAmount: 50)
         alarm.repeatDays = []
         alarm.enabled = true

--- a/SnoozePay/SnoozePayTests/BalanceServiceTests.swift
+++ b/SnoozePay/SnoozePayTests/BalanceServiceTests.swift
@@ -406,7 +406,7 @@ final class CreateAlarmViewModelTests: XCTestCase {
         vm.name = ""
         vm.save()
         // Verify the alarm was saved with default name
-        let saved = AlarmRepository().fetchAll().last
+        let saved = AlarmRepository(defaults: .standard).fetchAll().last
         XCTAssertEqual(saved?.name, "Будильник")
     }
 }


### PR DESCRIPTION
Fixes #69

## Что сделано
- Все production call sites переключены на `.shared`: `AppDelegate`, `AlarmsListViewModel`, `CreateAlarmViewModel`, `AlarmFiringViewModel`, `SettingsViewController` (alarms repo + transactions repo), `StatisticsViewModel`. Теперь все читатели/писатели UserDefaults идут через один serial queue.
- В `AlarmRepository` / `TransactionRepository` / `BalanceService` убран `#if DEBUG` gate. Оставлен `internal init(defaults:)` без default-аргумента (для тестов, инжектящих свой `UserDefaults` suite) и `private convenience init()`, который вызывает только `.shared`. Production-call вида `AlarmRepository()` больше **не компилируется** ни в Debug, ни в Release.
- `BalanceService` получил `convenience init(defaults:notificationCenter:)` — собирает совпадающий `TransactionRepository(defaults:)`, чтобы существующие тесты (`BalanceService(defaults: testDefaults)`) сохранили семантику без явного ledger-аргумента.
- Два теста, использовавших `AlarmRepository()` (без аргументов), переписаны на явный `AlarmRepository(defaults: .standard)` — поведение прежнее, но компилируется при новом доступе.

## Verify
- ✅ swiftlint: 0 errors на изменённых файлах (warnings только pre-existing в `SettingsViewController.swift`)
- ✅ build_sim Debug: succeeded (iPhone 16e)
- ✅ build_sim Release: succeeded (iPhone 16e) — это и есть основной критерий fix-а
- ⏭ test_sim: gate отключён (см. CLAUDE.md), запускать вручную при ревью
- ⏭ screenshot: gate отключён, UI не менялся

## Acceptance (из issue)
- [x] Release конфигурация компилируется (проверено вручную)
- [x] grep AlarmRepository() / TransactionRepository() в production коде — пусто; остаются только определения singleton'а (static let shared = ...) и комментарий в TransactionRepository
- [x] AppDelegate в notification handler использует .shared
- [x] Все ViewModel/VC используют .shared — единый serial queue между всеми callers