### PR TITLE
[fix] Detect and surface negative/NaN/Inf balance corruption (#119)

### DIFF
--- a/SnoozePay/SnoozePay/Services/BalanceService.swift
+++ b/SnoozePay/SnoozePay/Services/BalanceService.swift
@@ -61,6 +61,14 @@ final class BalanceService {
         self.defaults = defaults
         self.transactionRepository = transactionRepository
         self.notificationCenter = notificationCenter
+        // Detect corruption at construction time so the gate is set BEFORE any
+        // background `charge` (notification action handler) can silently hit the
+        // refusal branch with no observer in place. Without this probe the
+        // `balanceCorruptedNotification` fires only on the FIRST balance read,
+        // which can happen on a background thread before any UI listener is
+        // attached — `NotificationCenter.post` does not retro-deliver to late
+        // subscribers, so the alert would be dropped.
+        _ = queue.sync { readRawBalance() }
     }
 
     /// Convenience for tests that supply only `defaults`: builds a matching
@@ -254,8 +262,23 @@ final class BalanceService {
     /// allowed (issue #119).
     private func readRawBalance() -> Double {
         let raw = defaults.double(forKey: balanceKey)
-        guard raw < 0 else { return raw }
+        // Treat NaN, ±Infinity AND negative as corruption. UserDefaults stores
+        // doubles verbatim, so a non-finite value can land via concurrent write
+        // race or external write — and `NaN < 0` is `false`, so a negative-only
+        // guard would let NaN/Inf sail through and propagate through
+        // `current >= amount` (always false for NaN) silently disabling charge
+        // without surfacing the corruption flag. Reject anything that isn't a
+        // finite, non-negative double.
+        guard raw.isFinite, raw >= 0 else {
+            return latchCorruption(raw: raw)
+        }
+        return raw
+    }
 
+    /// Latches the corruption flag, logs once, and broadcasts the notification.
+    /// Always returns `0` so callers can treat the wallet as empty for math.
+    /// MUST be called inside `queue.sync`.
+    private func latchCorruption(raw: Double) -> Double {
         // Latch the flag the first time we observe corruption, log once, and
         // broadcast for UI. Subsequent reads stay clamped at 0 until the user
         // acknowledges via `acknowledgeCorruption()`.
@@ -263,7 +286,7 @@ final class BalanceService {
         _balanceCorrupted = true
         if firstObservation {
             os_log(
-                "Negative balance observed in storage: %{public}f — gating mutations until acknowledged",
+                "Corrupted balance observed in storage: %{public}f — gating mutations until acknowledged",
                 log: Self.log, type: .error, raw
             )
             notifyBalanceCorrupted(rawValue: raw)

--- a/SnoozePay/SnoozePay/Services/BalanceService.swift
+++ b/SnoozePay/SnoozePay/Services/BalanceService.swift
@@ -18,11 +18,32 @@ final class BalanceService {
     static let balanceChangedNotification = Notification.Name("snoozepay.balance.changed")
     static let balanceUserInfoKey = "balance"
 
+    /// Broadcast once per process when a negative `user_balance` is observed
+    /// in storage (concurrent write race, downgrade, manual tampering — see
+    /// issue #119). UI surfaces an alert and offers the user to wipe the
+    /// corrupt value via `acknowledgeCorruption()` (future Settings entry,
+    /// see #102). Mirrors the locked-ledger pattern from #72.
+    static let balanceCorruptedNotification = Notification.Name("snoozepay.balance.corrupted")
+    /// Carries the raw negative `Double` that was read from storage so the
+    /// UI / support tooling can display what was found.
+    static let balanceCorruptedRawValueKey = "rawValue"
+
     private let defaults: UserDefaults
     private let balanceKey = "user_balance"
     private let transactionRepository: TransactionRepository
     private let queue = DispatchQueue(label: "com.snoozepay.balance.serial")
     private let notificationCenter: NotificationCenter
+    private static let log = OSLog(
+        subsystem: "Ivan-Emelyanov.SnoozePay",
+        category: "BalanceService"
+    )
+
+    /// Set inside `queue.sync` whenever a negative raw balance is observed.
+    /// While true, `charge`/`topUp` refuse to mutate storage so the corrupt
+    /// value is not overwritten before the user has a chance to acknowledge
+    /// the loss (mirrors `TransactionRepository._lastLoadFailed`, issue #72).
+    private var _balanceCorrupted: Bool = false
+    var balanceCorrupted: Bool { queue.sync { _balanceCorrupted } }
 
     /// Production code MUST use `BalanceService.shared` to avoid creating
     /// isolated instances with separate serial queues (which reintroduces the
@@ -66,17 +87,22 @@ final class BalanceService {
     // MARK: - Read
 
     var balance: Double {
-        queue.sync { defaults.double(forKey: balanceKey) }
+        queue.sync { readRawBalance() }
     }
 
     // MARK: - Deduct (snooze penalty)
 
     /// Attempts to charge the given amount from balance.
-    /// Returns true if successful, false if insufficient funds.
+    /// Returns true if successful, false if insufficient funds OR if the
+    /// stored balance is corrupted (negative). When corrupted, the caller
+    /// should surface `balanceCorruptedNotification` UX and route the user
+    /// to `acknowledgeCorruption()` before any further wallet mutation
+    /// (mirrors locked-ledger pattern from #72).
     @discardableResult
     func charge(amount: Double, alarmID: UUID?) -> Bool {
         let result: (charged: Bool, newBalance: Double) = queue.sync {
-            let current = defaults.double(forKey: balanceKey)
+            let current = readRawBalance()
+            guard !_balanceCorrupted else { return (false, current) }
             guard current >= amount else { return (false, current) }
 
             let transaction = Transaction(
@@ -107,14 +133,17 @@ final class BalanceService {
     // MARK: - Top up (IAP)
 
     /// Returns `true` if the credit landed (balance moved AND ledger updated).
-    /// Returns `false` when the transaction repository is locked or encoding
-    /// failed — caller should surface this to the user instead of pretending
+    /// Returns `false` when the transaction repository is locked, encoding
+    /// failed, or the stored balance is corrupted (negative — see #119) —
+    /// caller should surface this to the user instead of pretending
     /// the IAP credited (silent ledger desync was the regression behind the #72
     /// PR #101 hunter feedback).
     @discardableResult
     func topUp(amount: Double) -> Bool {
         let result: (recorded: Bool, newBalance: Double) = queue.sync {
-            let current = defaults.double(forKey: balanceKey)
+            let current = readRawBalance()
+            guard !_balanceCorrupted else { return (false, current) }
+
             let transaction = Transaction(
                 type: .topup,
                 amount: amount
@@ -136,7 +165,25 @@ final class BalanceService {
     // MARK: - Validation
 
     func canAfford(_ amount: Double) -> Bool {
-        queue.sync { defaults.double(forKey: balanceKey) >= amount }
+        queue.sync { readRawBalance() >= amount }
+    }
+
+    // MARK: - Recovery (corruption)
+
+    /// Resets `user_balance` to `0` and clears the corruption flag. Called by
+    /// the future Settings "Стереть повреждённые данные" button (see #102)
+    /// after the user has acknowledged the loss. The notification is posted
+    /// so observers can refresh their view of the wallet to the new zero state.
+    func acknowledgeCorruption() {
+        let cleared: Bool = queue.sync {
+            guard _balanceCorrupted else { return false }
+            defaults.set(0.0, forKey: balanceKey)
+            _balanceCorrupted = false
+            return true
+        }
+        if cleared {
+            notifyBalanceChanged(0)
+        }
     }
 
     // MARK: - Typed API (phase 1 of #31)
@@ -149,7 +196,11 @@ final class BalanceService {
 
     /// Current balance as a `Money` value. Always non-nil — `Double` from
     /// `UserDefaults.double(forKey:)` defaults to `0` (which is valid).
-    /// If a corrupt negative value somehow exists, falls back to `.zero`.
+    /// A negative raw value flips `balanceCorrupted` (logged + broadcast via
+    /// `balanceCorruptedNotification`) and is reported as `.zero` so UI can
+    /// keep rendering while the user is prompted to acknowledge the loss
+    /// (issue #119). Subsequent `charge`/`topUp` are gated until cleared via
+    /// `acknowledgeCorruption()`.
     var balanceMoney: Money {
         Money(balance) ?? .zero
     }
@@ -192,6 +243,49 @@ final class BalanceService {
             name: Self.balanceChangedNotification,
             object: self,
             userInfo: [Self.balanceUserInfoKey: newBalance]
+        )
+    }
+
+    /// Reads the raw balance from storage and side-effects the corruption
+    /// flag if a negative value is observed. MUST be called inside `queue.sync`.
+    /// Returns `0` to callers when corrupt so downstream math (e.g. `canAfford`)
+    /// behaves as if the wallet is empty rather than negative — the corruption
+    /// flag is the single source of truth for whether further mutation is
+    /// allowed (issue #119).
+    private func readRawBalance() -> Double {
+        let raw = defaults.double(forKey: balanceKey)
+        guard raw < 0 else { return raw }
+
+        // Latch the flag the first time we observe corruption, log once, and
+        // broadcast for UI. Subsequent reads stay clamped at 0 until the user
+        // acknowledges via `acknowledgeCorruption()`.
+        let firstObservation = !_balanceCorrupted
+        _balanceCorrupted = true
+        if firstObservation {
+            os_log(
+                "Negative balance observed in storage: %{public}f — gating mutations until acknowledged",
+                log: Self.log, type: .error, raw
+            )
+            notifyBalanceCorrupted(rawValue: raw)
+        }
+        return 0
+    }
+
+    private func notifyBalanceCorrupted(rawValue: Double) {
+        if Thread.isMainThread {
+            postBalanceCorrupted(rawValue: rawValue)
+        } else {
+            DispatchQueue.main.async { [weak self] in
+                self?.postBalanceCorrupted(rawValue: rawValue)
+            }
+        }
+    }
+
+    private func postBalanceCorrupted(rawValue: Double) {
+        notificationCenter.post(
+            name: Self.balanceCorruptedNotification,
+            object: self,
+            userInfo: [Self.balanceCorruptedRawValueKey: rawValue]
         )
     }
 }

--- a/SnoozePay/SnoozePayTests/BalanceServiceTests.swift
+++ b/SnoozePay/SnoozePayTests/BalanceServiceTests.swift
@@ -225,6 +225,100 @@ final class BalanceServiceTests: XCTestCase {
         XCTAssertEqual(service.balance, initialBalance - Double(successes) * amount)
     }
 
+    // MARK: - Negative balance corruption (#119)
+
+    /// Synthetic negative `user_balance` (race / downgrade / tampering) MUST
+    /// flip `balanceCorrupted`, broadcast `balanceCorruptedNotification` with
+    /// the raw value, and report `balance == 0` to downstream math so the
+    /// wallet doesn't behave as if it owes money.
+    func testNegativeStoredBalance_flipsCorruptedFlagAndBroadcasts() {
+        let center = NotificationCenter()
+        // Inject the corrupt value directly — the public API would never
+        // produce this state, which is the whole point of the detection.
+        testDefaults.set(-42.5, forKey: "user_balance")
+        let service = BalanceService(defaults: testDefaults, notificationCenter: center)
+
+        let exp = expectation(description: "corruption notification fires")
+        var receivedRaw: Double?
+        let token = center.addObserver(
+            forName: BalanceService.balanceCorruptedNotification,
+            object: nil,
+            queue: .main
+        ) { note in
+            receivedRaw = note.userInfo?[BalanceService.balanceCorruptedRawValueKey] as? Double
+            exp.fulfill()
+        }
+        defer { center.removeObserver(token) }
+
+        // Reading triggers detection.
+        XCTAssertEqual(service.balance, 0,
+                       "Corrupt negative balance must be reported as 0 to downstream math")
+        wait(for: [exp], timeout: 1.0)
+
+        XCTAssertTrue(service.balanceCorrupted, "balanceCorrupted flag must latch on detection")
+        XCTAssertEqual(receivedRaw, -42.5, "Notification must carry the raw negative value")
+    }
+
+    /// Under corruption, `charge` must refuse and return `false` — mirrors the
+    /// locked-ledger gate from #72 so we don't silently mutate a corrupt store.
+    func testCharge_refusedUnderCorruption() {
+        let center = NotificationCenter()
+        let (service, ledger) = makeServiceWithLedger(balance: -10, notificationCenter: center)
+        _ = service.balance // trigger detection
+
+        XCTAssertTrue(service.balanceCorrupted)
+        XCTAssertFalse(service.charge(amount: 1, alarmID: nil),
+                       "charge must refuse when balance store is corrupted")
+        XCTAssertTrue(ledger.fetchAll().isEmpty,
+                      "No transaction may land while balance is corrupted")
+    }
+
+    /// Under corruption, `topUp` must refuse — otherwise an IAP would silently
+    /// land on top of a corrupt value the user hasn't acknowledged.
+    func testTopUp_refusedUnderCorruption() {
+        let center = NotificationCenter()
+        let (service, ledger) = makeServiceWithLedger(balance: -10, notificationCenter: center)
+        _ = service.balance // trigger detection
+
+        XCTAssertTrue(service.balanceCorrupted)
+        XCTAssertFalse(service.topUp(amount: 100),
+                       "topUp must refuse when balance store is corrupted")
+        XCTAssertTrue(ledger.fetchAll().isEmpty,
+                      "No transaction may land while balance is corrupted")
+    }
+
+    /// `acknowledgeCorruption` resets storage to 0, clears the flag, and
+    /// broadcasts a regular `balanceChangedNotification` so observers refresh
+    /// to the new zero state. After ack, `charge`/`topUp` work again.
+    func testAcknowledgeCorruption_clearsFlagAndRestoresMutability() {
+        let center = NotificationCenter()
+        testDefaults.set(-99.0, forKey: "user_balance")
+        let service = BalanceService(defaults: testDefaults, notificationCenter: center)
+        _ = service.balance // trigger detection
+        XCTAssertTrue(service.balanceCorrupted)
+
+        let changed = expectation(description: "balanceChanged fires after ack")
+        var receivedAmount: Double?
+        let token = center.addObserver(
+            forName: BalanceService.balanceChangedNotification,
+            object: nil,
+            queue: .main
+        ) { note in
+            receivedAmount = note.userInfo?[BalanceService.balanceUserInfoKey] as? Double
+            changed.fulfill()
+        }
+        defer { center.removeObserver(token) }
+
+        service.acknowledgeCorruption()
+
+        wait(for: [changed], timeout: 1.0)
+        XCTAssertEqual(receivedAmount, 0)
+        XCTAssertFalse(service.balanceCorrupted, "Flag must clear after acknowledgement")
+        XCTAssertEqual(service.balance, 0, "Balance must be reset to 0")
+        XCTAssertTrue(service.topUp(amount: 50), "Mutations must work again after ack")
+        XCTAssertEqual(service.balance, 50)
+    }
+
     func testConcurrentChargeAndTopUp_remainsConsistent() {
         let initialBalance: Double = 500
         let amount: Double = 5


### PR DESCRIPTION
Fixes #119

Replaces #122 (closed) — rebased onto current main after #112 (AppLogger) merged. Force-push blocked, so opening fresh.

## Summary

`BalanceService.balanceMoney` was silently coercing a negative stored balance to `Money.zero` via `Money(negative) ?? .zero`, masking ledger corruption. After the fix-loop addressing silent-failure-hunter findings, this PR:

- Detects negative AND non-finite (NaN, ±Inf) raw balance in `readRawBalance()`
- Probes corruption at construction time (`init` calls `_ = queue.sync { readRawBalance() }`) so the gate latches BEFORE any background charge can hit the refusal branch with no UI observer attached
- Latches `_balanceCorrupted` flag inside the serial queue
- Broadcasts `balanceCorruptedNotification` (UI surfaces alert via #102 follow-up, not in scope here)
- Gates `charge` and `topUp` to return `false` when corrupted (mirrors locked-ledger pattern from #72)
- Adds `acknowledgeCorruption()` recovery API
- Tests detect/refuse/recover paths

## Round 2 fixes (silent-failure-hunter)

1. NaN/Infinity covered (`raw < 0` → `raw.isFinite && raw >= 0`).
2. Init-time probe prevents broadcast-into-the-void scenario.

## Deferred (tracked separately)

- Notification observer wiring → depends on #102 (pm-input-needed)
- acknowledgeCorruption ledger reconciliation → design after #102 lands
- os_log → AppLogger.balance migration → repository-style consistent with TransactionRepository / AlarmRepository

🤖 Generated with [Claude Code](https://claude.com/claude-code)