### PR TITLE
[fix+ui] Restore os.Logger imports + add AppSpacing/AppTypography tokens (#83)

### DIFF
--- a/.xcodebuildmcp/config.yaml
+++ b/.xcodebuildmcp/config.yaml
@@ -1,0 +1,9 @@
+schemaVersion: 1
+sessionDefaults:
+  projectPath: /Users/ivanemelanov/Xcode/SnoozePay/SnoozePay/SnoozePay.xcodeproj
+  scheme: SnoozePay
+  configuration: Debug
+  simulatorId: 84737131-F188-4841-A4CE-38BC0DFD791A
+  bundleId: Ivan-Emelyanov.SnoozePay
+  simulatorName: iPhone 17
+  simulatorPlatform: iOS Simulator

--- a/SnoozePay/SnoozePay/AppDelegate.swift
+++ b/SnoozePay/SnoozePay/AppDelegate.swift
@@ -5,6 +5,7 @@
 
 import UIKit
 import UserNotifications
+import os
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {

--- a/SnoozePay/SnoozePay/Services/AlarmFiringCoordinator.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmFiringCoordinator.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// Handles the business logic triggered by notification actions on a fired
 /// alarm (snooze charge + reschedule). Extracted from AppDelegate so the same

--- a/SnoozePay/SnoozePay/Services/AlarmRepository.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmRepository.swift
@@ -1,5 +1,5 @@
 import Foundation
-import os.log
+import os
 
 /// Persists alarms in UserDefaults with a serial queue protecting all reads and writes.
 /// Without serialization, concurrent callers (UI edits + notification action handlers)

--- a/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
@@ -1,5 +1,6 @@
 import Foundation
 import UserNotifications
+import os
 
 /// Handles scheduling and cancelling alarms.
 /// Uses UNUserNotificationCenter (iOS 18+) as the scheduling backend.

--- a/SnoozePay/SnoozePay/Services/AudioService.swift
+++ b/SnoozePay/SnoozePay/Services/AudioService.swift
@@ -1,6 +1,7 @@
 import AVFoundation
 import AudioToolbox
 import Foundation
+import os
 
 /// Playback state of the alarm audio pipeline.
 ///

--- a/SnoozePay/SnoozePay/Services/BalanceService.swift
+++ b/SnoozePay/SnoozePay/Services/BalanceService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// Manages the user's local balance stored in UserDefaults.
 /// All operations are synchronous and offline-first.

--- a/SnoozePay/SnoozePay/Services/StoreKitService.swift
+++ b/SnoozePay/SnoozePay/Services/StoreKitService.swift
@@ -1,5 +1,6 @@
 import StoreKit
 import Foundation
+import os
 
 /// Manages consumable In-App Purchases using StoreKit 2.
 /// Five fixed packages: 49, 149, 299, 499, 999 RUB.

--- a/SnoozePay/SnoozePay/Utilities/AppColors.swift
+++ b/SnoozePay/SnoozePay/Utilities/AppColors.swift
@@ -33,7 +33,9 @@ enum AppColors {
     static let alarmFiringSnooze = UIColor(red: 0.91, green: 0.66, blue: 0.22, alpha: 1) // #E8A838
 }
 
-/// App-wide spacing constants
+/// App-wide spacing constants. T-shirt sizes (`xs`...`xxl`) are the underlying
+/// tokens; the semantic aliases below are what new code should reach for so a
+/// single design-system bump (e.g. screen inset 16 → 20) only touches one line.
 enum AppSpacing {
     static let xs: CGFloat = 4
     static let sm: CGFloat = 8
@@ -41,6 +43,20 @@ enum AppSpacing {
     static let lg: CGFloat = 16
     static let xl: CGFloat = 24
     static let xxl: CGFloat = 32
+
+    /// Standard horizontal inset for cards / banners against the screen edge.
+    static let screenInset: CGFloat = lg
+    /// Vertical gap between logical sections (e.g. between the balance card and
+    /// the alarms list).
+    static let sectionGap: CGFloat = xl
+    /// Vertical gap between rows / items inside the same section.
+    static let itemGap: CGFloat = md
+    /// Horizontal gap between an icon and its inline label.
+    static let inlineGap: CGFloat = sm
+    /// Vertical padding inside a card (top / bottom).
+    static let cardVerticalPadding: CGFloat = md
+    /// Horizontal padding inside a card (leading / trailing of card contents).
+    static let cardHorizontalPadding: CGFloat = lg
 }
 
 /// App-wide corner radius constants
@@ -49,4 +65,21 @@ enum AppRadius {
     static let md: CGFloat = 12
     static let lg: CGFloat = 16
     static let xl: CGFloat = 20
+
+    /// Canonical card corner radius — every standalone surface should round to
+    /// this value so cards on different screens read as the same primitive.
+    static let card: CGFloat = md
+}
+
+/// Typography tokens. Section headers had three slightly-different recipes
+/// across `SettingsVC` / `CreateAlarmVC` / `StatisticsVC`; route every site
+/// through these so future copy / weight changes happen in one place.
+enum AppTypography {
+    /// Font for table-view section headers and any "ВЕРХНИЙ ТЕКСТ"-style
+    /// uppercase label.
+    static let sectionHeader: UIFont = .preferredFont(forTextStyle: .footnote)
+    static let sectionHeaderColor: UIColor = .secondaryLabel
+    /// Letter-spacing applied to uppercase headers (matches iOS system grouped
+    /// table-view header tracking).
+    static let sectionHeaderKerning: CGFloat = 0.5
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/TopUpViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/TopUpViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import StoreKit
+import os
 
 /// Top-up balance screen with balance card, 5 IAP packages, and restore button.
 class TopUpViewController: UIViewController {

--- a/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// ViewModel for the alarm firing screen.
 /// Manages penalty calculation and balance deduction logic.
@@ -88,7 +89,7 @@ final class AlarmFiringViewModel {
         if alarm.repeatDays.isEmpty {
             let didUpdate = alarmRepository.setEnabled(false, id: alarm.id)
             if !didUpdate {
-                AppLogger.ui.notice("dismiss: alarm \(alarm.id, privacy: .private) already removed from repository")
+                AppLogger.ui.notice("dismiss: alarm \(self.alarm.id, privacy: .private) already removed from repository")
             }
         }
     }

--- a/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// ViewModel for the alarms list screen.
 /// Manages the alarm collection, balance display, and toggle state.


### PR DESCRIPTION
Fixes #83

## Two changes in one PR

### 1. Build-break fix (urgent)
PR #107 (`os.Logger` refactor) added `import os` to `AppLogger.swift` but did not propagate the import to the 9 consumer files that use string-interpolation privacy markers (`\(value, privacy: .public)`). Those API symbols live in the `os` module — without the import, every consumer file failed to compile.

Files patched: `AppDelegate.swift`, `AlarmFiringCoordinator.swift`, `AlarmRepository.swift` (had `os.log`, replaced with `os`), `AlarmScheduler.swift`, `AudioService.swift`, `BalanceService.swift`, `StoreKitService.swift`, `TopUpViewController.swift`, `AlarmFiringViewModel.swift`, `AlarmsListViewModel.swift`. Plus one `self.` annotation in `AlarmFiringViewModel.dismiss()` for Swift 6 closure capture rule.

### 2. Design-system semantic spacing/typography tokens (per #83)
Added on top of the existing `AppSpacing.xs/sm/md/lg/xl/xxl` t-shirt sizes:
- `AppSpacing.screenInset` — standard horizontal inset for cards/banners
- `AppSpacing.sectionGap` — vertical gap between logical sections
- `AppSpacing.itemGap` — vertical gap between rows inside a section
- `AppSpacing.inlineGap` — horizontal gap between icon and inline label
- `AppSpacing.cardVerticalPadding` / `cardHorizontalPadding`
- `AppRadius.card` — canonical card radius

New `AppTypography` namespace:
- `AppTypography.sectionHeader` — UIFont for "ВЕРХНИЙ ТЕКСТ" headers
- `AppTypography.sectionHeaderColor`
- `AppTypography.sectionHeaderKerning`

These give VC code a single source of truth so a future "screen inset 16 → 20" bump only touches one line.

**Issue #83 stays partially open** — the literal call-site rewrites across every VC are a multi-PR sweep. This lands the foundation; follow-up PRs will migrate VCs one-by-one.

Also includes `.xcodebuildmcp/config.yaml` which CLAUDE.md says should be tracked in git but was left untracked in the repo.

## Test plan
- [x] build_sim green (was broken before this PR — main has been red since #107).
- [ ] Visual: no regressions, no styling intentionally changes.