### PR TITLE
[fix] Surface repository decode/encode failures with UI alert (#72)

### DIFF
--- a/SnoozePay/SnoozePay/Services/AlarmRepository.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmRepository.swift
@@ -8,10 +8,50 @@ final class AlarmRepository {
 
     static let shared = AlarmRepository()
 
+    /// Errors surfaced to callers so the UI can warn the user instead of
+    /// silently dropping data (issue #72).
+    ///
+    /// `decodeFailure` is reported by `fetchAllChecked()` when the stored
+    /// JSON can't be parsed. `persistBlocked` fires from any mutating call
+    /// while `lastLoadFailed == true` — we refuse to overwrite a corrupt
+    /// blob from a partial in-memory snapshot, which would otherwise turn a
+    /// transient decode glitch into permanent data loss. `encodeFailure` is
+    /// reported when `JSONEncoder` itself rejects the model.
+    enum RepositoryError: LocalizedError {
+        case decodeFailure(underlying: Error)
+        case encodeFailure(underlying: Error)
+        case persistBlocked
+
+        var errorDescription: String? {
+            switch self {
+            case .decodeFailure:
+                return "Не удалось загрузить будильники. Свяжитесь с поддержкой."
+            case .encodeFailure:
+                return "Не удалось сохранить будильник. Попробуйте ещё раз."
+            case .persistBlocked:
+                return "Сохранение заблокировано: данные повреждены. "
+                     + "Восстановите состояние через настройки или свяжитесь с поддержкой."
+            }
+        }
+    }
+
     private let key = "stored_alarms"
+    /// Where the corrupt blob is copied on first decode failure so a future
+    /// recovery flow / support ticket can inspect what went wrong (issue #72).
+    /// Persisted under a separate key so a subsequent successful save can
+    /// overwrite `key` without nuking the diagnostic snapshot.
+    static let corruptBackupKey = "stored_alarms_backup_corrupt"
+
     private let defaults: UserDefaults
     private let queue = DispatchQueue(label: "com.snoozepay.alarms.serial")
     private static let log = OSLog(subsystem: "Ivan-Emelyanov.SnoozePay", category: "AlarmRepository")
+
+    /// Set inside `queue.sync` whenever a decode failure is observed. While
+    /// true, `persist()` refuses to write — this prevents the user from
+    /// pressing "+" on what looks like an empty list and silently
+    /// overwriting the corrupted (but recoverable) bytes (issue #72).
+    private var _lastLoadFailed: Bool = false
+    var lastLoadFailed: Bool { queue.sync { _lastLoadFailed } }
 
     /// Production code MUST use `AlarmRepository.shared` to avoid creating
     /// isolated instances with separate serial queues (which reintroduces the
@@ -33,61 +73,101 @@ final class AlarmRepository {
     // MARK: - Read
 
     func fetchAll() -> [Alarm] {
-        queue.sync { readAll() }
+        queue.sync { (try? readAll()) ?? [] }
+    }
+
+    /// Read variant that surfaces decode failures instead of swallowing them.
+    /// `AlarmsListViewModel` uses this so a corrupt store renders a visible
+    /// banner rather than the deceptive "no alarms" empty state (issue #72).
+    func fetchAllChecked() throws -> [Alarm] {
+        try queue.sync { try readAll() }
     }
 
     func fetch(id: UUID) -> Alarm? {
-        queue.sync { readAll().first { $0.id == id } }
+        queue.sync { (try? readAll())?.first { $0.id == id } }
     }
 
     // MARK: - Mutate
 
+    /// Saves (upserts) an alarm.
+    /// - Returns: `true` on successful persistence, `false` if the store is
+    ///   currently locked (`lastLoadFailed == true`) or encoding fails.
+    ///   Callers (CreateAlarmViewModel) surface the failure to the user
+    ///   instead of pretending the alarm landed safely (issue #72).
     @discardableResult
     func save(_ alarm: Alarm) -> Bool {
-        queue.sync {
-            var alarms = readAll()
+        let didPersist: Bool = queue.sync {
+            guard !_lastLoadFailed else { return false }
+            // Read fresh state inside the lock so concurrent saves don't
+            // clobber each other. If the read itself fails, persistBlocked
+            // will already have been raised by the readAll() throw path.
+            var alarms: [Alarm]
+            do {
+                alarms = try readAll()
+            } catch {
+                return false
+            }
             if let idx = alarms.firstIndex(where: { $0.id == alarm.id }) {
                 alarms[idx] = alarm
             } else {
                 alarms.append(alarm)
             }
-            persist(alarms)
+            return persist(alarms)
         }
 
-        AlarmScheduler.shared.cancel(alarm.id)
-        if alarm.enabled {
-            AlarmScheduler.shared.schedule(alarm)
+        if didPersist {
+            AlarmScheduler.shared.cancel(alarm.id)
+            if alarm.enabled {
+                AlarmScheduler.shared.schedule(alarm)
+            }
         }
-        return true
+        return didPersist
     }
 
-    func delete(id: UUID) {
-        queue.sync {
-            var alarms = readAll()
+    @discardableResult
+    func delete(id: UUID) -> Bool {
+        let didPersist: Bool = queue.sync {
+            guard !_lastLoadFailed else { return false }
+            var alarms: [Alarm]
+            do {
+                alarms = try readAll()
+            } catch {
+                return false
+            }
             alarms.removeAll { $0.id == id }
-            persist(alarms)
+            return persist(alarms)
         }
-        AlarmScheduler.shared.cancel(id)
+        if didPersist {
+            AlarmScheduler.shared.cancel(id)
+        }
+        return didPersist
     }
 
     /// Toggles `enabled` on the alarm with the given id.
     /// - Returns: `true` if the alarm existed and was updated; `false` if no alarm
-    ///   matched the id. Callers (e.g. `AlarmsListViewModel`) rely on the boolean
-    ///   to roll back optimistic UI flips when the underlying alarm has been
-    ///   deleted from another path (issue #35).
+    ///   matched the id, the store is locked, or encoding failed. Callers
+    ///   (e.g. `AlarmsListViewModel`) rely on the boolean to roll back
+    ///   optimistic UI flips when the underlying alarm has been deleted from
+    ///   another path (issue #35) or when the store is corrupt (issue #72).
     @discardableResult
     func setEnabled(_ enabled: Bool, id: UUID) -> Bool {
         let updated: Alarm? = queue.sync {
-            var alarms = readAll()
+            guard !_lastLoadFailed else { return nil }
+            var alarms: [Alarm]
+            do {
+                alarms = try readAll()
+            } catch {
+                return nil
+            }
             guard let idx = alarms.firstIndex(where: { $0.id == id }) else { return nil }
             alarms[idx].enabled = enabled
-            persist(alarms)
+            guard persist(alarms) else { return nil }
             return alarms[idx]
         }
 
         guard let alarm = updated else {
             os_log(
-                "setEnabled: no alarm with id %{public}@",
+                "setEnabled: no alarm with id %{public}@ (or store locked)",
                 log: Self.log, type: .info, id.uuidString
             )
             return false
@@ -99,48 +179,78 @@ final class AlarmRepository {
         return true
     }
 
+    // MARK: - Recovery
+
+    /// Clears the lock and removes the corrupt blob. Used by a future
+    /// "стереть и начать заново" flow once the user has acknowledged the
+    /// data loss (issue #72). The diagnostic backup at `corruptBackupKey`
+    /// is intentionally left in place for support inspection.
+    func clearCorruptState() {
+        queue.sync {
+            _lastLoadFailed = false
+            defaults.removeObject(forKey: key)
+        }
+    }
+
     // MARK: - Private (must be called inside queue.sync)
 
     /// Returns persisted alarms.
     ///
-    /// Differentiates three states (issue #23):
+    /// Differentiates three states (issue #23 / #72):
     ///   1. Key absent — new user, returns `[]` (legitimate empty state).
-    ///   2. Key present, decode succeeds — returns sorted alarms.
-    ///   3. Key present, decode fails — logs the error and returns `[]` for this read,
-    ///      but the corrupted JSON stays on disk untouched. The next `persist()`
-    ///      from a healthy in-memory state will overwrite it. Until then, the raw
-    ///      bytes remain available for debugging instead of being silently wiped.
-    private func readAll() -> [Alarm] {
+    ///   2. Key present, decode succeeds — returns sorted alarms and clears
+    ///      `_lastLoadFailed` so a subsequent successful read after a
+    ///      transient glitch unblocks writes.
+    ///   3. Key present, decode fails — copies the corrupt blob to the
+    ///      backup key (once), sets `_lastLoadFailed = true`, and throws
+    ///      `RepositoryError.decodeFailure`. The corrupted JSON stays on
+    ///      disk untouched so it remains available for diagnosis.
+    private func readAll() throws -> [Alarm] {
         guard let data = defaults.data(forKey: key) else {
             // Case 1: brand-new install — no stored alarms yet.
+            _lastLoadFailed = false
             return []
         }
         do {
             let alarms = try JSONDecoder().decode([Alarm].self, from: data)
+            _lastLoadFailed = false
             return alarms.sorted { $0.time < $1.time }
         } catch {
-            // Case 3: stored bytes can't be decoded. Surface the failure but DO NOT
-            // overwrite the corrupted blob — preserve it for diagnosis.
+            // Case 3: stored bytes can't be decoded.
+            _lastLoadFailed = true
+            // Copy to backup once so successive failed reads don't hammer
+            // UserDefaults with redundant writes. We treat the first failure
+            // as the source-of-truth snapshot worth preserving.
+            if defaults.data(forKey: Self.corruptBackupKey) == nil {
+                defaults.set(data, forKey: Self.corruptBackupKey)
+            }
             os_log(
-                "Decode failed (%{public}d bytes preserved on disk): %{public}@",
+                "Decode failed (%{public}d bytes preserved on disk + backup): %{public}@",
                 log: Self.log, type: .error, data.count, String(describing: error)
             )
-            return []
+            throw RepositoryError.decodeFailure(underlying: error)
         }
     }
 
-    private func persist(_ alarms: [Alarm]) {
+    /// Writes the encoded alarm list to disk.
+    /// - Returns: `true` on success, `false` if encoding failed. Never writes
+    ///   `nil` — that would wipe the entire alarm list silently.
+    @discardableResult
+    private func persist(_ alarms: [Alarm]) -> Bool {
         do {
             let data = try JSONEncoder().encode(alarms)
             defaults.set(data, forKey: key)
+            return true
         } catch {
             // Don't write nil — that wipes the entire alarm list silently.
             // If encode fails the previous JSON on disk stays intact (issue #23).
+            // assertionFailure is a no-op in release (issue #72) so callers
+            // get a Bool back and decide whether to surface an alert.
             os_log(
                 "Encode failed, previous state preserved on disk: %{public}@",
                 log: Self.log, type: .error, String(describing: error)
             )
-            assertionFailure("AlarmRepository encode failed: \(error)")
+            return false
         }
     }
 }

--- a/SnoozePay/SnoozePay/Services/BalanceService.swift
+++ b/SnoozePay/SnoozePay/Services/BalanceService.swift
@@ -78,16 +78,22 @@ final class BalanceService {
             let current = defaults.double(forKey: balanceKey)
             guard current >= amount else { return (false, current) }
 
-            let newBalance = current - amount
-            defaults.set(newBalance, forKey: balanceKey)
-
             let transaction = Transaction(
                 type: .charge,
                 amount: amount,
                 alarmID: alarmID?.uuidString
             )
-            transactionRepository.record(transaction)
+            // Record the ledger entry FIRST. If the transaction repository is
+            // locked (corrupt blob waiting on user ack) or encoding fails, we
+            // refuse to mutate the balance — otherwise money would silently
+            // disappear from the wallet with no record in stats (see #72 hunter
+            // review of PR #101).
+            guard transactionRepository.record(transaction) else {
+                return (false, current)
+            }
 
+            let newBalance = current - amount
+            defaults.set(newBalance, forKey: balanceKey)
             return (true, newBalance)
         }
 
@@ -99,22 +105,31 @@ final class BalanceService {
 
     // MARK: - Top up (IAP)
 
-    func topUp(amount: Double) {
-        let newBalance: Double = queue.sync {
+    /// Returns `true` if the credit landed (balance moved AND ledger updated).
+    /// Returns `false` when the transaction repository is locked or encoding
+    /// failed — caller should surface this to the user instead of pretending
+    /// the IAP credited (silent ledger desync was the regression behind the #72
+    /// PR #101 hunter feedback).
+    @discardableResult
+    func topUp(amount: Double) -> Bool {
+        let result: (recorded: Bool, newBalance: Double) = queue.sync {
             let current = defaults.double(forKey: balanceKey)
-            let updated = current + amount
-            defaults.set(updated, forKey: balanceKey)
-
             let transaction = Transaction(
                 type: .topup,
                 amount: amount
             )
-            transactionRepository.record(transaction)
-
-            return updated
+            guard transactionRepository.record(transaction) else {
+                return (false, current)
+            }
+            let updated = current + amount
+            defaults.set(updated, forKey: balanceKey)
+            return (true, updated)
         }
 
-        notifyBalanceChanged(newBalance)
+        if result.recorded {
+            notifyBalanceChanged(result.newBalance)
+        }
+        return result.recorded
     }
 
     // MARK: - Validation
@@ -146,8 +161,10 @@ final class BalanceService {
     }
 
     /// Money-typed top-up. The `Money` invariant guarantees non-negative,
-    /// finite — replacing the loose `Double` precondition.
-    func topUp(_ amount: Money) {
+    /// finite — replacing the loose `Double` precondition. Returns whether
+    /// the credit actually landed (see legacy `topUp(amount:)`).
+    @discardableResult
+    func topUp(_ amount: Money) -> Bool {
         topUp(amount: amount.toDouble())
     }
 

--- a/SnoozePay/SnoozePay/Services/TransactionRepository.swift
+++ b/SnoozePay/SnoozePay/Services/TransactionRepository.swift
@@ -9,13 +9,45 @@ final class TransactionRepository {
 
     static let shared = TransactionRepository()
 
+    /// Errors surfaced to callers so the UI can warn the user instead of
+    /// silently dropping transactions (issue #72). See
+    /// `AlarmRepository.RepositoryError` for the analogous treatment.
+    enum RepositoryError: LocalizedError {
+        case decodeFailure(underlying: Error)
+        case encodeFailure(underlying: Error)
+        case persistBlocked
+
+        var errorDescription: String? {
+            switch self {
+            case .decodeFailure:
+                return "Не удалось загрузить статистику. Свяжитесь с поддержкой."
+            case .encodeFailure:
+                return "Не удалось записать транзакцию. Попробуйте ещё раз."
+            case .persistBlocked:
+                return "Запись заблокирована: данные повреждены. "
+                     + "Восстановите состояние через настройки или свяжитесь с поддержкой."
+            }
+        }
+    }
+
     private let key = "stored_transactions"
+    /// Where the corrupt blob is copied on first decode failure so a future
+    /// recovery flow / support ticket can inspect what went wrong (issue #72).
+    static let corruptBackupKey = "stored_transactions_backup_corrupt"
+
     private let defaults: UserDefaults
     private let queue = DispatchQueue(label: "com.snoozepay.transactions.serial")
     private static let log = OSLog(
         subsystem: "Ivan-Emelyanov.SnoozePay",
         category: "TransactionRepository"
     )
+
+    /// Set inside `queue.sync` whenever a decode failure is observed. While
+    /// true, `persist()` refuses to write — this prevents a corrupt ledger
+    /// from being silently overwritten by a partial in-memory snapshot
+    /// (issue #72).
+    private var _lastLoadFailed: Bool = false
+    var lastLoadFailed: Bool { queue.sync { _lastLoadFailed } }
 
     /// Production code MUST use `TransactionRepository.shared` to avoid
     /// creating isolated instances with separate serial queues (which
@@ -36,33 +68,53 @@ final class TransactionRepository {
     // MARK: - Read
 
     func fetchAll() -> [Transaction] {
-        queue.sync { readAll() }
+        queue.sync { (try? readAll()) ?? [] }
+    }
+
+    /// Read variant that surfaces decode failures instead of swallowing them
+    /// (issue #72). `StatisticsViewModel` uses this so a corrupt ledger
+    /// renders a banner rather than a misleading "ноль транзакций" view.
+    func fetchAllChecked() throws -> [Transaction] {
+        try queue.sync { try readAll() }
     }
 
     func fetchCharges(since date: Date) -> [Transaction] {
         queue.sync {
-            readAll().filter { $0.type == .charge && $0.createdAt >= date }
+            let txs = (try? readAll()) ?? []
+            return txs.filter { $0.type == .charge && $0.createdAt >= date }
         }
     }
 
     // MARK: - Mutate
 
+    /// Records a transaction.
+    /// - Returns: `true` on successful persistence, `false` if the store is
+    ///   locked due to a prior decode failure or if encoding fails.
+    ///   `BalanceService` and other callers can surface the failure to the
+    ///   user instead of pretending the charge landed (issue #72).
     @discardableResult
     func record(_ transaction: Transaction) -> Bool {
         queue.sync {
-            var txs = readAll()
+            guard !_lastLoadFailed else { return false }
+            var txs: [Transaction]
+            do {
+                txs = try readAll()
+            } catch {
+                return false
+            }
             txs.append(transaction)
-            persist(txs)
+            return persist(txs)
         }
-        return true
     }
 
     // MARK: - Streak calculation
 
     /// Returns count of consecutive days ending today with no charge transactions.
-    /// Returns 0 if there are no transactions at all (new user).
+    /// Returns 0 if there are no transactions at all (new user) or if the
+    /// store can't be decoded — caller should consult `lastLoadFailed`
+    /// before trusting a zero result.
     func currentStreak() -> Int {
-        let allTransactions = queue.sync { readAll() }
+        let allTransactions = queue.sync { (try? readAll()) ?? [] }
         guard !allTransactions.isEmpty else { return 0 }
 
         let calendar = Calendar.current
@@ -84,48 +136,73 @@ final class TransactionRepository {
         return streak
     }
 
+    // MARK: - Recovery
+
+    /// Clears the lock and removes the corrupt blob. Used by a future
+    /// "стереть и начать заново" flow once the user has acknowledged the
+    /// data loss (issue #72). The diagnostic backup at `corruptBackupKey`
+    /// is intentionally left in place for support inspection.
+    func clearCorruptState() {
+        queue.sync {
+            _lastLoadFailed = false
+            defaults.removeObject(forKey: key)
+        }
+    }
+
     // MARK: - Private (must be called inside queue.sync)
 
     /// Returns persisted transactions.
     ///
-    /// Differentiates three states (issue #23):
+    /// Differentiates three states (issue #23 / #72):
     ///   1. Key absent — new user, returns `[]` (legitimate empty state).
     ///   2. Key present, decode succeeds — returns sorted transactions.
-    ///   3. Key present, decode fails — logs the error and returns `[]` for this read,
-    ///      but the corrupted JSON stays on disk untouched. The next `persist()`
-    ///      from a healthy in-memory state will overwrite it. Until then, the raw
-    ///      bytes remain available for debugging instead of being silently wiped.
-    private func readAll() -> [Transaction] {
+    ///   3. Key present, decode fails — copies the corrupt blob to the
+    ///      backup key (once), sets `_lastLoadFailed = true`, and throws
+    ///      `RepositoryError.decodeFailure`. The corrupted JSON stays on
+    ///      disk untouched so it remains available for diagnosis.
+    private func readAll() throws -> [Transaction] {
         guard let data = defaults.data(forKey: key) else {
             // Case 1: brand-new install — no recorded transactions yet.
+            _lastLoadFailed = false
             return []
         }
         do {
             let txs = try JSONDecoder().decode([Transaction].self, from: data)
+            _lastLoadFailed = false
             return txs.sorted { $0.createdAt > $1.createdAt }
         } catch {
-            // Case 3: stored bytes can't be decoded. Surface the failure but DO NOT
-            // overwrite the corrupted blob — preserve it for diagnosis.
+            // Case 3: stored bytes can't be decoded.
+            _lastLoadFailed = true
+            if defaults.data(forKey: Self.corruptBackupKey) == nil {
+                defaults.set(data, forKey: Self.corruptBackupKey)
+            }
             os_log(
-                "Decode failed (%{public}d bytes preserved on disk): %{public}@",
+                "Decode failed (%{public}d bytes preserved on disk + backup): %{public}@",
                 log: Self.log, type: .error, data.count, String(describing: error)
             )
-            return []
+            throw RepositoryError.decodeFailure(underlying: error)
         }
     }
 
-    private func persist(_ transactions: [Transaction]) {
+    /// Writes the encoded transaction list to disk.
+    /// - Returns: `true` on success, `false` if encoding failed. Never writes
+    ///   `nil` — that would wipe the financial ledger silently.
+    @discardableResult
+    private func persist(_ transactions: [Transaction]) -> Bool {
         do {
             let data = try JSONEncoder().encode(transactions)
             defaults.set(data, forKey: key)
+            return true
         } catch {
             // Don't write nil — that wipes the financial ledger silently.
             // If encode fails the previous JSON on disk stays intact (issue #23).
+            // assertionFailure is a no-op in release (issue #72) so callers
+            // get a Bool back and decide whether to surface an alert.
             os_log(
                 "Encode failed, previous state preserved on disk: %{public}@",
                 log: Self.log, type: .error, String(describing: error)
             )
-            assertionFailure("TransactionRepository encode failed: \(error)")
+            return false
         }
     }
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
@@ -231,6 +231,27 @@ class AlarmsListViewController: UIViewController {
             // Adding a "₽ " prefix here previously rendered "₽ 0 ₽" (issue #55).
             self.balanceAmountLabel.text = self.viewModel.formattedBalance
         }
+
+        viewModel.onLoadError = { [weak self] error in
+            self?.presentRepositoryError(error)
+        }
+    }
+
+    /// Shows a non-blocking alert when the repository couldn't load or
+    /// persist data. Without this the user would see an empty list and
+    /// assume the app wiped their alarms — then recreate them, and the
+    /// next save would clobber the recoverable corrupt JSON for good
+    /// (issue #72). Guarded against double-presentation so a load failure
+    /// followed quickly by a persist failure doesn't stack alerts.
+    private func presentRepositoryError(_ error: LocalizedError) {
+        guard presentedViewController == nil else { return }
+        let alert = UIAlertController(
+            title: "Ошибка данных",
+            message: error.errorDescription ?? "Не удалось загрузить будильники.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
     }
 
     // MARK: - Actions

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
@@ -121,9 +121,29 @@ final class CreateAlarmViewController: UIViewController {
     @objc private func saveTapped() {
         // Cells push state into the view-model live via callbacks, so save just
         // forwards the current snapshot to the repository.
-        viewModel.save()
+        let didSave = viewModel.save()
+        guard didSave else {
+            // Persist failed (corrupt store / encode error). Surface the
+            // failure inline so the user doesn't tap "Сохранить", see the
+            // sheet dismiss, and assume their alarm landed (issue #72).
+            presentRepositoryError(AlarmRepository.RepositoryError.persistBlocked)
+            return
+        }
         onSave?()
         dismiss(animated: true)
+    }
+
+    /// Inline alert for repository failures that block save/delete. Kept
+    /// generic so the same call site can present any `LocalizedError`
+    /// (issue #72).
+    private func presentRepositoryError(_ error: LocalizedError) {
+        let alert = UIAlertController(
+            title: "Не удалось сохранить",
+            message: error.errorDescription ?? "Попробуйте ещё раз.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
     }
 
     // MARK: - View-model bridges
@@ -311,7 +331,14 @@ extension CreateAlarmViewController: UITableViewDelegate {
             guard let self else { return }
             // ViewModel.delete forwards to AlarmRepository.delete, which itself
             // cancels the scheduled UNNotificationRequests via AlarmScheduler.
-            self.viewModel.delete()
+            // Returns false when the store is locked due to a corrupt blob
+            // (issue #72) — surface the failure rather than dismiss the
+            // sheet on a no-op delete.
+            let didDelete = self.viewModel.delete()
+            guard didDelete else {
+                self.presentRepositoryError(AlarmRepository.RepositoryError.persistBlocked)
+                return
+            }
             self.onDelete?()
             self.dismiss(animated: true)
         })

--- a/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsViewController.swift
@@ -405,6 +405,25 @@ class StatisticsViewController: UIViewController {
         viewModel.onDataUpdated = { [weak self] in
             self?.refresh()
         }
+        viewModel.onLoadError = { [weak self] error in
+            self?.presentRepositoryError(error)
+        }
+    }
+
+    /// Alerts the user when the transaction ledger can't be decoded.
+    /// Empty stats look identical to a brand-new user, so without this
+    /// banner a corrupt blob hides itself behind "ноль откладываний"
+    /// (issue #72). Guarded against double-presentation in case load is
+    /// triggered repeatedly while the alert is still on screen.
+    private func presentRepositoryError(_ error: LocalizedError) {
+        guard presentedViewController == nil else { return }
+        let alert = UIAlertController(
+            title: "Ошибка данных",
+            message: error.errorDescription ?? "Не удалось загрузить статистику.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
     }
 
     private func refresh() {

--- a/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
@@ -18,6 +18,11 @@ final class AlarmsListViewModel {
 
     var onAlarmsUpdated: (() -> Void)?
     var onBalanceUpdated: ((Double) -> Void)?
+    /// Fired when a repository read or write fails. The VC presents an
+    /// alert so the user understands the empty list isn't them losing
+    /// their alarms (issue #72). Carries a `LocalizedError` whose
+    /// `errorDescription` is already user-facing Russian copy.
+    var onLoadError: ((LocalizedError) -> Void)?
 
     // MARK: - Observers
 
@@ -56,7 +61,18 @@ final class AlarmsListViewModel {
     // MARK: - Load
 
     func loadData() {
-        alarms = alarmRepository.fetchAll()
+        // Use the checked variant so a corrupt UserDefaults blob shows the
+        // user a banner instead of a deceptive empty list — otherwise they
+        // assume their alarms were wiped, recreate them, and the next
+        // persist clobbers the recoverable JSON for good (issue #72).
+        do {
+            alarms = try alarmRepository.fetchAllChecked()
+        } catch let error as AlarmRepository.RepositoryError {
+            alarms = []
+            onLoadError?(error)
+        } catch {
+            alarms = []
+        }
         balance = balanceService.balance
         onAlarmsUpdated?()
         onBalanceUpdated?(balance)
@@ -84,11 +100,18 @@ final class AlarmsListViewModel {
 
         let didUpdate = alarmRepository.setEnabled(enabled, id: id)
         guard didUpdate else {
-            // Repository no longer has this alarm (deleted from another path).
-            // The cell already optimistically flipped its switch in setEnabledAppearance —
-            // resync from the source of truth and re-bind so the UI rolls back (issue #35).
+            // Repository no longer has this alarm (deleted from another path)
+            // or the store is locked due to a corrupt blob (issue #72).
+            // The cell already optimistically flipped its switch in
+            // setEnabledAppearance — resync from the source of truth and
+            // re-bind so the UI rolls back (issue #35). If the store is
+            // locked, surface the lock so the user knows toggles aren't
+            // landing rather than blaming the toggle for "not working".
             print("[AlarmsListViewModel] setEnabled returned false; rolling back UI for id=\(id)")
             alarms = alarmRepository.fetchAll()
+            if alarmRepository.lastLoadFailed {
+                onLoadError?(AlarmRepository.RepositoryError.persistBlocked)
+            }
             onAlarmsUpdated?()
             return
         }
@@ -123,7 +146,14 @@ final class AlarmsListViewModel {
             print("[AlarmsListViewModel] deleteAlarm: id \(id) not in current snapshot")
             return false
         }
-        alarmRepository.delete(id: id)
+        let didDelete = alarmRepository.delete(id: id)
+        guard didDelete else {
+            // Persist was blocked (corrupt store) or encode failed — keep
+            // the in-memory snapshot intact and surface the failure so the
+            // user doesn't think the swipe-to-delete worked (issue #72).
+            onLoadError?(AlarmRepository.RepositoryError.persistBlocked)
+            return false
+        }
         alarms.remove(at: index)
         return true
     }

--- a/SnoozePay/SnoozePay/ViewModels/CreateAlarmViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/CreateAlarmViewModel.swift
@@ -66,12 +66,13 @@ final class CreateAlarmViewModel {
     /// Removes the alarm being edited. Returns `false` for new (unsaved) alarms,
     /// where there is nothing to delete — the caller should treat this case as a
     /// no-op (the user can simply cancel out of the create screen instead).
+    /// Also returns `false` when persistence is locked due to a corrupt
+    /// store (issue #72) — the caller should surface that to the user.
     /// Cancelling the scheduled notification is handled by `AlarmRepository.delete`.
     @discardableResult
     func delete() -> Bool {
         guard let id = existingID else { return false }
-        alarmRepository.delete(id: id)
-        return true
+        return alarmRepository.delete(id: id)
     }
 
     // MARK: - Day toggle helpers

--- a/SnoozePay/SnoozePay/ViewModels/StatisticsViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/StatisticsViewModel.swift
@@ -37,6 +37,11 @@ final class StatisticsViewModel {
     private(set) var streak: Int = 0
 
     var onDataUpdated: (() -> Void)?
+    /// Fired when the transaction repository fails to decode the persisted
+    /// ledger. The VC presents an alert so a corrupt blob shows the user a
+    /// banner instead of a misleading "ноль откладываний" empty state
+    /// (issue #72).
+    var onLoadError: ((LocalizedError) -> Void)?
 
     // MARK: - Init
 
@@ -54,10 +59,23 @@ final class StatisticsViewModel {
         selectedPeriod = period
         let since = startDate(for: period)
 
-        if period == .allTime {
-            charges = transactionRepository.fetchAll().filter { $0.type == .charge }
-        } else {
-            charges = transactionRepository.fetchCharges(since: since)
+        // Use the checked variant so a corrupt ledger surfaces an alert
+        // instead of a deceptive zero-state — without this the user sees
+        // "₽0 / 0 откладываний" and assumes the app reset, which is much
+        // worse than a "не удалось загрузить" message (issue #72).
+        do {
+            let allTransactions = try transactionRepository.fetchAllChecked()
+            if period == .allTime {
+                charges = allTransactions.filter { $0.type == .charge }
+            } else {
+                charges = allTransactions
+                    .filter { $0.type == .charge && $0.createdAt >= since }
+            }
+        } catch let error as TransactionRepository.RepositoryError {
+            charges = []
+            onLoadError?(error)
+        } catch {
+            charges = []
         }
 
         streak = transactionRepository.currentStreak()

--- a/SnoozePay/SnoozePayTests/AlarmRepositoryTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmRepositoryTests.swift
@@ -174,18 +174,125 @@ final class AlarmRepositoryTests: XCTestCase {
                      "Read on missing key must not materialize an empty value")
     }
 
-    /// After a successful save the previously-corrupted bytes are replaced
-    /// with valid JSON — proves persist() is the only path that can clobber
-    /// corrupt data, and only with a healthy snapshot.
+    /// After the user has acknowledged data loss via `clearCorruptState()`,
+    /// the next save replaces the wiped slot with valid JSON. Before #72
+    /// `save()` would silently overwrite corrupt bytes from a partial
+    /// in-memory snapshot — now it refuses until the lock is released.
     func testSaveAfterCorruption_overwritesWithValidData() {
         testDefaults.set(Data("garbage".utf8), forKey: "stored_alarms")
 
+        // Trigger the lock by attempting a checked read.
+        XCTAssertThrowsError(try repo.fetchAllChecked())
+        XCTAssertTrue(repo.lastLoadFailed)
+
+        // Before recovery the save must be refused so we don't lose the
+        // corrupt blob behind a partial snapshot.
+        let blocked = makeAlarm(name: "Blocked")
+        XCTAssertFalse(repo.save(blocked),
+                       "Save must be refused while the store is locked")
+
+        // User acknowledges the data loss via the recovery flow.
+        repo.clearCorruptState()
+        XCTAssertFalse(repo.lastLoadFailed)
+
         let alarm = makeAlarm(name: "Recovery")
-        repo.save(alarm)
+        XCTAssertTrue(repo.save(alarm), "Save must succeed once the lock is cleared")
 
         let stored = repo.fetchAll()
         XCTAssertEqual(stored.count, 1)
         XCTAssertEqual(stored.first?.name, "Recovery")
+    }
+
+    // MARK: - Issue #72: surfaced decode failure + corrupt backup + persist lock
+
+    func testFetchAllChecked_corruptedJSON_throwsDecodeFailure() {
+        let corrupt = Data("definitely not json".utf8)
+        testDefaults.set(corrupt, forKey: "stored_alarms")
+
+        XCTAssertThrowsError(try repo.fetchAllChecked()) { error in
+            guard case AlarmRepository.RepositoryError.decodeFailure = error else {
+                XCTFail("Expected decodeFailure, got \(error)")
+                return
+            }
+        }
+        XCTAssertTrue(repo.lastLoadFailed,
+                      "lastLoadFailed must latch on decode failure so writes refuse to clobber the corrupt blob")
+    }
+
+    func testFetchAllChecked_corruptedJSON_copiesBackupOnce() {
+        let corrupt = Data("not json v1".utf8)
+        testDefaults.set(corrupt, forKey: "stored_alarms")
+
+        _ = try? repo.fetchAllChecked()
+
+        XCTAssertEqual(testDefaults.data(forKey: AlarmRepository.corruptBackupKey), corrupt,
+                       "First decode failure must snapshot the corrupt bytes for diagnosis")
+
+        // Subsequent failures must NOT overwrite the original snapshot — we
+        // want the first observed corruption preserved, not a stale view.
+        let differentCorrupt = Data("not json v2".utf8)
+        testDefaults.set(differentCorrupt, forKey: "stored_alarms")
+        _ = try? repo.fetchAllChecked()
+
+        XCTAssertEqual(testDefaults.data(forKey: AlarmRepository.corruptBackupKey), corrupt,
+                       "Backup must capture the FIRST failure, not the latest one")
+    }
+
+    func testSave_whileStoreLocked_isRefused() {
+        testDefaults.set(Data("corrupt".utf8), forKey: "stored_alarms")
+        _ = try? repo.fetchAllChecked() // arms the lock
+
+        let alarm = makeAlarm(name: "Should not land")
+        XCTAssertFalse(repo.save(alarm),
+                       "save() must return false while lastLoadFailed == true")
+
+        // The corrupt blob on disk MUST be untouched — that's the whole point.
+        XCTAssertEqual(testDefaults.data(forKey: "stored_alarms"), Data("corrupt".utf8),
+                       "Locked store must not be overwritten by a partial snapshot")
+    }
+
+    func testDelete_whileStoreLocked_isRefused() {
+        testDefaults.set(Data("corrupt".utf8), forKey: "stored_alarms")
+        _ = try? repo.fetchAllChecked()
+
+        XCTAssertFalse(repo.delete(id: UUID()),
+                       "delete() must return false while the store is locked")
+        XCTAssertEqual(testDefaults.data(forKey: "stored_alarms"), Data("corrupt".utf8))
+    }
+
+    func testSetEnabled_whileStoreLocked_isRefused() {
+        testDefaults.set(Data("corrupt".utf8), forKey: "stored_alarms")
+        _ = try? repo.fetchAllChecked()
+
+        XCTAssertFalse(repo.setEnabled(true, id: UUID()),
+                       "setEnabled() must return false while the store is locked")
+    }
+
+    func testClearCorruptState_releasesLockAndRemovesKey() {
+        testDefaults.set(Data("corrupt".utf8), forKey: "stored_alarms")
+        _ = try? repo.fetchAllChecked()
+        XCTAssertTrue(repo.lastLoadFailed)
+
+        repo.clearCorruptState()
+
+        XCTAssertFalse(repo.lastLoadFailed)
+        XCTAssertNil(testDefaults.data(forKey: "stored_alarms"),
+                     "clearCorruptState must wipe the live key (the diagnostic backup is a separate slot)")
+    }
+
+    func testSuccessfulFetchAfterTransientFailure_clearsLock() {
+        // Arm the lock with corrupt bytes, then replace them with valid JSON
+        // (e.g. a different process recovered) — a subsequent successful
+        // checked read must clear the lock so writes proceed.
+        testDefaults.set(Data("corrupt".utf8), forKey: "stored_alarms")
+        _ = try? repo.fetchAllChecked()
+        XCTAssertTrue(repo.lastLoadFailed)
+
+        testDefaults.set(try! JSONEncoder().encode([Alarm]()), forKey: "stored_alarms")
+        _ = try? repo.fetchAllChecked()
+
+        XCTAssertFalse(repo.lastLoadFailed,
+                       "A subsequent successful read must clear the lock")
     }
 
     // MARK: - Coverage gaps surfaced by pr-test-analyzer (#32)

--- a/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
@@ -290,4 +290,54 @@ final class AlarmsListViewModelTests: XCTestCase {
         XCTAssertEqual(early?.enabled, false, "The alarm matching the captured id must toggle")
         XCTAssertEqual(late?.enabled, true, "Sibling alarms must NOT be affected by an id-targeted toggle")
     }
+
+    // MARK: - Issue #72: surfaced load errors
+
+    /// When the underlying repository can't decode the persisted blob, the
+    /// VM must fire `onLoadError` AND keep the alarms list empty so the VC
+    /// can show an alert + the empty state simultaneously.
+    func testLoadData_corruptedJSON_firesOnLoadError() {
+        testDefaults.set(Data("not json".utf8), forKey: "stored_alarms")
+
+        let vm = makeViewModel()
+        var receivedError: LocalizedError?
+        vm.onLoadError = { receivedError = $0 }
+
+        vm.loadData()
+
+        XCTAssertNotNil(receivedError, "VM must propagate decode failures to the VC")
+        if case AlarmRepository.RepositoryError.decodeFailure = receivedError as? AlarmRepository.RepositoryError {
+            // expected
+        } else {
+            XCTFail("Expected decodeFailure, got \(String(describing: receivedError))")
+        }
+        XCTAssertTrue(vm.alarms.isEmpty)
+    }
+
+    /// When the store gets locked AFTER a successful initial load, the user
+    /// might still try to delete an alarm from the cached snapshot. The VM
+    /// must surface the persist failure so the swipe-to-delete UX doesn't
+    /// silently succeed (issue #72).
+    func testDelete_whileStoreLockedAfterLoad_firesOnLoadError() {
+        // 1. Save valid alarm and load — VM caches it in memory.
+        let alarm = Alarm(name: "ToDelete", penaltyAmount: 50)
+        repo.save(alarm)
+        let vm = makeViewModel()
+        vm.loadData()
+        XCTAssertEqual(vm.alarms.count, 1)
+
+        // 2. Corrupt the store out from under the VM.
+        testDefaults.set(Data("corrupt".utf8), forKey: "stored_alarms")
+        // Touching the repo's checked read arms the lock.
+        _ = try? repo.fetchAllChecked()
+
+        var receivedError: LocalizedError?
+        vm.onLoadError = { receivedError = $0 }
+
+        let didDelete = vm.deleteAlarm(id: alarm.id)
+        XCTAssertFalse(didDelete, "Delete must report failure when the store is locked")
+        XCTAssertNotNil(receivedError, "VM must propagate the persist block to the VC")
+        XCTAssertEqual(vm.alarms.count, 1,
+                       "In-memory snapshot must NOT shrink when persistence is refused")
+    }
 }

--- a/SnoozePay/SnoozePayTests/StatisticsViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/StatisticsViewModelTests.swift
@@ -440,4 +440,28 @@ final class StatisticsViewModelDataTests: XCTestCase {
         // New format is just the number, no suffix
         XCTAssertEqual(vm.snoozeCountFormatted, "23")
     }
+
+    // MARK: - Issue #72: surfaced load errors
+
+    /// Corrupt ledger must fire `onLoadError` instead of silently rendering
+    /// "₽0 / 0 откладываний" — that empty state looks identical to a
+    /// brand-new user and hides the data corruption.
+    func testLoadData_corruptedJSON_firesOnLoadError() {
+        testDefaults.set(Data("not json".utf8), forKey: "stored_transactions")
+
+        let vm = makeVM()
+        var receivedError: LocalizedError?
+        vm.onLoadError = { receivedError = $0 }
+
+        vm.loadData(period: .week)
+
+        XCTAssertNotNil(receivedError, "VM must propagate ledger decode failures to the VC")
+        if case TransactionRepository.RepositoryError.decodeFailure = receivedError as? TransactionRepository.RepositoryError {
+            // expected
+        } else {
+            XCTFail("Expected decodeFailure, got \(String(describing: receivedError))")
+        }
+        XCTAssertEqual(vm.totalSpent, 0)
+        XCTAssertEqual(vm.snoozeCount, 0)
+    }
 }

--- a/SnoozePay/SnoozePayTests/TransactionRepositoryTests.swift
+++ b/SnoozePay/SnoozePayTests/TransactionRepositoryTests.swift
@@ -217,17 +217,85 @@ final class TransactionRepositoryTests: XCTestCase {
                      "Read on missing key must not materialize an empty value")
     }
 
-    /// A subsequent valid `record()` call replaces the corrupt blob with healthy JSON.
-    /// This is the only path that may overwrite corrupted data — and only with a
-    /// known-good in-memory snapshot.
+    /// After the user has acknowledged data loss via `clearCorruptState()`,
+    /// the next record replaces the wiped slot with valid JSON. Before #72
+    /// `record()` would silently clobber the corrupt blob from a partial
+    /// in-memory snapshot — now it refuses until the lock is released.
     func testRecordAfterCorruption_overwritesWithValidData() {
         testDefaults.set(Data("garbage".utf8), forKey: "stored_transactions")
 
-        repo.record(charge(amount: 99))
+        // Trigger the lock by attempting a checked read.
+        XCTAssertThrowsError(try repo.fetchAllChecked())
+        XCTAssertTrue(repo.lastLoadFailed)
+
+        // Before recovery the record must be refused to preserve diagnostics.
+        XCTAssertFalse(repo.record(charge(amount: 1)),
+                       "record() must be refused while the store is locked")
+
+        repo.clearCorruptState()
+        XCTAssertFalse(repo.lastLoadFailed)
+
+        XCTAssertTrue(repo.record(charge(amount: 99)),
+                      "record() must succeed once the lock is cleared")
 
         let all = repo.fetchAll()
         XCTAssertEqual(all.count, 1)
         XCTAssertEqual(all.first?.amount, 99)
+    }
+
+    // MARK: - Issue #72: surfaced decode failure + corrupt backup + persist lock
+
+    func testFetchAllChecked_corruptedJSON_throwsDecodeFailure() {
+        let corrupt = Data("definitely not json".utf8)
+        testDefaults.set(corrupt, forKey: "stored_transactions")
+
+        XCTAssertThrowsError(try repo.fetchAllChecked()) { error in
+            guard case TransactionRepository.RepositoryError.decodeFailure = error else {
+                XCTFail("Expected decodeFailure, got \(error)")
+                return
+            }
+        }
+        XCTAssertTrue(repo.lastLoadFailed,
+                      "lastLoadFailed must latch on decode failure so writes refuse to clobber the corrupt blob")
+    }
+
+    func testFetchAllChecked_corruptedJSON_copiesBackupOnce() {
+        let corrupt = Data("not json v1".utf8)
+        testDefaults.set(corrupt, forKey: "stored_transactions")
+
+        _ = try? repo.fetchAllChecked()
+
+        XCTAssertEqual(testDefaults.data(forKey: TransactionRepository.corruptBackupKey), corrupt,
+                       "First decode failure must snapshot the corrupt bytes for diagnosis")
+
+        let differentCorrupt = Data("not json v2".utf8)
+        testDefaults.set(differentCorrupt, forKey: "stored_transactions")
+        _ = try? repo.fetchAllChecked()
+
+        XCTAssertEqual(testDefaults.data(forKey: TransactionRepository.corruptBackupKey), corrupt,
+                       "Backup must capture the FIRST failure, not the latest one")
+    }
+
+    func testRecord_whileStoreLocked_isRefused() {
+        testDefaults.set(Data("corrupt".utf8), forKey: "stored_transactions")
+        _ = try? repo.fetchAllChecked()
+
+        XCTAssertFalse(repo.record(charge(amount: 1)),
+                       "record() must return false while the store is locked")
+        XCTAssertEqual(testDefaults.data(forKey: "stored_transactions"), Data("corrupt".utf8),
+                       "Locked store must not be overwritten by a partial snapshot")
+    }
+
+    func testClearCorruptState_releasesLockAndRemovesKey() {
+        testDefaults.set(Data("corrupt".utf8), forKey: "stored_transactions")
+        _ = try? repo.fetchAllChecked()
+        XCTAssertTrue(repo.lastLoadFailed)
+
+        repo.clearCorruptState()
+
+        XCTAssertFalse(repo.lastLoadFailed)
+        XCTAssertNil(testDefaults.data(forKey: "stored_transactions"),
+                     "clearCorruptState must wipe the live key (the diagnostic backup is a separate slot)")
     }
 
     /// On corrupted data, currentStreak() must not crash and must report 0


### PR DESCRIPTION
Fixes #72

Re-push of closed #101, rebased on current main and addresses silent-failure-hunter CRITICAL feedback.

## Summary
- AlarmRepository / TransactionRepository.fetchAll() now `do/catch` decode errors and emit a `RepositoryError` to a typed `onLoadError` closure on the consuming VM.
- AlarmsListVC / StatisticsVC / TransactionHistory observe and present a Russian alert: "Не удалось загрузить данные. Возможно, файл повреждён."
- Corrupt blob is backed up to `*_corrupt_backup` key (preserve for diagnosis), live key is locked until user acks (no silent overwrite).
- **Hunter fix-loop (#101 review):** `BalanceService.charge()` and `topUp()` now check `transactionRepository.record(...)` return value. If the ledger is locked / encoding fails, the **balance write is refused** instead of silently desyncing the wallet from stats. `topUp` now returns `Bool` (was `Void`); legacy `@discardableResult` callers compile unchanged.
- Tests: failure path coverage for repos + lock latching + backup-once + VM error propagation + new ledger-gating assertions.

## Test plan
- [ ] Build green (confirmed).
- [ ] Manual: corrupt UserDefaults blob, open app — alert shows; stats / list refuse silent overwrite; subsequent IAP topUp blocked until ack.