### PR TITLE
[chore] Quality debt sweep: dead code + magic constants + naming (#79)

### DIFF
--- a/SnoozePay/SnoozePay/Utilities/AppColors.swift
+++ b/SnoozePay/SnoozePay/Utilities/AppColors.swift
@@ -25,6 +25,12 @@ enum AppColors {
     static let snoozeButton = UIColor.systemOrange
     static let dismissButton = UIColor(red: 0.19, green: 0.82, blue: 0.34, alpha: 1) // #30D158
     static let disabledButton = UIColor.systemGray
+
+    /// Warm orange/gold used for the active "Отложить" pill on the alarm-firing
+    /// screen (#E8A838). Kept distinct from `accentOrange`/`snoozeButton` so the
+    /// firing UI can preserve its specific Figma hue without leaking that
+    /// magic literal into the view code (#79).
+    static let alarmFiringSnooze = UIColor(red: 0.91, green: 0.66, blue: 0.22, alpha: 1) // #E8A838
 }
 
 /// App-wide spacing constants

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
@@ -42,11 +42,15 @@ class AlarmFiringViewController: UIViewController {
     /// "БУДИЛЬНИК" label at top (matches native iOS alarm)
     private let alarmTypeLabel: UILabel = {
         let label = UILabel()
-        label.text = "БУДИЛЬНИК"
+        let title = "БУДИЛЬНИК"
+        let attributed = NSAttributedString(
+            string: title,
+            attributes: [.kern: 2]
+        )
+        label.attributedText = attributed
         label.font = UIFont.systemFont(ofSize: 14, weight: .semibold)
         label.textColor = UIColor.white.withAlphaComponent(0.6)
         label.textAlignment = .center
-        label.letterSpacing = 2
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
@@ -97,14 +101,11 @@ class AlarmFiringViewController: UIViewController {
 
     /// "Отложить · X₽" — golden/warm orange pill with bell icon
     private let snoozeButton: UIButton = {
-        // #E8A838 warm orange/gold
-        let activeColor = UIColor(red: 0.91, green: 0.66, blue: 0.22, alpha: 1.0)
-
         var config = UIButton.Configuration.filled()
         config.image = UIImage(systemName: "bell.fill")
         config.imagePadding = 8
         config.imagePlacement = .leading
-        config.baseBackgroundColor = activeColor
+        config.baseBackgroundColor = AppColors.alarmFiringSnooze
         config.baseForegroundColor = .white
         config.cornerStyle = .capsule
         config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { attrs in
@@ -336,8 +337,7 @@ class AlarmFiringViewController: UIViewController {
         snoozeConfig?.title = viewModel.snoozeButtonTitle
 
         if viewModel.canSnooze {
-            // #E8A838 warm orange/gold
-            snoozeConfig?.baseBackgroundColor = UIColor(red: 0.91, green: 0.66, blue: 0.22, alpha: 1.0)
+            snoozeConfig?.baseBackgroundColor = AppColors.alarmFiringSnooze
             snoozeButton.configuration = snoozeConfig
             snoozeButton.isEnabled = true
         } else {
@@ -396,19 +396,5 @@ class AlarmFiringViewController: UIViewController {
             dismiss(animated: true)
         }
         // If failed (balance empty) — button is already disabled, nothing to do
-    }
-}
-
-// MARK: - UILabel letter spacing helper
-
-private extension UILabel {
-    var letterSpacing: CGFloat {
-        get { 0 }
-        set {
-            guard let text = text else { return }
-            let attrs = NSMutableAttributedString(string: text)
-            attrs.addAttribute(.kern, value: newValue, range: NSRange(location: 0, length: text.count))
-            attributedText = attrs
-        }
     }
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/SoundPickerViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/SoundPickerViewController.swift
@@ -98,28 +98,28 @@ final class SoundPickerRowCell: UITableViewCell {
     // MARK: - UI
 
     private let nameLabel: UILabel = {
-        let l = UILabel()
-        l.font = UIFont.systemFont(ofSize: 17)
-        return l
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 17)
+        return label
     }()
 
     private let playButton: UIButton = {
-        let b = UIButton(type: .system)
+        let button = UIButton(type: .system)
         let config = UIImage.SymbolConfiguration(pointSize: 22, weight: .medium)
-        b.setImage(UIImage(systemName: "play.circle", withConfiguration: config), for: .normal)
-        b.tintColor = AppColors.accentBlue
-        b.translatesAutoresizingMaskIntoConstraints = false
-        return b
+        button.setImage(UIImage(systemName: "play.circle", withConfiguration: config), for: .normal)
+        button.tintColor = AppColors.accentBlue
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
     }()
 
     private let checkmark: UIImageView = {
-        let iv = UIImageView()
-        iv.image = UIImage(systemName: "checkmark")?.withConfiguration(
+        let imageView = UIImageView()
+        imageView.image = UIImage(systemName: "checkmark")?.withConfiguration(
             UIImage.SymbolConfiguration(pointSize: 16, weight: .semibold)
         )
-        iv.tintColor = AppColors.accentBlue
-        iv.translatesAutoresizingMaskIntoConstraints = false
-        return iv
+        imageView.tintColor = AppColors.accentBlue
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
     }()
 
     // MARK: - Init

--- a/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsViewController.swift
@@ -439,7 +439,8 @@ class StatisticsViewController: UIViewController {
         averageValueLabel.text = viewModel.averagePerDayFormatted
 
         // Streak — when no active streak we show the zero-state caption but
-        // keep the card visible so the layout doesn't jump.
+        // keep the card visible so the layout doesn't jump. The card is
+        // never hidden anywhere, so no `isHidden = false` reset is needed.
         if viewModel.streakActive {
             streakLabel.text = viewModel.streakMessage
             bestStreakLabel.text = viewModel.bestStreakFormatted
@@ -447,7 +448,6 @@ class StatisticsViewController: UIViewController {
             streakLabel.text = viewModel.streakZeroMessage
             bestStreakLabel.text = ""
         }
-        streakCard?.isHidden = false
 
         // Motivation banner — VM decides whether there's anything to motivate
         // against; view just toggles visibility off the bool.

--- a/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
@@ -80,14 +80,11 @@ final class AlarmsListViewModel {
 
     // MARK: - Toggle
 
-    func toggleAlarm(at index: Int, enabled: Bool) {
-        guard index < alarms.count else { return }
-        toggleAlarm(id: alarms[index].id, enabled: enabled)
-    }
-
     /// Toggle by stable UUID rather than row index. Cells should call this so the
     /// right alarm flips even after the list has been reordered or items deleted
-    /// since the cell was configured.
+    /// since the cell was configured. The historical `toggleAlarm(at:)` shim was
+    /// removed in #79 — call sites must now resolve the UUID themselves so a
+    /// stale row index can never flip the wrong alarm.
     func toggleAlarm(id: UUID, enabled: Bool) {
         guard let index = alarms.firstIndex(where: { $0.id == id }) else {
             // Stale cell closure or deleted alarm — the cell already flipped its visual
@@ -192,13 +189,5 @@ final class AlarmsListViewModel {
     func alarmPenaltyString(at index: Int) -> String {
         guard index < alarms.count else { return "" }
         return "▲ ОТЛОЖИТЬ: \(Int(alarms[index].penaltyAmount)) ₽"
-    }
-
-    func alarmSubtitle(at index: Int) -> String {
-        guard index < alarms.count else { return "" }
-        let alarm = alarms[index]
-        let days = alarm.repeatDaysDescription
-        let penalty = "\(Int(alarm.penaltyAmount)) ₽"
-        return "\(days) \u{00B7} \(penalty)"
     }
 }

--- a/SnoozePay/SnoozePay/ViewModels/StatisticsViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/StatisticsViewModel.swift
@@ -30,6 +30,12 @@ final class StatisticsViewModel {
     private let transactionRepository: TransactionRepository
     private let defaults: UserDefaults
 
+    /// UserDefaults key under which the all-time best streak is persisted.
+    /// Centralised here so the read in `bestStreak` and the bump in `loadData`
+    /// can never drift apart (a typo in either site would silently reset the
+    /// user's record).
+    private static let bestStreakKey = "best_streak"
+
     // MARK: - State
 
     private(set) var selectedPeriod: Period = .week
@@ -81,8 +87,8 @@ final class StatisticsViewModel {
         streak = transactionRepository.currentStreak()
         // Bump persisted best streak only forward — never reset on streak = 0,
         // so the user's all-time record survives a slip-up.
-        if streak > defaults.integer(forKey: "best_streak") {
-            defaults.set(streak, forKey: "best_streak")
+        if streak > defaults.integer(forKey: Self.bestStreakKey) {
+            defaults.set(streak, forKey: Self.bestStreakKey)
         }
         onDataUpdated?()
     }
@@ -153,7 +159,7 @@ final class StatisticsViewModel {
 
     /// All-time best streak, persisted across launches and never reset on a slip-up.
     var bestStreak: Int {
-        defaults.integer(forKey: "best_streak")
+        defaults.integer(forKey: Self.bestStreakKey)
     }
 
     var bestStreakFormatted: String {

--- a/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
@@ -90,7 +90,8 @@ final class AlarmsListViewModelTests: XCTestCase {
         let vm = makeViewModel()
         vm.loadData()
         XCTAssertEqual(vm.alarmTimeString(at: 0), "")
-        XCTAssertEqual(vm.alarmSubtitle(at: 0), "")
+        XCTAssertEqual(vm.alarmDetail(at: 0), "")
+        XCTAssertEqual(vm.alarmPenaltyString(at: 0), "")
     }
 
     func testFormattedBalance_containsRubleSign() {
@@ -127,7 +128,7 @@ final class AlarmsListViewModelTests: XCTestCase {
         )
     }
 
-    // MARK: - toggleAlarm(at:enabled:)
+    // MARK: - toggleAlarm(id:enabled:)
 
     func testToggleAlarm_updatesInMemoryState() {
         let alarm = Alarm(penaltyAmount: 50, enabled: true)
@@ -137,7 +138,7 @@ final class AlarmsListViewModelTests: XCTestCase {
         vm.loadData()
         XCTAssertTrue(vm.alarms[0].enabled)
 
-        vm.toggleAlarm(at: 0, enabled: false)
+        vm.toggleAlarm(id: vm.alarms[0].id, enabled: false)
         XCTAssertFalse(vm.alarms[0].enabled, "In-memory alarm must reflect the new enabled state immediately")
     }
 
@@ -148,7 +149,7 @@ final class AlarmsListViewModelTests: XCTestCase {
         let vm = makeViewModel()
         vm.loadData()
 
-        vm.toggleAlarm(at: 0, enabled: false)
+        vm.toggleAlarm(id: vm.alarms[0].id, enabled: false)
         let stored = repo.fetchAll()
         XCTAssertEqual(stored.count, 1)
         XCTAssertFalse(stored[0].enabled, "Toggle must persist through the repository")
@@ -181,7 +182,7 @@ final class AlarmsListViewModelTests: XCTestCase {
         let vm = makeViewModel()
         vm.loadData()
 
-        vm.toggleAlarm(at: 0, enabled: false)
+        vm.toggleAlarm(id: vm.alarms[0].id, enabled: false)
 
         let cached = vm.alarms[0]
         XCTAssertEqual(cached.id, original.id)
@@ -219,7 +220,7 @@ final class AlarmsListViewModelTests: XCTestCase {
         XCTAssertEqual(emissions, 1, "loadData must emit onAlarmsUpdated exactly once on initial load")
         emissions = 0
 
-        vm.toggleAlarm(at: 0, enabled: false)
+        vm.toggleAlarm(id: vm.alarms[0].id, enabled: false)
 
         XCTAssertEqual(
             emissions, 0,


### PR DESCRIPTION
Refs #79 — focused subset of the audit findings, scoped small to avoid touching behavior or doing god-object splits.

## What's included
- **Dead code removed**
  - `AlarmsListViewModel.alarmSubtitle(at:)` — only its own tests called it.
  - Index-based `toggleAlarm(at:)` shim — replaced at the test sites with the UUID variant so call sites can never flip the wrong alarm.
  - `letterSpacing` `UILabel` extension in `AlarmFiringViewController` — getter was hardcoded to `0`; inlined the one setter use as a direct kern attribute.
  - No-op `streakCard?.isHidden = false` in `StatisticsViewController.refresh()` — the card is never hidden anywhere.
- **Magic constants extracted**
  - `"best_streak"` literal → `StatisticsViewModel.bestStreakKey` (private static), so the read in `bestStreak` and the bump in `loadData` can't drift apart on a typo.
  - `UIColor(red: 0.91, green: 0.66, blue: 0.22, …)` → `AppColors.alarmFiringSnooze`.
- **Naming**
  - `let l`/`let b`/`let iv` → `let label`/`let button`/`let imageView` in `SoundPickerViewController` (the file flagged by SwiftLint identifier_name errors — wider sweep is intentionally out of scope).

## What's intentionally NOT here (still on #79)
- God-object splits (Settings/Statistics/CreateAlarm VCs)
- MVVM violations (`TransactionHistoryViewModel` extraction)
- Lint debt in tests (205 warnings)
- Defensive `?? "..."` defaults that touch behavior

## Verify
- swiftlint: 0 errors on touched files (pre-existing `identifier_name` errors in `StatisticsViewController` are unchanged and out of scope)
- build_sim: succeeded (simulator: iPhone 17 Pro Max)
- test_sim: skipped (gate disabled per repo memory; tests updated to use `toggleAlarm(id:)` and the dropped `alarmSubtitle` reference replaced with `alarmDetail`/`alarmPenaltyString`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)