### PR TITLE
[chore] Replace print() with os.Logger across production code (#76)

### DIFF
--- a/SnoozePay/SnoozePay/AppDelegate.swift
+++ b/SnoozePay/SnoozePay/AppDelegate.swift
@@ -3,6 +3,7 @@
 //  SnoozePay
 //
 
+import os
 import UIKit
 import UserNotifications
 
@@ -17,7 +18,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         AlarmScheduler.shared.registerCategories()
         AlarmScheduler.shared.requestPermission { [weak self] granted in
             if !granted {
-                print("[AppDelegate] notification permission denied — alarms may not fire")
+                AppLogger.notifications.warning("permission denied — alarms may not fire")
                 self?.presentNotificationsDisabledAlert()
             }
         }
@@ -60,7 +61,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                     .first,
                 let rootVC = windowScene.windows.first?.rootViewController
             else {
-                print("[AppDelegate] no rootVC yet, deferring notifications-disabled alert")
+                AppLogger.notifications.debug("no rootVC yet, deferring notifications-disabled alert")
                 self?.deferNotificationsDisabledAlertUntilSceneActive()
                 return
             }
@@ -119,7 +120,9 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         guard let payload = AlarmNotificationPayload(userInfo: userInfo) else {
             // Malformed payload — surface and bail rather than playing audio we
             // can never stop because the firing screen will never be presented.
-            print("[AppDelegate] willPresent: invalid alarm payload \(userInfo)")
+            AppLogger.notifications.error(
+                "willPresent: invalid alarm payload \(String(describing: userInfo), privacy: .private)"
+            )
             completionHandler([])
             return
         }
@@ -151,7 +154,9 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             if let payload = AlarmNotificationPayload(userInfo: userInfo) {
                 presentAlarmFiringScreen(for: payload)
             } else {
-                print("[AppDelegate] default action: invalid alarm payload \(userInfo)")
+                AppLogger.notifications.error(
+                    "default action: invalid alarm payload \(String(describing: userInfo), privacy: .private)"
+                )
                 AudioService.shared.stopAlarmSound()
             }
 
@@ -160,13 +165,15 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             let outcome = AlarmFiringCoordinator.shared.handleSnooze(userInfo: userInfo)
             switch outcome {
             case .invalidPayload:
-                print("[AppDelegate] SNOOZE_ACTION: invalid payload, snooze skipped")
+                AppLogger.notifications.error("SNOOZE_ACTION: invalid payload, snooze skipped")
             case .alarmNotFound:
-                print("[AppDelegate] SNOOZE_ACTION: alarm not found, snooze skipped")
+                AppLogger.notifications.warning("SNOOZE_ACTION: alarm not found, snooze skipped")
             case .insufficientFunds:
-                print("[AppDelegate] SNOOZE_ACTION: insufficient funds — snooze skipped, alarm will not repeat")
+                AppLogger.notifications.notice(
+                    "SNOOZE_ACTION: insufficient funds — snooze skipped, alarm will not repeat"
+                )
             case let .scheduled(newSnoozeCount, charged):
-                print("[AppDelegate] SNOOZE_ACTION: snooze #\(newSnoozeCount) scheduled, charged=\(charged)")
+                AppLogger.notifications.info("SNOOZE_ACTION: snooze #\(newSnoozeCount) scheduled, charged=\(charged)")
             }
 
         case UNNotificationDismissActionIdentifier:
@@ -186,7 +193,9 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         guard let alarm = AlarmRepository.shared.fetch(id: payload.alarmID) else {
             // Audio may already be playing from willPresent — stop it so the user
             // is not stuck with a silent-screen + sounding alarm we can't dismiss.
-            print("[AppDelegate] alarm not found (repo returned nil for \(payload.alarmID)), stopping audio")
+            AppLogger.alarms.warning(
+                "alarm not found (repo returned nil for \(payload.alarmID, privacy: .private)), stopping audio"
+            )
             AudioService.shared.stopAlarmSound()
             return
         }
@@ -202,7 +211,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
                     .first,
                 let rootVC = windowScene.windows.first?.rootViewController
             else {
-                print("[AppDelegate] no window scene, stopping audio")
+                AppLogger.notifications.error("no window scene, stopping audio")
                 AudioService.shared.stopAlarmSound()
                 return
             }

--- a/SnoozePay/SnoozePay/Services/AlarmFiringCoordinator.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmFiringCoordinator.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// Handles the business logic triggered by notification actions on a fired
 /// alarm (snooze charge + reschedule). Extracted from AppDelegate so the same
@@ -69,12 +70,12 @@ final class AlarmFiringCoordinator {
     @discardableResult
     func handleSnooze(userInfo: [AnyHashable: Any]) -> SnoozeOutcome {
         guard let payload = AlarmNotificationPayload(userInfo: userInfo) else {
-            print("[AlarmFiringCoordinator] snooze: invalid payload \(userInfo)")
+            AppLogger.alarms.error("snooze: invalid payload \(String(describing: userInfo), privacy: .private)")
             return .invalidPayload
         }
 
         guard let alarm = alarmRepository.fetch(id: payload.alarmID) else {
-            print("[AlarmFiringCoordinator] snooze: alarm \(payload.alarmID) not in repository")
+            AppLogger.alarms.warning("snooze: alarm \(payload.alarmID, privacy: .private) not in repository")
             return .alarmNotFound
         }
 
@@ -83,12 +84,16 @@ final class AlarmFiringCoordinator {
 
         let charged = balanceService.charge(amount: penalty, alarmID: payload.alarmID)
         guard charged else {
-            print("[AlarmFiringCoordinator] snooze: insufficient funds for alarm \(payload.alarmID), \(penalty)")
+            AppLogger.alarms.notice(
+                "snooze: insufficient funds for alarm \(payload.alarmID, privacy: .private), penalty=\(penalty)"
+            )
             return .insufficientFunds
         }
 
         scheduler.scheduleSnooze(for: alarm, snoozeCount: newCount)
-        print("[AlarmFiringCoordinator] snooze: scheduled #\(newCount) for \(payload.alarmID), \(penalty)")
+        AppLogger.alarms.info(
+            "snooze: scheduled #\(newCount) for \(payload.alarmID, privacy: .private), penalty=\(penalty)"
+        )
         return .scheduled(newSnoozeCount: newCount, charged: penalty)
     }
 }

--- a/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 import UserNotifications
 
 /// Handles scheduling and cancelling alarms.
@@ -29,18 +30,28 @@ final class AlarmScheduler {
         // (no critical-alert) path even when standard permission succeeds.
         notificationCenter.requestAuthorization(options: [.alert, .sound, .badge, .criticalAlert]) { granted, error in
             if let error = error {
-                print("[AlarmScheduler] critical-alert request failed: \(error). Falling back to standard.")
+                AppLogger.notifications.warning(
+                    "critical-alert request failed: \(error.localizedDescription). Falling back to standard."
+                )
                 Self.criticalAlertsAvailable = false
                 let standardOptions: UNAuthorizationOptions = [.alert, .sound, .badge]
                 self.notificationCenter.requestAuthorization(options: standardOptions) { granted, fallbackError in
                     Self.criticalAlertsAvailable = false
-                    let errorPart = fallbackError.map { ", error=\($0)" } ?? ""
-                    print("[AlarmScheduler] resolved path=fallback granted=\(granted) critical=false\(errorPart)")
+                    if let fallbackError {
+                        let message = fallbackError.localizedDescription
+                        AppLogger.notifications.error(
+                            "resolved path=fallback granted=\(granted) critical=false error=\(message)"
+                        )
+                    } else {
+                        AppLogger.notifications.notice(
+                            "resolved path=fallback granted=\(granted) critical=false"
+                        )
+                    }
                     DispatchQueue.main.async { completion(granted) }
                 }
             } else {
                 Self.criticalAlertsAvailable = granted
-                print("[AlarmScheduler] resolved path=primary granted=\(granted) critical=\(granted)")
+                AppLogger.notifications.notice("resolved path=primary granted=\(granted) critical=\(granted)")
                 DispatchQueue.main.async { completion(granted) }
             }
         }
@@ -86,7 +97,7 @@ final class AlarmScheduler {
             )
             notificationCenter.add(request) { error in
                 if let error = error {
-                    print("[AlarmScheduler] schedule failed: \(error)")
+                    AppLogger.alarms.error("schedule failed: \(error.localizedDescription)")
                 }
             }
         }
@@ -109,7 +120,7 @@ final class AlarmScheduler {
         )
         notificationCenter.add(request) { error in
             if let error = error {
-                print("[AlarmScheduler] schedule failed: \(error)")
+                AppLogger.alarms.error("schedule snooze failed: \(error.localizedDescription)")
             }
         }
     }

--- a/SnoozePay/SnoozePay/Services/AudioService.swift
+++ b/SnoozePay/SnoozePay/Services/AudioService.swift
@@ -1,6 +1,7 @@
 import AVFoundation
 import AudioToolbox
 import Foundation
+import os
 
 /// Playback state of the alarm audio pipeline.
 ///
@@ -82,7 +83,7 @@ final class AudioService {
         do {
             try AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
         } catch {
-            print("[AudioService] failed to deactivate audio session: \(error)")
+            AppLogger.audio.warning("failed to deactivate audio session: \(error.localizedDescription)")
         }
     }
 
@@ -104,7 +105,7 @@ final class AudioService {
             // Audio session unavailable (e.g. another app holds it).
             // Cannot guarantee playback — skip vibration too and surface the
             // explicit fallback state so the UI can warn the user.
-            print("[AudioService] failed to configure audio session: \(error)")
+            AppLogger.audio.error("failed to configure audio session: \(error.localizedDescription)")
             state = .silentBecauseConfigFailed
             return
         }
@@ -125,7 +126,9 @@ final class AudioService {
                 player = try AVAudioPlayer(contentsOf: soundURL)
             } catch {
                 let name = soundURL.lastPathComponent
-                print("[AudioService] AVAudioPlayer init failed for \(name): \(error)")
+                AppLogger.audio.error(
+                    "AVAudioPlayer init failed for \(name, privacy: .public): \(error.localizedDescription)"
+                )
                 player = nil
             }
         }
