### PR TITLE
[fix] Surface AlarmScheduler schedule errors to UI (#118)

### DIFF
--- a/SnoozePay/SnoozePay/Services/AlarmRepository.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmRepository.swift
@@ -94,8 +94,19 @@ final class AlarmRepository {
     ///   currently locked (`lastLoadFailed == true`) or encoding fails.
     ///   Callers (CreateAlarmViewModel) surface the failure to the user
     ///   instead of pretending the alarm landed safely (issue #72).
+    ///
+    /// `schedulingResult` is invoked **only on the successful-persist path**
+    /// once `AlarmScheduler.schedule` finishes (issue #118). Disabled alarms
+    /// resolve with `.success(())` because there is no scheduling work, but
+    /// the closure is still called so async callers always observe
+    /// completion when `save` returned `true`. When `save` returns `false`
+    /// the closure is **not** invoked — the caller has already received the
+    /// failure synchronously via the boolean.
     @discardableResult
-    func save(_ alarm: Alarm) -> Bool {
+    func save(
+        _ alarm: Alarm,
+        schedulingResult: ((Result<Void, AlarmScheduler.SchedulingError>) -> Void)? = nil
+    ) -> Bool {
         let didPersist: Bool = queue.sync {
             guard !_lastLoadFailed else { return false }
             // Read fresh state inside the lock so concurrent saves don't
@@ -115,13 +126,17 @@ final class AlarmRepository {
             return persist(alarms)
         }
 
-        if didPersist {
-            AlarmScheduler.shared.cancel(alarm.id)
-            if alarm.enabled {
-                AlarmScheduler.shared.schedule(alarm)
-            }
+        guard didPersist else { return false }
+
+        AlarmScheduler.shared.cancel(alarm.id)
+        if alarm.enabled {
+            AlarmScheduler.shared.schedule(alarm, completion: schedulingResult)
+        } else {
+            // Disabled alarms don't schedule — report success so async
+            // callers don't hang waiting for a closure that never fires.
+            schedulingResult?(.success(()))
         }
-        return didPersist
+        return true
     }
 
     @discardableResult

--- a/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
@@ -2,6 +2,38 @@ import Foundation
 import UserNotifications
 import os
 
+/// Subset of `UNUserNotificationCenter` the scheduler depends on. Extracted as a
+/// protocol so unit tests can substitute a mock and verify error-propagation
+/// paths (issue #118) — the real `UNUserNotificationCenter.current()` is a
+/// process-wide singleton whose `add(_:)` failure modes (permission revoked
+/// mid-session, malformed trigger, 64-pending limit) cannot otherwise be
+/// reproduced deterministically.
+protocol NotificationScheduling: AnyObject {
+    // Sendable closures match `UNUserNotificationCenter`'s post-Swift-6
+    // signature. Without them the implicit conformance is a warning
+    // today and an error under Swift 6 strict concurrency.
+    func add(
+        _ request: UNNotificationRequest,
+        withCompletionHandler completion: (@Sendable (Error?) -> Void)?
+    )
+    func getPendingNotificationRequests(
+        completionHandler: @escaping @Sendable ([UNNotificationRequest]) -> Void
+    )
+    func removePendingNotificationRequests(withIdentifiers identifiers: [String])
+    func removeDeliveredNotifications(withIdentifiers identifiers: [String])
+    func getDeliveredNotifications(
+        completionHandler: @escaping @Sendable ([UNNotification]) -> Void
+    )
+    func setNotificationCategories(_ categories: Set<UNNotificationCategory>)
+    func removeAllPendingNotificationRequests()
+    func requestAuthorization(
+        options: UNAuthorizationOptions,
+        completionHandler: @escaping @Sendable (Bool, Error?) -> Void
+    )
+}
+
+extension UNUserNotificationCenter: NotificationScheduling {}
+
 /// Handles scheduling and cancelling alarms.
 /// Uses UNUserNotificationCenter (iOS 18+) as the scheduling backend.
 /// On iOS 26+ with AlarmKit, the system alarm engine takes over — this service
@@ -10,7 +42,39 @@ final class AlarmScheduler {
 
     static let shared = AlarmScheduler()
 
-    private let notificationCenter = UNUserNotificationCenter.current()
+    /// Errors surfaced to UI callers so the user sees a real explanation
+    /// instead of a fake "Будильник создан" toast on a notification that
+    /// never registered (issue #118).
+    enum SchedulingError: LocalizedError, Equatable {
+        /// `UNUserNotificationCenter.add` returned an error — typically a
+        /// revoked notification permission or a malformed trigger.
+        case system(message: String)
+        /// Pre-flight check found we are at or above the iOS 64-pending
+        /// notification cap. Adding another would silently evict an
+        /// existing one, so we refuse and let the user delete old alarms.
+        case pendingLimitReached(currentCount: Int)
+
+        var errorDescription: String? {
+            switch self {
+            case .system(let message):
+                return "Не удалось запланировать будильник: \(message). "
+                     + "Включите уведомления в Настройках или удалите старые будильники."
+            case .pendingLimitReached(let count):
+                return "Достигнут лимит iOS на запланированные уведомления (\(count) из 64). "
+                     + "Удалите старые будильники, чтобы освободить место."
+            }
+        }
+        // Equatable synthesis is automatic — `String` and `Int` associated
+        // values both conform out of the box.
+    }
+
+    /// iOS hard-cap on pending notification requests per app. Above this the
+    /// system silently drops additional requests (oldest-first), so we
+    /// pre-flight check and refuse rather than scheduling a request that may
+    /// or may not survive eviction.
+    static let pendingNotificationLimit = 64
+
+    private let notificationCenter: NotificationScheduling
 
     // Notification category and action IDs
     private let categoryID = "ALARM_CATEGORY"
@@ -20,7 +84,15 @@ final class AlarmScheduler {
     /// Whether the app has the critical alerts entitlement (set after permission request)
     private(set) static var criticalAlertsAvailable = false
 
-    private init() {}
+    private init() {
+        self.notificationCenter = UNUserNotificationCenter.current()
+    }
+
+    /// Test-only initializer that swaps the notification-center seam.
+    /// Production code MUST use `AlarmScheduler.shared` (see `singleton`).
+    init(notificationCenter: NotificationScheduling) {
+        self.notificationCenter = notificationCenter
+    }
 
     // MARK: - Permission
 
@@ -86,29 +158,66 @@ final class AlarmScheduler {
 
     // MARK: - Schedule alarm
 
-    func schedule(_ alarm: Alarm) {
-        guard alarm.enabled else { return }
+    /// Schedule the user's alarm.
+    /// - Parameters:
+    ///   - alarm: alarm model to schedule (no-op when `enabled == false`).
+    ///   - completion: optional callback invoked once on the main queue once
+    ///     all triggers have either landed or one of them failed. Failures
+    ///     are reported as `SchedulingError.system(message:)`. Default `nil`
+    ///     keeps the scheduler-driven call sites (`AlarmRepository.save`)
+    ///     backwards compatible (issue #118).
+    func schedule(_ alarm: Alarm, completion: ((Result<Void, SchedulingError>) -> Void)? = nil) {
+        guard alarm.enabled else {
+            completion?(.success(()))
+            return
+        }
 
         let content = makeContent(for: alarm, snoozeCount: 0)
         let triggers = makeTriggers(for: alarm)
 
-        for trigger in triggers {
-            let request = UNNotificationRequest(
-                identifier: notificationID(for: alarm.id, trigger: trigger.label),
-                content: content,
-                trigger: trigger.trigger
-            )
-            notificationCenter.add(request) { error in
-                if let error = error {
-                    AppLogger.scheduler.error("schedule failed: \(error.localizedDescription, privacy: .public)")
-                }
+        guard !triggers.isEmpty else {
+            completion?(.success(()))
+            return
+        }
+
+        // Pre-flight 64-pending limit check. We refuse to schedule when the
+        // batch we're about to add would push us over — iOS would otherwise
+        // silently evict our oldest pending request. Surface the situation
+        // to the user instead so they know to delete old alarms.
+        runPendingLimitPreflight(triggerCount: triggers.count) { [weak self] preflight in
+            guard let self else {
+                completion?(.success(()))
+                return
             }
+            if case .failure(let error) = preflight {
+                completion?(.failure(error))
+                return
+            }
+            self.dispatchAdds(
+                requests: triggers.map { trigger in
+                    UNNotificationRequest(
+                        identifier: self.notificationID(for: alarm.id, trigger: trigger.label),
+                        content: content,
+                        trigger: trigger.trigger
+                    )
+                },
+                completion: completion
+            )
         }
     }
 
     // MARK: - Schedule snooze
 
-    func scheduleSnooze(for alarm: Alarm, snoozeCount: Int) {
+    /// Schedule a follow-up snooze notification.
+    /// Carries the same `completion` semantics as `schedule(_:completion:)`
+    /// so `AlarmFiringViewModel` / `AlarmFiringCoordinator` can surface
+    /// scheduling failures instead of silently leaving the user without a
+    /// re-fire (issue #118).
+    func scheduleSnooze(
+        for alarm: Alarm,
+        snoozeCount: Int,
+        completion: ((Result<Void, SchedulingError>) -> Void)? = nil
+    ) {
         let content = makeContent(for: alarm, snoozeCount: snoozeCount)
 
         let fireDate = Self.scheduledFireDate(now: Date(), snoozeMinutes: alarm.snoozeMinutes)
@@ -121,9 +230,83 @@ final class AlarmScheduler {
             content: content,
             trigger: trigger
         )
-        notificationCenter.add(request) { error in
-            if let error = error {
-                AppLogger.scheduler.error("schedule failed: \(error.localizedDescription, privacy: .public)")
+
+        runPendingLimitPreflight(triggerCount: 1) { [weak self] preflight in
+            guard let self else {
+                completion?(.success(()))
+                return
+            }
+            if case .failure(let error) = preflight {
+                completion?(.failure(error))
+                return
+            }
+            self.dispatchAdds(requests: [request], completion: completion)
+        }
+    }
+
+    // MARK: - Private scheduling helpers
+
+    /// Run the iOS 64-pending-limit pre-flight. Resolves to `.failure` when
+    /// adding `triggerCount` requests would push us over the cap.
+    /// Always resolves on the main queue so callers don't need to bounce.
+    private func runPendingLimitPreflight(
+        triggerCount: Int,
+        completion: @escaping (Result<Void, SchedulingError>) -> Void
+    ) {
+        notificationCenter.getPendingNotificationRequests { requests in
+            let pending = requests.count
+            DispatchQueue.main.async {
+                if pending + triggerCount > Self.pendingNotificationLimit {
+                    let limit = Self.pendingNotificationLimit
+                    AppLogger.scheduler.error(
+                        "schedule blocked: pending=\(pending, privacy: .public) batch=\(triggerCount, privacy: .public) limit=\(limit, privacy: .public)"
+                    )
+                    completion(.failure(.pendingLimitReached(currentCount: pending)))
+                } else {
+                    completion(.success(()))
+                }
+            }
+        }
+    }
+
+    /// Add a batch of notification requests sequentially, fan-in their
+    /// completion blocks, and report the first error to the caller. We
+    /// fan-in instead of bailing on the first failure so partial success
+    /// (e.g. 5/7 weekday triggers landed, 2 rejected) is logged for every
+    /// failure even though only the first is surfaced to the UI.
+    private func dispatchAdds(
+        requests: [UNNotificationRequest],
+        completion: ((Result<Void, SchedulingError>) -> Void)?
+    ) {
+        guard !requests.isEmpty else {
+            completion?(.success(()))
+            return
+        }
+
+        let group = DispatchGroup()
+        var firstError: Error?
+        let errorLock = NSLock()
+
+        for request in requests {
+            group.enter()
+            notificationCenter.add(request) { error in
+                if let error = error {
+                    AppLogger.scheduler.error(
+                        "schedule failed: \(error.localizedDescription, privacy: .public)"
+                    )
+                    errorLock.lock()
+                    if firstError == nil { firstError = error }
+                    errorLock.unlock()
+                }
+                group.leave()
+            }
+        }
+
+        group.notify(queue: .main) {
+            if let error = firstError {
+                completion?(.failure(.system(message: error.localizedDescription)))
+            } else {
+                completion?(.success(()))
             }
         }
     }

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
@@ -413,10 +413,33 @@ class AlarmFiringViewController: UIViewController {
     }
 
     @objc private func snoozeTapped() {
-        let success = viewModel.snooze()
+        // Pass a scheduleCompletion so a notification-center failure (revoked
+        // permission, 64-pending-limit, malformed trigger) reaches the user
+        // even though the VM has already charged them — without this surface
+        // the user pays for a snooze that will never re-fire (silent-failure-
+        // hunter critical finding on PR #127).
+        let success = viewModel.snooze { [weak self] result in
+            guard let self else { return }
+            if case let .failure(error) = result {
+                self.presentSnoozeScheduleFailureAlert(error: error)
+            }
+        }
         if success {
             dismiss(animated: true)
         }
         // If failed (balance empty) — button is already disabled, nothing to do
+    }
+
+    private func presentSnoozeScheduleFailureAlert(
+        error: AlarmScheduler.SchedulingError
+    ) {
+        let detail = error.errorDescription ?? error.localizedDescription
+        let alert = UIAlertController(
+            title: "Снуз не запланирован",
+            message: "\(detail) Будильник не зазвенит повторно — установите запасной.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "Ок", style: .default))
+        present(alert, animated: true)
     }
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
@@ -121,24 +121,41 @@ final class CreateAlarmViewController: UIViewController {
     @objc private func saveTapped() {
         // Cells push state into the view-model live via callbacks, so save just
         // forwards the current snapshot to the repository.
-        let didSave = viewModel.save()
-        guard didSave else {
-            // Persist failed (corrupt store / encode error). Surface the
-            // failure inline so the user doesn't tap "Сохранить", see the
-            // sheet dismiss, and assume their alarm landed (issue #72).
-            presentRepositoryError(AlarmRepository.RepositoryError.persistBlocked)
-            return
+        // The async overload waits on `AlarmScheduler.schedule` to resolve so
+        // we don't dismiss-and-toast on a notification request that
+        // silently failed to register (issue #118).
+        viewModel.save { [weak self] outcome in
+            guard let self else { return }
+            switch outcome {
+            case .success:
+                self.onSave?()
+                self.dismiss(animated: true)
+            case .persistFailed:
+                // Persist failed (corrupt store / encode error). Surface the
+                // failure inline so the user doesn't tap "Сохранить", see the
+                // sheet dismiss, and assume their alarm landed (issue #72).
+                self.presentSaveError(
+                    title: "Не удалось сохранить",
+                    error: AlarmRepository.RepositoryError.persistBlocked
+                )
+            case .schedulingFailed(let error):
+                // Persist landed but the notification didn't — the user is
+                // about to go to bed thinking the alarm will ring. Tell
+                // them so they can fix the cause (issue #118).
+                self.presentSaveError(
+                    title: "Не удалось запланировать будильник",
+                    error: error
+                )
+            }
         }
-        onSave?()
-        dismiss(animated: true)
     }
 
-    /// Inline alert for repository failures that block save/delete. Kept
-    /// generic so the same call site can present any `LocalizedError`
-    /// (issue #72).
-    private func presentRepositoryError(_ error: LocalizedError) {
+    /// Inline alert for repository or scheduler failures that block the
+    /// save flow. Kept generic so the same call site can present any
+    /// `LocalizedError` (issues #72, #118).
+    private func presentSaveError(title: String, error: LocalizedError) {
         let alert = UIAlertController(
-            title: "Не удалось сохранить",
+            title: title,
             message: error.errorDescription ?? "Попробуйте ещё раз.",
             preferredStyle: .alert
         )
@@ -346,7 +363,10 @@ extension CreateAlarmViewController: UITableViewDelegate {
             // sheet on a no-op delete.
             let didDelete = self.viewModel.delete()
             guard didDelete else {
-                self.presentRepositoryError(AlarmRepository.RepositoryError.persistBlocked)
+                self.presentSaveError(
+                    title: "Не удалось сохранить",
+                    error: AlarmRepository.RepositoryError.persistBlocked
+                )
                 return
             }
             self.onDelete?()

--- a/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
@@ -61,16 +61,29 @@ final class AlarmFiringViewModel {
     // MARK: - Actions
 
     /// Deduct penalty and reschedule snooze.
-    /// Returns true if snooze was successful.
+    /// Returns true if charge + snoozeCount bump succeeded. The optional
+    /// `scheduleCompletion` is invoked AFTER the underlying scheduler reports
+    /// the result of registering the snooze trigger with iOS — if it fires
+    /// `.failure(SchedulingError)` the user has already been charged but the
+    /// alarm will NOT actually re-fire. The VC must surface the error so the
+    /// user knows to set a backup alarm (or contact support for refund).
+    /// Without consuming this completion the original silent-failure-class
+    /// from #118 reappears in the snooze flow (silent-failure-hunter #127).
     @discardableResult
-    func snooze() -> Bool {
+    func snooze(
+        scheduleCompletion: ((Result<Void, AlarmScheduler.SchedulingError>) -> Void)? = nil
+    ) -> Bool {
         guard canSnooze else { return false }
 
         let charged = balanceService.charge(amount: currentPenalty, alarmID: alarm.id)
         guard charged else { return false }
 
         snoozeCount += 1
-        scheduler.scheduleSnooze(for: alarm, snoozeCount: snoozeCount)
+        scheduler.scheduleSnooze(
+            for: alarm,
+            snoozeCount: snoozeCount,
+            completion: scheduleCompletion
+        )
         onStateChanged?()
         return true
     }

--- a/SnoozePay/SnoozePay/ViewModels/CreateAlarmViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/CreateAlarmViewModel.swift
@@ -44,9 +44,53 @@ final class CreateAlarmViewModel {
 
     // MARK: - Save
 
+    /// Outcome of `save()` reported to the view-controller.
+    /// `persistFailed` mirrors the original `false` return from #72 — the
+    /// store rejected the write (locked / encode error). `schedulingFailed`
+    /// is the new failure path from #118 — persistence succeeded but the
+    /// notification request itself didn't register, which historically
+    /// surfaced as a fake "Будильник создан" toast on a silently dropped
+    /// alarm.
+    enum SaveOutcome: Equatable {
+        case success
+        case persistFailed
+        case schedulingFailed(AlarmScheduler.SchedulingError)
+    }
+
+    /// Save the alarm and report the outcome asynchronously.
+    /// Persistence is synchronous, so `.persistFailed` resolves on the
+    /// caller's queue; the schedule branch resolves on main once the
+    /// notification request lands or fails (issue #118).
+    /// The repository contract guarantees `schedulingResult` only fires on
+    /// the successful-persist path, so we never deliver two outcomes.
+    func save(completion: @escaping (SaveOutcome) -> Void) {
+        let alarm = makeAlarmFromCurrentState()
+
+        let didPersist = alarmRepository.save(alarm) { schedulingResult in
+            switch schedulingResult {
+            case .success:
+                completion(.success)
+            case .failure(let error):
+                completion(.schedulingFailed(error))
+            }
+        }
+
+        if !didPersist {
+            completion(.persistFailed)
+        }
+    }
+
+    /// Synchronous persist-only save — kept for legacy call sites and unit
+    /// tests that don't care about the scheduling outcome (issue #72 used
+    /// the boolean to gate the dismiss path before #118 introduced the
+    /// scheduling failure path).
     @discardableResult
     func save() -> Bool {
-        let alarm = Alarm(
+        alarmRepository.save(makeAlarmFromCurrentState())
+    }
+
+    private func makeAlarmFromCurrentState() -> Alarm {
+        Alarm(
             id: existingID ?? UUID(),
             time: time,
             repeatDays: repeatDays,
@@ -58,7 +102,6 @@ final class CreateAlarmViewModel {
             progressiveScale: progressiveScale,
             enabled: enabled
         )
-        return alarmRepository.save(alarm)
     }
 
     // MARK: - Delete

--- a/SnoozePay/SnoozePayTests/AlarmSchedulerErrorPropagationTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmSchedulerErrorPropagationTests.swift
@@ -1,0 +1,189 @@
+import XCTest
+import UserNotifications
+@testable import SnoozePay
+
+/// Issue #118 — `AlarmScheduler.schedule` must surface `UNUserNotificationCenter.add`
+/// errors and the iOS 64-pending-limit cap to UI callers instead of swallowing them
+/// to `AppLogger.scheduler.error`. Without these tests the original silent-failure
+/// regression (a "Будильник создан" toast on a notification that never registered)
+/// can sneak back in undetected.
+final class AlarmSchedulerErrorPropagationTests: XCTestCase {
+
+    // MARK: - Mock notification center
+
+    private final class MockNotificationCenter: NotificationScheduling {
+        /// Pre-canned `add(_:)` failure. When non-nil every `add` call invokes its
+        /// completion with this error; otherwise the call is treated as a successful
+        /// schedule.
+        var addError: Error?
+        /// Pending requests reported by `getPendingNotificationRequests` — used by the
+        /// 64-limit pre-flight check.
+        var pendingRequests: [UNNotificationRequest] = []
+
+        private(set) var addedRequests: [UNNotificationRequest] = []
+
+        func add(
+            _ request: UNNotificationRequest,
+            withCompletionHandler completion: ((Error?) -> Void)?
+        ) {
+            addedRequests.append(request)
+            completion?(addError)
+        }
+
+        func getPendingNotificationRequests(
+            completionHandler: @escaping ([UNNotificationRequest]) -> Void
+        ) {
+            completionHandler(pendingRequests)
+        }
+
+        func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {}
+        func removeDeliveredNotifications(withIdentifiers identifiers: [String]) {}
+        func getDeliveredNotifications(
+            completionHandler: @escaping ([UNNotification]) -> Void
+        ) {
+            completionHandler([])
+        }
+        func setNotificationCategories(_ categories: Set<UNNotificationCategory>) {}
+        func removeAllPendingNotificationRequests() {}
+        func requestAuthorization(
+            options: UNAuthorizationOptions,
+            completionHandler: @escaping (Bool, Error?) -> Void
+        ) {
+            completionHandler(false, nil)
+        }
+    }
+
+    // MARK: - schedule(_:completion:) error path
+
+    func testSchedule_propagatesUNAddErrorToCompletion() {
+        let mock = MockNotificationCenter()
+        let underlyingMessage = "Notifications are not allowed for this application"
+        mock.addError = NSError(
+            domain: "UNErrorDomain",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: underlyingMessage]
+        )
+        let scheduler = AlarmScheduler(notificationCenter: mock)
+        let alarm = Alarm(penaltyAmount: 50, enabled: true)
+
+        let exp = expectation(description: "schedule completion called")
+        var captured: Result<Void, AlarmScheduler.SchedulingError>?
+        scheduler.schedule(alarm) { result in
+            captured = result
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
+
+        guard case .failure(let error) = captured else {
+            return XCTFail("Expected failure, got \(String(describing: captured))")
+        }
+        guard case .system(let message) = error else {
+            return XCTFail("Expected .system, got \(error)")
+        }
+        XCTAssertEqual(message, underlyingMessage,
+                       "UN error description must reach the VM verbatim")
+        XCTAssertNotNil(error.errorDescription,
+                        "SchedulingError must localize for UI alerts")
+        XCTAssertTrue(
+            error.errorDescription?.contains(underlyingMessage) ?? false,
+            "Error description must include underlying reason for the user"
+        )
+    }
+
+    func testSchedule_successPath_completesWithSuccess() {
+        let mock = MockNotificationCenter()
+        let scheduler = AlarmScheduler(notificationCenter: mock)
+        let alarm = Alarm(penaltyAmount: 50, enabled: true)
+
+        let exp = expectation(description: "schedule completion called")
+        var captured: Result<Void, AlarmScheduler.SchedulingError>?
+        scheduler.schedule(alarm) { result in
+            captured = result
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
+
+        guard case .success = captured else {
+            return XCTFail("Expected success, got \(String(describing: captured))")
+        }
+        XCTAssertFalse(mock.addedRequests.isEmpty,
+                       "Successful schedule must actually add a request")
+    }
+
+    func testSchedule_disabledAlarm_skipsAddAndReportsSuccess() {
+        let mock = MockNotificationCenter()
+        let scheduler = AlarmScheduler(notificationCenter: mock)
+        let alarm = Alarm(penaltyAmount: 50, enabled: false)
+
+        let exp = expectation(description: "schedule completion called")
+        scheduler.schedule(alarm) { result in
+            if case .success = result { exp.fulfill() }
+        }
+        wait(for: [exp], timeout: 1.0)
+
+        XCTAssertTrue(mock.addedRequests.isEmpty,
+                      "Disabled alarms must not register notifications")
+    }
+
+    // MARK: - 64-pending-limit pre-flight
+
+    func testSchedule_blocksWhenPendingLimitWouldExceed() {
+        let mock = MockNotificationCenter()
+        // Simulate a near-full pending queue. iOS hard cap is 64; we leave 0
+        // slots free so any new schedule trips the pre-flight.
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 60, repeats: false)
+        let content = UNMutableNotificationContent()
+        mock.pendingRequests = (0..<AlarmScheduler.pendingNotificationLimit).map { idx in
+            UNNotificationRequest(identifier: "stub_\(idx)", content: content, trigger: trigger)
+        }
+        let scheduler = AlarmScheduler(notificationCenter: mock)
+        let alarm = Alarm(penaltyAmount: 50, enabled: true)
+
+        let exp = expectation(description: "schedule completion called")
+        var captured: Result<Void, AlarmScheduler.SchedulingError>?
+        scheduler.schedule(alarm) { result in
+            captured = result
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
+
+        guard case .failure(let error) = captured else {
+            return XCTFail("Expected failure, got \(String(describing: captured))")
+        }
+        guard case .pendingLimitReached(let count) = error else {
+            return XCTFail("Expected pendingLimitReached, got \(error)")
+        }
+        XCTAssertEqual(count, AlarmScheduler.pendingNotificationLimit)
+        XCTAssertTrue(mock.addedRequests.isEmpty,
+                      "Pre-flight must short-circuit before any add() call")
+        XCTAssertTrue(
+            error.errorDescription?.contains("лимит") ?? false,
+            "Error description must mention the iOS limit so users understand the cause"
+        )
+    }
+
+    // MARK: - scheduleSnooze error path
+
+    func testScheduleSnooze_propagatesUNErrorToCompletion() {
+        let mock = MockNotificationCenter()
+        mock.addError = NSError(
+            domain: "UNErrorDomain",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Too many notifications"]
+        )
+        let scheduler = AlarmScheduler(notificationCenter: mock)
+        let alarm = Alarm(penaltyAmount: 50, enabled: true)
+
+        let exp = expectation(description: "scheduleSnooze completion called")
+        var captured: Result<Void, AlarmScheduler.SchedulingError>?
+        scheduler.scheduleSnooze(for: alarm, snoozeCount: 1) { result in
+            captured = result
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
+
+        guard case .failure = captured else {
+            return XCTFail("Expected failure, got \(String(describing: captured))")
+        }
+    }
+}


### PR DESCRIPTION
Fixes #118

## Что сделано
- `AlarmScheduler.schedule(_:completion:)` и `scheduleSnooze(...:completion:)` теперь принимают опциональный `((Result<Void, SchedulingError>) -> Void)?` коллбек (default `nil` для backwards compat). Failures `UNUserNotificationCenter.add` оборачиваются в `SchedulingError.system(message:)` и достигают UI вместо `AppLogger.scheduler.error` в логах.
- Pre-flight 64-pending-limit чек: до постановки `getPendingNotificationRequests` сравнивается с `Self.pendingNotificationLimit = 64`. При перепонке возвращается `SchedulingError.pendingLimitReached(currentCount:)` — пользователь видит что нужно удалить старые будильники.
- `AlarmRepository.save(_:schedulingResult:)` пропускает Result через на `CreateAlarmViewModel.save(completion:)` (новый async overload). Старый `save() -> Bool` сохранён для обратной совместимости с тестами и legacy callers.
- `CreateAlarmViewController.saveTapped` ждёт `SaveOutcome` перед dismiss — на `.schedulingFailed` показывает alert «Не удалось запланировать будильник: <reason>. Включите уведомления в Настройках или удалите старые будильники».
- Добавил `NotificationScheduling` protocol-seam для DI `UNUserNotificationCenter`, без которого failure path не тестируется (UN — process-wide singleton).
- Unit test `AlarmSchedulerErrorPropagationTests` покрывает: проброс UN error → `.system`, успешный путь, disabled alarm short-circuit, 64-limit pre-flight, snooze error path.

## Verify
- swiftlint: 0 errors (только pre-existing warnings: file_length / line_length / for_where в нетронутых участках scheduler-а)
- build_sim: succeeded (simulator: iPhone 17 Pro Max)
- test_sim: пропущен (gate отключен по memory)
- скриншот: пропущен (gate отключен по memory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)