### PR TITLE
[refactor] AlarmScheduler typed payload struct (#74)

### DIFF
--- a/SnoozePay/SnoozePay/AppDelegate.swift
+++ b/SnoozePay/SnoozePay/AppDelegate.swift
@@ -116,12 +116,19 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     ) {
         let userInfo = notification.request.content.userInfo
 
+        guard let payload = AlarmNotificationPayload(userInfo: userInfo) else {
+            // Malformed payload — surface and bail rather than playing audio we
+            // can never stop because the firing screen will never be presented.
+            print("[AppDelegate] willPresent: invalid alarm payload \(userInfo)")
+            completionHandler([])
+            return
+        }
+
         // Start continuous alarm sound immediately (before presenting the VC)
-        let soundID = userInfo["soundID"] as? String ?? "radar"
-        AudioService.shared.startAlarmSound(soundID: soundID)
+        AudioService.shared.startAlarmSound(soundID: payload.soundID)
 
         // Show the alarm firing screen
-        presentAlarmFiringScreen(for: userInfo)
+        presentAlarmFiringScreen(for: payload)
         completionHandler([])
     }
 
@@ -141,7 +148,12 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         case UNNotificationDefaultActionIdentifier:
             // User tapped notification banner — present alarm screen
             // AudioService will be started by AlarmFiringViewController
-            presentAlarmFiringScreen(for: userInfo)
+            if let payload = AlarmNotificationPayload(userInfo: userInfo) {
+                presentAlarmFiringScreen(for: payload)
+            } else {
+                print("[AppDelegate] default action: invalid alarm payload \(userInfo)")
+                AudioService.shared.stopAlarmSound()
+            }
 
         case "SNOOZE_ACTION":
             AudioService.shared.stopAlarmSound()
@@ -170,26 +182,17 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
 
     // MARK: - Helpers
 
