### PR TITLE
[test] Cover AlarmScheduler weekday math + snooze (#78)

### DIFF
--- a/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
@@ -97,7 +97,7 @@ final class AlarmScheduler {
     func scheduleSnooze(for alarm: Alarm, snoozeCount: Int) {
         let content = makeContent(for: alarm, snoozeCount: snoozeCount)
 
-        let fireDate = Date().addingTimeInterval(TimeInterval(alarm.snoozeMinutes * 60))
+        let fireDate = Self.scheduledFireDate(now: Date(), snoozeMinutes: alarm.snoozeMinutes)
         var components = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: fireDate)
         components.second = 0
         let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: false)
@@ -112,6 +112,13 @@ final class AlarmScheduler {
                 print("[AlarmScheduler] schedule failed: \(error)")
             }
         }
+    }
+
+    /// Pure factory for the snooze fire date — extracted so unit tests can pin the
+    /// arithmetic without touching UNUserNotificationCenter. Bug guard for mistaken
+    /// unit conversions (minutes vs seconds vs hours).
+    static func scheduledFireDate(now: Date, snoozeMinutes: Int) -> Date {
+        now.addingTimeInterval(TimeInterval(snoozeMinutes * 60))
     }
 
     // MARK: - Cancel
@@ -177,13 +184,15 @@ final class AlarmScheduler {
         return content
     }
 
-    private struct TriggerWithLabel {
+    struct TriggerWithLabel {
         let label: String
         let trigger: UNNotificationTrigger
     }
 
     /// Build triggers for all active repeat days, or a one-time trigger if no repeat days.
-    private func makeTriggers(for alarm: Alarm) -> [TriggerWithLabel] {
+    /// Exposed as `internal` so tests can pin the legacy 0=Mon → Calendar.weekday 1=Sun
+    /// mapping; an off-by-one here means "alarm on Saturday rings on Sunday".
+    func makeTriggers(for alarm: Alarm) -> [TriggerWithLabel] {
         let calendar = Calendar.current
         let timeComponents = calendar.dateComponents([.hour, .minute], from: alarm.time)
 
@@ -220,7 +229,7 @@ final class AlarmScheduler {
         "alarm_\(alarmID.uuidString)_"
     }
 
-    private func snoozeNotificationID(for alarmID: UUID) -> String {
+    func snoozeNotificationID(for alarmID: UUID) -> String {
         "snooze_\(alarmID.uuidString)"
     }
 

--- a/SnoozePay/SnoozePayTests/AlarmSchedulerSnoozeTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmSchedulerSnoozeTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+import UserNotifications
+@testable import SnoozePay
+
+/// Pins the snooze fire-date arithmetic and identifier scheme.
+///
+/// The arithmetic is dangerous: `now + snoozeMinutes * 60`. If the `* 60`
+/// drops, snooze fires immediately; if it becomes `* 60 * 60`, snooze fires
+/// hours later. Both regressions silently break the core product, so we
+/// pin them via the pure factory `AlarmScheduler.scheduledFireDate`.
+final class AlarmSchedulerSnoozeTests: XCTestCase {
+
+    private let scheduler = AlarmScheduler.shared
+
+    // MARK: - scheduledFireDate arithmetic
+
+    func testScheduledFireDate_addsExactlyTheGivenMinutesInSeconds() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let snoozeMinutes = 9
+
+        let fireDate = AlarmScheduler.scheduledFireDate(now: now, snoozeMinutes: snoozeMinutes)
+
+        XCTAssertEqual(
+            fireDate.timeIntervalSince(now),
+            TimeInterval(9 * 60),
+            accuracy: 0.001,
+            "9 minutes must add 540 seconds — guards against minute↔hour↔second unit confusion"
+        )
+    }
+
+    func testScheduledFireDate_zeroMinutes_returnsNow() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let fireDate = AlarmScheduler.scheduledFireDate(now: now, snoozeMinutes: 0)
+        XCTAssertEqual(fireDate.timeIntervalSince(now), 0, accuracy: 0.001)
+    }
+
+    func testScheduledFireDate_oneMinute_addsSixtySeconds() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let fireDate = AlarmScheduler.scheduledFireDate(now: now, snoozeMinutes: 1)
+        XCTAssertEqual(fireDate.timeIntervalSince(now), 60, accuracy: 0.001)
+    }
+
+    func testScheduledFireDate_fifteenMinutes_addsNineHundredSeconds() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let fireDate = AlarmScheduler.scheduledFireDate(now: now, snoozeMinutes: 15)
+        XCTAssertEqual(
+            fireDate.timeIntervalSince(now),
+            900,
+            accuracy: 0.001,
+            "15 min must be exactly 900s — not 15h (54000s) or 15s"
+        )
+    }
+
+    /// Verify a future date (real `Date()`) wires through correctly — the
+    /// previous tests use a fixed timestamp; this one mimics the production
+    /// call site at `scheduleSnooze`.
+    func testScheduledFireDate_realNow_isInFutureBySnoozeMinutes() {
+        let before = Date()
+        let fireDate = AlarmScheduler.scheduledFireDate(now: before, snoozeMinutes: 5)
+        let after = Date()
+
+        XCTAssertGreaterThanOrEqual(fireDate.timeIntervalSince(before), 5 * 60 - 0.001)
+        XCTAssertLessThanOrEqual(fireDate.timeIntervalSince(after), 5 * 60 + 0.001)
+    }
+
+    // MARK: - Snooze notification identifier
+
+    func testSnoozeNotificationID_isStableAndScopedToAlarmID() {
+        let alarmID = UUID()
+        let id = scheduler.snoozeNotificationID(for: alarmID)
+
+        XCTAssertEqual(id, "snooze_\(alarmID.uuidString)",
+                       "Snooze identifier must follow `snooze_<alarmUUID>` — used by cancel(_:)")
+    }
+
+    func testSnoozeNotificationID_differsBetweenAlarms() {
+        let id1 = scheduler.snoozeNotificationID(for: UUID())
+        let id2 = scheduler.snoozeNotificationID(for: UUID())
+        XCTAssertNotEqual(id1, id2,
+                          "Different alarms must get distinct snooze IDs to avoid clobbering each other")
+    }
+
+    /// `cancel(_:)` filters pending requests by both the per-trigger prefix
+    /// (`alarm_<UUID>_*`) and the snooze ID. Pinning the prefix here guards
+    /// against the IOS-070-style regression where cancel missed a label.
+    func testSnoozeNotificationID_doesNotShareScheduledAlarmPrefix() {
+        let alarmID = UUID()
+        let snoozeID = scheduler.snoozeNotificationID(for: alarmID)
+
+        XCTAssertFalse(snoozeID.hasPrefix("alarm_"),
+                       "Snooze ID must use a distinct prefix from scheduled-day IDs " +
+                       "so cancel(_:) can filter both sets independently")
+    }
+
+    // MARK: - Snooze notification content (payload contents)
+
+    func testScheduleSnooze_contentReflectsSnoozeCount() {
+        let alarm = Alarm(penaltyAmount: 50)
+        let content = scheduler.makeContent(for: alarm, snoozeCount: 1)
+
+        XCTAssertEqual(content.userInfo["snoozeCount"] as? Int, 1,
+                       "Snooze re-fire payload must carry the running snooze count " +
+                       "so the next charge is calculated from the right base")
+    }
+
+    func testScheduleSnooze_contentEscalatesPenaltyForProgressiveScale() {
+        let alarm = Alarm(penaltyAmount: 50, progressiveScale: true)
+
+        // After 1 snooze, the next charge would be the 2nd snooze → 50 * 2 = 100
+        let content = scheduler.makeContent(for: alarm, snoozeCount: 1)
+
+        XCTAssertEqual(content.subtitle, "Отложить \u{00B7} 100 ₽",
+                       "Progressive scale must compound the penalty across snooze re-fires")
+    }
+}

