### PR TITLE
[fix] Surface AlarmRepository decode failures via UI alerts (#117)

### DIFF
--- a/SnoozePay/SnoozePay/AppDelegate.swift
+++ b/SnoozePay/SnoozePay/AppDelegate.swift
@@ -232,7 +232,23 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     // MARK: - Helpers
 
     private func presentAlarmFiringScreen(for payload: AlarmNotificationPayload) {
-        guard let alarm = AlarmRepository.shared.fetch(id: payload.alarmID) else {
+        let alarm: Alarm?
+        do {
+            // Use the checked variant so a corrupt UserDefaults blob surfaces
+            // a logged decode error instead of being indistinguishable from
+            // "alarm doesn't exist" — without this we silently bail on a
+            // recoverable glitch and the user wonders why the alarm fired
+            // but never showed a screen (issue #117).
+            alarm = try AlarmRepository.shared.fetchChecked(id: payload.alarmID)
+        } catch {
+            let errorDesc = String(describing: error)
+            AppLogger.appDelegate.error(
+                "alarm fetch failed for \(payload.alarmID, privacy: .private): \(errorDesc, privacy: .public)"
+            )
+            AudioService.shared.stopAlarmSound()
+            return
+        }
+        guard let alarm else {
             // Audio may already be playing from willPresent — stop it so the user
             // is not stuck with a silent-screen + sounding alarm we can't dismiss.
             AppLogger.appDelegate.error(

--- a/SnoozePay/SnoozePay/AppDelegate.swift
+++ b/SnoozePay/SnoozePay/AppDelegate.swift
@@ -246,6 +246,11 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
                 "alarm fetch failed for \(payload.alarmID, privacy: .private): \(errorDesc, privacy: .public)"
             )
             AudioService.shared.stopAlarmSound()
+            // Surface the decode failure to the user — without this they hear
+            // the alarm cut off and get no firing screen with no diagnostic.
+            // The alert is presented from the same dispatch we'd use for the
+            // firing screen so it reaches whichever VC is on top.
+            presentAlarmDataCorruptedAlert(error: error)
             return
         }
         guard let alarm else {
@@ -290,4 +295,41 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         }
     }
 
+    /// Presents an alert on the topmost VC explaining that the alarm fired
+    /// but its data couldn't be decoded. Without this surface the user just
+    /// hears their alarm cut off with no explanation — silently regressing
+    /// the very pattern #117 is fixing.
+    private func presentAlarmDataCorruptedAlert(error: Error) {
+        let message: String
+        if let repoError = error as? AlarmRepository.RepositoryError,
+           case let .decodeFailure(detail) = repoError {
+            message = "Будильник прозвенел, но его данные повреждены и экран не загрузился. Подробности: \(detail)"
+        } else {
+            message = "Будильник прозвенел, но его данные не удалось загрузить. Откройте приложение и проверьте список будильников."
+        }
+        DispatchQueue.main.async {
+            guard
+                let windowScene = UIApplication.shared.connectedScenes
+                    .compactMap({ $0 as? UIWindowScene })
+                    .first,
+                let rootVC = windowScene.windows.first?.rootViewController
+            else {
+                AppLogger.appDelegate.error(
+                    "decode-failure alert: no window scene to present on"
+                )
+                return
+            }
+            var topVC = rootVC
+            while let presented = topVC.presentedViewController {
+                topVC = presented
+            }
+            let alert = UIAlertController(
+                title: "Будильник",
+                message: message,
+                preferredStyle: .alert
+            )
+            alert.addAction(UIAlertAction(title: "Ок", style: .default))
+            topVC.present(alert, animated: true)
+        }
+    }
 }

--- a/SnoozePay/SnoozePay/Services/AlarmFiringCoordinator.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmFiringCoordinator.swift
@@ -74,7 +74,21 @@ final class AlarmFiringCoordinator {
             return .invalidPayload
         }
 
-        guard let alarm = alarmRepository.fetch(id: payload.alarmID) else {
+        let alarm: Alarm?
+        do {
+            // Use the checked variant so a corrupt store surfaces in logs
+            // rather than collapsing into the "alarmNotFound" outcome —
+            // otherwise a transient decode glitch silently turns into
+            // "snooze didn't work" with no diagnostic trail (issue #117).
+            alarm = try alarmRepository.fetchChecked(id: payload.alarmID)
+        } catch {
+            let errorDesc = String(describing: error)
+            AppLogger.coordinator.error(
+                "snooze: fetch failed for \(payload.alarmID, privacy: .private): \(errorDesc, privacy: .public)"
+            )
+            return .alarmNotFound
+        }
+        guard let alarm else {
             AppLogger.coordinator.error("snooze: alarm \(payload.alarmID, privacy: .private) not in repository")
             return .alarmNotFound
         }

--- a/SnoozePay/SnoozePay/Services/AlarmRepository.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmRepository.swift
@@ -87,6 +87,16 @@ final class AlarmRepository {
         queue.sync { (try? readAll())?.first { $0.id == id } }
     }
 
+    /// Single-alarm read variant that surfaces decode failures instead of
+    /// swallowing them. Callers on hot paths (AppDelegate presenting the
+    /// firing screen, AlarmFiringCoordinator routing snooze) use this so a
+    /// corrupt blob is logged + visible to the user instead of being
+    /// indistinguishable from "alarm doesn't exist" (issue #117). Returns
+    /// `nil` when the id is genuinely absent — only throws on decode failure.
+    func fetchChecked(id: UUID) throws -> Alarm? {
+        try queue.sync { try readAll().first { $0.id == id } }
+    }
+
     // MARK: - Mutate
 
     /// Saves (upserts) an alarm.

--- a/SnoozePay/SnoozePay/Services/TransactionRepository.swift
+++ b/SnoozePay/SnoozePay/Services/TransactionRepository.swift
@@ -113,18 +113,40 @@ final class TransactionRepository {
     /// Returns 0 if there are no transactions at all (new user) or if the
     /// store can't be decoded — caller should consult `lastLoadFailed`
     /// before trusting a zero result.
+    ///
+    /// Production callers that have already paid the cost of a checked read
+    /// (StatisticsViewModel) should use `currentStreak(from:)` to avoid a
+    /// redundant decode on the hot path AND to share the surfaced error
+    /// (issue #117).
     func currentStreak() -> Int {
         let allTransactions = queue.sync { (try? readAll()) ?? [] }
-        guard !allTransactions.isEmpty else { return 0 }
+        return Self.computeStreak(from: allTransactions)
+    }
+
+    /// Streak computation against a caller-supplied transaction list. Used
+    /// by callers that already loaded transactions via `fetchAllChecked`,
+    /// so a single decode failure surfaces once instead of twice and a
+    /// transient zero from a hidden re-read can't contradict the surfaced
+    /// banner (issue #117).
+    func currentStreak(from transactions: [Transaction]) -> Int {
+        Self.computeStreak(from: transactions)
+    }
+
+    /// Pure function over a transaction list — extracted so `currentStreak()`
+    /// and `currentStreak(from:)` cannot drift apart. Lives as `static` so
+    /// it can't accidentally read instance state and reintroduce the silent
+    /// decode the caller-supplied variant exists to avoid.
+    private static func computeStreak(from transactions: [Transaction]) -> Int {
+        guard !transactions.isEmpty else { return 0 }
 
         let calendar = Calendar.current
         var streak = 0
         var checkDate = calendar.startOfDay(for: Date())
-        let allCharges = allTransactions.filter { $0.type == .charge }
+        let allCharges = transactions.filter { $0.type == .charge }
         let chargeDates = Set(allCharges.map { calendar.startOfDay(for: $0.createdAt) })
 
         let firstTransactionDate = calendar.startOfDay(
-            for: allTransactions.map { $0.createdAt }.min() ?? Date()
+            for: transactions.map { $0.createdAt }.min() ?? Date()
         )
 
         while !chargeDates.contains(checkDate) && checkDate >= firstTransactionDate {

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import os
 
 /// Settings screen matching Figma design: account, theme, legal, contact sections.
 class SettingsViewController: UIViewController {
@@ -409,8 +410,28 @@ final class TransactionHistoryViewController: UIViewController {
     }
 
     private func loadTransactions() {
-        transactions = TransactionRepository.shared.fetchAll()
+        // Use the checked variant so a corrupt ledger surfaces an alert
+        // instead of rendering the misleading "Нет транзакций" empty state
+        // — that would let the user assume the app reset itself (issue #117).
+        do {
+            transactions = try TransactionRepository.shared.fetchAllChecked()
+        } catch let error as TransactionRepository.RepositoryError {
+            transactions = []
+            presentLoadError(error)
+        } catch {
+            transactions = []
+        }
         tableView.reloadData()
+    }
+
+    private func presentLoadError(_ error: LocalizedError) {
+        let alert = UIAlertController(
+            title: "Ошибка",
+            message: error.errorDescription,
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
     }
 }
 
@@ -440,10 +461,21 @@ extension TransactionHistoryViewController: UITableViewDataSource, UITableViewDe
 
         let transaction = transactions[indexPath.row]
 
-        // Look up alarm name if available
+        // Look up alarm name if available — best-effort enrichment. If the
+        // alarm store is corrupt we log and fall back to nil so the row
+        // still renders (transaction amount/date is still meaningful).
+        // Without this, a single corrupt alarms blob would silently strip
+        // alarm names from every history row (issue #117).
         var alarmName: String?
         if let alarmIDString = transaction.alarmID, let alarmUUID = UUID(uuidString: alarmIDString) {
-            alarmName = alarmRepository.fetch(id: alarmUUID)?.name
+            do {
+                alarmName = try alarmRepository.fetchChecked(id: alarmUUID)?.name
+            } catch {
+                let errorDesc = String(describing: error)
+                AppLogger.ui.error(
+                    "TxHistory: name lookup failed for \(alarmUUID, privacy: .private): \(errorDesc, privacy: .public)"
+                )
+            }
         }
 
         cell.configure(with: transaction, alarmName: alarmName)

--- a/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
@@ -106,7 +106,22 @@ final class AlarmsListViewModel {
             // locked, surface the lock so the user knows toggles aren't
             // landing rather than blaming the toggle for "not working".
             AppLogger.ui.notice("setEnabled returned false; rolling back UI for id=\(id, privacy: .private)")
-            alarms = alarmRepository.fetchAll()
+            // Use the checked variant on the rollback read so a decode failure
+            // surfaces directly instead of returning [] and forcing the user
+            // to infer corruption from the toggle silently snapping back
+            // (issue #117). The persistBlocked branch below remains a separate
+            // case because `setEnabled` can return false with a healthy store
+            // (alarm deleted from another path, #35).
+            do {
+                alarms = try alarmRepository.fetchAllChecked()
+            } catch let error as AlarmRepository.RepositoryError {
+                alarms = []
+                onLoadError?(error)
+                onAlarmsUpdated?()
+                return
+            } catch {
+                alarms = []
+            }
             if alarmRepository.lastLoadFailed {
                 onLoadError?(AlarmRepository.RepositoryError.persistBlocked)
             }

--- a/SnoozePay/SnoozePay/ViewModels/StatisticsViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/StatisticsViewModel.swift
@@ -69,6 +69,12 @@ final class StatisticsViewModel {
         // instead of a deceptive zero-state — without this the user sees
         // "₽0 / 0 откладываний" and assumes the app reset, which is much
         // worse than a "не удалось загрузить" message (issue #72).
+        //
+        // Streak is computed from the same in-memory transaction list rather
+        // than re-reading via `currentStreak()` — that earlier path silently
+        // returned 0 on a transient decode glitch and contradicted the
+        // banner we surface here (issue #117). Sharing one read keeps the
+        // banner and the streak number consistent.
         do {
             let allTransactions = try transactionRepository.fetchAllChecked()
             if period == .allTime {
@@ -77,16 +83,19 @@ final class StatisticsViewModel {
                 charges = allTransactions
                     .filter { $0.type == .charge && $0.createdAt >= since }
             }
+            streak = transactionRepository.currentStreak(from: allTransactions)
         } catch let error as TransactionRepository.RepositoryError {
             charges = []
+            streak = 0
             onLoadError?(error)
         } catch {
             charges = []
+            streak = 0
         }
 
-        streak = transactionRepository.currentStreak()
         // Bump persisted best streak only forward — never reset on streak = 0,
-        // so the user's all-time record survives a slip-up.
+        // so the user's all-time record survives a slip-up. Skipped on a
+        // decode failure because `streak == 0` is a fallback, not a truth.
         if streak > defaults.integer(forKey: Self.bestStreakKey) {
             defaults.set(streak, forKey: Self.bestStreakKey)
         }

--- a/SnoozePay/SnoozePayTests/AlarmFiringCoordinatorTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmFiringCoordinatorTests.swift
@@ -130,4 +130,28 @@ final class AlarmFiringCoordinatorTests: XCTestCase {
         XCTAssertEqual(outcome, .scheduled(newSnoozeCount: 1, charged: 75))
         XCTAssertEqual(balanceService.balance, 0)
     }
+
+    // MARK: - Issue #117: corrupted store must not collapse into alarmNotFound silently
+
+    /// When the alarm store is corrupt, `handleSnooze` must still report
+    /// `.alarmNotFound` (callers can't do anything else from a notification
+    /// action), but the path must run through the throwing fetch so the
+    /// decode error gets logged and the persistence lock arms — without
+    /// this the snooze silently drops with no diagnostic trail (issue #117).
+    func testHandleSnooze_corruptedAlarmStore_returnsAlarmNotFoundAndArmsLock() {
+        // Save an alarm so `valid UUID + missing key` isn't the failure mode,
+        // then corrupt the persistence store under the coordinator's feet.
+        let alarm = makeAlarm()
+        testDefaults.set(Data("not json".utf8), forKey: "stored_alarms")
+
+        let outcome = coordinator.handleSnooze(userInfo: [
+            "alarmID": alarm.id.uuidString,
+            "snoozeCount": 0
+        ])
+
+        XCTAssertEqual(outcome, .alarmNotFound,
+                       "From a notification action there's no recovery UI, so collapse to alarmNotFound")
+        XCTAssertTrue(alarmRepo.lastLoadFailed,
+                      "The checked fetch must arm the persistence lock so a follow-up save can't clobber the corrupt blob")
+    }
 }

--- a/SnoozePay/SnoozePayTests/AlarmRepositoryTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmRepositoryTests.swift
@@ -367,4 +367,40 @@ final class AlarmRepositoryTests: XCTestCase {
         // Final state must match one of the writers, not torn (penaltyAmount preserved).
         XCTAssertEqual(final?.penaltyAmount, alarm.penaltyAmount)
     }
+
+    // MARK: - Issue #117: fetchChecked(id:) surfaces decode failures
+
+    /// Happy path: a known id returns the matching alarm via the checked variant.
+    func testFetchCheckedById_returnsAlarmWhenPresent() throws {
+        let alarm = makeAlarm(name: "Found")
+        repo.save(alarm)
+
+        let fetched = try repo.fetchChecked(id: alarm.id)
+        XCTAssertEqual(fetched?.id, alarm.id)
+    }
+
+    /// Happy path: a missing id returns nil rather than throwing — the
+    /// decode succeeded, the alarm just isn't there. Callers distinguish
+    /// "decode failed" (catch) from "doesn't exist" (nil).
+    func testFetchCheckedById_returnsNilWhenAbsent() throws {
+        let fetched = try repo.fetchChecked(id: UUID())
+        XCTAssertNil(fetched)
+    }
+
+    /// Sad path: a corrupt blob throws `decodeFailure` instead of silently
+    /// returning nil — without this, AppDelegate / AlarmFiringCoordinator
+    /// would treat corruption as "alarm not found" and bail with no
+    /// diagnostic trail (issue #117).
+    func testFetchCheckedById_corruptedJSON_throwsDecodeFailure() {
+        testDefaults.set(Data("not json".utf8), forKey: "stored_alarms")
+
+        XCTAssertThrowsError(try repo.fetchChecked(id: UUID())) { error in
+            guard case AlarmRepository.RepositoryError.decodeFailure = error else {
+                XCTFail("Expected decodeFailure, got \(error)")
+                return
+            }
+        }
+        XCTAssertTrue(repo.lastLoadFailed,
+                      "Checked single-id fetch must arm the persistence lock just like fetchAllChecked")
+    }
 }

--- a/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
@@ -316,6 +316,44 @@ final class AlarmsListViewModelTests: XCTestCase {
         XCTAssertTrue(vm.alarms.isEmpty)
     }
 
+    /// Issue #117: when `setEnabled` returns false because the persisted
+    /// alarms blob became corrupt mid-session, the rollback read must use
+    /// the checked variant and surface a `decodeFailure` to the VC. Before
+    /// this fix the VM read via `fetchAll()`, got `[]`, and the user saw the
+    /// toggle snap back with no banner explaining why.
+    func testToggleAlarm_corruptStoreDuringRollback_firesDecodeFailure() {
+        // 1. Healthy load.
+        let alarm = Alarm(name: "Rollback", penaltyAmount: 50, enabled: true)
+        repo.save(alarm)
+        let vm = makeViewModel()
+        vm.loadData()
+        XCTAssertEqual(vm.alarms.count, 1)
+
+        // 2. Corrupt the store after the initial load — the next setEnabled
+        //    will fail (lastLoadFailed-armed inside the lock) and the VM
+        //    enters the rollback branch.
+        testDefaults.set(Data("garbage".utf8), forKey: "stored_alarms")
+
+        var receivedError: LocalizedError?
+        var rebindFired = false
+        vm.onLoadError = { receivedError = $0 }
+        vm.onAlarmsUpdated = { rebindFired = true }
+
+        vm.toggleAlarm(id: alarm.id, enabled: false)
+
+        XCTAssertTrue(rebindFired, "Rollback path must trigger a UI re-bind")
+        XCTAssertNotNil(receivedError, "Decode failure during rollback must surface to the VC")
+        if let typed = receivedError as? AlarmRepository.RepositoryError,
+           case .decodeFailure = typed {
+            // expected — the error must be the original decode failure, not a
+            // generic persistBlocked, so the user sees the right message.
+        } else {
+            XCTFail("Expected decodeFailure, got \(String(describing: receivedError))")
+        }
+        XCTAssertTrue(vm.alarms.isEmpty,
+                      "Rollback after a decode failure must clear the in-memory snapshot")
+    }
+
     /// When the store gets locked AFTER a successful initial load, the user
     /// might still try to delete an alarm from the cached snapshot. The VM
     /// must surface the persist failure so the swipe-to-delete UX doesn't

--- a/SnoozePay/SnoozePayTests/TransactionRepositoryTests.swift
+++ b/SnoozePay/SnoozePayTests/TransactionRepositoryTests.swift
@@ -306,6 +306,43 @@ final class TransactionRepositoryTests: XCTestCase {
         XCTAssertEqual(repo.currentStreak(), 0)
     }
 
+    // MARK: - Issue #117: caller-supplied streak variant
+
+    /// `currentStreak(from:)` lets callers that already paid the cost of a
+    /// checked read share the result so a transient decode glitch can't
+    /// produce a banner + a contradicting "0 days" elsewhere on the same
+    /// screen (issue #117).
+    func testCurrentStreakFromTransactions_matchesInternalImplementation() {
+        repo.record(charge(amount: 50, daysAgo: 3))
+        repo.record(topup(amount: 500, daysAgo: 0))
+
+        let allTransactions = repo.fetchAll()
+
+        XCTAssertEqual(repo.currentStreak(from: allTransactions), repo.currentStreak(),
+                       "Pre-loaded variant must match the internal-read variant on identical data")
+        XCTAssertEqual(repo.currentStreak(from: allTransactions), 3)
+    }
+
+    func testCurrentStreakFromTransactions_emptyArray_returnsZero() {
+        XCTAssertEqual(repo.currentStreak(from: []), 0)
+    }
+
+    /// Even if the persisted store is corrupt, passing a healthy in-memory
+    /// snapshot to `currentStreak(from:)` must yield the right answer —
+    /// proves the pure variant doesn't secretly re-read.
+    func testCurrentStreakFromTransactions_ignoresPersistedStore() {
+        testDefaults.set(Data("garbage".utf8), forKey: "stored_transactions")
+
+        let calendar = Calendar.current
+        let snapshot = [
+            Transaction(type: .charge, amount: 50,
+                        createdAt: calendar.date(byAdding: .day, value: -2, to: Date())!),
+            Transaction(type: .topup, amount: 100, createdAt: Date())
+        ]
+        XCTAssertEqual(repo.currentStreak(from: snapshot), 2,
+                       "Pre-loaded variant must compute against the supplied list, not re-read storage")
+    }
+
     // MARK: - Concurrency
 
     func testConcurrentRecord_allTransactionsLanded() {


### PR DESCRIPTION
Fixes #117

## What changed

Migrate the 5 unchecked `fetchAll()` / `fetch(id:)` / `currentStreak()` callers identified by the silent-failure-hunter to checked variants that propagate decode errors to the UI:

- **`AppDelegate.presentAlarmFiringScreen`** — use `fetchChecked(id:)`, stop audio + `AppLogger.appDelegate.error` on decode failure instead of collapsing into the "alarm not found" branch.
- **`AlarmFiringCoordinator.handleSnooze`** — same `fetchChecked(id:)` migration so a corrupt store arms the persistence lock (preventing follow-up clobber) and surfaces in logs.
- **`AlarmsListViewModel` toggle rollback path** — switch from `fetchAll()` to `fetchAllChecked()` so a decode glitch fires `onLoadError(decodeFailure)` instead of the toggle snapping back with no banner.
- **`SettingsViewController.TransactionHistoryViewController`** — use `fetchAllChecked()` for the list (presents an alert on failure) and `fetchChecked(id:)` for alarm-name enrichment, falling back to `nil` + `AppLogger.ui.error`.
- **`StatisticsViewModel`** — compute streak from the already-loaded transaction list via a new `currentStreak(from:)` overload, sharing one decode with the banner so a transient glitch can't produce a banner + a contradicting "0 days" on the same screen.

## Repository surface

Minimum-blast-radius additions:
- `AlarmRepository.fetchChecked(id:) throws -> Alarm?`
- `TransactionRepository.currentStreak(from: [Transaction]) -> Int` (shares logic with existing `currentStreak()` via a private `static computeStreak`)

Unchecked methods left intact for backward compatibility — no public API removed.

## Tests added

- `AlarmRepositoryTests.testFetchCheckedById_{returnsAlarmWhenPresent, returnsNilWhenAbsent, corruptedJSON_throwsDecodeFailure}`
- `TransactionRepositoryTests.testCurrentStreakFromTransactions_{matchesInternalImplementation, emptyArray_returnsZero, ignoresPersistedStore}`
- `AlarmFiringCoordinatorTests.testHandleSnooze_corruptedAlarmStore_returnsAlarmNotFoundAndArmsLock`
- `AlarmsListViewModelTests.testToggleAlarm_corruptStoreDuringRollback_firesDecodeFailure`

## Verify

- swiftlint: 0 errors in touched files (warnings are pre-existing line-length/file-length on legacy lines)
- xcodebuild build: BUILD SUCCEEDED (iPhone 17 Pro simulator)
- xcodebuild build-for-testing: TEST BUILD SUCCEEDED

## Test plan

- [ ] Corrupt `stored_alarms` UserDefaults blob, fire an alarm — confirm alarm-firing screen does NOT silently appear-and-vanish; instead audio stops + log entry surfaces.
- [ ] Corrupt `stored_transactions`, open Settings → История транзакций — confirm an "Не удалось загрузить статистику" alert appears instead of "Нет транзакций".
- [ ] Corrupt `stored_alarms` between launch and a toggle tap — confirm the toggle snaps back AND a decode-failure banner shows.
- [ ] Corrupt `stored_transactions`, open Statistics → confirm the existing #72 banner still fires AND streak shows 0 (matching the banner, not contradicting it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)