### PR TITLE
[fix] Restore test compile + clear 15 swiftlint serious errors (audit)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController.swift
@@ -82,9 +82,9 @@ final class OnboardingViewController: UIViewController {
         config.baseForegroundColor = .white
         config.cornerStyle = .large
         config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { attrs in
-            var a = attrs
-            a.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
-            return a
+            var modified = attrs
+            modified.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
+            return modified
         }
         let button = UIButton(configuration: config)
         button.translatesAutoresizingMaskIntoConstraints = false

--- a/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsViewController.swift
@@ -36,67 +36,67 @@ class StatisticsViewController: UIViewController {
     // MARK: Two-column summary
 
     private let spentTitleLabel: UILabel = {
-        let l = UILabel()
-        l.text = "Потрачено"
-        l.font = UIFont.systemFont(ofSize: 13)
-        l.textColor = .secondaryLabel
-        l.translatesAutoresizingMaskIntoConstraints = false
-        return l
+        let label = UILabel()
+        label.text = "Потрачено"
+        label.font = UIFont.systemFont(ofSize: 13)
+        label.textColor = .secondaryLabel
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
     }()
 
     private let spentAmountLabel: UILabel = {
-        let l = UILabel()
-        l.font = UIFont.systemFont(ofSize: 32, weight: .bold)
-        l.textColor = AppColors.accentOrange
-        l.translatesAutoresizingMaskIntoConstraints = false
-        return l
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 32, weight: .bold)
+        label.textColor = AppColors.accentOrange
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
     }()
 
     private let snoozeTitleLabel: UILabel = {
-        let l = UILabel()
-        l.text = "Откладываний"
-        l.font = UIFont.systemFont(ofSize: 13)
-        l.textColor = .secondaryLabel
-        l.translatesAutoresizingMaskIntoConstraints = false
-        return l
+        let label = UILabel()
+        label.text = "Откладываний"
+        label.font = UIFont.systemFont(ofSize: 13)
+        label.textColor = .secondaryLabel
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
     }()
 
     private let snoozeCountLabel: UILabel = {
-        let l = UILabel()
-        l.font = UIFont.systemFont(ofSize: 32, weight: .bold)
-        l.textColor = .label
-        l.translatesAutoresizingMaskIntoConstraints = false
-        return l
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 32, weight: .bold)
+        label.textColor = .label
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
     }()
 
     // MARK: Average card
 
     private let averageTitleLabel: UILabel = {
-        let l = UILabel()
-        l.text = "Среднее"
-        l.font = UIFont.systemFont(ofSize: 13)
-        l.textColor = .secondaryLabel
-        l.translatesAutoresizingMaskIntoConstraints = false
-        return l
+        let label = UILabel()
+        label.text = "Среднее"
+        label.font = UIFont.systemFont(ofSize: 13)
+        label.textColor = .secondaryLabel
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
     }()
 
     private let averageValueLabel: UILabel = {
-        let l = UILabel()
-        l.font = UIFont.systemFont(ofSize: 28, weight: .bold)
-        l.textColor = .label
-        l.translatesAutoresizingMaskIntoConstraints = false
-        return l
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 28, weight: .bold)
+        label.textColor = .label
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
     }()
 
     // MARK: Chart
 
     private let chartTitleLabel: UILabel = {
-        let l = UILabel()
-        l.text = "График по дням"
-        l.font = UIFont.systemFont(ofSize: 15, weight: .semibold)
-        l.textColor = .label
-        l.translatesAutoresizingMaskIntoConstraints = false
-        return l
+        let label = UILabel()
+        label.text = "График по дням"
+        label.font = UIFont.systemFont(ofSize: 15, weight: .semibold)
+        label.textColor = .label
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
     }()
 
     private var chartHostingController: UIHostingController<StatisticsChartView>?
@@ -129,56 +129,56 @@ class StatisticsViewController: UIViewController {
     }()
 
     private let streakLabel: UILabel = {
-        let l = UILabel()
-        l.font = UIFont.systemFont(ofSize: 20, weight: .bold)
-        l.textColor = .label
-        l.numberOfLines = 0
-        l.translatesAutoresizingMaskIntoConstraints = false
-        return l
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 20, weight: .bold)
+        label.textColor = .label
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
     }()
 
     private let bestStreakLabel: UILabel = {
-        let l = UILabel()
-        l.font = UIFont.systemFont(ofSize: 13)
-        l.textColor = .secondaryLabel
-        l.translatesAutoresizingMaskIntoConstraints = false
-        return l
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 13)
+        label.textColor = .secondaryLabel
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
     }()
 
     // MARK: Motivation banner
 
     private let motivationCard: UIView = {
-        let v = UIView()
-        v.backgroundColor = AppColors.accentOrange
-        v.layer.cornerRadius = AppRadius.md
-        v.translatesAutoresizingMaskIntoConstraints = false
-        return v
+        let view = UIView()
+        view.backgroundColor = AppColors.accentOrange
+        view.layer.cornerRadius = AppRadius.md
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
     }()
 
     private let motivationIconLabel: UILabel = {
-        let l = UILabel()
-        l.text = "↗️"
-        l.font = UIFont.systemFont(ofSize: 24)
-        l.translatesAutoresizingMaskIntoConstraints = false
-        return l
+        let label = UILabel()
+        label.text = "↗️"
+        label.font = UIFont.systemFont(ofSize: 24)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
     }()
 
     private let motivationTitleLabel: UILabel = {
-        let l = UILabel()
-        l.text = "Мотивация"
-        l.font = UIFont.systemFont(ofSize: 15, weight: .bold)
-        l.textColor = .white
-        l.translatesAutoresizingMaskIntoConstraints = false
-        return l
+        let label = UILabel()
+        label.text = "Мотивация"
+        label.font = UIFont.systemFont(ofSize: 15, weight: .bold)
+        label.textColor = .white
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
     }()
 
     private let motivationMessageLabel: UILabel = {
-        let l = UILabel()
-        l.font = UIFont.systemFont(ofSize: 14)
-        l.textColor = UIColor.white.withAlphaComponent(0.9)
-        l.numberOfLines = 0
-        l.translatesAutoresizingMaskIntoConstraints = false
-        return l
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 14)
+        label.textColor = UIColor.white.withAlphaComponent(0.9)
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
     }()
 
     // MARK: - Lifecycle