--- a/SnoozePay/SnoozePayTests/AlarmSchedulerWeekdayTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmSchedulerWeekdayTests.swift
@@ -1,0 +1,143 @@
+import XCTest
+import UserNotifications
+@testable import SnoozePay
+
+/// Pins the legacy `0 = Monday … 6 = Sunday` repeat-day convention used in
+/// `Alarm.repeatDays` to Apple's `Calendar.weekday` (`1 = Sunday … 7 = Saturday`).
+///
+/// An off-by-one in `AlarmScheduler.makeTriggers(for:)` would mean "alarm on
+/// Saturday rings on Sunday" — a critical regression for the core product.
+/// These tests deliberately do NOT touch `UNUserNotificationCenter`; they only
+/// assert on the trigger components produced by the pure mapping.
+final class AlarmSchedulerWeekdayTests: XCTestCase {
+
+    private let scheduler = AlarmScheduler.shared
+
+    // MARK: - Helpers
+
+    /// Build an alarm whose `time` is exactly the given hour:minute today.
+    private func alarm(hour: Int, minute: Int, repeatDays: [Int]) -> Alarm {
+        var components = Calendar.current.dateComponents([.year, .month, .day], from: Date())
+        components.hour = hour
+        components.minute = minute
+        components.second = 0
+        let time = Calendar.current.date(from: components) ?? Date()
+        return Alarm(time: time, repeatDays: repeatDays)
+    }
+
+    private func calendarTrigger(_ trigger: AlarmScheduler.TriggerWithLabel) -> UNCalendarNotificationTrigger? {
+        trigger.trigger as? UNCalendarNotificationTrigger
+    }
+
+    // MARK: - Empty repeatDays → single one-shot trigger
+
+    func testMakeTriggers_emptyRepeatDays_producesSingleNonRepeatingTrigger() {
+        let alarm = self.alarm(hour: 7, minute: 30, repeatDays: [])
+
+        let triggers = scheduler.makeTriggers(for: alarm)
+
+        XCTAssertEqual(triggers.count, 1, "Empty repeatDays should produce one one-shot trigger")
+        XCTAssertEqual(triggers.first?.label, "once",
+                       "Single-fire trigger must be labelled 'once' (used by cancel)")
+        let calendarTrigger = self.calendarTrigger(triggers[0])
+        XCTAssertNotNil(calendarTrigger)
+        XCTAssertEqual(calendarTrigger?.repeats, false,
+                       "One-shot alarm must not repeat")
+        XCTAssertEqual(calendarTrigger?.dateComponents.hour, 7)
+        XCTAssertEqual(calendarTrigger?.dateComponents.minute, 30)
+        XCTAssertEqual(calendarTrigger?.dateComponents.second, 0)
+        XCTAssertNil(calendarTrigger?.dateComponents.weekday,
+                     "One-shot trigger must not pin a weekday — fires at next occurrence of HH:MM")
+    }
+
+    // MARK: - All 7 days → 7 repeating calendar triggers
+
+    func testMakeTriggers_allSevenDays_producesSevenRepeatingTriggers() {
+        let alarm = self.alarm(hour: 6, minute: 0, repeatDays: [0, 1, 2, 3, 4, 5, 6])
+
+        let triggers = scheduler.makeTriggers(for: alarm)
+
+        XCTAssertEqual(triggers.count, 7,
+                       "All-day alarm must produce one trigger per weekday — separate triggers " +
+                       "let cancel(_:) remove them by alarm ID prefix")
+
+        // Every trigger must be a repeating calendar trigger pinned to the alarm's HH:MM.
+        for entry in triggers {
+            let trigger = calendarTrigger(entry)
+            XCTAssertNotNil(trigger)
+            XCTAssertEqual(trigger?.repeats, true)
+            XCTAssertEqual(trigger?.dateComponents.hour, 6)
+            XCTAssertEqual(trigger?.dateComponents.minute, 0)
+            XCTAssertNotNil(trigger?.dateComponents.weekday)
+        }
+
+        // Labels must cover every day0…day6 exactly once.
+        let labels = Set(triggers.map { $0.label })
+        XCTAssertEqual(labels, Set((0...6).map { "day\($0)" }))
+
+        // Calendar weekdays must cover the full 1…7 range exactly once.
+        let weekdays = triggers.compactMap { calendarTrigger($0)?.dateComponents.weekday }
+        XCTAssertEqual(Set(weekdays), Set(1...7))
+    }
+
+    // MARK: - Individual day mapping (legacy 0..6 → Calendar 1..7)
+
+    private struct WeekdayMapping {
+        let legacyDay: Int
+        let calendarWeekday: Int
+        let name: String
+    }
+
+    /// Single source of truth for the mapping — keep these expectations together
+    /// so any future Calendar locale change is loud.
+    private static let expectedWeekdayMapping: [WeekdayMapping] = [
+        WeekdayMapping(legacyDay: 0, calendarWeekday: 2, name: "Monday"),
+        WeekdayMapping(legacyDay: 1, calendarWeekday: 3, name: "Tuesday"),
+        WeekdayMapping(legacyDay: 2, calendarWeekday: 4, name: "Wednesday"),
+        WeekdayMapping(legacyDay: 3, calendarWeekday: 5, name: "Thursday"),
+        WeekdayMapping(legacyDay: 4, calendarWeekday: 6, name: "Friday"),
+        WeekdayMapping(legacyDay: 5, calendarWeekday: 7, name: "Saturday"),
+        WeekdayMapping(legacyDay: 6, calendarWeekday: 1, name: "Sunday")
+    ]
+
+    func testMakeTriggers_individualDay_mapsToCorrectCalendarWeekday() {
+        for entry in Self.expectedWeekdayMapping {
+            let alarm = self.alarm(hour: 8, minute: 15, repeatDays: [entry.legacyDay])
+
+            let triggers = scheduler.makeTriggers(for: alarm)
+
+            XCTAssertEqual(triggers.count, 1, "\(entry.name): single repeat day → single trigger")
+            XCTAssertEqual(triggers.first?.label, "day\(entry.legacyDay)")
+
+            let trigger = calendarTrigger(triggers[0])
+            XCTAssertEqual(trigger?.repeats, true, "\(entry.name): repeating-day trigger must repeat")
+            XCTAssertEqual(trigger?.dateComponents.hour, 8, "\(entry.name): hour preserved")
+            XCTAssertEqual(trigger?.dateComponents.minute, 15, "\(entry.name): minute preserved")
+            XCTAssertEqual(trigger?.dateComponents.second, 0, "\(entry.name): second normalized to 0")
+            XCTAssertEqual(
+                trigger?.dateComponents.weekday,
+                entry.calendarWeekday,
+                "\(entry.name): legacy day \(entry.legacyDay) must map to Calendar.weekday \(entry.calendarWeekday)"
+            )
+        }
+    }
+
+    // MARK: - Critical edge cases (Saturday & Sunday boundary)
+
+    /// The off-by-one most likely to surface in `((day + 1) % 7) + 1` is at the
+    /// boundary between Saturday (legacy 5 → Cal 7) and Sunday (legacy 6 → Cal 1).
+    /// Pin both explicitly so a future refactor of the formula trips this test.
+    func testMakeTriggers_saturday_mapsToCalendarSaturday() {
+        let alarm = self.alarm(hour: 9, minute: 0, repeatDays: [5])
+        let triggers = scheduler.makeTriggers(for: alarm)
+        XCTAssertEqual(calendarTrigger(triggers[0])?.dateComponents.weekday, 7,
+                       "Legacy 5 (Sat) must map to Calendar.weekday 7 (Saturday)")
+    }
+
+    func testMakeTriggers_sunday_mapsToCalendarSunday() {
+        let alarm = self.alarm(hour: 9, minute: 0, repeatDays: [6])
+        let triggers = scheduler.makeTriggers(for: alarm)
+        XCTAssertEqual(calendarTrigger(triggers[0])?.dateComponents.weekday, 1,
+                       "Legacy 6 (Sun) must map to Calendar.weekday 1 (Sunday) — this is the wrap-around case")
+    }
+}


