### PR TITLE
[chore] Replace production print() with os.Logger (#76)

### DIFF
--- a/SnoozePay/SnoozePay/AppDelegate.swift
+++ b/SnoozePay/SnoozePay/AppDelegate.swift
@@ -17,7 +17,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         AlarmScheduler.shared.registerCategories()
         AlarmScheduler.shared.requestPermission { [weak self] granted in
             if !granted {
-                print("[AppDelegate] notification permission denied — alarms may not fire")
+                AppLogger.appDelegate.notice("notification permission denied — alarms may not fire")
                 self?.presentNotificationsDisabledAlert()
             }
         }
@@ -60,7 +60,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                     .first,
                 let rootVC = windowScene.windows.first?.rootViewController
             else {
-                print("[AppDelegate] no rootVC yet, deferring notifications-disabled alert")
+                AppLogger.appDelegate.info("no rootVC yet, deferring notifications-disabled alert")
                 self?.deferNotificationsDisabledAlertUntilSceneActive()
                 return
             }
@@ -119,7 +119,9 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         guard let payload = AlarmNotificationPayload(userInfo: userInfo) else {
             // Malformed payload — surface and bail rather than playing audio we
             // can never stop because the firing screen will never be presented.
-            print("[AppDelegate] willPresent: invalid alarm payload \(userInfo)")
+            AppLogger.appDelegate.error(
+                "willPresent: invalid alarm payload \(userInfo, privacy: .private(mask: .hash))"
+            )
             completionHandler([])
             return
         }
@@ -151,7 +153,9 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             if let payload = AlarmNotificationPayload(userInfo: userInfo) {
                 presentAlarmFiringScreen(for: payload)
             } else {
-                print("[AppDelegate] default action: invalid alarm payload \(userInfo)")
+                AppLogger.appDelegate.error(
+                    "default action: invalid alarm payload \(userInfo, privacy: .private(mask: .hash))"
+                )
                 AudioService.shared.stopAlarmSound()
             }
 
@@ -160,13 +164,17 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             let outcome = AlarmFiringCoordinator.shared.handleSnooze(userInfo: userInfo)
             switch outcome {
             case .invalidPayload:
-                print("[AppDelegate] SNOOZE_ACTION: invalid payload, snooze skipped")
+                AppLogger.appDelegate.error("SNOOZE_ACTION: invalid payload, snooze skipped")
             case .alarmNotFound:
-                print("[AppDelegate] SNOOZE_ACTION: alarm not found, snooze skipped")
+                AppLogger.appDelegate.notice("SNOOZE_ACTION: alarm not found, snooze skipped")
             case .insufficientFunds:
-                print("[AppDelegate] SNOOZE_ACTION: insufficient funds — snooze skipped, alarm will not repeat")
+                AppLogger.appDelegate.notice(
+                    "SNOOZE_ACTION: insufficient funds — snooze skipped, alarm will not repeat"
+                )
             case let .scheduled(newSnoozeCount, charged):
-                print("[AppDelegate] SNOOZE_ACTION: snooze #\(newSnoozeCount) scheduled, charged=\(charged)")
+                AppLogger.appDelegate.info(
+                    "SNOOZE_ACTION: snooze #\(newSnoozeCount, privacy: .public) scheduled, charged=\(charged, privacy: .public)"
+                )
             }
 
         case UNNotificationDismissActionIdentifier:
@@ -186,7 +194,9 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         guard let alarm = AlarmRepository.shared.fetch(id: payload.alarmID) else {
             // Audio may already be playing from willPresent — stop it so the user
             // is not stuck with a silent-screen + sounding alarm we can't dismiss.
-            print("[AppDelegate] alarm not found (repo returned nil for \(payload.alarmID)), stopping audio")
+            AppLogger.appDelegate.error(
+                "alarm not found (repo returned nil for \(payload.alarmID, privacy: .private)), stopping audio"
+            )
             AudioService.shared.stopAlarmSound()
             return
         }
@@ -202,7 +212,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
                     .first,
                 let rootVC = windowScene.windows.first?.rootViewController
             else {
-                print("[AppDelegate] no window scene, stopping audio")
+                AppLogger.appDelegate.error("no window scene, stopping audio")
                 AudioService.shared.stopAlarmSound()
                 return
             }

--- a/SnoozePay/SnoozePay/Services/AlarmFiringCoordinator.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmFiringCoordinator.swift
@@ -69,12 +69,12 @@ final class AlarmFiringCoordinator {
     @discardableResult
     func handleSnooze(userInfo: [AnyHashable: Any]) -> SnoozeOutcome {
         guard let payload = AlarmNotificationPayload(userInfo: userInfo) else {
-            print("[AlarmFiringCoordinator] snooze: invalid payload \(userInfo)")
+            AppLogger.coordinator.error("snooze: invalid payload \(userInfo, privacy: .private(mask: .hash))")
             return .invalidPayload
         }
 
         guard let alarm = alarmRepository.fetch(id: payload.alarmID) else {
-            print("[AlarmFiringCoordinator] snooze: alarm \(payload.alarmID) not in repository")
+            AppLogger.coordinator.error("snooze: alarm \(payload.alarmID, privacy: .private) not in repository")
             return .alarmNotFound
         }
 
@@ -83,12 +83,16 @@ final class AlarmFiringCoordinator {
 
         let charged = balanceService.charge(amount: penalty, alarmID: payload.alarmID)
         guard charged else {
-            print("[AlarmFiringCoordinator] snooze: insufficient funds for alarm \(payload.alarmID), \(penalty)")
+            AppLogger.coordinator.notice(
+                "snooze: insufficient funds for alarm \(payload.alarmID, privacy: .private), penalty=\(penalty, privacy: .public)"
+            )
             return .insufficientFunds
         }
 
         scheduler.scheduleSnooze(for: alarm, snoozeCount: newCount)
-        print("[AlarmFiringCoordinator] snooze: scheduled #\(newCount) for \(payload.alarmID), \(penalty)")
+        AppLogger.coordinator.info(
+            "snooze: scheduled #\(newCount, privacy: .public) for \(payload.alarmID, privacy: .private), penalty=\(penalty, privacy: .public)"
+        )
         return .scheduled(newSnoozeCount: newCount, charged: penalty)
     }
 }

--- a/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
@@ -29,18 +29,31 @@ final class AlarmScheduler {
         // (no critical-alert) path even when standard permission succeeds.
         notificationCenter.requestAuthorization(options: [.alert, .sound, .badge, .criticalAlert]) { granted, error in
             if let error = error {
-                print("[AlarmScheduler] critical-alert request failed: \(error). Falling back to standard.")
+                let desc = error.localizedDescription
+                AppLogger.scheduler.error(
+                    "critical-alert request failed: \(desc, privacy: .public). Falling back to standard."
+                )
                 Self.criticalAlertsAvailable = false
                 let standardOptions: UNAuthorizationOptions = [.alert, .sound, .badge]
                 self.notificationCenter.requestAuthorization(options: standardOptions) { granted, fallbackError in
                     Self.criticalAlertsAvailable = false
-                    let errorPart = fallbackError.map { ", error=\($0)" } ?? ""
-                    print("[AlarmScheduler] resolved path=fallback granted=\(granted) critical=false\(errorPart)")
+                    if let fallbackError = fallbackError {
+                        let fallbackDesc = fallbackError.localizedDescription
+                        AppLogger.scheduler.error(
+                            "resolved path=fallback granted=\(granted, privacy: .public) critical=false error=\(fallbackDesc, privacy: .public)"
+                        )
+                    } else {
+                        AppLogger.scheduler.notice(
+                            "resolved path=fallback granted=\(granted, privacy: .public) critical=false"
+                        )
+                    }
                     DispatchQueue.main.async { completion(granted) }
                 }
             } else {
                 Self.criticalAlertsAvailable = granted
-                print("[AlarmScheduler] resolved path=primary granted=\(granted) critical=\(granted)")
+                AppLogger.scheduler.notice(
+                    "resolved path=primary granted=\(granted, privacy: .public) critical=\(granted, privacy: .public)"
+                )
                 DispatchQueue.main.async { completion(granted) }
             }
         }
@@ -86,7 +99,7 @@ final class AlarmScheduler {
             )
             notificationCenter.add(request) { error in
                 if let error = error {
-                    print("[AlarmScheduler] schedule failed: \(error)")
+                    AppLogger.scheduler.error("schedule failed: \(error.localizedDescription, privacy: .public)")
                 }
             }
         }
@@ -109,7 +122,7 @@ final class AlarmScheduler {
         )
         notificationCenter.add(request) { error in
             if let error = error {
-                print("[AlarmScheduler] schedule failed: \(error)")
+                AppLogger.scheduler.error("schedule failed: \(error.localizedDescription, privacy: .public)")
             }
         }
     }

--- a/SnoozePay/SnoozePay/Services/AudioService.swift
+++ b/SnoozePay/SnoozePay/Services/AudioService.swift
@@ -82,7 +82,7 @@ final class AudioService {
         do {
             try AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
         } catch {
-            print("[AudioService] failed to deactivate audio session: \(error)")
+            AppLogger.audio.error("failed to deactivate audio session: \(error.localizedDescription, privacy: .public)")
         }
     }
 
@@ -104,7 +104,7 @@ final class AudioService {
             // Audio session unavailable (e.g. another app holds it).
             // Cannot guarantee playback — skip vibration too and surface the
             // explicit fallback state so the UI can warn the user.
-            print("[AudioService] failed to configure audio session: \(error)")
+            AppLogger.audio.error("failed to configure audio session: \(error.localizedDescription, privacy: .public)")
             state = .silentBecauseConfigFailed
             return
         }
@@ -125,7 +125,10 @@ final class AudioService {
                 player = try AVAudioPlayer(contentsOf: soundURL)
             } catch {
                 let name = soundURL.lastPathComponent
-                print("[AudioService] AVAudioPlayer init failed for \(name): \(error)")
+                let desc = error.localizedDescription
+                AppLogger.audio.error(
+                    "AVAudioPlayer init failed for \(name, privacy: .public): \(desc, privacy: .public)"
+                )
                 player = nil
             }
         }
