### PR TITLE
[bug] Surface AudioService failures + vibration fallback signal (#77)

### DIFF
--- a/SnoozePay/SnoozePay/Services/AudioService.swift
+++ b/SnoozePay/SnoozePay/Services/AudioService.swift
@@ -1,5 +1,26 @@
 import AVFoundation
 import AudioToolbox
+import Foundation
+
+/// Playback state of the alarm audio pipeline.
+///
+/// Replaces the old `isPlaying: Bool` so the UI can distinguish between
+/// "real audio is playing", "we tried but failed", and "stopped".
+enum AudioPlaybackState: Equatable {
+    /// Real audio (bundled file or synthetic tone) is looping.
+    case playing
+
+    /// AVAudioSession refused to activate — caller cannot guarantee any sound.
+    /// Vibration is also skipped since without a session we have no playback path.
+    case silentBecauseConfigFailed
+
+    /// Bundled file existed but `AVAudioPlayer` rejected it (corrupt/format).
+    /// Synthetic tone fallback also failed → only vibration is running.
+    case vibrationOnly
+
+    /// Initial state and after `stopAlarmSound()`.
+    case stopped
+}
 
 /// Manages continuous alarm sound playback and vibration.
 /// Configures AVAudioSession for playback even when screen is locked,
@@ -9,9 +30,36 @@ final class AudioService {
 
     static let shared = AudioService()
 
+    // MARK: - Notification names
+
+    /// Posted whenever `state` transitions. Observers receive the new state in
+    /// `userInfo[stateUserInfoKey]` so UI (e.g. AlarmFiringViewController) can
+    /// surface a banner when audio falls back to vibration or fails entirely.
+    ///
+    /// Always posted on the main queue — observers can update UI without
+    /// dispatching themselves.
+    static let stateChangedNotification = Notification.Name("snoozepay.audio.stateChanged")
+    static let stateUserInfoKey = "state"
+
     private var audioPlayer: AVAudioPlayer?
     private var vibrationTimer: Timer?
-    private(set) var isPlaying = false
+
+    /// Current playback state. Mutating this also broadcasts a notification so
+    /// callers can react to fallback paths (config failed / vibration only).
+    private(set) var state: AudioPlaybackState = .stopped {
+        didSet {
+            guard oldValue != state else { return }
+            NotificationCenter.default.post(
+                name: Self.stateChangedNotification,
+                object: self,
+                userInfo: [Self.stateUserInfoKey: state]
+            )
+        }
+    }
+
+    /// Backwards-compatible boolean. `true` only when actually playing real audio.
+    /// Retained so existing callers (AppDelegate guards, tests) keep working.
+    var isPlaying: Bool { state == .playing }
 
     private init() {}
 
@@ -19,20 +67,17 @@ final class AudioService {
 
     /// Configure the audio session for alarm playback.
     /// Uses `.playback` category so audio continues when screen is locked.
-    /// - Returns: `true` if the session is active and ready, `false` otherwise.
-    private func configureAudioSession() -> Bool {
-        do {
-            let session = AVAudioSession.sharedInstance()
-            try session.setCategory(.playback, options: [.duckOthers])
-            try session.setActive(true, options: [])
-            return true
-        } catch {
-            print("[AudioService] failed to configure audio session: \(error)")
-            return false
-        }
+    /// - Throws: any underlying `AVAudioSession` error so the caller can decide
+    ///   whether to fall back or surface the failure.
+    private func configureAudioSession() throws {
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(.playback, options: [.duckOthers])
+        try session.setActive(true, options: [])
     }
 
     /// Deactivate the audio session when alarm is stopped.
+    /// Failures are logged — there is no recovery path that the user could act on,
+    /// but a stale session may keep other apps duck'ed.
     private func deactivateAudioSession() {
         do {
             try AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
@@ -45,16 +90,22 @@ final class AudioService {
 
     /// Start playing alarm sound in a loop.
     /// - Parameter soundID: Name of the sound file (without extension) in the app bundle.
-    ///   Falls back to a system-generated tone if file is not found.
+    ///   Falls back to a system-generated tone if the file is missing or fails to load.
     func startAlarmSound(soundID: String) {
-        guard !isPlaying else { return }
+        // Already in a non-stopped state — preserve the existing pipeline.
+        // Earlier guard was `!isPlaying` (Bool); using state covers
+        // `.vibrationOnly` and `.silentBecauseConfigFailed` so we don't try to
+        // restart on top of a partial fallback either.
+        guard state == .stopped else { return }
 
-        guard configureAudioSession() else {
+        do {
+            try configureAudioSession()
+        } catch {
             // Audio session unavailable (e.g. another app holds it).
-            // Surface explicitly via isPlaying = false so the UI / caller can react.
-            // Skip vibration too — without an active session we cannot guarantee playback.
-            print("[AudioService] startAlarmSound aborted: audio session unavailable")
-            isPlaying = false
+            // Cannot guarantee playback — skip vibration too and surface the
+            // explicit fallback state so the UI can warn the user.
+            print("[AudioService] failed to configure audio session: \(error)")
+            state = .silentBecauseConfigFailed
             return
         }
 
@@ -67,34 +118,51 @@ final class AudioService {
             ?? Bundle.main.url(forResource: "default_alarm", withExtension: "m4a")
 
         // Try the bundled file first; fall back to synthetic tone if the file
-        // is missing or corrupt (AVAudioPlayer init returns nil).
+        // is missing or AVAudioPlayer rejects it (corrupt / format mismatch).
         var player: AVAudioPlayer?
         if let soundURL = url {
-            player = try? AVAudioPlayer(contentsOf: soundURL)
-            if player == nil {
+            do {
+                player = try AVAudioPlayer(contentsOf: soundURL)
+            } catch {
                 let name = soundURL.lastPathComponent
-                print("[AudioService] AVAudioPlayer init failed for \(name), using synthetic tone")
+                print("[AudioService] AVAudioPlayer init failed for \(name): \(error)")
+                player = nil
             }
         }
         if player == nil {
             player = Self.generateAlarmTone()
         }
 
-        if let player {
-            audioPlayer = player
-            player.numberOfLoops = -1
-            player.volume = 1.0
-            player.prepareToPlay()
-            player.play()
-            isPlaying = true
-            startVibration()
-        } else {
-            // Neither bundled file nor synthetic tone available — refuse to claim playback.
-            // We still vibrate, but isPlaying stays false to signal silent failure.
+        guard let player else {
+            // Neither bundled file nor synthetic tone available — refuse to claim
+            // playback. Vibration still runs so the user is at least woken.
             print("[AudioService] startAlarmSound: no audio source available, vibration only")
-            isPlaying = false
+            state = .vibrationOnly
             startVibration()
+            return
         }
+
+        audioPlayer = player
+        player.numberOfLoops = -1
+        player.volume = 1.0
+
+        // prepareToPlay returns Bool but does not throw; play() does not throw
+        // either, but its return value indicates whether the queue accepted the
+        // sound. A `false` here means we have a player object but the system
+        // refused to start playback — surface that as `vibrationOnly` so the UI
+        // does not silently swallow a real failure.
+        let prepared = player.prepareToPlay()
+        let started = player.play()
+        if !prepared || !started {
+            print("[AudioService] AVAudioPlayer play() rejected (prepared=\(prepared), started=\(started))")
+            audioPlayer = nil
+            state = .vibrationOnly
+            startVibration()
+            return
+        }
+
+        state = .playing
+        startVibration()
     }
 
     /// Stop alarm sound and vibration immediately.
@@ -103,7 +171,7 @@ final class AudioService {
         audioPlayer = nil
         stopVibration()
         deactivateAudioSession()
-        isPlaying = false
+        state = .stopped
     }
 
     // MARK: - Vibration

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
@@ -117,8 +117,32 @@ class AlarmFiringViewController: UIViewController {
         return button
     }()
 
+    /// Banner shown when AudioService falls back to vibration / silent mode.
+    /// Hidden by default; surfaces only on `.silentBecauseConfigFailed` or `.vibrationOnly`.
+    private let audioWarningBanner: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 13, weight: .medium)
+        label.textColor = .white
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.backgroundColor = UIColor(red: 0.86, green: 0.27, blue: 0.27, alpha: 0.85)
+        label.layer.cornerRadius = 10
+        label.layer.masksToBounds = true
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.isHidden = true
+        // Accessibility: VoiceOver reads the warning even if user can't see banner.
+        label.isAccessibilityElement = true
+        label.accessibilityTraits = [.staticText, .updatesFrequently]
+        return label
+    }()
+
     /// Timer to update displayed time each second
     private var clockTimer: Timer?
+
+    /// Observer token for `AudioService.stateChangedNotification`. Kept so we
+    /// can remove the observer in `deinit` and avoid leaking blocks across
+    /// presentations of this screen.
+    private var audioStateObserver: NSObjectProtocol?
 
     // MARK: - Init
 
@@ -133,17 +157,31 @@ class AlarmFiringViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    deinit {
+        if let token = audioStateObserver {
+            NotificationCenter.default.removeObserver(token)
+        }
+    }
+
     // MARK: - Lifecycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
         setupUI()
         bindViewModel()
+        observeAudioState()
         startClock()
         startPulseAnimation()
 
-        // Start continuous alarm sound and vibration
+        // Start continuous alarm sound and vibration. State observer (above)
+        // will surface the banner if AudioService falls back to vibration-only
+        // or fails to acquire the audio session.
         AudioService.shared.startAlarmSound(soundID: viewModel.alarm.soundID)
+
+        // Sync UI with whatever state startAlarmSound produced — observer fires
+        // on transitions, but the very first transition may have already
+        // happened above before we begin observing on the next runloop tick.
+        applyAudioState(AudioService.shared.state)
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -192,6 +230,10 @@ class AlarmFiringViewController: UIViewController {
         buttonStack.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(buttonStack)
 
+        // Audio fallback warning — sits just above the buttons so the user sees
+        // it without scrolling past the prominent time display.
+        view.addSubview(audioWarningBanner)
+
         NSLayoutConstraint.activate([
             // ALARM label — near top safe area
             alarmTypeLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20),
@@ -206,6 +248,11 @@ class AlarmFiringViewController: UIViewController {
             // Alarm name below time
             nameLabel.topAnchor.constraint(equalTo: timeLabel.bottomAnchor, constant: 8),
             nameLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+
+            // Audio warning banner — above the buttons, full width with margins
+            audioWarningBanner.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
+            audioWarningBanner.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+            audioWarningBanner.bottomAnchor.constraint(equalTo: buttonStack.topAnchor, constant: -16),
 
             // Buttons — pinned to bottom safe area
             buttonStack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
@@ -238,6 +285,46 @@ class AlarmFiringViewController: UIViewController {
     private func bindViewModel() {
         viewModel.onStateChanged = { [weak self] in
             self?.updateUI()
+        }
+    }
+
+    /// Observe `AudioService.stateChangedNotification` and reflect the new state
+    /// in the warning banner. Notification is posted on the main queue by the
+    /// service, so no extra hop is needed.
+    private func observeAudioState() {
+        audioStateObserver = NotificationCenter.default.addObserver(
+            forName: AudioService.stateChangedNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            guard
+                let self,
+                let newState = note.userInfo?[AudioService.stateUserInfoKey] as? AudioPlaybackState
+            else { return }
+            self.applyAudioState(newState)
+        }
+    }
+
+    /// Surface (or hide) the warning banner depending on AudioService state.
+    /// Decoupled from `observeAudioState` so we can call it once after
+    /// `startAlarmSound` to catch the synchronous initial transition.
+    private func applyAudioState(_ newState: AudioPlaybackState) {
+        switch newState {
+        case .playing, .stopped:
+            audioWarningBanner.isHidden = true
+            audioWarningBanner.text = nil
+            audioWarningBanner.accessibilityLabel = nil
+        case .silentBecauseConfigFailed:
+            let text = "Звук недоступен — другое приложение использует аудио. " +
+                "Проверьте режим звука."
+            audioWarningBanner.text = "  \(text)  "
+            audioWarningBanner.accessibilityLabel = text
+            audioWarningBanner.isHidden = false
+        case .vibrationOnly:
+            let text = "Звук не воспроизводится — будильник вибрирует."
+            audioWarningBanner.text = "  \(text)  "
+            audioWarningBanner.accessibilityLabel = text
+            audioWarningBanner.isHidden = false
         }
     }
 

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/SoundPickerViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/SoundPickerViewController.swift
@@ -44,7 +44,7 @@ final class SoundPickerViewController: UITableViewController {
         super.viewDidLoad()
         title = "Выбор звука"
         view.backgroundColor = .systemGroupedBackground
-        tableView.register(SoundCell.self, forCellReuseIdentifier: SoundCell.reuseID)
+        tableView.register(SoundPickerRowCell.self, forCellReuseIdentifier: SoundPickerRowCell.reuseID)
     }
 
     // MARK: - Table View
@@ -59,8 +59,8 @@ final class SoundPickerViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(
-            withIdentifier: SoundCell.reuseID, for: indexPath
-        ) as? SoundCell else {
+            withIdentifier: SoundPickerRowCell.reuseID, for: indexPath
+        ) as? SoundPickerRowCell else {
             return UITableViewCell()
         }
 
@@ -89,9 +89,9 @@ final class SoundPickerViewController: UITableViewController {
 
 // MARK: - Sound Cell
 
-final class SoundCell: UITableViewCell {
+final class SoundPickerRowCell: UITableViewCell {
 
-    static let reuseID = "SoundCell"
+    static let reuseID = "SoundPickerRowCell"
 
     var onPlayTapped: (() -> Void)?
 

--- a/SnoozePay/SnoozePayTests/AudioServiceTests.swift
+++ b/SnoozePay/SnoozePayTests/AudioServiceTests.swift
@@ -107,4 +107,62 @@ final class AudioServiceTests: XCTestCase {
         service.stopAlarmSound()
         XCTAssertFalse(service.isPlaying)
     }
+
+    // MARK: - State + notifications (IOS-077)
+
+    /// Successful start path must transition state through `.stopped → .playing`
+    /// and broadcast the change via `stateChangedNotification`.
+    func testStartAlarmSound_postsPlayingStateNotification() {
+        let service = AudioService.shared
+        service.stopAlarmSound()
+        XCTAssertEqual(service.state, .stopped)
+
+        var observedStates: [AudioPlaybackState] = []
+        let token = NotificationCenter.default.addObserver(
+            forName: AudioService.stateChangedNotification,
+            object: service,
+            queue: nil
+        ) { note in
+            if let state = note.userInfo?[AudioService.stateUserInfoKey] as? AudioPlaybackState {
+                observedStates.append(state)
+            }
+        }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        service.startAlarmSound(soundID: "nonexistent_test_sound")
+        XCTAssertEqual(service.state, .playing)
+        XCTAssertTrue(observedStates.contains(.playing),
+                      "Expected .playing state to be broadcast, got \(observedStates)")
+
+        service.stopAlarmSound()
+        XCTAssertEqual(service.state, .stopped)
+        XCTAssertTrue(observedStates.contains(.stopped),
+                      "Expected .stopped state to be broadcast, got \(observedStates)")
+    }
+
+    /// Restarting while already playing must not re-emit `.playing` (didSet
+    /// guards on equality). This protects observers from spurious banner flicker.
+    func testStateNotification_notRepostedOnSameState() {
+        let service = AudioService.shared
+        service.stopAlarmSound()
+
+        var emissionCount = 0
+        let token = NotificationCenter.default.addObserver(
+            forName: AudioService.stateChangedNotification,
+            object: service,
+            queue: nil
+        ) { _ in emissionCount += 1 }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        service.startAlarmSound(soundID: "x") // → .playing  (1)
+        let afterFirstStart = emissionCount
+
+        // Second call hits `guard state == .stopped` and returns early — no new
+        // notification should fire.
+        service.startAlarmSound(soundID: "y")
+        XCTAssertEqual(emissionCount, afterFirstStart,
+                       "Re-entrant start must not republish the same state")
+
+        service.stopAlarmSound()
+    }
 }


### PR DESCRIPTION
Fixes #77

## Summary

`AudioService` had multiple silent-failure paths — `try?` swallowed `AVAudioPlayer` init errors, the audio-session config bail returned a Bool that the UI never observed, and a missing sound file would leave the alarm vibrating with `isPlaying = false` and no user feedback. The user could be charged for snoozes on an alarm they never heard.

This PR replaces `isPlaying: Bool` with an explicit `AudioPlaybackState` enum (`.playing` / `.silentBecauseConfigFailed` / `.vibrationOnly` / `.stopped`) and broadcasts each transition via `NotificationCenter`. `AlarmFiringViewController` observes the state and surfaces a red inline banner (Russian copy) when audio falls back so the user is never left in the dark.

## Changes

- `Services/AudioService.swift` — new `AudioPlaybackState` enum, `state` property with `didSet` posting `stateChangedNotification`. `try?` removed in favour of `do/catch` for `setCategory`/`setActive` and `AVAudioPlayer(contentsOf:)`. `play()`/`prepareToPlay()` return values respected — rejected playback drops to vibration instead of silently claiming success. Backwards-compat `isPlaying: Bool` kept (`state == .playing`) so existing AppDelegate guards keep working.
- `ViewControllers/Alarms/AlarmFiringViewController.swift` — adds `audioWarningBanner` UILabel above the action buttons. Subscribes to `stateChangedNotification` in `viewDidLoad`, removes observer in `deinit`. Banner copy: «Звук недоступен — другое приложение использует аудио. Проверьте режим звука.» / «Звук не воспроизводится — будильник вибрирует.»
- `SnoozePayTests/AudioServiceTests.swift` — new tests for state transitions, notification broadcast, and the no-double-emission guard on re-entrant start.
- `ViewControllers/Alarms/SoundPickerViewController.swift` — incidental: renames the inline `SoundCell` → `SoundPickerRowCell` to break the build-blocking duplicate-class collision with `Cells/SoundCell.swift` introduced in PR #88. Tracked as #100. Mechanical class+reuseID rename, no behaviour change.

## Verify

- swiftlint: 0 errors in touched files (pre-existing warnings/errors in unrelated files left alone)
- build_sim: succeeded (simulator: iPhone 17 Pro Max, derivedDataPath isolated to this worktree)
- test_sim: not run (test gate currently disabled per project memory). Tests added cover happy path + notification semantics; manual verification of fallback paths needs a device with sound-conflict / corrupted bundle.
- screenshot: not run (screenshot gate disabled)

## Manual test plan (for QA)

1. Trigger alarm normally — banner stays hidden, sound plays.
2. Start a parallel music app with exclusive audio session, trigger alarm — banner shows «Звук недоступен…» and no audio.
3. Replace bundled alarm sound with a 0-byte file, trigger alarm — banner shows «Звук не воспроизводится — будильник вибрирует» and only vibration runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)