### PR TITLE
[ui] Add cards/shadows/borders for light mode visual hierarchy (#82)

### DIFF
--- a/SnoozePay/SnoozePay/Utilities/AppColors.swift
+++ b/SnoozePay/SnoozePay/Utilities/AppColors.swift
@@ -7,6 +7,29 @@ enum AppColors {
     static let surface = UIColor.secondarySystemBackground
     static let surface2 = UIColor.tertiarySystemBackground
 
+    // MARK: - Cards
+    /// Fill colour for card-like containers. Same as `surface` but named after
+    /// its semantic role so `UIView.applyCardStyle()` callers don't have to
+    /// reach for `surface`. Re-bind here if cards ever need a different tint
+    /// (e.g. brighter than other secondary surfaces) without changing call sites.
+    static let cardSurface = UIColor.secondarySystemBackground
+    /// Hairline border colour for cards. `UIColor.separator` is fully opaque
+    /// grey in light mode (visible against `secondarySystemBackground`) and a
+    /// subtle dim in dark mode — so a single token works for both.
+    static let cardBorder = UIColor.separator
+    /// Background tint for screens that host insetGrouped tables of cards.
+    /// Light mode darkens the system grouped background a notch so each card
+    /// (`secondarySystemBackground`) reads as a distinct surface — the default
+    /// `systemGroupedBackground` (#F2F2F7) and `secondarySystemBackground`
+    /// (#FFFFFF) are only ~5% luminance apart, which renders as one
+    /// undifferentiated block. Dark mode keeps the system colour: contrast is
+    /// already sufficient and overriding would break trait-aware tinting.
+    static let groupedBackground: UIColor = UIColor { traits in
+        traits.userInterfaceStyle == .dark
+            ? .systemGroupedBackground
+            : UIColor(white: 0.92, alpha: 1.0) // ~#EBEBEB, ~+5% darker than #F2F2F7
+    }
+
     // MARK: - Text
     static let textPrimary = UIColor.label
     static let textSecondary = UIColor.secondaryLabel

--- a/SnoozePay/SnoozePay/Utilities/UIView+CardStyle.swift
+++ b/SnoozePay/SnoozePay/Utilities/UIView+CardStyle.swift
@@ -1,0 +1,95 @@
+import UIKit
+
+/// Shared visual treatment for "card" containers across the app.
+///
+/// Light mode is the problem case: `secondarySystemBackground` (#FFFFFF) sits on
+/// `systemGroupedBackground` (#F2F2F7) — only ~5% luminance delta. Without a
+/// shadow + hairline border every screen reads as one undifferentiated block.
+/// `AlarmCell` solved this for one cell type in IOS-063; this helper extracts
+/// the styling so every card-shaped container (statistics widgets, balance
+/// hero, top-up package row, transaction history row, etc.) renders with the
+/// same affordance and we don't drift over time.
+///
+/// Callers must keep their card view's `clipsToBounds` / `masksToBounds` off
+/// (the helper sets `masksToBounds = false`) — the shadow is rendered outside
+/// the rounded bounds and is clipped by `clipsToBounds = true`.
+extension UIView {
+
+    /// Apply the standard card visual treatment: rounded corners, hairline
+    /// border, subtle drop shadow.
+    ///
+    /// - Parameter cornerRadius: corner radius to use. Defaults to `AppRadius.md`
+    ///   to match the existing `AlarmCell` look. Use `AppRadius.lg` for hero
+    ///   cards (e.g. balance) where a slightly softer edge reads better.
+    func applyCardStyle(cornerRadius: CGFloat = AppRadius.md) {
+        layer.cornerRadius = cornerRadius
+        // Subviews are constrained inside the card via Auto Layout, so they
+        // won't overflow even without clipping the layer.
+        layer.masksToBounds = false
+
+        // Subtle drop shadow lifts the card off the background. In light mode
+        // this is the primary visual separator since `secondarySystemBackground`
+        // (#FFFFFF) sits on top of `systemGroupedBackground` (#F2F2F7) — only
+        // ~5% luminance delta. In dark mode the shadow is barely visible (black
+        // on near-black), and the border carries the work.
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOpacity = 0.06
+        layer.shadowRadius = 8
+        layer.shadowOffset = CGSize(width: 0, height: 2)
+
+        // Hairline border reinforces the edge in light mode (UIColor.separator
+        // is fully opaque grey in light, faint in dark — auto-adapts).
+        layer.borderWidth = 0.5
+        layer.borderColor = AppColors.cardBorder.cgColor
+    }
+
+    /// Refresh the card's `borderColor` against the current trait collection.
+    /// `CALayer.cgColor` doesn't auto-resolve dynamic `UIColor` values, so a
+    /// light → dark switch would leave the border stuck at the previous mode's
+    /// colour. Call from `layoutSubviews` and from a trait-change registration
+    /// (or tableView cell `traitCollectionDidChange` equivalent).
+    func refreshCardBorderColor() {
+        layer.borderColor = AppColors.cardBorder.resolvedColor(
+            with: traitCollection
+        ).cgColor
+    }
+
+    /// Pre-rasterize the shadow against a rounded path so scrolling doesn't
+    /// pay the per-pixel offscreen pass cost. Call from `layoutSubviews` once
+    /// the view has its final bounds.
+    func updateCardShadowPath(cornerRadius: CGFloat = AppRadius.md) {
+        layer.shadowPath = UIBezierPath(
+            roundedRect: bounds,
+            cornerRadius: cornerRadius
+        ).cgPath
+    }
+}
+
+/// Self-maintaining card surface — applies the standard card style on init and
+/// keeps `shadowPath` / `borderColor` in sync with `bounds` and trait changes
+/// via `layoutSubviews`. Use anywhere a host VC would otherwise have to wire
+/// up `viewDidLayoutSubviews` + `traitCollectionDidChange` boilerplate just to
+/// keep a card looking right after rotation or a light/dark switch.
+final class CardView: UIView {
+
+    private let cornerRadius: CGFloat
+
+    init(cornerRadius: CGFloat = AppRadius.md) {
+        self.cornerRadius = cornerRadius
+        super.init(frame: .zero)
+        backgroundColor = AppColors.cardSurface
+        translatesAutoresizingMaskIntoConstraints = false
+        applyCardStyle(cornerRadius: cornerRadius)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        guard bounds.width > 0 else { return }
+        updateCardShadowPath(cornerRadius: cornerRadius)
+        refreshCardBorderColor()
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmCell.swift
@@ -7,25 +7,13 @@ final class AlarmCell: UITableViewCell {
 
     // MARK: - UI Elements
 
+    /// Card visual treatment is shared with every other card-shaped container in
+    /// the app via `applyCardStyle()` (see `UIView+CardStyle.swift`). Keeping
+    /// the styling inside the helper means a future colour-token change touches
+    /// one place instead of sprawling across cells.
     private let cardView: UIView = {
         let view = UIView()
-        view.backgroundColor = AppColors.surface
-        view.layer.cornerRadius = AppRadius.md
-        // Keep masksToBounds off so the drop shadow can render outside the rounded
-        // bounds. Subviews are constrained inside the card via Auto Layout, so they
-        // won't visually overflow even without clipping.
-        view.layer.masksToBounds = false
-        // Subtle drop shadow lifts the card off the background. In light mode this is
-        // the primary visual separator since `secondarySystemBackground` (#FFFFFF) sits
-        // on top of `systemGroupedBackground` (#F2F2F7) — only ~5% luminance delta.
-        view.layer.shadowColor = UIColor.black.cgColor
-        view.layer.shadowOpacity = 0.06
-        view.layer.shadowRadius = 8
-        view.layer.shadowOffset = CGSize(width: 0, height: 2)
-        // Hairline border reinforces the edge in light mode (UIColor.separator is
-        // fully opaque grey in light, and very faint in dark — auto-adapts).
-        view.layer.borderWidth = 0.5
-        view.layer.borderColor = UIColor.separator.cgColor
+        view.backgroundColor = AppColors.cardSurface
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
@@ -73,6 +61,7 @@ final class AlarmCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setupUI()
+        cardView.applyCardStyle()
         // Wire the target once at cell creation so re-configuration in
         // `cellForRowAt` never accumulates duplicate handlers.
         toggleSwitch.addTarget(self, action: #selector(toggleSwitchChanged), for: .valueChanged)
@@ -80,9 +69,7 @@ final class AlarmCell: UITableViewCell {
         // CALayer's `cgColor` properties don't auto-resolve dynamic UIColors,
         // so refresh the border whenever the trait collection (light/dark) flips.
         registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (cell: AlarmCell, _) in
-            cell.cardView.layer.borderColor = UIColor.separator.resolvedColor(
-                with: cell.traitCollection
-            ).cgColor
+            cell.cardView.refreshCardBorderColor()
         }
     }
 
@@ -143,15 +130,10 @@ final class AlarmCell: UITableViewCell {
         super.layoutSubviews()
         // Pre-rasterize the shadow against the rounded card frame so scrolling
         // doesn't pay the per-pixel offscreen pass cost.
-        cardView.layer.shadowPath = UIBezierPath(
-            roundedRect: cardView.bounds,
-            cornerRadius: AppRadius.md
-        ).cgPath
+        cardView.updateCardShadowPath()
         // Keep the border colour in sync with the current trait collection
         // (cgColor doesn't auto-update for dynamic UIColors).
-        cardView.layer.borderColor = UIColor.separator.resolvedColor(
-            with: traitCollection
-        ).cgColor
+        cardView.refreshCardBorderColor()
     }
 
     // MARK: - Configure

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
@@ -11,7 +11,10 @@ class AlarmsListViewController: UIViewController {
 
     private let tableView: UITableView = {
         let table = UITableView(frame: .zero, style: .plain)
-        table.backgroundColor = .systemGroupedBackground
+        // `AppColors.groupedBackground` darkens light-mode background a notch so
+        // each `AlarmCell` card (#FFFFFF) reads as a distinct surface — see
+        // `UIView+CardStyle.swift` for the contrast rationale.
+        table.backgroundColor = AppColors.groupedBackground
         table.separatorStyle = .none
         table.translatesAutoresizingMaskIntoConstraints = false
         return table
@@ -65,7 +68,7 @@ class AlarmsListViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .systemGroupedBackground
+        view.backgroundColor = AppColors.groupedBackground
         setupNavigationBar()
         setupTableView()
         setupBalanceHeader()
@@ -113,10 +116,19 @@ class AlarmsListViewController: UIViewController {
         // Container for the balance card with padding
         let headerContainer = UIView()
 
-        // Balance card styling — blue background
+        // Balance card styling — blue background. Shadow lifts it off the
+        // table background so the hero stays visually distinct from the
+        // alarm cards stacked below in light mode (matches the lift treatment
+        // applied via `UIView+CardStyle.swift` to neutral cards).
         balanceCard.backgroundColor = AppColors.accentBlue
         balanceCard.layer.cornerRadius = AppRadius.md
-        balanceCard.clipsToBounds = true
+        // Don't clip — the drop shadow renders outside the rounded bounds.
+        // Subviews are constrained inside via Auto Layout so they stay put.
+        balanceCard.layer.masksToBounds = false
+        balanceCard.layer.shadowColor = UIColor.black.cgColor
+        balanceCard.layer.shadowOpacity = 0.10
+        balanceCard.layer.shadowRadius = 10
+        balanceCard.layer.shadowOffset = CGSize(width: 0, height: 3)
         balanceCard.translatesAutoresizingMaskIntoConstraints = false
 
         // "БАЛАНС" small label
@@ -204,6 +216,15 @@ class AlarmsListViewController: UIViewController {
         if header.frame.height != newHeight {
             header.frame.size = CGSize(width: tableView.bounds.width, height: newHeight)
             tableView.tableHeaderView = header
+        }
+
+        // Pre-rasterize the balance card's drop shadow against the rounded
+        // path so scrolling doesn't pay the per-pixel offscreen cost.
+        if balanceCard.bounds.width > 0 {
+            balanceCard.layer.shadowPath = UIBezierPath(
+                roundedRect: balanceCard.bounds,
+                cornerRadius: AppRadius.md
+            ).cgPath
         }
     }
 

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
@@ -59,7 +59,11 @@ final class CreateAlarmViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         title = viewModel.isEditing ? "Редактировать" : "Новый будильник"
-        view.backgroundColor = .systemGroupedBackground
+        // Slightly darker than `systemGroupedBackground` in light mode so the
+        // insetGrouped rows (Sound, Vibration, Penalty…) read as distinct
+        // cards instead of dissolving into the page. See `AppColors.groupedBackground`.
+        view.backgroundColor = AppColors.groupedBackground
+        tableView.backgroundColor = AppColors.groupedBackground
         setupNavigationBar()
         setupTableView()
     }

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/SoundPickerViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/SoundPickerViewController.swift
@@ -43,7 +43,11 @@ final class SoundPickerViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "Выбор звука"
-        view.backgroundColor = .systemGroupedBackground
+        // Tracks the rest of the app: light mode darkens the page background a
+        // notch so each sound row reads as a distinct card. See
+        // `AppColors.groupedBackground`.
+        view.backgroundColor = AppColors.groupedBackground
+        tableView.backgroundColor = AppColors.groupedBackground
         tableView.register(SoundPickerRowCell.self, forCellReuseIdentifier: SoundPickerRowCell.reuseID)
     }
 

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController.swift
@@ -48,7 +48,11 @@ class SettingsViewController: UIViewController {
         super.viewDidLoad()
         title = "Настройки"
         navigationController?.navigationBar.prefersLargeTitles = true
-        view.backgroundColor = .systemGroupedBackground
+        // Slightly darker than the system grouped background in light mode so
+        // the white insetGrouped cells read as distinct cards (~5% luminance
+        // delta at default is too subtle). See `AppColors.groupedBackground`.
+        view.backgroundColor = AppColors.groupedBackground
+        tableView.backgroundColor = AppColors.groupedBackground
         setupUI()
         observeBalanceChanges()
     }
@@ -380,7 +384,8 @@ final class TransactionHistoryViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "История транзакций"
-        view.backgroundColor = .systemGroupedBackground
+        view.backgroundColor = AppColors.groupedBackground
+        tableView.backgroundColor = AppColors.groupedBackground
         setupTableView()
         loadTransactions()
     }
@@ -606,7 +611,7 @@ final class LegalViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         title = legalTitle
-        view.backgroundColor = .systemGroupedBackground
+        view.backgroundColor = AppColors.groupedBackground
 
         let textView = UITextView()
         textView.text = "\(legalTitle)\n\nДокумент будет добавлен перед публикацией в App Store."

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/TopUpViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/TopUpViewController.swift
@@ -56,7 +56,11 @@ class TopUpViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "Пополнить баланс"
-        view.backgroundColor = .systemGroupedBackground
+        // Slightly darker than the system grouped background in light mode so
+        // the white insetGrouped package rows read as distinct cards. See
+        // `AppColors.groupedBackground` for the contrast rationale.
+        view.backgroundColor = AppColors.groupedBackground
+        tableView.backgroundColor = AppColors.groupedBackground
 
         navigationItem.leftBarButtonItem = UIBarButtonItem(
             barButtonSystemItem: .cancel,
@@ -125,11 +129,10 @@ class TopUpViewController: UIViewController {
         let headerHeight: CGFloat = 140
         let header = UIView(frame: CGRect(x: 0, y: 0, width: view.bounds.width, height: headerHeight))
 
-        let card = UIView()
-        card.backgroundColor = .secondarySystemBackground
-        card.layer.cornerRadius = AppRadius.md
-        card.layer.masksToBounds = true
-        card.translatesAutoresizingMaskIntoConstraints = false
+        // `CardView` applies the shared shadow + hairline border treatment and
+        // self-maintains its shadow path / dynamic border colour across
+        // rotation and light/dark switches. See `UIView+CardStyle.swift`.
+        let card = CardView()
         header.addSubview(card)
 
         let titleLabel = UILabel()

--- a/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsViewController.swift
@@ -187,7 +187,11 @@ class StatisticsViewController: UIViewController {
         super.viewDidLoad()
         title = "Статистика"
         navigationController?.navigationBar.prefersLargeTitles = true
-        view.backgroundColor = .systemGroupedBackground
+        // Slightly darker than `systemGroupedBackground` in light mode so the
+        // statistics widgets (`makeCard()` returns a `secondarySystemBackground`
+        // surface) stand out — without it the card edges only differ from the
+        // page by ~5% luminance. See `AppColors.groupedBackground`.
+        view.backgroundColor = AppColors.groupedBackground
         setupUI()
         bindViewModel()
     }
@@ -297,7 +301,10 @@ class StatisticsViewController: UIViewController {
 
     private func makeChartCard() -> UIView {
         let card = makeCard()
-        card.clipsToBounds = true
+        // Don't clip — `applyCardStyle()` renders a drop shadow that lives
+        // outside the rounded bounds, and `clipsToBounds = true` would mask
+        // it. Subviews are constrained inside `card` via Auto Layout, so
+        // they won't visually overflow regardless.
 
         // Title label
         card.addSubview(chartTitleLabel)
@@ -388,15 +395,25 @@ class StatisticsViewController: UIViewController {
             hStack.bottomAnchor.constraint(equalTo: motivationCard.bottomAnchor, constant: -AppSpacing.lg)
         ])
 
+        // Shadow lift parity with the other cards. The motivation card stays
+        // orange-tinted (intentional accent) so we don't apply the full
+        // `applyCardStyle` (which sets a hairline `separator` border that
+        // would clash with the bright fill); just the shadow here.
+        motivationCard.layer.masksToBounds = false
+        motivationCard.layer.shadowColor = UIColor.black.cgColor
+        motivationCard.layer.shadowOpacity = 0.08
+        motivationCard.layer.shadowRadius = 8
+        motivationCard.layer.shadowOffset = CGSize(width: 0, height: 2)
+
         return motivationCard
     }
 
+    /// Returns a `CardView` so each widget reads as a distinct surface in light
+    /// mode (see `UIView+CardStyle.swift`). `CardView` self-maintains its
+    /// shadow path and border colour across rotation / theme switches — the
+    /// hosting VC stays free of layout boilerplate.
     private func makeCard() -> UIView {
-        let view = UIView()
-        view.backgroundColor = .secondarySystemBackground
-        view.layer.cornerRadius = AppRadius.md
-        view.translatesAutoresizingMaskIntoConstraints = false
-        return view
+        CardView()
     }
 
     // MARK: - Binding


### PR DESCRIPTION
Fixes #82

## Что сделано

- Новые design tokens в `AppColors`: `cardSurface`, `cardBorder`, `groupedBackground` (light-mode dynamic — на ~5% темнее системного, чтобы белые карточки читались как distinct surfaces).
- Новый `UIView+CardStyle.swift` helper: `applyCardStyle()`, `refreshCardBorderColor()`, `updateCardShadowPath()`, плюс self-maintaining `CardView` subclass — единая точка для shadow + hairline border + corner radius.
- AlarmCell, StatisticsVC widgets (`makeCard`), TopUpVC balance hero — переведены на shared helper / CardView.
- AlarmsList balance hero — добавлен matching shadow lift (синий accent оставлен).
- StatisticsVC motivation banner — shadow parity (оранжевый акцент сохраняется, без border, чтобы не клэшил).
- Все grouped-style экраны (Settings, TopUp, CreateAlarm, SoundPicker, Statistics, TransactionHistory, Legal) — переключены на AppColors.groupedBackground в light mode → светлые insetGrouped cells теперь явно выделяются от фона.

## Acceptance criteria
- AppColors.cardSurface + AppColors.cardBorder константы добавлены
- AlarmCell, SettingsVC cells (через darker bg + insetGrouped), CreateAlarmVC cells (idem), StatisticsVC widgets, Settings transaction-history (idem) — единый visual approach
- Light mode: видимая граница каждой карточки (shadow + 0.5pt border на standalone, darker bg + iOS native rounding на insetGrouped)
- Dark mode: shadow едва заметен (как и было), border auto-adapts через UIColor.separator, groupedBackground остаётся системным

## Verify
- swiftlint: 0 новых errors в моих файлах (16 pre-existing на main, 16 на ветке)
- build_sim: succeeded (simulator: iPhone 17 Pro Max)
- test_sim: ОТКЛЮЧЕН per CLAUDE.md memory
- screenshot: ОТКЛЮЧЕН per CLAUDE.md memory

🤖 Generated with [Claude Code](https://claude.com/claude-code)