@@ -136,7 +139,7 @@ final class AudioService {
         guard let player else {
             // Neither bundled file nor synthetic tone available — refuse to claim
             // playback. Vibration still runs so the user is at least woken.
-            print("[AudioService] startAlarmSound: no audio source available, vibration only")
+            AppLogger.audio.notice("startAlarmSound: no audio source available, vibration only")
             state = .vibrationOnly
             startVibration()
             return
@@ -154,7 +157,9 @@ final class AudioService {
         let prepared = player.prepareToPlay()
         let started = player.play()
         if !prepared || !started {
-            print("[AudioService] AVAudioPlayer play() rejected (prepared=\(prepared), started=\(started))")
+            AppLogger.audio.error(
+                "AVAudioPlayer play() rejected (prepared=\(prepared, privacy: .public), started=\(started, privacy: .public))"
+            )
             audioPlayer = nil
             state = .vibrationOnly
             startVibration()

--- a/SnoozePay/SnoozePay/Services/StoreKitService.swift
+++ b/SnoozePay/SnoozePay/Services/StoreKitService.swift
@@ -88,7 +88,7 @@ final class StoreKitService {
             products = loaded.sorted { $0.price < $1.price }
             postProductsLoaded(products)
         } catch {
-            print("[StoreKit] product load failed: \(error)")
+            AppLogger.storeKit.error("product load failed: \(error.localizedDescription, privacy: .public)")
             postPurchaseFailed("Не удалось загрузить пакеты пополнения. Проверь интернет-соединение.")
         }
     }
@@ -102,7 +102,9 @@ final class StoreKitService {
             case .success(let verification):
                 let transaction = try checkVerified(verification)
                 guard markProcessed(transactionID: transaction.id) else {
-                    print("[StoreKit] tx \(transaction.id) already processed — skipping double credit")
+                    AppLogger.storeKit.notice(
+                        "tx \(transaction.id, privacy: .private) already processed — skipping double credit"
+                    )
                     await transaction.finish()
                     return
                 }
@@ -118,7 +120,7 @@ final class StoreKitService {
                 postPurchasePending()
 
             @unknown default:
-                print("[StoreKit] unknown PurchaseResult case — likely future StoreKit addition")
+                AppLogger.storeKit.error("unknown PurchaseResult case — likely future StoreKit addition")
                 postPurchaseFailed("Покупка не выполнена. Обнови приложение и попробуй ещё раз.")
             }
         } catch {
@@ -138,7 +140,9 @@ final class StoreKitService {
             // do finish so it stops being delivered. For consumables we cannot reverse
             // a spent balance — track this as a known limitation (see #22-style follow-up).
             guard transaction.revocationDate == nil else {
-                print("[StoreKit] revoked tx \(transaction.id) productID=\(transaction.productID)")
+                AppLogger.storeKit.notice(
+                    "revoked tx \(transaction.id, privacy: .private) productID=\(transaction.productID, privacy: .public)"
+                )
                 await transaction.finish()
                 return
             }
@@ -150,14 +154,18 @@ final class StoreKitService {
             // Order matters — check amount before markProcessed.
             let amount = Self.creditAmount(for: transaction.productID, fallbackPrice: nil)
             guard amount > 0 else {
-                print("[StoreKit] unknown productID \(transaction.productID) tx=\(transaction.id) — not finishing")
+                AppLogger.storeKit.error(
+                    "unknown productID \(transaction.productID, privacy: .public) tx=\(transaction.id, privacy: .private) — not finishing"
+                )
                 postPurchaseFailed("Неизвестный пакет пополнения. Обнови приложение.")
                 return
             }
             // Idempotency — guard against StoreKit replaying a transaction we already
             // credited (e.g. if the previous run crashed between topUp and finish()).
             guard markProcessed(transactionID: transaction.id) else {
-                print("[StoreKit] tx \(transaction.id) already processed — finishing without re-credit")
+                AppLogger.storeKit.notice(
+                    "tx \(transaction.id, privacy: .private) already processed — finishing without re-credit"
+                )
                 await transaction.finish()
                 return
             }
@@ -169,7 +177,10 @@ final class StoreKitService {
             // Don't finish — let Apple retry next launch. Verification can fail temporarily
             // (clock drift, cert refresh). Finishing here would discard a potentially valid
             // purchase. WWDC sample code (Fruta, Backyard Birds) follows this pattern too.
-            print("[StoreKit] unverified tx=\(transaction.id) productID=\(transaction.productID) error=\(error)")
+            let errDesc = error.localizedDescription
+            AppLogger.storeKit.error(
+                "unverified tx=\(transaction.id, privacy: .private) productID=\(transaction.productID, privacy: .public) error=\(errDesc, privacy: .public)"
+            )
             postPurchaseFailed("Не удалось проверить чек покупки. Если деньги списаны — напиши в поддержку.")
         }
     }

--- a/SnoozePay/SnoozePay/Utilities/AppLogger.swift
+++ b/SnoozePay/SnoozePay/Utilities/AppLogger.swift
@@ -1,0 +1,48 @@
+import Foundation
+import os
+
+/// Category-scoped `os.Logger` instances for production logging.
+///
+/// Replaces ad-hoc `print("[Tag] msg")` statements scattered across services
+/// and view models so logs:
+///   * land in unified Apple logging (Console.app, Xcode Organizer, sysdiagnose)
+///     with severity, subsystem, and category — searchable instead of grep'ing
+///     stdout;
+///   * honour `os_log` privacy markers so identifiers (alarm UUIDs,
+///     transaction IDs) don't leak into shared diagnostics by default;
+///   * avoid the main-thread cost of `print()` on hot paths.
+///
+/// Subsystem matches the bundle identifier so logs filter cleanly to this
+/// app in tools that aggregate across processes.
+///
+/// Usage:
+///   AppLogger.scheduler.error("schedule failed: \(error.localizedDescription, privacy: .public)")
+///   AppLogger.audio.notice("startAlarmSound: vibration only — no audio source")
+enum AppLogger {
+
+    private static let subsystem = "Ivan-Emelyanov.SnoozePay"
+
+    /// AlarmScheduler — permission flow, schedule failures, snooze rescheduling.
+    static let scheduler = Logger(subsystem: subsystem, category: "Scheduler")
+
+    /// AudioService — audio session config, AVAudioPlayer init/play, fallback paths.
+    static let audio = Logger(subsystem: subsystem, category: "Audio")
+
+    /// BalanceService — charge / topUp diagnostics (currently unused; reserved).
+    static let balance = Logger(subsystem: subsystem, category: "Balance")
+
+    /// AlarmRepository / TransactionRepository — persistence read/write failures.
+    static let repository = Logger(subsystem: subsystem, category: "Repo")
+
+    /// StoreKitService — purchase, restore, verification, idempotency dedup.
+    static let storeKit = Logger(subsystem: subsystem, category: "StoreKit")
+
+    /// AlarmFiringCoordinator — snooze action routing from notification taps.
+    static let coordinator = Logger(subsystem: subsystem, category: "Coordinator")
+
+    /// AppDelegate — launch wiring, notification permission, willPresent / didReceive.
+    static let appDelegate = Logger(subsystem: subsystem, category: "AppDelegate")
+
+    /// ViewModels / ViewControllers — UI-side diagnostics that don't fit a service.
+    static let ui = Logger(subsystem: subsystem, category: "UI")
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/TopUpViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/TopUpViewController.swift
@@ -379,7 +379,7 @@ extension TopUpViewController {
                 if (error as NSError).code == NSUserCancelledError {
                     return
                 }
-                print("[TopUpVC] performRestorePurchases failed: \(error)")
+                AppLogger.storeKit.error("performRestorePurchases failed: \(error.localizedDescription, privacy: .public)")
                 self.presentRestoreError(error)
             }
         }

--- a/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
@@ -88,7 +88,7 @@ final class AlarmFiringViewModel {
         if alarm.repeatDays.isEmpty {
             let didUpdate = alarmRepository.setEnabled(false, id: alarm.id)
             if !didUpdate {
-                print("[AlarmFiringViewModel] dismiss: alarm \(alarm.id) already removed from repository")
+                AppLogger.ui.notice("dismiss: alarm \(alarm.id, privacy: .private) already removed from repository")
             }
         }
     }

--- a/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
@@ -93,7 +93,7 @@ final class AlarmsListViewModel {
             // Stale cell closure or deleted alarm — the cell already flipped its visual
             // state in setEnabledAppearance. Force a re-bind so the list reverts to truth.
             assertionFailure("toggleAlarm: id \(id) not found (count=\(alarms.count))")
-            print("[AlarmsListViewModel] toggleAlarm called for missing id=\(id)")
+            AppLogger.ui.error("toggleAlarm called for missing id=\(id, privacy: .private)")
             onAlarmsUpdated?()
             return
         }
@@ -107,7 +107,7 @@ final class AlarmsListViewModel {
             // re-bind so the UI rolls back (issue #35). If the store is
             // locked, surface the lock so the user knows toggles aren't
             // landing rather than blaming the toggle for "not working".
-            print("[AlarmsListViewModel] setEnabled returned false; rolling back UI for id=\(id)")
+            AppLogger.ui.notice("setEnabled returned false; rolling back UI for id=\(id, privacy: .private)")
             alarms = alarmRepository.fetchAll()
             if alarmRepository.lastLoadFailed {
                 onLoadError?(AlarmRepository.RepositoryError.persistBlocked)
@@ -143,7 +143,7 @@ final class AlarmsListViewModel {
     @discardableResult
     func deleteAlarm(id: UUID) -> Bool {
         guard let index = alarms.firstIndex(where: { $0.id == id }) else {
-            print("[AlarmsListViewModel] deleteAlarm: id \(id) not in current snapshot")
+            AppLogger.ui.notice("deleteAlarm: id \(id, privacy: .private) not in current snapshot")
             return false
         }
         let didDelete = alarmRepository.delete(id: id)


### PR DESCRIPTION
Fixes #76

## Что сделано
- Создан `Utilities/AppLogger.swift` с категориями `Scheduler`, `Audio`, `Balance`, `Repo`, `StoreKit`, `Coordinator`, `AppDelegate`, `UI` (subsystem = bundle ID)
- Заменены ~22 production `print("[Tag] msg")` в `AppDelegate`, `AlarmScheduler`, `AudioService`, `AlarmFiringCoordinator`, `StoreKitService`, `AlarmsListViewModel`, `AlarmFiringViewModel`, `TopUpViewController` на типизированные `Logger.error / .notice / .info`
- Privacy markers: `\(value, privacy: .public)` для невидимых-PII значений (counts, granted flags, productID); `\(uuid, privacy: .private)` для alarm UUIDs и transaction IDs; `\(userInfo, privacy: .private(mask: .hash))` для непрозрачных payload-ов
- Тесты не затронуты — там `print` оставлен как debugging aid

## Verify
- swiftlint: 0 errors в затронутых файлах (16 errors остаются — все pre-existing в `StatisticsViewController`, `OnboardingViewController`, `SoundPickerViewController`)
- build_sim: succeeded (simulator: iPhone 17 Pro)
- test_sim / screenshot: DISABLED per orchestrator
- grep `print(` в `SnoozePay/SnoozePay/SnoozePay` — пусто кроме упоминаний в doc-комментарии `AppLogger.swift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)