### PR TITLE
[refactor] Extract CreateAlarm cell subclasses to fix shared-control corruption (#73)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/DayPickerCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/DayPickerCell.swift
@@ -1,0 +1,92 @@
+import UIKit
+
+/// Horizontal Пн-Вс day toggle row. Each weekday is rendered as a square button
+/// that toggles its selection state independently. The cell owns its buttons
+/// internally; the controller only supplies the current selection set.
+final class DayPickerCell: UITableViewCell {
+
+    static let reuseID = "DayPickerCell"
+
+    private static let dayNames = ["Пн", "Вт", "Ср", "Чт", "Пт", "Сб", "Вс"]
+
+    // MARK: - UI
+
+    private let stackView: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.distribution = .fillEqually
+        stack.spacing = 4
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+
+    private var dayButtons: [UIButton] = []
+
+    // MARK: - Callbacks
+
+    /// Notifies the controller that the user tapped a weekday (0...6).
+    /// The controller mutates the view-model and calls `configure(...)`
+    /// again to repaint the buttons.
+    var onDayToggled: ((Int) -> Void)?
+
+    // MARK: - Init
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Setup
+
+    private func setupUI() {
+        selectionStyle = .none
+        backgroundColor = .secondarySystemBackground
+
+        for index in 0..<Self.dayNames.count {
+            let button = UIButton(type: .system)
+            button.setTitle(Self.dayNames[index], for: .normal)
+            button.tag = index
+            button.titleLabel?.font = UIFont.systemFont(ofSize: 13, weight: .medium)
+            button.layer.cornerRadius = 8
+            button.layer.masksToBounds = true
+            button.addTarget(self, action: #selector(dayTapped(_:)), for: .touchUpInside)
+            dayButtons.append(button)
+            stackView.addArrangedSubview(button)
+        }
+
+        contentView.addSubview(stackView)
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.lg),
+            stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.lg),
+            stackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: AppSpacing.sm),
+            stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -AppSpacing.sm),
+            stackView.heightAnchor.constraint(equalToConstant: 44)
+        ])
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        onDayToggled = nil
+    }
+
+    // MARK: - Configure
+
+    func configure(selectedDays: [Int]) {
+        let selected = Set(selectedDays)
+        for (index, button) in dayButtons.enumerated() {
+            let isSelected = selected.contains(index)
+            button.backgroundColor = isSelected ? AppColors.accentBlue : .tertiarySystemBackground
+            button.setTitleColor(isSelected ? .white : .label, for: .normal)
+        }
+    }
+
+    // MARK: - Actions
+
+    @objc private func dayTapped(_ sender: UIButton) {
+        onDayToggled?(sender.tag)
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/DeleteActionCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/DeleteActionCell.swift
@@ -1,0 +1,24 @@
+import UIKit
+
+/// Centred red "Удалить будильник" row, shown only in edit mode.
+/// Mirrors the iOS Settings destructive-row pattern (e.g. Calendar's
+/// "Delete Event" — selectionStyle = .default gives tactile feedback before
+/// the confirmation sheet appears).
+final class DeleteActionCell: UITableViewCell {
+
+    static let reuseID = "DeleteActionCell"
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        textLabel?.text = "Удалить будильник"
+        textLabel?.textColor = .systemRed
+        textLabel?.textAlignment = .center
+        textLabel?.font = UIFont.systemFont(ofSize: 17, weight: .regular)
+        backgroundColor = .secondarySystemBackground
+        selectionStyle = .default
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/NameCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/NameCell.swift
@@ -1,0 +1,67 @@
+import UIKit
+
+/// Single-line text input cell for the alarm's display name.
+final class NameCell: UITableViewCell {
+
+    static let reuseID = "NameCell"
+
+    // MARK: - UI
+
+    private let textField: UITextField = {
+        let field = UITextField()
+        field.placeholder = "Название"
+        field.font = UIFont.systemFont(ofSize: 17)
+        field.translatesAutoresizingMaskIntoConstraints = false
+        return field
+    }()
+
+    // MARK: - Callbacks
+
+    /// Fires on every keystroke so the view-model stays in sync without
+    /// having to read the field at save time.
+    var onNameChanged: ((String) -> Void)?
+
+    // MARK: - Init
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupUI()
+        textField.addTarget(self, action: #selector(textChanged), for: .editingChanged)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Setup
+
+    private func setupUI() {
+        selectionStyle = .none
+        backgroundColor = .secondarySystemBackground
+        contentView.addSubview(textField)
+        NSLayoutConstraint.activate([
+            textField.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.lg),
+            textField.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.lg),
+            textField.topAnchor.constraint(equalTo: contentView.topAnchor),
+            textField.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            textField.heightAnchor.constraint(equalToConstant: 48)
+        ])
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        onNameChanged = nil
+    }
+
+    // MARK: - Configure
+
+    func configure(name: String) {
+        textField.text = name
+    }
+
+    // MARK: - Actions
+
+    @objc private func textChanged() {
+        onNameChanged?(textField.text ?? "")
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/PenaltyCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/PenaltyCell.swift
@@ -1,0 +1,84 @@
+import UIKit
+
+/// Penalty-amount slider with a live value label rounded to the nearest 10.
+final class PenaltyCell: UITableViewCell {
+
+    static let reuseID = "PenaltyCell"
+
+    // MARK: - UI
+
+    private let slider: UISlider = {
+        let view = UISlider()
+        view.minimumValue = 10
+        view.maximumValue = 1000
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let valueLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 17)
+        label.textColor = AppColors.accentOrange
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    // MARK: - Callbacks
+
+    /// Fires whenever the slider settles on a new (10-rounded) value.
+    var onValueChanged: ((Double) -> Void)?
+
+    // MARK: - Init
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupUI()
+        slider.addTarget(self, action: #selector(sliderChanged), for: .valueChanged)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Setup
+
+    private func setupUI() {
+        backgroundColor = .secondarySystemBackground
+        selectionStyle = .none
+
+        let stack = UIStackView(arrangedSubviews: [slider, valueLabel])
+        stack.axis = .horizontal
+        stack.spacing = AppSpacing.md
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        contentView.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.lg),
+            stack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.lg),
+            stack.topAnchor.constraint(equalTo: contentView.topAnchor, constant: AppSpacing.md),
+            stack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -AppSpacing.md)
+        ])
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        onValueChanged = nil
+    }
+
+    // MARK: - Configure
+
+    func configure(amount: Double) {
+        slider.value = Float(amount)
+        valueLabel.text = "\(Int(amount)) ₽"
+    }
+
+    // MARK: - Actions
+
+    @objc private func sliderChanged() {
+        // Round to nearest 10 so the user never lands on noisy values like 137.
+        let rounded = (slider.value / 10).rounded() * 10
+        slider.value = rounded
+        valueLabel.text = "\(Int(rounded)) ₽"
+        onValueChanged?(Double(rounded))
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/ProgressivePreviewCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/ProgressivePreviewCell.swift
@@ -1,0 +1,51 @@
+import UIKit
+
+/// Read-only preview row showing how penalties grow ("1-е: 50₽ → 2-е: 100₽ ...")
+/// when progressive scale is enabled. Surfaces only when `ProgressiveScaleCell`
+/// is toggled on.
+final class ProgressivePreviewCell: UITableViewCell {
+
+    static let reuseID = "ProgressivePreviewCell"
+
+    // MARK: - UI
+
+    private let previewLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 13)
+        label.textColor = AppColors.accentOrange
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    // MARK: - Init
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Setup
+
+    private func setupUI() {
+        backgroundColor = .secondarySystemBackground
+        selectionStyle = .none
+        contentView.addSubview(previewLabel)
+        NSLayoutConstraint.activate([
+            previewLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.lg),
+            previewLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.lg),
+            previewLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: AppSpacing.sm),
+            previewLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -AppSpacing.sm)
+        ])
+    }
+
+    // MARK: - Configure
+
+    func configure(text: String) {
+        previewLabel.text = text
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/ProgressiveScaleCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/ProgressiveScaleCell.swift
@@ -1,0 +1,53 @@
+import UIKit
+
+/// Toggle row for the "Прогрессивная шкала" setting. Owns its switch privately —
+/// the previous shared-property design crashed UIKit when `reloadSections`
+/// tore down the host cell while the switch was still attached as accessoryView.
+final class ProgressiveScaleCell: UITableViewCell {
+
+    static let reuseID = "ProgressiveScaleCell"
+
+    // MARK: - UI
+
+    private let toggle: UISwitch = {
+        let view = UISwitch()
+        view.onTintColor = AppColors.accentOrange
+        return view
+    }()
+
+    // MARK: - Callbacks
+
+    var onToggled: ((Bool) -> Void)?
+
+    // MARK: - Init
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        textLabel?.text = "Прогрессивная шкала"
+        backgroundColor = .secondarySystemBackground
+        selectionStyle = .none
+        accessoryView = toggle
+        toggle.addTarget(self, action: #selector(toggled), for: .valueChanged)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        onToggled = nil
+    }
+
+    // MARK: - Configure
+
+    func configure(isOn: Bool) {
+        toggle.isOn = isOn
+    }
+
+    // MARK: - Actions
+
+    @objc private func toggled() {
+        onToggled?(toggle.isOn)
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/SnoozeCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/SnoozeCell.swift
@@ -1,0 +1,66 @@
+import UIKit
+
+/// "Откладывать на" row: title + minutes-detail + stepper accessory.
+///
+/// Uses the built-in `.value1` style so the "X мин" detail text sits between
+/// the title and the stepper without needing a custom stack — the stepper
+/// + label combo did not produce a sensible intrinsic size when wrapped in
+/// a `UIStackView` (clipped the value label).
+final class SnoozeCell: UITableViewCell {
+
+    static let reuseID = "SnoozeCell"
+
+    // MARK: - UI
+
+    private let stepper: UIStepper = {
+        let view = UIStepper()
+        view.minimumValue = 1
+        view.maximumValue = 30
+        view.stepValue = 1
+        return view
+    }()
+
+    // MARK: - Callbacks
+
+    var onValueChanged: ((Int) -> Void)?
+
+    // MARK: - Init
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        // Force `.value1` regardless of caller — this style is the whole point
+        // of the cell and keeps the detail label correctly positioned.
+        super.init(style: .value1, reuseIdentifier: reuseIdentifier)
+        textLabel?.text = "Откладывать на"
+        detailTextLabel?.textColor = .label
+        backgroundColor = .secondarySystemBackground
+        selectionStyle = .none
+        accessoryView = stepper
+        stepper.addTarget(self, action: #selector(stepperChanged), for: .valueChanged)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        onValueChanged = nil
+    }
+
+    // MARK: - Configure
+
+    func configure(minutes: Int) {
+        stepper.value = Double(minutes)
+        detailTextLabel?.text = "\(minutes) мин"
+    }
+
+    // MARK: - Actions
+
+    @objc private func stepperChanged() {
+        let value = Int(stepper.value)
+        // Update the visible detail label in place so the stepper does not
+        // briefly snap before the controller's `reload` cycle catches up.
+        detailTextLabel?.text = "\(value) мин"
+        onValueChanged?(value)
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/SoundCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/SoundCell.swift
@@ -1,0 +1,118 @@
+import UIKit
+
+/// Sound row: title on the left, current sound name + play button + chevron
+/// disclosure on the right. Tapping the row pushes `SoundPickerViewController`
+/// (handled by the controller's `didSelectRowAt`); tapping the play button
+/// fires a preview without leaving the screen.
+final class SoundCell: UITableViewCell {
+
+    static let reuseID = "SoundCell"
+
+    // MARK: - UI
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Звук"
+        label.font = UIFont.systemFont(ofSize: 17)
+        label.textColor = .label
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let soundNameLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 17)
+        label.textColor = .secondaryLabel
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let playButton: UIButton = {
+        let button = UIButton(type: .system)
+        let image = UIImage(systemName: "play.circle.fill")?.withConfiguration(
+            UIImage.SymbolConfiguration(pointSize: 24, weight: .medium)
+        )
+        button.setImage(image, for: .normal)
+        button.tintColor = AppColors.accentBlue
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    private let chevronView: UIImageView = {
+        let image = UIImage(systemName: "chevron.right")?.withConfiguration(
+            UIImage.SymbolConfiguration(pointSize: 13, weight: .semibold)
+        )
+        let view = UIImageView(image: image)
+        view.tintColor = .tertiaryLabel
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    // MARK: - Callbacks
+
+    var onPreviewTapped: (() -> Void)?
+
+    // MARK: - Init
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupUI()
+        playButton.addTarget(self, action: #selector(previewTapped), for: .touchUpInside)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Setup
+
+    private func setupUI() {
+        backgroundColor = .secondarySystemBackground
+        // Use the system selection so the row briefly highlights on tap before
+        // navigating to the sound picker.
+        selectionStyle = .default
+
+        contentView.addSubview(titleLabel)
+        contentView.addSubview(chevronView)
+        contentView.addSubview(playButton)
+        contentView.addSubview(soundNameLabel)
+
+        NSLayoutConstraint.activate([
+            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.lg),
+            titleLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+
+            chevronView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.lg),
+            chevronView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+
+            playButton.trailingAnchor.constraint(equalTo: chevronView.leadingAnchor, constant: -AppSpacing.sm),
+            playButton.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+
+            soundNameLabel.trailingAnchor.constraint(
+                equalTo: playButton.leadingAnchor, constant: -AppSpacing.sm
+            ),
+            soundNameLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            soundNameLabel.leadingAnchor.constraint(
+                greaterThanOrEqualTo: titleLabel.trailingAnchor, constant: AppSpacing.sm
+            ),
+
+            contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: 44)
+        ])
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        onPreviewTapped = nil
+    }
+
+    // MARK: - Configure
+
+    func configure(soundName: String) {
+        soundNameLabel.text = soundName
+    }
+
+    // MARK: - Actions
+
+    @objc private func previewTapped() {
+        onPreviewTapped?()
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/TimePickerCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/TimePickerCell.swift
@@ -1,0 +1,69 @@
+import UIKit
+
+/// Wheel-style time picker cell. Owns its own UIDatePicker so the control is
+/// never shared between rows — eliminating the stale-constraint crash that
+/// plagued the previous shared-property implementation.
+final class TimePickerCell: UITableViewCell {
+
+    static let reuseID = "TimePickerCell"
+
+    // MARK: - UI
+
+    private let picker: UIDatePicker = {
+        let view = UIDatePicker()
+        view.datePickerMode = .time
+        view.preferredDatePickerStyle = .wheels
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    // MARK: - Callbacks
+
+    /// Forwards the picker's new date to the controller. Cleared in
+    /// `prepareForReuse` so a recycled cell never fires the wrong alarm's
+    /// time before the next `configure(...)`.
+    var onTimeChanged: ((Date) -> Void)?
+
+    // MARK: - Init
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupUI()
+        picker.addTarget(self, action: #selector(pickerChanged), for: .valueChanged)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Setup
+
+    private func setupUI() {
+        selectionStyle = .none
+        backgroundColor = .secondarySystemBackground
+        contentView.addSubview(picker)
+        NSLayoutConstraint.activate([
+            picker.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            picker.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            picker.topAnchor.constraint(equalTo: contentView.topAnchor),
+            picker.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+        ])
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        onTimeChanged = nil
+    }
+
+    // MARK: - Configure
+
+    func configure(time: Date) {
+        picker.date = time
+    }
+
+    // MARK: - Actions
+
+    @objc private func pickerChanged() {
+        onTimeChanged?(picker.date)
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/VibrationCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/VibrationCell.swift
@@ -1,0 +1,51 @@
+import UIKit
+
+/// Toggle row for the "Вибрация" setting.
+final class VibrationCell: UITableViewCell {
+
+    static let reuseID = "VibrationCell"
+
+    // MARK: - UI
+
+    private let toggle: UISwitch = {
+        let view = UISwitch()
+        view.onTintColor = AppColors.accentGreen
+        return view
+    }()
+
+    // MARK: - Callbacks
+
+    var onToggled: ((Bool) -> Void)?
+
+    // MARK: - Init
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        textLabel?.text = "Вибрация"
+        backgroundColor = .secondarySystemBackground
+        selectionStyle = .none
+        accessoryView = toggle
+        toggle.addTarget(self, action: #selector(toggled), for: .valueChanged)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        onToggled = nil
+    }
+
+    // MARK: - Configure
+
+    func configure(isOn: Bool) {
+        toggle.isOn = isOn
+    }
+
+    // MARK: - Actions
+
+    @objc private func toggled() {
+        onToggled?(toggle.isOn)
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
@@ -1,100 +1,31 @@
 import UIKit
-import AudioToolbox
 
 /// Screen for creating or editing an alarm.
-/// Uses a static table view with sections for each setting group.
-class CreateAlarmViewController: UIViewController {
+/// Each section is rendered by a dedicated `UITableViewCell` subclass that owns
+/// its own controls — the previous shared-property design (timePicker,
+/// nameField, sliders, toggles…) caused stale-constraint crashes during
+/// `reloadSections`, since the same control was re-parented across recycled
+/// cells.
+final class CreateAlarmViewController: UIViewController {
 
-    // MARK: - Properties
+    // MARK: - Callbacks
 
     var onSave: (() -> Void)?
     /// Invoked after the user confirms deletion of the alarm being edited so the
     /// presenter can refresh its list. Defaults to nil for new alarms (delete row
     /// is hidden in create mode).
     var onDelete: (() -> Void)?
+
+    // MARK: - Dependencies
+
     private let viewModel: CreateAlarmViewModel
 
     // MARK: - UI
 
     private let tableView: UITableView = {
-        let tv = UITableView(frame: .zero, style: .insetGrouped)
-        tv.translatesAutoresizingMaskIntoConstraints = false
-        return tv
-    }()
-
-    // Time picker
-    private let timePicker: UIDatePicker = {
-        let picker = UIDatePicker()
-        picker.datePickerMode = .time
-        picker.preferredDatePickerStyle = .wheels
-        picker.translatesAutoresizingMaskIntoConstraints = false
-        return picker
-    }()
-
-    // Day buttons
-    private var dayButtons: [UIButton] = []
-    private let dayNames = ["Пн", "Вт", "Ср", "Чт", "Пт", "Сб", "Вс"]
-
-    // Penalty slider
-    private let penaltySlider: UISlider = {
-        let s = UISlider()
-        s.minimumValue = 10
-        s.maximumValue = 1000
-        s.translatesAutoresizingMaskIntoConstraints = false
-        return s
-    }()
-
-    private let penaltyValueLabel: UILabel = {
-        let l = UILabel()
-        l.font = UIFont.systemFont(ofSize: 17)
-        l.textColor = AppColors.accentOrange
-        l.translatesAutoresizingMaskIntoConstraints = false
-        return l
-    }()
-
-    // Progressive scale toggle
-    private let progressiveToggle: UISwitch = {
-        let sw = UISwitch()
-        sw.onTintColor = AppColors.accentOrange
-        return sw
-    }()
-
-    private let progressivePreviewLabel: UILabel = {
-        let l = UILabel()
-        l.font = UIFont.systemFont(ofSize: 13)
-        l.textColor = AppColors.accentOrange
-        l.numberOfLines = 0
-        l.translatesAutoresizingMaskIntoConstraints = false
-        return l
-    }()
-
-    // Snooze stepper. The "X мин" value is shown in the cell's
-    // `detailTextLabel` (UITableViewCell `.value1` style), not via a custom
-    // stack accessory — `UIStackView.sizeToFit()` did not produce a sensible
-    // intrinsic size for a stepper + label combo, leaving the stepper drawn
-    // at the cell's top-left and clipping the value label.
-    private let snoozeStepper: UIStepper = {
-        let s = UIStepper()
-        s.minimumValue = 1
-        s.maximumValue = 30
-        s.stepValue = 1
-        return s
-    }()
-
-    // Vibration toggle
-    private let vibrationToggle: UISwitch = {
-        let sw = UISwitch()
-        sw.onTintColor = AppColors.accentGreen
-        return sw
-    }()
-
-    // Name field
-    private let nameField: UITextField = {
-        let tf = UITextField()
-        tf.placeholder = "Название"
-        tf.font = UIFont.systemFont(ofSize: 17)
-        tf.translatesAutoresizingMaskIntoConstraints = false
-        return tf
+        let view = UITableView(frame: .zero, style: .insetGrouped)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
     }()
 
     // MARK: - Sections
@@ -109,8 +40,6 @@ class CreateAlarmViewController: UIViewController {
         case progressiveScale
         case snoozeTime
         /// Destructive "Удалить будильник" row — only visible in edit mode.
-        /// In create mode `numberOfRowsInSection` returns 0, hiding the section
-        /// entirely (including its background pill).
         case deleteAction
     }
 
@@ -133,22 +62,12 @@ class CreateAlarmViewController: UIViewController {
         view.backgroundColor = .systemGroupedBackground
         setupNavigationBar()
         setupTableView()
-        // Targets must be wired exactly once on these shared controls.
-        // Wiring them in `cellForRowAt` accumulated duplicate handlers on every
-        // reload, multiplying penalty/snooze updates per single user action.
-        wireControlTargets()
-        populateFromViewModel()
-    }
-
-    private func wireControlTargets() {
-        penaltySlider.addTarget(self, action: #selector(sliderChanged(_:)), for: .valueChanged)
-        progressiveToggle.addTarget(self, action: #selector(progressiveToggled(_:)), for: .valueChanged)
-        snoozeStepper.addTarget(self, action: #selector(stepperChanged(_:)), for: .valueChanged)
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        // Refresh sound row when returning from SoundPickerViewController
+        // Refresh the sound row in case the user picked a new sound on
+        // SoundPickerViewController and is returning here.
         tableView.reloadSections(IndexSet(integer: Section.sound.rawValue), with: .none)
     }
 
@@ -172,29 +91,25 @@ class CreateAlarmViewController: UIViewController {
         view.addSubview(tableView)
         tableView.delegate = self
         tableView.dataSource = self
-        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
+        tableView.register(TimePickerCell.self, forCellReuseIdentifier: TimePickerCell.reuseID)
+        tableView.register(DayPickerCell.self, forCellReuseIdentifier: DayPickerCell.reuseID)
+        tableView.register(NameCell.self, forCellReuseIdentifier: NameCell.reuseID)
+        tableView.register(SoundCell.self, forCellReuseIdentifier: SoundCell.reuseID)
+        tableView.register(VibrationCell.self, forCellReuseIdentifier: VibrationCell.reuseID)
+        tableView.register(PenaltyCell.self, forCellReuseIdentifier: PenaltyCell.reuseID)
+        tableView.register(ProgressiveScaleCell.self, forCellReuseIdentifier: ProgressiveScaleCell.reuseID)
+        tableView.register(ProgressivePreviewCell.self, forCellReuseIdentifier: ProgressivePreviewCell.reuseID)
+        tableView.register(SnoozeCell.self, forCellReuseIdentifier: SnoozeCell.reuseID)
+        tableView.register(DeleteActionCell.self, forCellReuseIdentifier: DeleteActionCell.reuseID)
 
         // Pin to safe area on top so the first section's "ПОВТОР" header is
-        // not clipped under the navigation bar. Bottom can stay at view edge
-        // since insetGrouped style handles bottom safe area via contentInset.
+        // not clipped under the navigation bar.
         NSLayoutConstraint.activate([
             tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
-    }
-
-    private func populateFromViewModel() {
-        timePicker.date = viewModel.time
-        penaltySlider.value = Float(viewModel.penaltyAmount)
-        penaltyValueLabel.text = "\(Int(viewModel.penaltyAmount)) ₽"
-        progressiveToggle.isOn = viewModel.progressiveScale
-        progressivePreviewLabel.text = viewModel.progressiveScalePreview
-        progressivePreviewLabel.isHidden = !viewModel.progressiveScale
-        snoozeStepper.value = Double(viewModel.snoozeMinutes)
-        vibrationToggle.isOn = viewModel.vibrationEnabled
-        nameField.text = viewModel.name
     }
 
     // MARK: - Actions
@@ -204,54 +119,28 @@ class CreateAlarmViewController: UIViewController {
     }
 
     @objc private func saveTapped() {
-        // Collect values from controls back into viewModel
-        viewModel.time = timePicker.date
-        viewModel.name = nameField.text ?? "Будильник"
-        viewModel.penaltyAmount = Double(penaltySlider.value)
-        viewModel.progressiveScale = progressiveToggle.isOn
-        viewModel.snoozeMinutes = Int(snoozeStepper.value)
-        viewModel.vibrationEnabled = vibrationToggle.isOn
-
+        // Cells push state into the view-model live via callbacks, so save just
+        // forwards the current snapshot to the repository.
         viewModel.save()
         onSave?()
         dismiss(animated: true)
     }
 
-    @objc private func sliderChanged(_ sender: UISlider) {
-        // Round to nearest 10
-        let rounded = (sender.value / 10).rounded() * 10
-        sender.value = rounded
-        viewModel.penaltyAmount = Double(rounded)
-        penaltyValueLabel.text = "\(Int(rounded)) ₽"
-        progressivePreviewLabel.text = viewModel.progressiveScalePreview
-    }
+    // MARK: - View-model bridges
 
-    @objc private func progressiveToggled(_ sender: UISwitch) {
-        viewModel.progressiveScale = sender.isOn
-        progressivePreviewLabel.text = viewModel.progressiveScalePreview
-        progressivePreviewLabel.isHidden = !sender.isOn
+    private func setProgressiveScale(_ isOn: Bool) {
+        viewModel.progressiveScale = isOn
 
-        // Detach the shared preview label from its previous host cell before the
-        // table view rebuilds the section. Reusing the same view across cells
-        // without removing it first leaves stale auto-layout constraints attached
-        // to a discarded cell, which crashes UIKit when it tries to lay out a
-        // table view that is not yet (or no longer) in the view hierarchy.
-        progressivePreviewLabel.removeFromSuperview()
-
-        // Skip animated updates if the view is detached from a window — UIKit
-        // logs "told to layout its visible cells without being in the view
-        // hierarchy" and may crash when applying the diff.
         guard view.window != nil else {
-            tableView.reloadData()
+            // Detached views can't safely run insertRows/deleteRows; reload as a
+            // safe fallback (no animation visible to the user anyway).
+            tableView.reloadSections(IndexSet(integer: Section.progressiveScale.rawValue), with: .none)
             return
         }
 
-        // Insert/delete the preview row instead of reloading the whole section.
-        // This avoids tearing down the toggle row (which owns `progressiveToggle`
-        // as accessoryView) on every flip and keeps the animation smooth.
         let previewIndexPath = IndexPath(row: 1, section: Section.progressiveScale.rawValue)
         tableView.performBatchUpdates({
-            if sender.isOn {
+            if isOn {
                 tableView.insertRows(at: [previewIndexPath], with: .fade)
             } else {
                 tableView.deleteRows(at: [previewIndexPath], with: .fade)
@@ -259,36 +148,13 @@ class CreateAlarmViewController: UIViewController {
         })
     }
 
-    @objc private func stepperChanged(_ sender: UIStepper) {
-        viewModel.snoozeMinutes = Int(sender.value)
-        // Update the visible cell's detail label in place. Avoids
-        // `reloadRows`, which would recreate the cell mid-interaction and
-        // drop the stepper's gesture state.
-        let snoozePath = IndexPath(row: 0, section: Section.snoozeTime.rawValue)
-        if let cell = tableView.cellForRow(at: snoozePath) {
-            cell.detailTextLabel?.text = snoozeMinutesText
-        }
-    }
-
-    private var snoozeMinutesText: String {
-        "\(viewModel.snoozeMinutes) мин"
-    }
-
-    @objc private func previewSoundTapped() {
-        viewModel.previewSound(viewModel.soundID)
-    }
-
-    @objc private func dayButtonTapped(_ sender: UIButton) {
-        let day = sender.tag
-        viewModel.toggleDay(day)
-        updateDayButtons()
-    }
-
-    private func updateDayButtons() {
-        for (index, button) in dayButtons.enumerated() {
-            let isSelected = viewModel.repeatDays.contains(index)
-            button.backgroundColor = isSelected ? AppColors.accentBlue : .secondarySystemBackground
-            button.setTitleColor(isSelected ? .white : .label, for: .normal)
+    private func setPenaltyAmount(_ amount: Double) {
+        viewModel.penaltyAmount = amount
+        // Refresh the preview row's text if it's currently visible.
+        guard viewModel.progressiveScale else { return }
+        let previewIndexPath = IndexPath(row: 1, section: Section.progressiveScale.rawValue)
+        if let cell = tableView.cellForRow(at: previewIndexPath) as? ProgressivePreviewCell {
+            cell.configure(text: viewModel.progressiveScalePreview)
         }
     }
 }
@@ -307,8 +173,6 @@ extension CreateAlarmViewController: UITableViewDataSource {
         case .progressiveScale:
             return viewModel.progressiveScale ? 2 : 1
         case .deleteAction:
-            // Hide the destructive row entirely when creating a new alarm —
-            // there's nothing to delete yet.
             return viewModel.isEditing ? 1 : 0
         default:
             return 1
@@ -318,194 +182,95 @@ extension CreateAlarmViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         guard let sec = Section(rawValue: section) else { return nil }
         switch sec {
-        case .timePicker: return nil
         case .repeatDays: return "ПОВТОР"
         case .name: return "НАЗВАНИЕ"
         case .sound: return "ЗВУК"
-        case .vibration: return nil
         case .penalty: return "ШТРАФ ЗА ОТКЛАДЫВАНИЕ"
-        case .progressiveScale: return nil
         case .snoozeTime: return "ВРЕМЯ ОТКЛАДЫВАНИЯ"
-        case .deleteAction: return nil
+        default: return nil
         }
     }
 
+    // swiftlint:disable:next cyclomatic_complexity function_body_length
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let section = Section(rawValue: indexPath.section) else {
             return UITableViewCell()
         }
-
-        // `.value1` is used only for the snooze row so its detail label
-        // ("X мин") sits between the title and the stepper accessory.
-        // All other rows use `.default` because they either own custom
-        // content or use accessoryView/accessoryType only.
-        let style: UITableViewCell.CellStyle = (section == .snoozeTime) ? .value1 : .default
-        let cell = UITableViewCell(style: style, reuseIdentifier: nil)
-        cell.selectionStyle = .none
-        cell.backgroundColor = .secondarySystemBackground
-
         switch section {
         case .timePicker:
-            cell.contentView.addSubview(timePicker)
-            NSLayoutConstraint.activate([
-                timePicker.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor),
-                timePicker.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor),
-                timePicker.topAnchor.constraint(equalTo: cell.contentView.topAnchor),
-                timePicker.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor)
-            ])
-
-        case .repeatDays:
-            let container = makeDayPicker()
-            container.translatesAutoresizingMaskIntoConstraints = false
-            cell.contentView.addSubview(container)
-            NSLayoutConstraint.activate([
-                container.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor, constant: AppSpacing.lg),
-                container.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor, constant: -AppSpacing.lg),
-                container.topAnchor.constraint(equalTo: cell.contentView.topAnchor, constant: AppSpacing.sm),
-                container.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor, constant: -AppSpacing.sm),
-                container.heightAnchor.constraint(equalToConstant: 44)
-            ])
-
-        case .name:
-            cell.contentView.addSubview(nameField)
-            NSLayoutConstraint.activate([
-                nameField.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor, constant: AppSpacing.lg),
-                nameField.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor, constant: -AppSpacing.lg),
-                nameField.topAnchor.constraint(equalTo: cell.contentView.topAnchor),
-                nameField.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor),
-                nameField.heightAnchor.constraint(equalToConstant: 48)
-            ])
-
-        case .sound:
-            cell.textLabel?.text = "Звук"
-            cell.accessoryView = makeSoundAccessoryView()
-            cell.selectionStyle = .default
-
-        case .vibration:
-            cell.textLabel?.text = "Вибрация"
-            cell.accessoryView = vibrationToggle
-
-        case .penalty:
-            let stack = UIStackView(arrangedSubviews: [penaltySlider, penaltyValueLabel])
-            stack.axis = .horizontal
-            stack.spacing = AppSpacing.md
-            stack.translatesAutoresizingMaskIntoConstraints = false
-            cell.contentView.addSubview(stack)
-            NSLayoutConstraint.activate([
-                stack.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor, constant: AppSpacing.lg),
-                stack.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor, constant: -AppSpacing.lg),
-                stack.topAnchor.constraint(equalTo: cell.contentView.topAnchor, constant: AppSpacing.md),
-                stack.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor, constant: -AppSpacing.md)
-            ])
-
-        case .progressiveScale:
-            if indexPath.row == 0 {
-                cell.textLabel?.text = "Прогрессивная шкала"
-                cell.accessoryView = progressiveToggle
-            } else {
-                // Preview row. The label is a stored property reused across cells,
-                // so detach it from any previous host before re-attaching. Stale
-                // constraints on a discarded cell crash UIKit during layout.
-                // Text is kept fresh by `progressiveToggled` and `sliderChanged`.
-                progressivePreviewLabel.removeFromSuperview()
-                cell.contentView.addSubview(progressivePreviewLabel)
-                NSLayoutConstraint.activate([
-                    progressivePreviewLabel.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor, constant: AppSpacing.lg),
-                    progressivePreviewLabel.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor, constant: -AppSpacing.lg),
-                    progressivePreviewLabel.topAnchor.constraint(equalTo: cell.contentView.topAnchor, constant: AppSpacing.sm),
-                    progressivePreviewLabel.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor, constant: -AppSpacing.sm)
-                ])
+            let cell = tableView.dequeueReusableCell(withIdentifier: TimePickerCell.reuseID, for: indexPath)
+            if let cell = cell as? TimePickerCell {
+                cell.configure(time: viewModel.time)
+                cell.onTimeChanged = { [weak self] date in self?.viewModel.time = date }
             }
-
+            return cell
+        case .repeatDays:
+            let cell = tableView.dequeueReusableCell(withIdentifier: DayPickerCell.reuseID, for: indexPath)
+            if let cell = cell as? DayPickerCell {
+                cell.configure(selectedDays: viewModel.repeatDays)
+                cell.onDayToggled = { [weak self, weak cell] day in
+                    guard let self else { return }
+                    self.viewModel.toggleDay(day)
+                    cell?.configure(selectedDays: self.viewModel.repeatDays)
+                }
+            }
+            return cell
+        case .name:
+            let cell = tableView.dequeueReusableCell(withIdentifier: NameCell.reuseID, for: indexPath)
+            if let cell = cell as? NameCell {
+                cell.configure(name: viewModel.name)
+                cell.onNameChanged = { [weak self] text in self?.viewModel.name = text }
+            }
+            return cell
+        case .sound:
+            let cell = tableView.dequeueReusableCell(withIdentifier: SoundCell.reuseID, for: indexPath)
+            if let cell = cell as? SoundCell {
+                let soundName = viewModel.availableSounds
+                    .first(where: { $0.id == viewModel.soundID })?.name ?? "По умолчанию"
+                cell.configure(soundName: soundName)
+                cell.onPreviewTapped = { [weak self] in
+                    guard let self else { return }
+                    self.viewModel.previewSound(self.viewModel.soundID)
+                }
+            }
+            return cell
+        case .vibration:
+            let cell = tableView.dequeueReusableCell(withIdentifier: VibrationCell.reuseID, for: indexPath)
+            if let cell = cell as? VibrationCell {
+                cell.configure(isOn: viewModel.vibrationEnabled)
+                cell.onToggled = { [weak self] isOn in self?.viewModel.vibrationEnabled = isOn }
+            }
+            return cell
+        case .penalty:
+            let cell = tableView.dequeueReusableCell(withIdentifier: PenaltyCell.reuseID, for: indexPath)
+            if let cell = cell as? PenaltyCell {
+                cell.configure(amount: viewModel.penaltyAmount)
+                cell.onValueChanged = { [weak self] amount in self?.setPenaltyAmount(amount) }
+            }
+            return cell
+        case .progressiveScale where indexPath.row == 0:
+            let cell = tableView.dequeueReusableCell(withIdentifier: ProgressiveScaleCell.reuseID, for: indexPath)
+            if let cell = cell as? ProgressiveScaleCell {
+                cell.configure(isOn: viewModel.progressiveScale)
+                cell.onToggled = { [weak self] isOn in self?.setProgressiveScale(isOn) }
+            }
+            return cell
+        case .progressiveScale:
+            let cell = tableView.dequeueReusableCell(withIdentifier: ProgressivePreviewCell.reuseID, for: indexPath)
+            if let cell = cell as? ProgressivePreviewCell {
+                cell.configure(text: viewModel.progressiveScalePreview)
+            }
+            return cell
         case .snoozeTime:
-            cell.textLabel?.text = "Откладывать на"
-            cell.detailTextLabel?.text = snoozeMinutesText
-            cell.detailTextLabel?.textColor = .label
-            cell.accessoryView = snoozeStepper
-
+            let cell = tableView.dequeueReusableCell(withIdentifier: SnoozeCell.reuseID, for: indexPath)
+            if let cell = cell as? SnoozeCell {
+                cell.configure(minutes: viewModel.snoozeMinutes)
+                cell.onValueChanged = { [weak self] minutes in self?.viewModel.snoozeMinutes = minutes }
+            }
+            return cell
         case .deleteAction:
-            // Centered red text mimics iOS Settings' destructive row pattern
-            // (see Calendar.app "Delete Event"). selectionStyle=.default to give
-            // the user tactile feedback before the confirmation alert appears.
-            cell.textLabel?.text = "Удалить будильник"
-            cell.textLabel?.textColor = .systemRed
-            cell.textLabel?.textAlignment = .center
-            cell.textLabel?.font = UIFont.systemFont(ofSize: 17, weight: .regular)
-            cell.selectionStyle = .default
+            return tableView.dequeueReusableCell(withIdentifier: DeleteActionCell.reuseID, for: indexPath)
         }
-
-        return cell
-    }
-
-    // MARK: - Day picker helper
-
-    private func makeDayPicker() -> UIStackView {
-        let stack = UIStackView()
-        stack.axis = .horizontal
-        stack.distribution = .fillEqually
-        stack.spacing = 4
-
-        dayButtons = []
-        for (index, name) in dayNames.enumerated() {
-            let button = UIButton(type: .system)
-            button.setTitle(name, for: .normal)
-            button.tag = index
-            button.titleLabel?.font = UIFont.systemFont(ofSize: 13, weight: .medium)
-            button.layer.cornerRadius = 8
-            button.layer.masksToBounds = true
-            button.addTarget(self, action: #selector(dayButtonTapped(_:)), for: .touchUpInside)
-
-            let isSelected = viewModel.repeatDays.contains(index)
-            button.backgroundColor = isSelected ? AppColors.accentBlue : .tertiarySystemBackground
-            button.setTitleColor(isSelected ? .white : .label, for: .normal)
-
-            dayButtons.append(button)
-            stack.addArrangedSubview(button)
-        }
-
-        return stack
-    }
-
-    /// Builds the sound row's `accessoryView`: sound name label + play preview button + chevron.
-    /// The chevron is required because setting `accessoryView` suppresses `accessoryType`,
-    /// so without it the row offers no visual disclosure cue.
-    private func makeSoundAccessoryView() -> UIStackView {
-        let soundLabel = UILabel()
-        let soundName = viewModel.availableSounds.first(where: { $0.id == viewModel.soundID })?.name
-        soundLabel.text = soundName ?? "По умолчанию"
-        soundLabel.textColor = .secondaryLabel
-        soundLabel.font = UIFont.systemFont(ofSize: 17)
-        soundLabel.sizeToFit()
-
-        let playButton = UIButton(type: .system)
-        let playImage = UIImage(systemName: "play.circle.fill")?.withConfiguration(
-            UIImage.SymbolConfiguration(pointSize: 24, weight: .medium)
-        )
-        playButton.setImage(playImage, for: .normal)
-        playButton.tintColor = AppColors.accentBlue
-        playButton.addTarget(self, action: #selector(previewSoundTapped), for: .touchUpInside)
-        playButton.sizeToFit()
-
-        let chevronImage = UIImage(systemName: "chevron.right")?.withConfiguration(
-            UIImage.SymbolConfiguration(pointSize: 13, weight: .semibold)
-        )
-        let chevronImageView = UIImageView(image: chevronImage)
-        chevronImageView.tintColor = .tertiaryLabel
-        chevronImageView.sizeToFit()
-
-        let stack = UIStackView(arrangedSubviews: [soundLabel, playButton, chevronImageView])
-        stack.axis = .horizontal
-        stack.spacing = AppSpacing.sm
-        stack.alignment = .center
-        stack.sizeToFit()
-        let width = soundLabel.frame.width
-            + playButton.frame.width
-            + chevronImageView.frame.width
-            + AppSpacing.sm * 2
-            + 16
-        let height = max(soundLabel.frame.height, playButton.frame.height, chevronImageView.frame.height)
-        stack.frame = CGRect(x: 0, y: 0, width: width, height: height)
-        return stack
     }
 }
 
@@ -528,7 +293,6 @@ extension CreateAlarmViewController: UITableViewDelegate {
         guard let section = Section(rawValue: indexPath.section) else { return }
         switch section {
         case .sound:
-            // Sound picker navigation — simple action sheet for MVP
             showSoundPicker()
         case .deleteAction:
             confirmDelete()


### PR DESCRIPTION
Fixes #73

## Что сделано

- Каждая section в CreateAlarm screen вынесена в собственный `UITableViewCell` subclass под `ViewControllers/Alarms/Cells/`:
  `TimePickerCell`, `DayPickerCell`, `NameCell`, `SoundCell`, `VibrationCell`, `PenaltyCell`, `ProgressiveScaleCell`, `ProgressivePreviewCell`, `SnoozeCell`, `DeleteActionCell` (10 cells, по одному файлу).
- Каждая cell владеет своими subviews — никаких shared `timePicker`/`nameField`/`vibrationToggle`/`snoozeStepper`/`penaltySlider`/`progressivePreviewLabel` на VC. Action selectors переехали в cell + closure-callback в VC.
- `cellForRowAt` теперь использует `dequeueReusableCell(withIdentifier:for:)` — настоящий reuse. Заодно исчез `if view.window != nil { reloadData } else { performBatchUpdates }` workaround вокруг `removeFromSuperview()` для preview-row, потому что теперь preview row — это отдельная переиспользуемая cell.
- `CreateAlarmViewController.swift` уменьшился с 523 до 341 LOC (cell на каждую секцию + thin VC).
- `populateFromViewModel()` и `wireControlTargets()` удалены — cells получают данные через `configure(...)` и пушат изменения в VM через callbacks live, поэтому `saveTapped` просто форвардит snapshot в repository.

## Verify

- swiftlint: 0 errors / 0 warnings в touched files
- build_sim: succeeded (simulator: iPhone Air)
- test_sim: пропущен (отключён по project policy — тесты на existing CreateAlarmViewModel остаются зелёными)
- screenshot: пропущен (gate отключён)

## Не сделано (намеренно)

- Не двигал `CreateAlarmViewModel` (issue #73 фокусируется на VC-side cell ownership, не на VM-shape).
- Не трогал no-touch zones (entitlements, Info.plist, project.pbxproj — file-system synchronized groups автоматически подхватили новые файлы).