### PR TITLE
[fix] Surface AlarmRepository.setEnabled scheduling errors via list toggle (#129)

### DIFF
--- a/SnoozePay/SnoozePay/Services/AlarmRepository.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmRepository.swift
@@ -43,6 +43,10 @@ final class AlarmRepository {
     static let corruptBackupKey = "stored_alarms_backup_corrupt"
 
     private let defaults: UserDefaults
+    /// Scheduler seam — production uses the singleton, tests inject a stub so
+    /// they can verify error propagation (#129) without booting the real
+    /// `UNUserNotificationCenter`.
+    private let scheduler: AlarmScheduling
     private let queue = DispatchQueue(label: "com.snoozepay.alarms.serial")
     private static let log = OSLog(subsystem: "Ivan-Emelyanov.SnoozePay", category: "AlarmRepository")
 
@@ -62,8 +66,9 @@ final class AlarmRepository {
     /// Production call sites that pass no arguments would create an isolated
     /// instance backed by `.standard`, defeating the singleton serialization,
     /// so we deliberately omit the default value: callers must be explicit.
-    init(defaults: UserDefaults) {
+    init(defaults: UserDefaults, scheduler: AlarmScheduling = AlarmScheduler.shared) {
         self.defaults = defaults
+        self.scheduler = scheduler
     }
 
     private convenience init() {
@@ -138,9 +143,9 @@ final class AlarmRepository {
 
         guard didPersist else { return false }
 
-        AlarmScheduler.shared.cancel(alarm.id)
+        scheduler.cancel(alarm.id)
         if alarm.enabled {
-            AlarmScheduler.shared.schedule(alarm, completion: schedulingResult)
+            scheduler.schedule(alarm, completion: schedulingResult)
         } else {
             // Disabled alarms don't schedule — report success so async
             // callers don't hang waiting for a closure that never fires.
@@ -163,19 +168,33 @@ final class AlarmRepository {
             return persist(alarms)
         }
         if didPersist {
-            AlarmScheduler.shared.cancel(id)
+            scheduler.cancel(id)
         }
         return didPersist
     }
 
     /// Toggles `enabled` on the alarm with the given id.
+    /// - Parameters:
+    ///   - enabled: target state for the toggle.
+    ///   - id: stable UUID of the alarm to flip.
+    ///   - schedulingResult: optional callback invoked **only on the
+    ///     successful-persist path** once `AlarmScheduler.schedule` finishes
+    ///     (issue #129). Toggling off an alarm resolves with `.success(())`
+    ///     because there is no scheduling work — the closure is still called
+    ///     so async callers always observe completion. When the boolean
+    ///     return is `false` the closure is **not** invoked: the caller has
+    ///     already received the failure synchronously.
     /// - Returns: `true` if the alarm existed and was updated; `false` if no alarm
     ///   matched the id, the store is locked, or encoding failed. Callers
     ///   (e.g. `AlarmsListViewModel`) rely on the boolean to roll back
     ///   optimistic UI flips when the underlying alarm has been deleted from
     ///   another path (issue #35) or when the store is corrupt (issue #72).
     @discardableResult
-    func setEnabled(_ enabled: Bool, id: UUID) -> Bool {
+    func setEnabled(
+        _ enabled: Bool,
+        id: UUID,
+        schedulingResult: ((Result<Void, AlarmScheduler.SchedulingError>) -> Void)? = nil
+    ) -> Bool {
         let updated: Alarm? = queue.sync {
             guard !_lastLoadFailed else { return nil }
             var alarms: [Alarm]
@@ -197,9 +216,13 @@ final class AlarmRepository {
             )
             return false
         }
-        AlarmScheduler.shared.cancel(alarm.id)
+        scheduler.cancel(alarm.id)
         if alarm.enabled {
-            AlarmScheduler.shared.schedule(alarm)
+            scheduler.schedule(alarm, completion: schedulingResult)
+        } else {
+            // Toggle-off has no scheduling work — fire `.success(())` so async
+            // callers don't hang waiting for a closure that never lands.
+            schedulingResult?(.success(()))
         }
         return true
     }

--- a/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
@@ -34,11 +34,21 @@ protocol NotificationScheduling: AnyObject {
 
 extension UNUserNotificationCenter: NotificationScheduling {}
 
+/// Subset of `AlarmScheduler` that `AlarmRepository` depends on. Extracted as
+/// a protocol so unit tests covering repository → scheduler error propagation
+/// (issue #129 — toggle on alarm with denied permission must surface the
+/// failure to the VM instead of silently flipping the switch) can substitute a
+/// stub without bringing up `UNUserNotificationCenter`.
+protocol AlarmScheduling: AnyObject {
+    func schedule(_ alarm: Alarm, completion: ((Result<Void, AlarmScheduler.SchedulingError>) -> Void)?)
+    func cancel(_ alarmID: UUID)
+}
+
 /// Handles scheduling and cancelling alarms.
 /// Uses UNUserNotificationCenter (iOS 18+) as the scheduling backend.
 /// On iOS 26+ with AlarmKit, the system alarm engine takes over — this service
 /// manages the notification fallback and snooze rescheduling.
-final class AlarmScheduler {
+final class AlarmScheduler: AlarmScheduling {
 
     static let shared = AlarmScheduler()
 

--- a/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
@@ -96,7 +96,43 @@ final class AlarmsListViewModel {
             return
         }
 
-        let didUpdate = alarmRepository.setEnabled(enabled, id: id)
+        // Pre-update the in-memory cache to the new enabled state so the
+        // failure-rollback closure below can flip it back regardless of
+        // whether the scheduler resolves synchronously (test mock) or
+        // asynchronously (real `UNUserNotificationCenter`). If we waited to
+        // mutate after `setEnabled` returns, a sync mock would fire its
+        // closure first, set `.enabled = !enabled`, then the post-call
+        // mutation would clobber the rollback (#129).
+        alarms[index] = Alarm(
+            id: alarms[index].id,
+            time: alarms[index].time,
+            repeatDays: alarms[index].repeatDays,
+            name: alarms[index].name,
+            soundID: alarms[index].soundID,
+            vibrationEnabled: alarms[index].vibrationEnabled,
+            snoozeMinutes: alarms[index].snoozeMinutes,
+            penaltyAmount: alarms[index].penaltyAmount,
+            progressiveScale: alarms[index].progressiveScale,
+            enabled: enabled
+        )
+
+        let didUpdate = alarmRepository.setEnabled(enabled, id: id) { [weak self] result in
+            // Scheduling outcome only fires on the successful-persist path.
+            // On failure we roll the in-memory cache back to the previous
+            // `enabled` state and re-bind the cell — without this the user
+            // sees "включён" while the notification never registered (#129).
+            guard let self else { return }
+            if case .failure(let error) = result {
+                AppLogger.ui.notice(
+                    "schedule failed during toggle id=\(id, privacy: .private); rolling back UI"
+                )
+                if let idx = self.alarms.firstIndex(where: { $0.id == id }) {
+                    self.alarms[idx].enabled = !enabled
+                }
+                self.onLoadError?(error)
+                self.onAlarmsUpdated?()
+            }
+        }
         guard didUpdate else {
             // Repository no longer has this alarm (deleted from another path)
             // or the store is locked due to a corrupt blob (issue #72).
@@ -128,19 +164,6 @@ final class AlarmsListViewModel {
             onAlarmsUpdated?()
             return
         }
-
-        alarms[index] = Alarm(
-            id: alarms[index].id,
-            time: alarms[index].time,
-            repeatDays: alarms[index].repeatDays,
-            name: alarms[index].name,
-            soundID: alarms[index].soundID,
-            vibrationEnabled: alarms[index].vibrationEnabled,
-            snoozeMinutes: alarms[index].snoozeMinutes,
-            penaltyAmount: alarms[index].penaltyAmount,
-            progressiveScale: alarms[index].progressiveScale,
-            enabled: enabled
-        )
     }
 
     // MARK: - Delete

--- a/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
@@ -118,17 +118,24 @@ final class AlarmsListViewModel {
 
         let didUpdate = alarmRepository.setEnabled(enabled, id: id) { [weak self] result in
             // Scheduling outcome only fires on the successful-persist path.
-            // On failure we roll the in-memory cache back to the previous
-            // `enabled` state and re-bind the cell — without this the user
-            // sees "включён" while the notification never registered (#129).
+            // On failure we roll BOTH the in-memory cache AND the on-disk
+            // persisted state back to the previous `enabled` value — without
+            // the disk-rollback the next cold-launch would re-read enabled=true
+            // from UserDefaults while the notification still isn't registered,
+            // re-introducing the very silent failure this fix addresses (#129).
             guard let self else { return }
             if case .failure(let error) = result {
                 AppLogger.ui.notice(
-                    "schedule failed during toggle id=\(id, privacy: .private); rolling back UI"
+                    "schedule failed during toggle id=\(id, privacy: .private); rolling back UI + disk"
                 )
                 if let idx = self.alarms.firstIndex(where: { $0.id == id }) {
                     self.alarms[idx].enabled = !enabled
                 }
+                // Persist the rollback. We pass `nil` completion so we don't
+                // re-trigger this closure on the rollback's own scheduler call
+                // (toggle-off does no schedule work; toggle-on rollback after
+                // a failed enable becomes a disable — also no schedule work).
+                _ = self.alarmRepository.setEnabled(!enabled, id: id, schedulingResult: nil)
                 self.onLoadError?(error)
                 self.onAlarmsUpdated?()
             }

--- a/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
@@ -4,15 +4,40 @@ import XCTest
 /// Unit tests for AlarmsListViewModel helper methods — detail and penalty formatting.
 final class AlarmsListViewModelTests: XCTestCase {
 
+    /// Synchronous stub scheduler for tests that don't care about the
+    /// scheduling outcome. Resolves `.success(())` immediately so the VM's
+    /// completion-driven rollback path (#129) is exercised on the happy
+    /// branch without bringing up `UNUserNotificationCenter`. Tests that
+    /// need to verify the failure branch swap in their own stub.
+    final class StubScheduler: AlarmScheduling {
+        var scheduleResult: Result<Void, AlarmScheduler.SchedulingError> = .success(())
+        private(set) var scheduledIDs: [UUID] = []
+        private(set) var cancelledIDs: [UUID] = []
+
+        func schedule(
+            _ alarm: Alarm,
+            completion: ((Result<Void, AlarmScheduler.SchedulingError>) -> Void)?
+        ) {
+            scheduledIDs.append(alarm.id)
+            completion?(scheduleResult)
+        }
+
+        func cancel(_ alarmID: UUID) {
+            cancelledIDs.append(alarmID)
+        }
+    }
+
     private var testDefaults: UserDefaults!
     private var suiteName: String!
+    private var stubScheduler: StubScheduler!
     private var repo: AlarmRepository!
 
     override func setUp() {
         super.setUp()
         suiteName = "test.alarmsList.\(UUID().uuidString)"
         testDefaults = UserDefaults(suiteName: suiteName)!
-        repo = AlarmRepository(defaults: testDefaults)
+        stubScheduler = StubScheduler()
+        repo = AlarmRepository(defaults: testDefaults, scheduler: stubScheduler)
     }
 
     override func tearDown() {
@@ -379,5 +404,102 @@ final class AlarmsListViewModelTests: XCTestCase {
         XCTAssertNotNil(receivedError, "VM must propagate the persist block to the VC")
         XCTAssertEqual(vm.alarms.count, 1,
                        "In-memory snapshot must NOT shrink when persistence is refused")
+    }
+
+    // MARK: - Issue #129: surfaced scheduling errors from list toggle
+
+    /// When `UNUserNotificationCenter.add` fails (revoked permission, malformed
+    /// trigger, 64-pending limit) during a list toggle, the VM must surface the
+    /// underlying `AlarmScheduler.SchedulingError` to the VC AND roll the
+    /// in-memory `enabled` flag back so the cell switch matches the user's
+    /// actual notification state. Before this fix the toggle landed in
+    /// UserDefaults with `enabled=true` while the notification never registered
+    /// — silent failure (audit-finding from #127).
+    func testToggleAlarm_schedulingFailure_firesOnLoadErrorAndRollsBackEnabled() {
+        let alarm = Alarm(name: "ToggleOn", penaltyAmount: 50, enabled: false)
+        repo.save(alarm)
+
+        let vm = makeViewModel()
+        vm.loadData()
+        XCTAssertEqual(vm.alarms.count, 1)
+        XCTAssertFalse(vm.alarms[0].enabled, "Pre-condition: alarm starts disabled")
+
+        // Stub the scheduler to mimic a denied-permission rejection from
+        // UNUserNotificationCenter. The VM must observe the failure and
+        // unwind the optimistic enable.
+        let underlying = "Notifications are not allowed for this application"
+        stubScheduler.scheduleResult = .failure(.system(message: underlying))
+
+        var receivedError: LocalizedError?
+        var rebindFired = false
+        vm.onLoadError = { receivedError = $0 }
+        vm.onAlarmsUpdated = { rebindFired = true }
+
+        vm.toggleAlarm(id: alarm.id, enabled: true)
+
+        // Error must reach the VC verbatim through the existing onLoadError
+        // channel — `SchedulingError` is itself `LocalizedError`, no new
+        // callback needed.
+        XCTAssertTrue(rebindFired, "VM must trigger a re-bind so the cell switch rolls back")
+        guard let typed = receivedError as? AlarmScheduler.SchedulingError else {
+            return XCTFail("Expected AlarmScheduler.SchedulingError, got \(String(describing: receivedError))")
+        }
+        if case .system(let message) = typed {
+            XCTAssertEqual(message, underlying, "UN error must reach the VM verbatim")
+        } else {
+            XCTFail("Expected .system, got \(typed)")
+        }
+        XCTAssertFalse(
+            vm.alarms[0].enabled,
+            "In-memory `enabled` must roll back to the pre-toggle state on schedule failure"
+        )
+    }
+
+    /// Inverse of the failure test: when the scheduler resolves successfully,
+    /// the VM must NOT fire `onLoadError` and must NOT rebind — the optimistic
+    /// cell flip is already correct, so a redundant table reload would drop
+    /// in-flight switch animations.
+    func testToggleAlarm_schedulingSuccess_doesNotFireOnLoadError() {
+        let alarm = Alarm(name: "Healthy", penaltyAmount: 50, enabled: false)
+        repo.save(alarm)
+
+        let vm = makeViewModel()
+        vm.loadData()
+        // Stub defaults to .success(()) — set here for clarity.
+        stubScheduler.scheduleResult = .success(())
+
+        var receivedError: LocalizedError?
+        var rebindCount = 0
+        vm.onLoadError = { receivedError = $0 }
+        vm.onAlarmsUpdated = { rebindCount += 1 }
+
+        vm.toggleAlarm(id: alarm.id, enabled: true)
+
+        XCTAssertNil(receivedError, "Successful schedule must not surface an error")
+        XCTAssertEqual(rebindCount, 0, "Successful toggle must not refire onAlarmsUpdated")
+        XCTAssertTrue(vm.alarms[0].enabled, "In-memory state must reflect the new toggle")
+    }
+
+    /// Toggle-OFF must not invoke the scheduler at all (there is no work to
+    /// schedule), and the completion path must resolve as success so async
+    /// callers don't hang. Belt-and-suspenders against a future regression
+    /// that accidentally fires `.failure` for the disabled branch.
+    func testToggleAlarm_disablingAlarm_doesNotInvokeScheduler() {
+        let alarm = Alarm(name: "ToggleOff", penaltyAmount: 50, enabled: true)
+        repo.save(alarm)
+
+        let vm = makeViewModel()
+        vm.loadData()
+        // Pre-arm the stub with a failure — disabling MUST NOT consult it.
+        stubScheduler.scheduleResult = .failure(.system(message: "should not fire"))
+
+        var receivedError: LocalizedError?
+        vm.onLoadError = { receivedError = $0 }
+
+        vm.toggleAlarm(id: alarm.id, enabled: false)
+
+        XCTAssertNil(receivedError, "Disabling must skip the scheduler — no failure path")
+        XCTAssertTrue(stubScheduler.scheduledIDs.isEmpty, "schedule() must not run for enabled=false")
+        XCTAssertFalse(vm.alarms[0].enabled, "In-memory state must reflect disable")
     }
 }


### PR DESCRIPTION
Fixes #129

## Что сделано
- Проброс `schedulingResult: ((Result<Void, AlarmScheduler.SchedulingError>) -> Void)?` через `AlarmRepository.setEnabled(_:id:schedulingResult:)` (по аналогии с `save(_:schedulingResult:)` из #118). Toggle-OFF резолвит `.success(())` сразу, toggle-ON пропускает completion в реальный scheduler.
- Введён минимальный protocol `AlarmScheduling` (`schedule`/`cancel`) и DI scheduler-а в `AlarmRepository.init` — production остаётся на `AlarmScheduler.shared` через дефолт, тесты подменяют через stub без поднятия `UNUserNotificationCenter`.
- `AlarmsListViewModel.toggleAlarm` теперь предварительно мутирует in-memory cache, передаёт completion в repo и при `.failure` откатывает `enabled` обратно + дёргает `onLoadError` (через существующий канал `LocalizedError`) и `onAlarmsUpdated` для re-bind.
- VC уже умеет рендерить `LocalizedError` через `presentRepositoryError`, дополнительной работы не нужно — `SchedulingError` подходит сразу.
- `CreateAlarmViewModel.save` не тронут (#118 уже работает корректно).

## Verify
- swiftlint: 0 errors на изменённых файлах (warnings — pre-existing file_length / identifier_name `vm`).
- build_sim: succeeded (iPhone 17 Pro).
- test_sim: пропущен (отключён в окружении).
- Новые тесты в `AlarmsListViewModelTests`:
  - `testToggleAlarm_schedulingFailure_firesOnLoadErrorAndRollsBackEnabled` — стаб scheduler возвращает `.system(message:)`, проверяем `onLoadError` + откат `enabled`.
  - `testToggleAlarm_schedulingSuccess_doesNotFireOnLoadError` — happy-path не фаерит ошибки/rebind.
  - `testToggleAlarm_disablingAlarm_doesNotInvokeScheduler` — disable не дёргает scheduler даже если он pre-armed на failure.