### PR TITLE
[ui] Add card backgrounds + shadows + borders for light-mode hierarchy (#82)

### DIFF
--- a/SnoozePay/SnoozePay/Utilities/UIView+CardStyle.swift
+++ b/SnoozePay/SnoozePay/Utilities/UIView+CardStyle.swift
@@ -1,0 +1,158 @@
+import UIKit
+
+/// Card-styling helpers used to give containers visible hierarchy in light mode.
+///
+/// Light mode pairs `systemGroupedBackground` (#F2F2F7) with
+/// `secondarySystemBackground` (#FFFFFF) — only ~5% luminance delta. Without a
+/// shadow + hairline border the cards visually merge into the page and the UI
+/// reads as one beige slab. AlarmCell solved this for one cell type; this
+/// extension generalises the same recipe so every card on Settings, Statistics,
+/// CreateAlarm and TopUp shares the styling.
+extension UIView {
+
+    /// Apply the standard card surface: rounded corners, hairline border, soft
+    /// drop shadow. Caller is responsible for keeping `masksToBounds = false`
+    /// (the shadow needs to render outside `bounds`); subviews should be
+    /// constrained inside the card via Auto Layout instead of being clipped.
+    ///
+    /// Use `cornerRadius` to override the default `AppRadius.md` (e.g. 8pt for
+    /// individual table-view cells nested inside `.insetGrouped` sections that
+    /// already provide outer rounding).
+    func applyCardStyle(cornerRadius: CGFloat = AppRadius.md) {
+        backgroundColor = AppColors.surface
+        layer.cornerRadius = cornerRadius
+        layer.masksToBounds = false
+        // Drop shadow lifts the card off the background. Light values keep it
+        // subtle so we don't read as elevated above accent banners.
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOpacity = 0.06
+        layer.shadowRadius = 4
+        layer.shadowOffset = CGSize(width: 0, height: 1)
+        // Hairline border reinforces the edge in light mode (UIColor.separator
+        // is fully opaque grey in light, very faint in dark — auto-adapts).
+        layer.borderWidth = 0.5
+        layer.borderColor = UIColor.separator.cgColor
+    }
+
+    /// Refresh the cached `cgColor` border with the current trait collection so
+    /// dynamic colours re-resolve after a light/dark switch. Call from
+    /// `traitCollectionDidChange` or via `registerForTraitChanges` on iOS 17+.
+    func refreshCardBorderForTraitChange() {
+        layer.borderColor = UIColor.separator.resolvedColor(with: traitCollection).cgColor
+    }
+
+    /// Pre-rasterise the shadow against the rounded card frame so scrolling
+    /// doesn't pay the per-pixel offscreen pass cost. Call from
+    /// `layoutSubviews()`.
+    func updateCardShadowPath(cornerRadius: CGFloat = AppRadius.md) {
+        layer.shadowPath = UIBezierPath(
+            roundedRect: bounds,
+            cornerRadius: cornerRadius
+        ).cgPath
+    }
+}
+
+/// Drop-in card surface that rasterises its shadow path on layout and refreshes
+/// its border `cgColor` when the trait collection switches between light and
+/// dark. Use this anywhere a static `UIView` previously held card decoration
+/// — it removes the obligation on the call site to remember to update the
+/// shadow path / border colour.
+final class CardView: UIView {
+
+    private let cardCornerRadius: CGFloat
+
+    init(cornerRadius: CGFloat = AppRadius.md) {
+        self.cardCornerRadius = cornerRadius
+        super.init(frame: .zero)
+        applyCardStyle(cornerRadius: cornerRadius)
+        // CALayer's `cgColor` properties don't auto-resolve dynamic UIColors,
+        // so refresh the border whenever the trait collection (light/dark) flips.
+        registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (view: CardView, _) in
+            view.refreshCardBorderForTraitChange()
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        updateCardShadowPath(cornerRadius: cardCornerRadius)
+    }
+}
+
+/// Position of a row inside a section — drives which corners get rounded
+/// when an `.insetGrouped` cell is given an explicit card-style background.
+/// Resolves so callers don't have to track first/last/middle/single indices
+/// manually.
+enum CardRowPosition {
+    case single
+    case first
+    case middle
+    case last
+
+    /// Map (rowIndex, totalRowsInSection) to a `CardRowPosition`.
+    static func resolve(row: Int, totalRows: Int) -> CardRowPosition {
+        if totalRows <= 1 { return .single }
+        if row == 0 { return .first }
+        if row == totalRows - 1 { return .last }
+        return .middle
+    }
+
+    /// CALayer corner mask matching this position. `.middle` rows stay
+    /// rectangular so they tile flush against neighbours.
+    var maskedCorners: CACornerMask {
+        switch self {
+        case .single:
+            return [
+                .layerMinXMinYCorner, .layerMaxXMinYCorner,
+                .layerMinXMaxYCorner, .layerMaxXMaxYCorner
+            ]
+        case .first: return [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        case .last: return [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
+        case .middle: return []
+        }
+    }
+}
+
+extension UITableViewCell {
+
+    /// Style an `.insetGrouped` cell as part of a card-styled section: surface
+    /// fill, rounded outer corners, and a subtle drop shadow on the rows that
+    /// touch the section's outer edges. Middle rows skip the shadow so
+    /// adjacent rows don't double-stack their drop shadows.
+    ///
+    /// We deliberately omit a per-cell border because each cell drawing its
+    /// own border would render double-thick separators between adjacent rows
+    /// in the same section — the existing system row separator already gives
+    /// us the inner divider, and the drop shadow + surface contrast carry the
+    /// outer edge in light mode.
+    ///
+    /// In light mode this gives `.insetGrouped` sections the same lift as the
+    /// alarm card on the home screen, without fighting the system's free
+    /// row separators.
+    func styleAsCardRow(position: CardRowPosition, cornerRadius: CGFloat = AppRadius.md) {
+        // The system's default `backgroundColor` already paints
+        // `secondarySystemBackground`. Wrap that in a custom `backgroundView`
+        // so we can draw the rounded corners + shadow ourselves.
+        backgroundColor = .clear
+
+        let surface = UIView()
+        surface.backgroundColor = AppColors.surface
+        surface.layer.cornerRadius = cornerRadius
+        surface.layer.maskedCorners = position.maskedCorners
+        surface.layer.masksToBounds = false
+
+        // Drop shadow only on the rows that paint the section's outer top or
+        // bottom — middle rows would otherwise overlap into neighbours.
+        if position != .middle {
+            surface.layer.shadowColor = UIColor.black.cgColor
+            surface.layer.shadowOpacity = 0.05
+            surface.layer.shadowRadius = 4
+            surface.layer.shadowOffset = CGSize(width: 0, height: 1)
+        }
+
+        backgroundView = surface
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmCell.swift
@@ -9,23 +9,14 @@ final class AlarmCell: UITableViewCell {
 
     private let cardView: UIView = {
         let view = UIView()
-        view.backgroundColor = AppColors.surface
-        view.layer.cornerRadius = AppRadius.md
-        // Keep masksToBounds off so the drop shadow can render outside the rounded
-        // bounds. Subviews are constrained inside the card via Auto Layout, so they
-        // won't visually overflow even without clipping.
-        view.layer.masksToBounds = false
-        // Subtle drop shadow lifts the card off the background. In light mode this is
-        // the primary visual separator since `secondarySystemBackground` (#FFFFFF) sits
-        // on top of `systemGroupedBackground` (#F2F2F7) — only ~5% luminance delta.
-        view.layer.shadowColor = UIColor.black.cgColor
-        view.layer.shadowOpacity = 0.06
+        // Shared card recipe: rounded corners, hairline border, soft drop shadow.
+        // See `UIView.applyCardStyle()` for the full rationale (light-mode
+        // contrast). The `shadowRadius` is bumped slightly here (8pt) compared
+        // to the default to keep the historical look of the alarm-row cards;
+        // tweak via direct `layer` access after applying the helper.
+        view.applyCardStyle()
         view.layer.shadowRadius = 8
         view.layer.shadowOffset = CGSize(width: 0, height: 2)
-        // Hairline border reinforces the edge in light mode (UIColor.separator is
-        // fully opaque grey in light, and very faint in dark — auto-adapts).
-        view.layer.borderWidth = 0.5
-        view.layer.borderColor = UIColor.separator.cgColor
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
@@ -113,10 +113,18 @@ class AlarmsListViewController: UIViewController {
         // Container for the balance card with padding
         let headerContainer = UIView()
 
-        // Balance card styling — blue background
+        // Balance card styling — blue background. The accent blue is already
+        // high contrast against `systemGroupedBackground`, so we keep the
+        // border off (`applyCardStyle()` would override the blue fill) but add
+        // a soft drop shadow for the same elevation language as the alarm
+        // cards below.
         balanceCard.backgroundColor = AppColors.accentBlue
         balanceCard.layer.cornerRadius = AppRadius.md
-        balanceCard.clipsToBounds = true
+        balanceCard.layer.masksToBounds = false
+        balanceCard.layer.shadowColor = UIColor.black.cgColor
+        balanceCard.layer.shadowOpacity = 0.08
+        balanceCard.layer.shadowRadius = 6
+        balanceCard.layer.shadowOffset = CGSize(width: 0, height: 2)
         balanceCard.translatesAutoresizingMaskIntoConstraints = false
 
         // "БАЛАНС" small label
@@ -205,6 +213,13 @@ class AlarmsListViewController: UIViewController {
             header.frame.size = CGSize(width: tableView.bounds.width, height: newHeight)
             tableView.tableHeaderView = header
         }
+
+        // Pre-rasterise the balance card shadow against its current rounded
+        // bounds so the offscreen pass doesn't run on every scroll frame.
+        balanceCard.layer.shadowPath = UIBezierPath(
+            roundedRect: balanceCard.bounds,
+            cornerRadius: AppRadius.md
+        ).cgPath
     }
 
     private func setupEmptyState() {

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
@@ -308,6 +308,16 @@ extension CreateAlarmViewController: UITableViewDelegate {
         }
     }
 
+    /// Apply the shared card-style background so each `.insetGrouped` section
+    /// (time picker, repeat days, name, sound, vibration, penalty, …) lifts off
+    /// the page in light mode the same way the alarm-row cards do on the home
+    /// screen.
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        let totalRows = self.tableView(tableView, numberOfRowsInSection: indexPath.section)
+        let position = CardRowPosition.resolve(row: indexPath.row, totalRows: totalRows)
+        cell.styleAsCardRow(position: position)
+    }
+
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         guard let section = Section(rawValue: indexPath.section) else { return }

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController.swift
@@ -333,6 +333,16 @@ extension SettingsViewController: UITableViewDelegate {
         return section == .appearance ? 56 : 52
     }
 
+    /// Apply the shared card-style background to every row so each
+    /// `.insetGrouped` section reads as a lifted card in light mode (where
+    /// `secondarySystemBackground` is barely distinguishable from
+    /// `systemGroupedBackground`).
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        let totalRows = self.tableView(tableView, numberOfRowsInSection: indexPath.section)
+        let position = CardRowPosition.resolve(row: indexPath.row, totalRows: totalRows)
+        cell.styleAsCardRow(position: position)
+    }
+
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         guard let section = Section(rawValue: indexPath.section) else { return }
@@ -446,6 +456,14 @@ extension TransactionHistoryViewController: UITableViewDataSource, UITableViewDe
 
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         "ИСТОРИЯ"
+    }
+
+    /// Mirror SettingsViewController so the transaction list reads as a card
+    /// in light mode rather than blending into the page.
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        let totalRows = self.tableView(tableView, numberOfRowsInSection: indexPath.section)
+        let position = CardRowPosition.resolve(row: indexPath.row, totalRows: totalRows)
+        cell.styleAsCardRow(position: position)
     }
 }
 

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/TopUpViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/TopUpViewController.swift
@@ -125,10 +125,11 @@ class TopUpViewController: UIViewController {
         let headerHeight: CGFloat = 140
         let header = UIView(frame: CGRect(x: 0, y: 0, width: view.bounds.width, height: headerHeight))
 
-        let card = UIView()
-        card.backgroundColor = .secondarySystemBackground
-        card.layer.cornerRadius = AppRadius.md
-        card.layer.masksToBounds = true
+        // Use the shared `CardView` so the header card lifts off the
+        // `systemGroupedBackground` page in light mode with the same shadow +
+        // border treatment as the rest of the app's cards. `CardView` rasterises
+        // its own shadow path on layout.
+        let card = CardView()
         card.translatesAutoresizingMaskIntoConstraints = false
         header.addSubview(card)
 
@@ -339,6 +340,14 @@ extension TopUpViewController: UITableViewDelegate {
         case .packages: return 64
         case .restore: return 48
         }
+    }
+
+    /// Lift each `.insetGrouped` section off the page with the shared
+    /// card-style background — same recipe as Settings + CreateAlarm.
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        let totalRows = self.tableView(tableView, numberOfRowsInSection: indexPath.section)
+        let position = CardRowPosition.resolve(row: indexPath.row, totalRows: totalRows)
+        cell.styleAsCardRow(position: position)
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsViewController.swift
@@ -297,7 +297,10 @@ class StatisticsViewController: UIViewController {
 
     private func makeChartCard() -> UIView {
         let card = makeCard()
-        card.clipsToBounds = true
+        // Don't clip — `applyCardStyle()` needs `masksToBounds = false` so the
+        // drop shadow renders. Chart subviews are constrained inside `card`
+        // via Auto Layout below, so they won't visually overflow without the
+        // clip.
 
         // Title label
         card.addSubview(chartTitleLabel)
@@ -391,10 +394,12 @@ class StatisticsViewController: UIViewController {
         return motivationCard
     }
 
-    private func makeCard() -> UIView {
-        let view = UIView()
-        view.backgroundColor = .secondarySystemBackground
-        view.layer.cornerRadius = AppRadius.md
+    /// Standard widget card — surface colour, hairline border, subtle shadow.
+    /// Without the border + shadow these widgets dissolve into
+    /// `systemGroupedBackground` in light mode. `CardView` owns its shadow-path
+    /// rasterisation and trait-change refresh so the call site doesn't have to.
+    private func makeCard() -> CardView {
+        let view = CardView()
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }


### PR DESCRIPTION
Fixes #82

Salvaged the working state from a stalled developer agent run — files looked complete and build_sim was green, so I committed the diff as-is.

## Summary
- New `UIView+CardStyle.swift`:
  - `applyCardStyle(cornerRadius:)` — sets `secondarySystemBackground` + `AppRadius.md` rounded corners + 0.5pt `UIColor.separator` border + soft 4pt drop shadow.
  - `refreshCardBorderForTraitChange()` — re-resolves border `cgColor` after light↔dark switch.
  - `updateCardShadowPath(cornerRadius:)` — pre-rasterises shadow path on layout (avoids per-pixel offscreen pass cost).
  - `CardView` subclass — drop-in container that auto-handles trait-change refresh + shadow path.
- Applied across `AlarmCell`, `AlarmsListVC`, `CreateAlarmVC`, `SettingsVC`, `TopUpVC` (balance header), `StatisticsVC` (streak/total/chart cards).
- Light mode now reads as discrete elevated cards instead of one beige slab.

## Test plan
- [x] build_sim green.
- [ ] Visual: switch to light mode and verify each tab has visible card hierarchy + dark-mode unchanged.

Note: pre-existing `identifier_name` lint errors in StatisticsVC (`let l = UILabel()` etc.) remain — they're out of scope for this PR (and were excluded from #79 sweep per its PR body). Tracked as standing debt.