--- a/SnoozePay/SnoozePayTests/AlarmRepositoryTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmRepositoryTests.swift
@@ -288,7 +288,8 @@ final class AlarmRepositoryTests: XCTestCase {
         _ = try? repo.fetchAllChecked()
         XCTAssertTrue(repo.lastLoadFailed)
 
-        testDefaults.set(try! JSONEncoder().encode([Alarm]()), forKey: "stored_alarms")
+        let emptyAlarmsData = (try? JSONEncoder().encode([Alarm]())) ?? Data()
+        testDefaults.set(emptyAlarmsData, forKey: "stored_alarms")
         _ = try? repo.fetchAllChecked()
 
         XCTAssertFalse(repo.lastLoadFailed,

--- a/SnoozePay/SnoozePayTests/AlarmSchedulerTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmSchedulerTests.swift
@@ -170,7 +170,7 @@ final class AlarmSchedulerTests: XCTestCase {
     // is removed. We can't go through schedule() in the test process because that
     // requires notification permission and a real future trigger date.
 
-    func testCancel_removesAllVariantsIncludingOnce() {
+    func testCancel_removesAllVariantsIncludingOnce() throws {
         let alarmID = UUID()
         let center = UNUserNotificationCenter.current()
         let prefix = "alarm_\(alarmID.uuidString)_"

--- a/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
@@ -307,7 +307,8 @@ final class AlarmsListViewModelTests: XCTestCase {
         vm.loadData()
 
         XCTAssertNotNil(receivedError, "VM must propagate decode failures to the VC")
-        if case AlarmRepository.RepositoryError.decodeFailure = receivedError as? AlarmRepository.RepositoryError {
+        if let typed = receivedError as? AlarmRepository.RepositoryError,
+           case .decodeFailure = typed {
             // expected
         } else {
             XCTFail("Expected decodeFailure, got \(String(describing: receivedError))")

--- a/SnoozePay/SnoozePayTests/StatisticsViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/StatisticsViewModelTests.swift
@@ -456,7 +456,8 @@ final class StatisticsViewModelDataTests: XCTestCase {
         vm.loadData(period: .week)
 
         XCTAssertNotNil(receivedError, "VM must propagate ledger decode failures to the VC")
-        if case TransactionRepository.RepositoryError.decodeFailure = receivedError as? TransactionRepository.RepositoryError {
+        if let typed = receivedError as? TransactionRepository.RepositoryError,
+           case .decodeFailure = typed {
             // expected
         } else {
             XCTFail("Expected decodeFailure, got \(String(describing: receivedError))")


### PR DESCRIPTION
Fixes audit findings.

## Build / lint state going in
- `build_sim` GREEN
- `test_sim` RED — test target failed to compile (3 errors)
- `swiftlint` 15 serious errors

## Changes

### 1. Test target compile (3 patches)
- `AlarmSchedulerTests.testCancel_removesAllVariantsIncludingOnce` — added `throws` so `try XCTSkipIf` is allowed
- `AlarmsListViewModelTests.testLoadData_corruptedJSON_firesOnLoadError` — pattern-matched optional `RepositoryError` via `if let typed = receivedError as? ..., case .decodeFailure = typed`
- `StatisticsViewModelTests.testLoadData_corruptedJSON_firesOnLoadError` — same fix

### 2. Identifier-name lint errors (14)
- `StatisticsViewController` — renamed 13 closure-local `let l = UILabel()` / `let v = UIView()` → `label`/`view`
- `OnboardingViewController:85` — `var a = attrs` → `var modified = attrs` in titleTextAttributesTransformer

### 3. force_try (1)
- `AlarmRepositoryTests:291` — replaced `try! JSONEncoder().encode(...)` with safe `try?` + Data() fallback

## Test plan
- [x] build_sim green
- [ ] test_sim should now run (gate disabled per CLAUDE.md, will verify locally if needed)
- [x] swiftlint serious errors: 15 → 0