@@ -136,7 +139,7 @@ final class AudioService {
         guard let player else {
             // Neither bundled file nor synthetic tone available — refuse to claim
             // playback. Vibration still runs so the user is at least woken.
-            print("[AudioService] startAlarmSound: no audio source available, vibration only")
+            AppLogger.audio.warning("startAlarmSound: no audio source available, vibration only")
             state = .vibrationOnly
             startVibration()
             return
@@ -154,7 +157,7 @@ final class AudioService {
         let prepared = player.prepareToPlay()
         let started = player.play()
         if !prepared || !started {
-            print("[AudioService] AVAudioPlayer play() rejected (prepared=\(prepared), started=\(started))")
+            AppLogger.audio.error("AVAudioPlayer play() rejected (prepared=\(prepared), started=\(started))")
             audioPlayer = nil
             state = .vibrationOnly
             startVibration()

--- a/SnoozePay/SnoozePay/Services/StoreKitService.swift
+++ b/SnoozePay/SnoozePay/Services/StoreKitService.swift
@@ -1,5 +1,6 @@
-import StoreKit
 import Foundation
+import os
+import StoreKit
 
 /// Manages consumable In-App Purchases using StoreKit 2.
 /// Five fixed packages: 49, 149, 299, 499, 999 RUB.
@@ -88,7 +89,7 @@ final class StoreKitService {
             products = loaded.sorted { $0.price < $1.price }
             postProductsLoaded(products)
         } catch {
-            print("[StoreKit] product load failed: \(error)")
+            AppLogger.storeKit.error("product load failed: \(error.localizedDescription)")
             postPurchaseFailed("Не удалось загрузить пакеты пополнения. Проверь интернет-соединение.")
         }
     }
@@ -102,7 +103,9 @@ final class StoreKitService {
             case .success(let verification):
                 let transaction = try checkVerified(verification)
                 guard markProcessed(transactionID: transaction.id) else {
-                    print("[StoreKit] tx \(transaction.id) already processed — skipping double credit")
+                    AppLogger.storeKit.notice(
+                        "tx \(transaction.id, privacy: .private) already processed — skipping double credit"
+                    )
                     await transaction.finish()
                     return
                 }
@@ -118,7 +121,7 @@ final class StoreKitService {
                 postPurchasePending()
 
             @unknown default:
-                print("[StoreKit] unknown PurchaseResult case — likely future StoreKit addition")
+                AppLogger.storeKit.error("unknown PurchaseResult case — likely future StoreKit addition")
                 postPurchaseFailed("Покупка не выполнена. Обнови приложение и попробуй ещё раз.")
             }
         } catch {
@@ -138,7 +141,11 @@ final class StoreKitService {
             // do finish so it stops being delivered. For consumables we cannot reverse
             // a spent balance — track this as a known limitation (see #22-style follow-up).
             guard transaction.revocationDate == nil else {
-                print("[StoreKit] revoked tx \(transaction.id) productID=\(transaction.productID)")
+                let productID = transaction.productID
+                let txID = transaction.id
+                AppLogger.storeKit.notice(
+                    "revoked tx \(txID, privacy: .private) productID=\(productID, privacy: .public)"
+                )
                 await transaction.finish()
                 return
             }
@@ -150,14 +157,20 @@ final class StoreKitService {
             // Order matters — check amount before markProcessed.
             let amount = Self.creditAmount(for: transaction.productID, fallbackPrice: nil)
             guard amount > 0 else {
-                print("[StoreKit] unknown productID \(transaction.productID) tx=\(transaction.id) — not finishing")
+                let productID = transaction.productID
+                let txID = transaction.id
+                AppLogger.storeKit.error(
+                    "unknown productID \(productID, privacy: .public) tx=\(txID, privacy: .private) — not finishing"
+                )
                 postPurchaseFailed("Неизвестный пакет пополнения. Обнови приложение.")
                 return
             }
             // Idempotency — guard against StoreKit replaying a transaction we already
             // credited (e.g. if the previous run crashed between topUp and finish()).
             guard markProcessed(transactionID: transaction.id) else {
-                print("[StoreKit] tx \(transaction.id) already processed — finishing without re-credit")
+                AppLogger.storeKit.notice(
+                    "tx \(transaction.id, privacy: .private) already processed — finishing without re-credit"
+                )
                 await transaction.finish()
                 return
             }
@@ -169,7 +182,12 @@ final class StoreKitService {
             // Don't finish — let Apple retry next launch. Verification can fail temporarily
             // (clock drift, cert refresh). Finishing here would discard a potentially valid
             // purchase. WWDC sample code (Fruta, Backyard Birds) follows this pattern too.
-            print("[StoreKit] unverified tx=\(transaction.id) productID=\(transaction.productID) error=\(error)")
+            let productID = transaction.productID
+            let txID = transaction.id
+            let message = error.localizedDescription
+            AppLogger.storeKit.error(
+                "unverified tx=\(txID, privacy: .private) productID=\(productID, privacy: .public) error=\(message)"
+            )
             postPurchaseFailed("Не удалось проверить чек покупки. Если деньги списаны — напиши в поддержку.")
         }
     }

--- a/SnoozePay/SnoozePay/Utilities/AppLogger.swift
+++ b/SnoozePay/SnoozePay/Utilities/AppLogger.swift
@@ -1,0 +1,44 @@
+import Foundation
+import os
+
+/// Unified `os.Logger` access for production code.
+///
+/// Replaces ad-hoc `print("[Subsystem] ...")` statements scattered across
+/// services, view-models and the AppDelegate. Each category surfaces in
+/// Console.app and Xcode's debug console with a consistent subsystem so
+/// support sessions / TestFlight crash investigations can be filtered by
+/// `subsystem == "app.snoozepay"` and drilled down by category.
+///
+/// Use the level that matches the event:
+/// - `.debug` — verbose diagnostic only useful while reproducing a bug.
+/// - `.info` — routine lifecycle events (purchase succeeded, snooze scheduled).
+/// - `.notice` — noteworthy but non-error transitions (fallback paths taken).
+/// - `.warning` — recoverable malfunctions the user might notice.
+/// - `.error` — failures that prevent the requested operation.
+///
+/// Sensitive identifiers (alarm UUIDs, StoreKit transaction IDs) MUST use
+/// `privacy: .private` interpolation so they are redacted in shipping logs.
+enum AppLogger {
+
+    /// Subsystem string used by every logger. Matches the bundle's
+    /// reverse-DNS prefix so Console.app filters work identically against
+    /// debug builds and TestFlight archives.
+    private static let subsystem = "app.snoozepay"
+
+    /// Alarm scheduling, list / firing view-model state transitions.
+    static let alarms = Logger(subsystem: subsystem, category: "alarms")
+
+    /// StoreKit purchase / restore / verification flows.
+    static let storeKit = Logger(subsystem: subsystem, category: "storekit")
+
+    /// UNUserNotificationCenter delegate events and permission state.
+    static let notifications = Logger(subsystem: subsystem, category: "notifications")
+
+    /// AVAudioSession configuration and AVAudioPlayer playback state.
+    static let audio = Logger(subsystem: subsystem, category: "audio")
+
+    /// Persistence layer (UserDefaults-backed repositories) — reserved for
+    /// future use; centralising the category here so callers don't invent
+    /// ad-hoc strings.
+    static let repository = Logger(subsystem: subsystem, category: "repository")
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/TopUpViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/TopUpViewController.swift
@@ -1,5 +1,6 @@
-import UIKit
+import os
 import StoreKit
+import UIKit
 
 /// Top-up balance screen with balance card, 5 IAP packages, and restore button.
 class TopUpViewController: UIViewController {
@@ -379,7 +380,7 @@ extension TopUpViewController {
                 if (error as NSError).code == NSUserCancelledError {
                     return
                 }
-                print("[TopUpVC] performRestorePurchases failed: \(error)")
+                AppLogger.storeKit.error("performRestorePurchases failed: \(error.localizedDescription)")
                 self.presentRestoreError(error)
             }
         }

--- a/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// ViewModel for the alarm firing screen.
 /// Manages penalty calculation and balance deduction logic.
@@ -88,7 +89,10 @@ final class AlarmFiringViewModel {
         if alarm.repeatDays.isEmpty {
             let didUpdate = alarmRepository.setEnabled(false, id: alarm.id)
             if !didUpdate {
-                print("[AlarmFiringViewModel] dismiss: alarm \(alarm.id) already removed from repository")
+                let alarmID = alarm.id
+                AppLogger.alarms.notice(
+                    "dismiss: alarm \(alarmID, privacy: .private) already removed from repository"
+                )
             }
         }
     }

--- a/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// ViewModel for the alarms list screen.
 /// Manages the alarm collection, balance display, and toggle state.
@@ -93,7 +94,7 @@ final class AlarmsListViewModel {
             // Stale cell closure or deleted alarm — the cell already flipped its visual
             // state in setEnabledAppearance. Force a re-bind so the list reverts to truth.
             assertionFailure("toggleAlarm: id \(id) not found (count=\(alarms.count))")
-            print("[AlarmsListViewModel] toggleAlarm called for missing id=\(id)")
+            AppLogger.alarms.warning("toggleAlarm called for missing id=\(id, privacy: .private)")
             onAlarmsUpdated?()
             return
         }
@@ -107,7 +108,7 @@ final class AlarmsListViewModel {
             // re-bind so the UI rolls back (issue #35). If the store is
             // locked, surface the lock so the user knows toggles aren't
             // landing rather than blaming the toggle for "not working".
-            print("[AlarmsListViewModel] setEnabled returned false; rolling back UI for id=\(id)")
+            AppLogger.alarms.warning("setEnabled returned false; rolling back UI for id=\(id, privacy: .private)")
             alarms = alarmRepository.fetchAll()
             if alarmRepository.lastLoadFailed {
                 onLoadError?(AlarmRepository.RepositoryError.persistBlocked)
@@ -143,7 +144,7 @@ final class AlarmsListViewModel {
     @discardableResult
     func deleteAlarm(id: UUID) -> Bool {
         guard let index = alarms.firstIndex(where: { $0.id == id }) else {
-            print("[AlarmsListViewModel] deleteAlarm: id \(id) not in current snapshot")
+            AppLogger.alarms.warning("deleteAlarm: id \(id, privacy: .private) not in current snapshot")
             return false
         }
         let didDelete = alarmRepository.delete(id: id)


### PR DESCRIPTION
Fixes #76

## Что сделано
- Добавлен `Utilities/AppLogger.swift` — обёртка над `os.Logger` с категориями `alarms`, `storeKit`, `notifications`, `audio`, `repository` (subsystem `app.snoozepay`)
- Заменены ~30 production `print("[X] ...")` на `AppLogger.<category>.<level>(...)` (debug / info / notice / warning / error по смыслу события)
- Privacy markers применены к UUID будильников и StoreKit transaction IDs: `\(alarmID, privacy: .private)`, `\(productID, privacy: .public)` — в TestFlight/release logs приватные идентификаторы редактируются автоматически
- `import os` добавлен в файлы, использующие OSLogPrivacy interpolation (AppDelegate, Services/*, ViewModels/*, TopUpViewController)

## Затронутые файлы
- `Utilities/AppLogger.swift` (новый)
- `AppDelegate.swift` (10 заменён)
- `Services/StoreKitService.swift` (8)
- `Services/AlarmScheduler.swift` (4)
- `Services/AudioService.swift` (5)
- `Services/AlarmFiringCoordinator.swift` (4)
- `ViewModels/AlarmsListViewModel.swift` (3)
- `ViewModels/AlarmFiringViewModel.swift` (1)
- `ViewControllers/Settings/TopUpViewController.swift` (1)

## Verify
- swiftlint: 0 errors в затронутых файлах (16 pre-existing errors в Onboarding/Statistics/SoundPicker — не задевал)
- build_sim: succeeded (simulator: iPhone 17 Pro)
- `grep -rn "print(" SnoozePay/SnoozePay/ --include='*.swift' | grep -v "/// "` → пусто

## Acceptance из issue
- [x] grep `print(` в production коде — пусто
- [x] Все логи доступны через subsystem `app.snoozepay` в Console.app
- [x] Privacy markers применены к UUIDs / transaction IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)