### PR TITLE
[fix] Rename duplicate SoundCell to unblock build (#100)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/SoundPickerViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/SoundPickerViewController.swift
@@ -44,7 +44,7 @@ final class SoundPickerViewController: UITableViewController {
         super.viewDidLoad()
         title = "Выбор звука"
         view.backgroundColor = .systemGroupedBackground
-        tableView.register(SoundCell.self, forCellReuseIdentifier: SoundCell.reuseID)
+        tableView.register(SoundPickerRowCell.self, forCellReuseIdentifier: SoundPickerRowCell.reuseID)
     }
 
     // MARK: - Table View
@@ -59,8 +59,8 @@ final class SoundPickerViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(
-            withIdentifier: SoundCell.reuseID, for: indexPath
-        ) as? SoundCell else {
+            withIdentifier: SoundPickerRowCell.reuseID, for: indexPath
+        ) as? SoundPickerRowCell else {
             return UITableViewCell()
         }
 
@@ -89,9 +89,9 @@ final class SoundPickerViewController: UITableViewController {
 
 // MARK: - Sound Cell
 
-final class SoundCell: UITableViewCell {
+final class SoundPickerRowCell: UITableViewCell {
 
-    static let reuseID = "SoundCell"
+    static let reuseID = "SoundPickerRowCell"
 
     var onPlayTapped: (() -> Void)?
 


### PR DESCRIPTION
Fixes #100

## Summary
PR #88 extracted `Cells/SoundCell.swift` for CreateAlarmVC's sound row but did not remove the older `SoundCell` class still living inline at the bottom of `SoundPickerViewController.swift`. With the project's FileSystemSynchronized groups picking up both, `swiftc` errors with `invalid redeclaration of 'SoundCell'` and main is dead.

Renamed the SoundPicker's local class to `SoundPickerRowCell` (5 self-contained references in one file). Cells/SoundCell.swift keeps its name as the canonical type.

## Test plan
- [x] `build_sim` green.
- [ ] Sound picker still opens and rows still tap.