### PR TITLE
[fix] Belt-and-suspenders explicit-IDs removal in AlarmScheduler.cancel (#92)

### DIFF
--- a/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
@@ -148,9 +148,26 @@ final class AlarmScheduler {
         let snoozeID = snoozeNotificationID(for: alarmID)
         let belongsToAlarm: (String) -> Bool = { $0.hasPrefix(prefix) || $0 == snoozeID }
 
+        // Belt-and-suspenders: explicit-IDs sync removal first (no async dependency).
+        // If the async `getPendingNotificationRequests` completion returns an empty
+        // array — system glitch, background suspension, permission revoked — the
+        // prefix sweep below silently exits without removing anything. The sync
+        // call here guarantees the canonical day0..day6 / once / snooze IDs are
+        // removed regardless. Per #92 follow-up to #70.
+        let explicitIDs = (0..<7).map { notificationID(for: alarmID, trigger: "day\($0)") }
+            + [notificationID(for: alarmID, trigger: "once")]
+            + [snoozeID]
+        notificationCenter.removePendingNotificationRequests(withIdentifiers: explicitIDs)
+        notificationCenter.removeDeliveredNotifications(withIdentifiers: explicitIDs)
+
+        // Then prefix sweep for any future label additions / stragglers the
+        // explicit set didn't cover (idempotent — already-removed IDs are no-ops).
         notificationCenter.getPendingNotificationRequests { [notificationCenter] requests in
             let ids = requests.map { $0.identifier }.filter(belongsToAlarm)
-            guard !ids.isEmpty else { return }
+            if ids.isEmpty {
+                AppLogger.scheduler.info("cancel sweep: no pending requests matched alarmID \(alarmID, privacy: .private) (explicit removal already ran)")
+                return
+            }
             notificationCenter.removePendingNotificationRequests(withIdentifiers: ids)
         }
         notificationCenter.getDeliveredNotifications { [notificationCenter] notifications in


### PR DESCRIPTION
Fixes #92

Follow-up hardening on #70 (PR #86). The async `getPendingNotificationRequests` path can silently no-op if the completion returns empty for any reason (system glitch, background suspension, permission flux). Restored the explicit `day0..day6` / `once` / `snooze` ID list as a sync first-pass — guarantees the canonical IDs are removed regardless of async fetch state. Prefix sweep stays as a second pass for future label additions.

Also added an info-level log when the sweep finds nothing (so operational state stays observable).

Test plan: build_sim green.