### PR DESCRIPTION
Fixes #78 (partial — AlarmScheduler portion only)

## Что сделано

Закрыто два из критических test gaps, выявленных в #78:

### 1. AlarmScheduler weekday math (`AlarmSchedulerWeekdayTests.swift`)
Пинит конвертацию `legacy 0=Mon..6=Sun` → `Calendar.weekday 1=Sun..7=Sat`. Off-by-one тут = «будильник в субботу звонит в воскресенье», core regression.

Покрыто:
- `repeatDays = []` → один `once` non-repeating trigger без weekday
- Все 7 дней → 7 repeating триггеров, weekdays = `Set(1...7)`, labels = `Set(day0..day6)`
- Индивидуальное соответствие `legacyDay → calendarWeekday` для всех 7 дней
- Явные edge-кейсы Saturday (5→7) и Sunday (6→1) — точка где `((day + 1) % 7) + 1` оборачивается

### 2. AlarmScheduler snooze (`AlarmSchedulerSnoozeTests.swift`)
Пинит арифметику `now + minutes * 60` (защита от unit confusion: minutes↔seconds↔hours), идентификатор `snooze_<UUID>`, и payload (snoozeCount + progressive penalty subtitle).

### Minimal refactor (`AlarmScheduler.swift`)
- `makeTriggers` + nested `TriggerWithLabel` подняты до `internal` — только access modifier, поведение не меняется
- Извлечён `static func scheduledFireDate(now:snoozeMinutes:)` — pure factory, тестируется без `UNUserNotificationCenter`
- `snoozeNotificationID` поднят до `internal`