-    private func presentAlarmFiringScreen(for userInfo: [AnyHashable: Any]) {
-        guard
-            let alarmIDString = userInfo["alarmID"] as? String,
-            let alarmID = UUID(uuidString: alarmIDString)
-        else {
+    private func presentAlarmFiringScreen(for payload: AlarmNotificationPayload) {
+        guard let alarm = AlarmRepository.shared.fetch(id: payload.alarmID) else {
             // Audio may already be playing from willPresent — stop it so the user
             // is not stuck with a silent-screen + sounding alarm we can't dismiss.
-            print("[AppDelegate] alarm not found (missing/invalid alarmID), stopping audio")
-            AudioService.shared.stopAlarmSound()
-            return
-        }
-
-        guard let alarm = AlarmRepository.shared.fetch(id: alarmID) else {
-            print("[AppDelegate] alarm not found (repo returned nil for \(alarmID)), stopping audio")
+            print("[AppDelegate] alarm not found (repo returned nil for \(payload.alarmID)), stopping audio")
             AudioService.shared.stopAlarmSound()
             return
         }
 
         DispatchQueue.main.async {
-            let firingVC = AlarmFiringViewController(alarm: alarm, snoozeCount: userInfo["snoozeCount"] as? Int ?? 0)
+            let firingVC = AlarmFiringViewController(alarm: alarm, snoozeCount: payload.snoozeCount)
             firingVC.modalPresentationStyle = .fullScreen
 
             // Find the topmost presented view controller to avoid "already presenting" issues

--- a/SnoozePay/SnoozePay/Models/AlarmNotificationPayload.swift
+++ b/SnoozePay/SnoozePay/Models/AlarmNotificationPayload.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Typed payload encoded into `UNNotificationContent.userInfo` so callers do not
+/// have to scrape stringly-typed dictionaries with `as? String` / `as? Int`.
+///
+/// Three sites used to read this dict independently (`AlarmFiringCoordinator`,
+/// `AppDelegate.userNotificationCenter(_:willPresent:...)`, and
+/// `AppDelegate.userNotificationCenter(_:didReceive:...)`) — a single key typo
+/// (`"alarmId"` vs `"alarmID"`) or type mismatch was enough to silently drop a
+/// snooze action. This struct is the single source of truth for what we put in
+/// and what we get out.
+///
+/// The payload bridges through a plain `[String: Any]` dictionary (instead of a
+/// JSON blob) because Apple's local-push pipeline already accepts `userInfo`
+/// dictionaries verbatim and we want the keys to remain inspectable in
+/// Console.app and in unit tests. Each field is encoded with its primitive
+/// representation (`UUID` → `String`, others as-is).
+///
+/// Phase 2 of #31 (typed `Money` / `AlarmSound`) will tighten the field types;
+/// today we mirror the underlying `Alarm` storage so the refactor stays a
+/// pure rename.
+struct AlarmNotificationPayload: Equatable {
+
+    let alarmID: UUID
+    let penaltyAmount: Double
+    let progressiveScale: Bool
+    let snoozeCount: Int
+    let snoozeMinutes: Int
+    let soundID: String
+
+    // MARK: - userInfo keys
+    //
+    // Centralised so a typo lives in exactly one place. The string values match
+    // the historical keys used before this refactor — changing them would
+    // invalidate any pending notifications scheduled by an older build.
+    enum Key {
+        static let alarmID = "alarmID"
+        static let penaltyAmount = "penaltyAmount"
+        static let progressiveScale = "progressiveScale"
+        static let snoozeCount = "snoozeCount"
+        static let snoozeMinutes = "snoozeMinutes"
+        static let soundID = "soundID"
+    }
+
+    // MARK: - Construction from an alarm
+
+    /// Build the payload that goes into a fresh / snooze notification. The
+    /// `snoozeCount` is the count *up to and including* the most recent snooze
+    /// the user has performed — the firing coordinator increments it before
+    /// charging the next penalty.
+    init(alarm: Alarm, snoozeCount: Int) {
+        self.alarmID = alarm.id
+        self.penaltyAmount = alarm.penaltyAmount
+        self.progressiveScale = alarm.progressiveScale
+        self.snoozeCount = snoozeCount
+        self.snoozeMinutes = alarm.snoozeMinutes
+        self.soundID = alarm.soundID
+    }
+
+    /// Designated init for tests / decode paths.
+    init(
+        alarmID: UUID,
+        penaltyAmount: Double,
+        progressiveScale: Bool,
+        snoozeCount: Int,
+        snoozeMinutes: Int,
+        soundID: String
+    ) {
+        self.alarmID = alarmID
+        self.penaltyAmount = penaltyAmount
+        self.progressiveScale = progressiveScale
+        self.snoozeCount = snoozeCount
+        self.snoozeMinutes = snoozeMinutes
+        self.soundID = soundID
+    }
+
+    // MARK: - userInfo bridge
+
+    /// Decode from a `UNNotificationContent.userInfo` dictionary. Returns `nil`
+    /// if any required field is missing or has the wrong type — callers MUST
+    /// surface this as a typed error path (log + early return), never proceed
+    /// with synthesised defaults.
+    init?(userInfo: [AnyHashable: Any]) {
+        guard
+            let alarmIDString = userInfo[Key.alarmID] as? String,
+            let alarmID = UUID(uuidString: alarmIDString),
+            let penaltyAmount = userInfo[Key.penaltyAmount] as? Double,
+            let progressiveScale = userInfo[Key.progressiveScale] as? Bool,
+            let snoozeCount = userInfo[Key.snoozeCount] as? Int,
+            let snoozeMinutes = userInfo[Key.snoozeMinutes] as? Int,
+            let soundID = userInfo[Key.soundID] as? String
+        else {
+            return nil
+        }
+
+        self.alarmID = alarmID
+        self.penaltyAmount = penaltyAmount
+        self.progressiveScale = progressiveScale
+        self.snoozeCount = snoozeCount
+        self.snoozeMinutes = snoozeMinutes
+        self.soundID = soundID
+    }
+
+    /// Encode as the dictionary that `UNMutableNotificationContent.userInfo`
+    /// expects. Only `Plist`-compatible value types are produced so iOS can
+    /// serialize it across the notification daemon.
+    func asUserInfo() -> [String: Any] {
+        [
+            Key.alarmID: alarmID.uuidString,
+            Key.penaltyAmount: penaltyAmount,
+            Key.progressiveScale: progressiveScale,
+            Key.snoozeCount: snoozeCount,
+            Key.snoozeMinutes: snoozeMinutes,
+            Key.soundID: soundID
+        ]
+    }
+}

--- a/SnoozePay/SnoozePay/Services/AlarmFiringCoordinator.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmFiringCoordinator.swift
@@ -68,31 +68,27 @@ final class AlarmFiringCoordinator {
     /// (and tests) can assert exactly what happened without scraping logs.
     @discardableResult
     func handleSnooze(userInfo: [AnyHashable: Any]) -> SnoozeOutcome {
-        guard
-            let alarmIDString = userInfo["alarmID"] as? String,
-            let alarmID = UUID(uuidString: alarmIDString),
-            let snoozeCount = userInfo["snoozeCount"] as? Int
-        else {
+        guard let payload = AlarmNotificationPayload(userInfo: userInfo) else {
             print("[AlarmFiringCoordinator] snooze: invalid payload \(userInfo)")
             return .invalidPayload
         }
 
-        guard let alarm = alarmRepository.fetch(id: alarmID) else {
-            print("[AlarmFiringCoordinator] snooze: alarm \(alarmID) not in repository")
+        guard let alarm = alarmRepository.fetch(id: payload.alarmID) else {
+            print("[AlarmFiringCoordinator] snooze: alarm \(payload.alarmID) not in repository")
             return .alarmNotFound
         }
 
-        let newCount = snoozeCount + 1
+        let newCount = payload.snoozeCount + 1
         let penalty = alarm.penalty(forSnoozeCount: newCount)
 
-        let charged = balanceService.charge(amount: penalty, alarmID: alarmID)
+        let charged = balanceService.charge(amount: penalty, alarmID: payload.alarmID)
         guard charged else {
-            print("[AlarmFiringCoordinator] snooze: insufficient funds for alarm \(alarmID), penalty=\(penalty)")
+            print("[AlarmFiringCoordinator] snooze: insufficient funds for alarm \(payload.alarmID), \(penalty)")
             return .insufficientFunds
         }
 
         scheduler.scheduleSnooze(for: alarm, snoozeCount: newCount)
-        print("[AlarmFiringCoordinator] snooze: scheduled #\(newCount) for alarm \(alarmID), charged=\(penalty)")
+        print("[AlarmFiringCoordinator] snooze: scheduled #\(newCount) for \(payload.alarmID), \(penalty)")
         return .scheduled(newSnoozeCount: newCount, charged: penalty)
     }
 }

--- a/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
@@ -169,15 +169,10 @@ final class AlarmScheduler {
         content.categoryIdentifier = categoryID
         content.interruptionLevel = Self.criticalAlertsAvailable ? .critical : .timeSensitive
 
-        // Pass alarm metadata via userInfo for handling in AppDelegate
-        content.userInfo = [
-            "alarmID": alarm.id.uuidString,
-            "penaltyAmount": alarm.penaltyAmount,
-            "progressiveScale": alarm.progressiveScale,
-            "snoozeCount": snoozeCount,
-            "snoozeMinutes": alarm.snoozeMinutes,
-            "soundID": alarm.soundID
-        ]
+        // Pass alarm metadata via a typed payload so AppDelegate /
+        // AlarmFiringCoordinator can decode it without ad-hoc `as?` casts.
+        content.userInfo = AlarmNotificationPayload(alarm: alarm, snoozeCount: snoozeCount)
+            .asUserInfo()
 
         return content
     }

--- a/SnoozePay/SnoozePayTests/AlarmNotificationPayloadTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmNotificationPayloadTests.swift
@@ -1,0 +1,225 @@
+import XCTest
+@testable import SnoozePay
+
+/// Round-trip and malformed-input coverage for the typed notification payload.
+///
+/// The struct is the single source of truth for what we put into and read out
+/// of `UNNotificationContent.userInfo`. Three independent reader sites used to
+/// scrape this dict with stringly-typed `as?` casts; a single key typo or type
+/// mismatch silently dropped a snooze. These tests guarantee we surface that
+/// kind of regression instead of returning a partially-populated struct.
+final class AlarmNotificationPayloadTests: XCTestCase {
+
+    // MARK: - Construction from Alarm
+
+    func testInit_fromAlarm_copiesAllFields() {
+        let alarm = Alarm(
+            id: UUID(),
+            name: "Утренний",
+            soundID: "morning_bells",
+            snoozeMinutes: 7,
+            penaltyAmount: 75,
+            progressiveScale: true
+        )
+        let payload = AlarmNotificationPayload(alarm: alarm, snoozeCount: 2)
+
+        XCTAssertEqual(payload.alarmID, alarm.id)
+        XCTAssertEqual(payload.penaltyAmount, 75)
+        XCTAssertEqual(payload.progressiveScale, true)
+        XCTAssertEqual(payload.snoozeCount, 2)
+        XCTAssertEqual(payload.snoozeMinutes, 7)
+        XCTAssertEqual(payload.soundID, "morning_bells")
+    }
+
+    // MARK: - Round-trip
+
+    func testRoundTrip_preservesAllFields() {
+        let original = AlarmNotificationPayload(
+            alarmID: UUID(),
+            penaltyAmount: 125,
+            progressiveScale: true,
+            snoozeCount: 4,
+            snoozeMinutes: 9,
+            soundID: "radar"
+        )
+
+        let dict = original.asUserInfo()
+        let decoded = AlarmNotificationPayload(userInfo: dict)
+
+        XCTAssertEqual(decoded, original)
+    }
+
+    func testRoundTrip_throughAnyHashableDict_preservesFields() {
+        // UNNotificationContent.userInfo is exposed as `[AnyHashable: Any]` to
+        // callers — round-trip through that shape too, in case Foundation
+        // ever bridges the keys differently from a plain `[String: Any]`.
+        let original = AlarmNotificationPayload(
+            alarmID: UUID(),
+            penaltyAmount: 50,
+            progressiveScale: false,
+            snoozeCount: 0,
+            snoozeMinutes: 9,
+            soundID: "default_alarm"
+        )
+
+        let raw = original.asUserInfo()
+        let bridged: [AnyHashable: Any] = raw.reduce(into: [:]) { acc, pair in
+            acc[pair.key] = pair.value
+        }
+        let decoded = AlarmNotificationPayload(userInfo: bridged)
+
+        XCTAssertEqual(decoded, original)
+    }
+
+    // MARK: - asUserInfo emits Plist-compatible types
+
+    func testAsUserInfo_emitsExpectedKeys() {
+        let payload = AlarmNotificationPayload(
+            alarmID: UUID(),
+            penaltyAmount: 100,
+            progressiveScale: true,
+            snoozeCount: 1,
+            snoozeMinutes: 5,
+            soundID: "radar"
+        )
+        let dict = payload.asUserInfo()
+
+        XCTAssertEqual(Set(dict.keys), [
+            "alarmID",
+            "penaltyAmount",
+            "progressiveScale",
+            "snoozeCount",
+            "snoozeMinutes",
+            "soundID"
+        ])
+        XCTAssertTrue(dict["alarmID"] is String)
+        XCTAssertTrue(dict["penaltyAmount"] is Double)
+        XCTAssertTrue(dict["progressiveScale"] is Bool)
+        XCTAssertTrue(dict["snoozeCount"] is Int)
+        XCTAssertTrue(dict["snoozeMinutes"] is Int)
+        XCTAssertTrue(dict["soundID"] is String)
+    }
+
+    // MARK: - Malformed input → nil
+
+    func testInit_emptyUserInfo_returnsNil() {
+        XCTAssertNil(AlarmNotificationPayload(userInfo: [:]))
+    }
+
+    func testInit_missingAlarmID_returnsNil() {
+        let dict: [AnyHashable: Any] = [
+            "penaltyAmount": 50.0,
+            "progressiveScale": false,
+            "snoozeCount": 0,
+            "snoozeMinutes": 9,
+            "soundID": "radar"
+        ]
+        XCTAssertNil(AlarmNotificationPayload(userInfo: dict))
+    }
+
+    func testInit_invalidUUIDString_returnsNil() {
+        let dict: [AnyHashable: Any] = [
+            "alarmID": "not-a-real-uuid",
+            "penaltyAmount": 50.0,
+            "progressiveScale": false,
+            "snoozeCount": 0,
+            "snoozeMinutes": 9,
+            "soundID": "radar"
+        ]
+        XCTAssertNil(AlarmNotificationPayload(userInfo: dict))
+    }
+
+    func testInit_alarmIDAsUUIDInsteadOfString_returnsNil() {
+        // Defensive: someone could try to put a UUID() directly. We require the
+        // string representation because that's what survives Plist encoding
+        // through the notification daemon.
+        let dict: [AnyHashable: Any] = [
+            "alarmID": UUID(),
+            "penaltyAmount": 50.0,
+            "progressiveScale": false,
+            "snoozeCount": 0,
+            "snoozeMinutes": 9,
+            "soundID": "radar"
+        ]
+        XCTAssertNil(AlarmNotificationPayload(userInfo: dict))
+    }
+
+    func testInit_penaltyAsString_returnsNil() {
+        let dict: [AnyHashable: Any] = [
+            "alarmID": UUID().uuidString,
+            "penaltyAmount": "50",
+            "progressiveScale": false,
+            "snoozeCount": 0,
+            "snoozeMinutes": 9,
+            "soundID": "radar"
+        ]
+        XCTAssertNil(AlarmNotificationPayload(userInfo: dict))
+    }
+
+    func testInit_snoozeCountAsDouble_returnsNil() {
+        // We require Int specifically — a Double would silently discard the
+        // user's intent if someone in a callsite ever wrote `5.5`.
+        let dict: [AnyHashable: Any] = [
+            "alarmID": UUID().uuidString,
+            "penaltyAmount": 50.0,
+            "progressiveScale": false,
+            "snoozeCount": 0.5,
+            "snoozeMinutes": 9,
+            "soundID": "radar"
+        ]
+        XCTAssertNil(AlarmNotificationPayload(userInfo: dict))
+    }
+
+    func testInit_progressiveScaleMissing_returnsNil() {
+        let dict: [AnyHashable: Any] = [
+            "alarmID": UUID().uuidString,
+            "penaltyAmount": 50.0,
+            "snoozeCount": 0,
+            "snoozeMinutes": 9,
+            "soundID": "radar"
+        ]
+        XCTAssertNil(AlarmNotificationPayload(userInfo: dict))
+    }
+
+    func testInit_soundIDMissing_returnsNil() {
+        let dict: [AnyHashable: Any] = [
+            "alarmID": UUID().uuidString,
+            "penaltyAmount": 50.0,
+            "progressiveScale": false,
+            "snoozeCount": 0,
+            "snoozeMinutes": 9
+        ]
+        XCTAssertNil(AlarmNotificationPayload(userInfo: dict))
+    }
+
+    func testInit_typoedKeyAlarmId_returnsNil() {
+        // Regression: the original silent-failure path caught by /audit was
+        // exactly this — someone read `"alarmId"` (lowercase d) instead of
+        // `"alarmID"`. Now the entire payload bails so the typo is loud.
+        let dict: [AnyHashable: Any] = [
+            "alarmId": UUID().uuidString,
+            "penaltyAmount": 50.0,
+            "progressiveScale": false,
+            "snoozeCount": 0,
+            "snoozeMinutes": 9,
+            "soundID": "radar"
+        ]
+        XCTAssertNil(AlarmNotificationPayload(userInfo: dict))
+    }
+
+    // MARK: - Compatibility with existing keys
+    //
+    // The keys here are the exact strings AlarmScheduler / AlarmFiringCoordinator
+    // / AppDelegate used before this refactor. Pinning them in a test guarantees
+    // a future rename can't silently invalidate a notification that was
+    // scheduled by an older build still pending in the system queue.
+
+    func testKeys_areStableContract() {
+        XCTAssertEqual(AlarmNotificationPayload.Key.alarmID, "alarmID")
+        XCTAssertEqual(AlarmNotificationPayload.Key.penaltyAmount, "penaltyAmount")
+        XCTAssertEqual(AlarmNotificationPayload.Key.progressiveScale, "progressiveScale")
+        XCTAssertEqual(AlarmNotificationPayload.Key.snoozeCount, "snoozeCount")
+        XCTAssertEqual(AlarmNotificationPayload.Key.snoozeMinutes, "snoozeMinutes")
+        XCTAssertEqual(AlarmNotificationPayload.Key.soundID, "soundID")
+    }
+}


### PR DESCRIPTION
Fixes #74

Re-push of closed #93 rebased on current main (which now contains merged #87 and #88).

## Summary
- New `AlarmNotificationPayload` struct (Codable, plist-bridged) replaces stringly-typed `userInfo: [String: Any]` in AlarmScheduler.
- All read sites (AppDelegate willPresent / didReceive, AlarmFiringCoordinator.handleSnooze) decode via `init?(userInfo:)` with explicit error handling — no silent default-fallback paths.
- 12 unit tests: round-trip + 9 malformed cases + key-stability contract.
- Backwards compatible — existing pending notifications keep working.

## Test plan
- [ ] Build green.
- [ ] Tests pass (12 new tests, no existing regressions).