## Что НЕ сделано (отложено)

StoreKit DI часть issue #78 — требует введения `StoreKitClient` protocol и `AlarmNotificationCenter` protocol, это отдельный refactor (meta-blocker в issue body). Лучше как follow-up, чтобы этот PR оставался минимальным test-only изменением.

Прочие test gaps из #78 (CreateAlarmViewModel edit path, Alarm Codable round-trip, AlarmFiringCoordinator invariants) тоже оставлены под follow-up — каждое требует отдельного контекста и должно быть отдельной маленькой PR-кой.

## Verify

- swiftlint: 0 errors на тронутых файлах (2 pre-existing for_where warnings в `alarmSoundFileName` — не моего касания)
- build_sim: ❌ **сломан на main**, не из-за этой PR. Видно в #100 — `SoundCell` redeclared after PR #88. Эта PR компилируется в изоляции; merge должен подождать фикса #100.
- test_sim: gate отключён глобально (CLAUDE.md memory); ручной запуск `xcodebuild test` блокирован тем же #100.

## Test plan
- [ ] Дождаться фикса #100 (SoundCell duplicate)
- [ ] Прогнать `mcp__XcodeBuildMCP__test_sim` — все новые тесты должны быть green
- [ ] При следующем `/audit` — проверить что StoreKit DI gaps закрыты отдельной issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)