### PR TITLE
[fix] Surface coordinator snooze schedule failures + refund penalty (#130)

### DIFF
--- a/SnoozePay/SnoozePay/AppDelegate.swift
+++ b/SnoozePay/SnoozePay/AppDelegate.swift
@@ -171,21 +171,17 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
 
         case "SNOOZE_ACTION":
             stopAlarmSoundIfOwner(of: payload, action: "SNOOZE_ACTION")
-            let outcome = AlarmFiringCoordinator.shared.handleSnooze(userInfo: userInfo)
-            switch outcome {
-            case .invalidPayload:
-                AppLogger.appDelegate.error("SNOOZE_ACTION: invalid payload, snooze skipped")
-            case .alarmNotFound:
-                AppLogger.appDelegate.notice("SNOOZE_ACTION: alarm not found, snooze skipped")
-            case .insufficientFunds:
-                AppLogger.appDelegate.notice(
-                    "SNOOZE_ACTION: insufficient funds — snooze skipped, alarm will not repeat"
-                )
-            case let .scheduled(newSnoozeCount, charged):
-                AppLogger.appDelegate.info(
-                    "SNOOZE_ACTION: snooze #\(newSnoozeCount, privacy: .public) scheduled, charged=\(charged, privacy: .public)"
-                )
+            // `handleSnooze` is async — we must keep the system
+            // `completionHandler` alive until it resolves, otherwise iOS may
+            // suspend the app before the scheduler callback fires (#130).
+            AlarmFiringCoordinator.shared.handleSnooze(userInfo: userInfo) { [weak self] outcome in
+                self?.logSnoozeOutcome(outcome)
+                if case let .scheduleFailed(error) = outcome {
+                    self?.postSnoozeScheduleFailedBanner(error: error)
+                }
+                completionHandler()
             }
+            return // async path owns `completionHandler` from here on
 
         case UNNotificationDismissActionIdentifier:
             // User swiped away notification — stop sound. Gate on ownership
@@ -292,6 +288,72 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             }
 
             topVC.present(firingVC, animated: false)
+        }
+    }
+
+    /// Centralised logging for every `SnoozeOutcome` branch — extracted from
+    /// the `didReceive` switch so that path stays under cyclomatic-complexity
+    /// limits and the logging vocabulary lives next to the fallback-banner
+    /// helper that depends on the same outcome.
+    private func logSnoozeOutcome(_ outcome: AlarmFiringCoordinator.SnoozeOutcome) {
+        switch outcome {
+        case .invalidPayload:
+            AppLogger.appDelegate.error("SNOOZE_ACTION: invalid payload, snooze skipped")
+        case .alarmNotFound:
+            AppLogger.appDelegate.notice("SNOOZE_ACTION: alarm not found, snooze skipped")
+        case .insufficientFunds:
+            AppLogger.appDelegate.notice(
+                "SNOOZE_ACTION: insufficient funds — snooze skipped, alarm will not repeat"
+            )
+        case let .scheduled(newSnoozeCount, charged):
+            AppLogger.appDelegate.info(
+                "SNOOZE_ACTION: scheduled #\(newSnoozeCount, privacy: .public) charged=\(charged, privacy: .public)"
+            )
+        case let .scheduleFailed(error):
+            // Penalty was refunded inside the coordinator. We log the cause
+            // here and rely on the caller to post the user-facing banner.
+            let desc = error.localizedDescription
+            AppLogger.appDelegate.error(
+                "SNOOZE_ACTION: schedule failed (\(desc, privacy: .public)) — posting fallback banner"
+            )
+        }
+    }
+
+    /// Schedule a local notification that surfaces immediately when the
+    /// snooze action's reschedule attempt failed. The user is no longer in
+    /// the app (notification actions run from the lock screen / banner), so
+    /// a UIAlertController would never reach them — only a banner the system
+    /// itself delivers will. The penalty has already been refunded by the
+    /// coordinator before this is called (issue #130).
+    private func postSnoozeScheduleFailedBanner(error: AlarmScheduler.SchedulingError) {
+        let detail = error.errorDescription ?? error.localizedDescription
+        let content = UNMutableNotificationContent()
+        content.title = "Снуз не запланирован"
+        content.body = "Установите запасной — \(detail)"
+        content.sound = .default
+        // Time-sensitive so it pierces Focus modes the same way the alarm
+        // itself does — the user needs to know NOW that there's no re-fire.
+        content.interruptionLevel = .timeSensitive
+
+        // Fire ASAP. UNTimeIntervalNotificationTrigger requires > 0; 1s is
+        // the minimum that survives the daemon's clamp without being silently
+        // dropped, and is imperceptible to the user.
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
+        let request = UNNotificationRequest(
+            identifier: "snooze_schedule_failed_\(UUID().uuidString)",
+            content: content,
+            trigger: trigger
+        )
+        UNUserNotificationCenter.current().add(request) { fallbackError in
+            if let fallbackError = fallbackError {
+                // Even the fallback banner failed to register — usually
+                // because notification permission was revoked, which is
+                // exactly the same root cause the snooze hit. Nothing left
+                // to surface from a notification action context.
+                AppLogger.appDelegate.fault(
+                    "snooze fallback banner failed: \(fallbackError.localizedDescription, privacy: .public)"
+                )
+            }
         }
     }
 

--- a/SnoozePay/SnoozePay/AppDelegate.swift
+++ b/SnoozePay/SnoozePay/AppDelegate.swift
@@ -174,14 +174,43 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             // `handleSnooze` is async — we must keep the system
             // `completionHandler` alive until it resolves, otherwise iOS may
             // suspend the app before the scheduler callback fires (#130).
-            AlarmFiringCoordinator.shared.handleSnooze(userInfo: userInfo) { [weak self] outcome in
-                self?.logSnoozeOutcome(outcome)
-                if case let .scheduleFailed(error) = outcome {
-                    self?.postSnoozeScheduleFailedBanner(error: error)
-                }
+            //
+            // BUT: if the scheduler chain hangs (UN daemon unresponsive, main
+            // queue starved) the closure never fires and iOS terminates the
+            // process at ~30s, silently dropping the snooze and the fallback
+            // banner. A 25s watchdog calls `completionHandler` once whichever
+            // path resolves first wins — preventing the timeout class of
+            // silent failure (silent-failure-hunter CRITICAL on #132).
+            let resolveLock = NSLock()
+            var didResolve = false
+            let resolveOnce: () -> Void = {
+                resolveLock.lock()
+                defer { resolveLock.unlock() }
+                guard !didResolve else { return }
+                didResolve = true
                 completionHandler()
             }
-            return // async path owns `completionHandler` from here on
+            let watchdog = DispatchWorkItem {
+                AppLogger.appDelegate.fault(
+                    "SNOOZE_ACTION watchdog fired — coordinator did not resolve in 25s, releasing completionHandler"
+                )
+                resolveOnce()
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 25, execute: watchdog)
+            AlarmFiringCoordinator.shared.handleSnooze(userInfo: userInfo) { [weak self] outcome in
+                watchdog.cancel()
+                self?.logSnoozeOutcome(outcome)
+                switch outcome {
+                case let .scheduleFailed(error):
+                    self?.postSnoozeScheduleFailedBanner(error: error, refundLanded: true)
+                case let .scheduleFailedAndRefundFailed(error):
+                    self?.postSnoozeScheduleFailedBanner(error: error, refundLanded: false)
+                default:
+                    break
+                }
+                resolveOnce()
+            }
+            return // async path + watchdog own `completionHandler` from here on
 
         case UNNotificationDismissActionIdentifier:
             // User swiped away notification — stop sound. Gate on ownership
@@ -314,7 +343,15 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             // here and rely on the caller to post the user-facing banner.
             let desc = error.localizedDescription
             AppLogger.appDelegate.error(
-                "SNOOZE_ACTION: schedule failed (\(desc, privacy: .public)) — posting fallback banner"
+                "SNOOZE_ACTION: schedule failed (\(desc, privacy: .public)) — posting fallback banner (refunded)"
+            )
+        case let .scheduleFailedAndRefundFailed(error):
+            // Both schedule AND refund failed — money was taken, alarm won't
+            // re-fire, refund didn't land. Stronger banner copy is posted by
+            // the caller; we log at fault-level for forensics.
+            let desc = error.localizedDescription
+            AppLogger.appDelegate.fault(
+                "SNOOZE_ACTION: schedule AND refund failed (\(desc, privacy: .public)) — wallet desync"
             )
         }
     }
@@ -325,11 +362,20 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     /// a UIAlertController would never reach them — only a banner the system
     /// itself delivers will. The penalty has already been refunded by the
     /// coordinator before this is called (issue #130).
-    private func postSnoozeScheduleFailedBanner(error: AlarmScheduler.SchedulingError) {
+    private func postSnoozeScheduleFailedBanner(
+        error: AlarmScheduler.SchedulingError,
+        refundLanded: Bool
+    ) {
         let detail = error.errorDescription ?? error.localizedDescription
         let content = UNMutableNotificationContent()
         content.title = "Снуз не запланирован"
-        content.body = "Установите запасной — \(detail)"
+        if refundLanded {
+            content.body = "Установите запасной — \(detail)"
+        } else {
+            // Penalty was charged but refund failed — surface this so the user
+            // knows to reach out instead of silently absorbing the loss.
+            content.body = "Установите запасной. Списание не возвращено — обратитесь в поддержку. \(detail)"
+        }
         content.sound = .default
         // Time-sensitive so it pierces Focus modes the same way the alarm
         // itself does — the user needs to know NOW that there's no re-fire.

--- a/SnoozePay/SnoozePay/Services/AlarmFiringCoordinator.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmFiringCoordinator.swift
@@ -37,6 +37,13 @@ final class AlarmFiringCoordinator {
         /// wallet reflects the unsuccessful snooze. Callers (AppDelegate) MUST
         /// surface a local banner so the user knows the alarm will not re-fire.
         case scheduleFailed(error: AlarmScheduler.SchedulingError)
+        /// Charge succeeded, schedule failed, AND the offsetting refund also
+        /// failed (typically because the ledger is locked from a corrupt blob,
+        /// see #72/#119). Wallet is in a degraded state — money was taken,
+        /// alarm will not re-fire, refund did not land. Callers MUST surface
+        /// a stronger banner instructing the user to contact support so they
+        /// don't silently lose the penalty (silent-failure-hunter HIGH on #132).
+        case scheduleFailedAndRefundFailed(error: AlarmScheduler.SchedulingError)
     }
 
     // MARK: - Dependencies
@@ -176,20 +183,22 @@ final class AlarmFiringCoordinator {
                     refunded=\(penalty, privacy: .public) reason=\(desc, privacy: .public)
                     """
                 )
+                completion?(.scheduleFailed(error: error))
             } else {
                 // Refund itself failed — wallet is in a degraded state
                 // (charge recorded, refund didn't land — typically because
                 // the ledger is locked from a corrupt blob, see #72/#119).
-                // Surface separately so this doesn't masquerade as a
-                // successful refund in the logs.
+                // Distinct outcome so AppDelegate can post a stronger banner
+                // ("обратитесь в поддержку") rather than the standard "снуз
+                // не запланирован" message that implies money was returned.
                 AppLogger.coordinator.fault(
                     """
                     snooze: schedule failed alarm=\(alarmID, privacy: .private) \
                     AND refund failed — wallet desync, manual reconciliation required
                     """
                 )
+                completion?(.scheduleFailedAndRefundFailed(error: error))
             }
-            completion?(.scheduleFailed(error: error))
         }
     }
 }

--- a/SnoozePay/SnoozePay/Services/AlarmFiringCoordinator.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmFiringCoordinator.swift
@@ -16,9 +16,11 @@ final class AlarmFiringCoordinator {
     // MARK: - Outcome
 
     /// Result of attempting a snooze from a notification action.
-    /// Surfaced for tests and future telemetry — AppDelegate currently ignores
-    /// the value because there's no UI affordance once the alarm screen is
-    /// already dismissed.
+    /// Surfaced for tests and AppDelegate so a `.scheduleFailed` can drive a
+    /// user-visible local notification — without that surface a `UN.add`
+    /// failure here silently swallows the snooze and the user has already
+    /// paid the penalty (issue #130, follow-up to #118 / silent-failure-hunter
+    /// review of #127).
     enum SnoozeOutcome: Equatable {
         /// Required identifiers (alarmID/snoozeCount) were missing or malformed.
         case invalidPayload
@@ -28,6 +30,13 @@ final class AlarmFiringCoordinator {
         case insufficientFunds
         /// Charge succeeded and a new snooze notification was scheduled.
         case scheduled(newSnoozeCount: Int, charged: Double)
+        /// Charge succeeded but the underlying `UNUserNotificationCenter.add`
+        /// rejected the snooze trigger (revoked permission, 64-pending-limit,
+        /// malformed trigger). The penalty has been **refunded** synchronously
+        /// inside the coordinator before this outcome is reported, so the
+        /// wallet reflects the unsuccessful snooze. Callers (AppDelegate) MUST
+        /// surface a local banner so the user knows the alarm will not re-fire.
+        case scheduleFailed(error: AlarmScheduler.SchedulingError)
     }
 
     // MARK: - Dependencies
@@ -65,13 +74,29 @@ final class AlarmFiringCoordinator {
 
     /// Resolves the alarm + snoozeCount from a notification's userInfo dict,
     /// charges the appropriate (possibly progressive) penalty, and schedules
-    /// the next snooze notification. Returns a structured outcome so callers
-    /// (and tests) can assert exactly what happened without scraping logs.
-    @discardableResult
-    func handleSnooze(userInfo: [AnyHashable: Any]) -> SnoozeOutcome {
+    /// the next snooze notification. The outcome is delivered via `completion`
+    /// because `scheduleSnooze` is asynchronous — callers (AppDelegate, tests)
+    /// must wait for the scheduler to confirm registration before they can
+    /// distinguish `.scheduled` from `.scheduleFailed` (issue #130).
+    ///
+    /// On `.scheduleFailed` the penalty is refunded via
+    /// `BalanceService.topUp` so the user is not billed for a snooze that
+    /// will never re-fire. The refund posts an offsetting ledger entry —
+    /// transaction history therefore shows both the charge and the refund,
+    /// which is the consistent representation for stats/auditing (mirrors the
+    /// rollback pattern from StoreKitService dedup-mark in #72).
+    ///
+    /// Synchronous early-exit branches (invalid payload, alarm missing,
+    /// insufficient funds) call `completion` inline before returning so the
+    /// caller sees a single resolution per invocation.
+    func handleSnooze(
+        userInfo: [AnyHashable: Any],
+        completion: ((SnoozeOutcome) -> Void)? = nil
+    ) {
         guard let payload = AlarmNotificationPayload(userInfo: userInfo) else {
             AppLogger.coordinator.error("snooze: invalid payload \(userInfo, privacy: .private(mask: .hash))")
-            return .invalidPayload
+            completion?(.invalidPayload)
+            return
         }
 
         let alarm: Alarm?
@@ -86,11 +111,13 @@ final class AlarmFiringCoordinator {
             AppLogger.coordinator.error(
                 "snooze: fetch failed for \(payload.alarmID, privacy: .private): \(errorDesc, privacy: .public)"
             )
-            return .alarmNotFound
+            completion?(.alarmNotFound)
+            return
         }
         guard let alarm else {
             AppLogger.coordinator.error("snooze: alarm \(payload.alarmID, privacy: .private) not in repository")
-            return .alarmNotFound
+            completion?(.alarmNotFound)
+            return
         }
 
         let newCount = payload.snoozeCount + 1
@@ -98,16 +125,71 @@ final class AlarmFiringCoordinator {
 
         let charged = balanceService.charge(amount: penalty, alarmID: payload.alarmID)
         guard charged else {
+            let alarmID = payload.alarmID
             AppLogger.coordinator.notice(
-                "snooze: insufficient funds for alarm \(payload.alarmID, privacy: .private), penalty=\(penalty, privacy: .public)"
+                "snooze: insufficient funds alarm=\(alarmID, privacy: .private) penalty=\(penalty, privacy: .public)"
             )
-            return .insufficientFunds
+            completion?(.insufficientFunds)
+            return
         }
 
-        scheduler.scheduleSnooze(for: alarm, snoozeCount: newCount)
-        AppLogger.coordinator.info(
-            "snooze: scheduled #\(newCount, privacy: .public) for \(payload.alarmID, privacy: .private), penalty=\(penalty, privacy: .public)"
-        )
-        return .scheduled(newSnoozeCount: newCount, charged: penalty)
+        scheduler.scheduleSnooze(for: alarm, snoozeCount: newCount) { [weak self] result in
+            self?.handleScheduleResult(
+                result,
+                alarmID: payload.alarmID,
+                newCount: newCount,
+                penalty: penalty,
+                completion: completion
+            )
+        }
+    }
+
+    /// Resolves the async scheduler result into a `SnoozeOutcome`. On failure
+    /// the penalty is refunded via `BalanceService.topUp` so the user is not
+    /// billed for a snooze that won't re-fire — extracted from `handleSnooze`
+    /// to keep the entry-point readable and to give the refund logic its own
+    /// log seam.
+    private func handleScheduleResult(
+        _ result: Result<Void, AlarmScheduler.SchedulingError>,
+        alarmID: UUID,
+        newCount: Int,
+        penalty: Double,
+        completion: ((SnoozeOutcome) -> Void)?
+    ) {
+        switch result {
+        case .success:
+            AppLogger.coordinator.info(
+                "snooze: scheduled #\(newCount, privacy: .public) alarm=\(alarmID, privacy: .private)"
+            )
+            completion?(.scheduled(newSnoozeCount: newCount, charged: penalty))
+        case .failure(let error):
+            // Refund the penalty so the user isn't billed for a snooze that
+            // will never re-fire. `topUp` records an offsetting ledger entry
+            // (rather than mutating storage directly) so transaction history
+            // shows both the charge and the refund — stats stay auditable.
+            let refunded = balanceService.topUp(amount: penalty)
+            let desc = error.errorDescription ?? error.localizedDescription
+            if refunded {
+                AppLogger.coordinator.error(
+                    """
+                    snooze: schedule failed alarm=\(alarmID, privacy: .private) \
+                    refunded=\(penalty, privacy: .public) reason=\(desc, privacy: .public)
+                    """
+                )
+            } else {
+                // Refund itself failed — wallet is in a degraded state
+                // (charge recorded, refund didn't land — typically because
+                // the ledger is locked from a corrupt blob, see #72/#119).
+                // Surface separately so this doesn't masquerade as a
+                // successful refund in the logs.
+                AppLogger.coordinator.fault(
+                    """
+                    snooze: schedule failed alarm=\(alarmID, privacy: .private) \
+                    AND refund failed — wallet desync, manual reconciliation required
+                    """
+                )
+            }
+            completion?(.scheduleFailed(error: error))
+        }
     }
 }

--- a/SnoozePay/SnoozePayTests/AlarmFiringCoordinatorTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmFiringCoordinatorTests.swift
@@ -1,8 +1,9 @@
 import XCTest
+import UserNotifications
 @testable import SnoozePay
 
 /// Unit tests for AlarmFiringCoordinator — the snooze-from-notification flow
-/// extracted out of AppDelegate. Exercises the four `SnoozeOutcome` branches
+/// extracted out of AppDelegate. Exercises every `SnoozeOutcome` branch
 /// against an isolated balance + repo so the real singletons stay untouched.
 final class AlarmFiringCoordinatorTests: XCTestCase {
 
@@ -11,6 +12,8 @@ final class AlarmFiringCoordinatorTests: XCTestCase {
     private var alarmRepo: AlarmRepository!
     private var balanceService: BalanceService!
     private var coordinator: AlarmFiringCoordinator!
+    private var mockCenter: MockNotificationCenter!
+    private var scheduler: AlarmScheduler!
 
     override func setUp() {
         super.setUp()
@@ -18,17 +21,20 @@ final class AlarmFiringCoordinatorTests: XCTestCase {
         testDefaults = UserDefaults(suiteName: suiteName)!
         alarmRepo = AlarmRepository(defaults: testDefaults)
         balanceService = BalanceService(defaults: testDefaults)
+        // Inject a stub UNUserNotificationCenter so the success path doesn't
+        // pollute the real notification daemon and the failure path is
+        // reproducible (revoked permission / 64-pending limit). Production
+        // code keeps using `AlarmScheduler.shared`.
+        mockCenter = MockNotificationCenter()
+        scheduler = AlarmScheduler(notificationCenter: mockCenter)
         coordinator = AlarmFiringCoordinator(
             alarmRepository: alarmRepo,
             balanceService: balanceService,
-            scheduler: AlarmScheduler.shared
+            scheduler: scheduler
         )
     }
 
     override func tearDown() {
-        // Clean up any notifications the coordinator may have scheduled during
-        // the success path so subsequent tests / app launches start clean.
-        AlarmScheduler.shared.cancelAll()
         testDefaults.removePersistentDomain(forName: suiteName)
         super.tearDown()
     }
@@ -41,15 +47,36 @@ final class AlarmFiringCoordinatorTests: XCTestCase {
         return alarm
     }
 
+    /// Drive `handleSnooze` to a single resolution and return its outcome.
+    /// Wraps the async completion in an expectation so tests stay imperative.
+    private func resolveSnooze(
+        userInfo: [AnyHashable: Any],
+        timeout: TimeInterval = 1.0,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) -> AlarmFiringCoordinator.SnoozeOutcome? {
+        let exp = expectation(description: "handleSnooze completion")
+        var captured: AlarmFiringCoordinator.SnoozeOutcome?
+        coordinator.handleSnooze(userInfo: userInfo) { outcome in
+            captured = outcome
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: timeout)
+        if captured == nil {
+            XCTFail("handleSnooze never produced an outcome", file: file, line: line)
+        }
+        return captured
+    }
+
     // MARK: - Invalid payload
 
     func testHandleSnooze_missingAlarmID_returnsInvalidPayload() {
-        let outcome = coordinator.handleSnooze(userInfo: ["snoozeCount": 0])
+        let outcome = resolveSnooze(userInfo: ["snoozeCount": 0])
         XCTAssertEqual(outcome, .invalidPayload)
     }
 
     func testHandleSnooze_invalidAlarmIDString_returnsInvalidPayload() {
-        let outcome = coordinator.handleSnooze(userInfo: [
+        let outcome = resolveSnooze(userInfo: [
             "alarmID": "not-a-uuid",
             "snoozeCount": 0
         ])
@@ -58,7 +85,7 @@ final class AlarmFiringCoordinatorTests: XCTestCase {
 
     func testHandleSnooze_missingSnoozeCount_returnsInvalidPayload() {
         let alarm = makeAlarm()
-        let outcome = coordinator.handleSnooze(userInfo: [
+        let outcome = resolveSnooze(userInfo: [
             "alarmID": alarm.id.uuidString
         ])
         XCTAssertEqual(outcome, .invalidPayload)
@@ -68,7 +95,7 @@ final class AlarmFiringCoordinatorTests: XCTestCase {
 
     func testHandleSnooze_unknownAlarmID_returnsAlarmNotFound() {
         // Valid UUID, but no alarm with that ID was saved.
-        let outcome = coordinator.handleSnooze(userInfo: [
+        let outcome = resolveSnooze(userInfo: [
             "alarmID": UUID().uuidString,
             "snoozeCount": 0
         ])
@@ -80,7 +107,7 @@ final class AlarmFiringCoordinatorTests: XCTestCase {
     func testHandleSnooze_insufficientBalance_returnsInsufficientFunds() {
         let alarm = makeAlarm(penalty: 100)
         // Balance is 0 (fresh UserDefaults suite).
-        let outcome = coordinator.handleSnooze(userInfo: [
+        let outcome = resolveSnooze(userInfo: [
             "alarmID": alarm.id.uuidString,
             "snoozeCount": 0
         ])
@@ -94,7 +121,7 @@ final class AlarmFiringCoordinatorTests: XCTestCase {
         let alarm = makeAlarm(penalty: 50)
         balanceService.topUp(amount: 200)
 
-        let outcome = coordinator.handleSnooze(userInfo: [
+        let outcome = resolveSnooze(userInfo: [
             "alarmID": alarm.id.uuidString,
             "snoozeCount": 0
         ])
@@ -108,7 +135,7 @@ final class AlarmFiringCoordinatorTests: XCTestCase {
         let alarm = makeAlarm(penalty: 50, progressive: true)
         balanceService.topUp(amount: 500)
 
-        let outcome = coordinator.handleSnooze(userInfo: [
+        let outcome = resolveSnooze(userInfo: [
             "alarmID": alarm.id.uuidString,
             "snoozeCount": 1
         ])
@@ -122,7 +149,7 @@ final class AlarmFiringCoordinatorTests: XCTestCase {
         let alarm = makeAlarm(penalty: 75)
         balanceService.topUp(amount: 75)
 
-        let outcome = coordinator.handleSnooze(userInfo: [
+        let outcome = resolveSnooze(userInfo: [
             "alarmID": alarm.id.uuidString,
             "snoozeCount": 0
         ])
@@ -144,7 +171,7 @@ final class AlarmFiringCoordinatorTests: XCTestCase {
         let alarm = makeAlarm()
         testDefaults.set(Data("not json".utf8), forKey: "stored_alarms")
 
-        let outcome = coordinator.handleSnooze(userInfo: [
+        let outcome = resolveSnooze(userInfo: [
             "alarmID": alarm.id.uuidString,
             "snoozeCount": 0
         ])
@@ -153,5 +180,116 @@ final class AlarmFiringCoordinatorTests: XCTestCase {
                        "From a notification action there's no recovery UI, so collapse to alarmNotFound")
         XCTAssertTrue(alarmRepo.lastLoadFailed,
                       "The checked fetch must arm the persistence lock so a follow-up save can't clobber the corrupt blob")
+    }
+
+    // MARK: - Issue #130: scheduler failure must surface and refund the user
+
+    /// Stub the notification center to reject `add(_:)` so the scheduler's
+    /// `scheduleSnooze` resolves to `.failure(.system)`. The coordinator must:
+    ///   1. Surface `.scheduleFailed(error:)` as the outcome
+    ///   2. Refund the penalty (balance back to pre-charge amount)
+    ///   3. Keep ledger consistent — both charge and refund recorded.
+    /// Without this fix the user pays for a snooze that never re-fires
+    /// (silent-failure-hunter critical finding on PR #127).
+    func testHandleSnooze_schedulerRejectsAdd_refundsBalanceAndReportsScheduleFailed() {
+        let alarm = makeAlarm(penalty: 50)
+        balanceService.topUp(amount: 200)
+        let preCharge = balanceService.balance
+        XCTAssertEqual(preCharge, 200)
+
+        mockCenter.addError = NSError(
+            domain: "UNErrorDomain",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Notifications are not allowed for this application"]
+        )
+
+        let outcome = resolveSnooze(userInfo: [
+            "alarmID": alarm.id.uuidString,
+            "snoozeCount": 0
+        ])
+
+        guard case .scheduleFailed(let error) = outcome else {
+            return XCTFail("Expected .scheduleFailed, got \(String(describing: outcome))")
+        }
+        guard case .system(let message) = error else {
+            return XCTFail("Expected .system error, got \(error)")
+        }
+        XCTAssertEqual(message, "Notifications are not allowed for this application",
+                       "Underlying UN error message must reach the outcome verbatim")
+        XCTAssertEqual(balanceService.balance, preCharge,
+                       "Penalty must be refunded so the user isn't billed for a snooze that won't fire")
+    }
+
+    /// 64-pending-limit pre-flight failure path. Same contract as the
+    /// `.system` test above but with a different `SchedulingError` variant —
+    /// the refund must happen regardless of which scheduling error class
+    /// surfaces.
+    func testHandleSnooze_schedulerHitsPendingLimit_refundsBalance() {
+        let alarm = makeAlarm(penalty: 50)
+        balanceService.topUp(amount: 200)
+
+        // Saturate the pending-request queue so the pre-flight rejects.
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 60, repeats: false)
+        let content = UNMutableNotificationContent()
+        mockCenter.pendingRequests = (0..<AlarmScheduler.pendingNotificationLimit).map { idx in
+            UNNotificationRequest(identifier: "stub_\(idx)", content: content, trigger: trigger)
+        }
+
+        let outcome = resolveSnooze(userInfo: [
+            "alarmID": alarm.id.uuidString,
+            "snoozeCount": 0
+        ])
+
+        guard case .scheduleFailed(let error) = outcome else {
+            return XCTFail("Expected .scheduleFailed, got \(String(describing: outcome))")
+        }
+        guard case .pendingLimitReached = error else {
+            return XCTFail("Expected .pendingLimitReached, got \(error)")
+        }
+        XCTAssertEqual(balanceService.balance, 200,
+                       "Penalty must be refunded when the pending-limit pre-flight rejects")
+        XCTAssertTrue(mockCenter.addedRequests.isEmpty,
+                      "Pre-flight must short-circuit before any add() call, so no notification was registered")
+    }
+}
+
+// MARK: - Test doubles
+
+/// Lightweight stub for `NotificationScheduling`. Mirrors the one used in
+/// `AlarmSchedulerErrorPropagationTests`; lifted here so the coordinator tests
+/// can exercise success and failure paths without touching the real daemon.
+private final class MockNotificationCenter: NotificationScheduling {
+    var addError: Error?
+    var pendingRequests: [UNNotificationRequest] = []
+    private(set) var addedRequests: [UNNotificationRequest] = []
+
+    func add(
+        _ request: UNNotificationRequest,
+        withCompletionHandler completion: ((Error?) -> Void)?
+    ) {
+        addedRequests.append(request)
+        completion?(addError)
+    }
+
+    func getPendingNotificationRequests(
+        completionHandler: @escaping ([UNNotificationRequest]) -> Void
+    ) {
+        completionHandler(pendingRequests)
+    }
+
+    func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {}
+    func removeDeliveredNotifications(withIdentifiers identifiers: [String]) {}
+    func getDeliveredNotifications(
+        completionHandler: @escaping ([UNNotification]) -> Void
+    ) {
+        completionHandler([])
+    }
+    func setNotificationCategories(_ categories: Set<UNNotificationCategory>) {}
+    func removeAllPendingNotificationRequests() {}
+    func requestAuthorization(
+        options: UNAuthorizationOptions,
+        completionHandler: @escaping (Bool, Error?) -> Void
+    ) {
+        completionHandler(false, nil)
     }
 }


### PR DESCRIPTION
Fixes #130

## Что сделано
- `AlarmFiringCoordinator.handleSnooze` теперь асинхронный: ждёт результат `scheduler.scheduleSnooze` и сообщает исход через `completion`. Раньше completion от scheduler'а молча игнорировался, поэтому пользователь платил пеналти, а будильник не перезванивал.
- Добавлен новый кейс `SnoozeOutcome.scheduleFailed(error: AlarmScheduler.SchedulingError)`. Сразу перед его возвратом койордин делает **рефанд** через `BalanceService.topUp(amount: penalty)` — это пишет offsetting запись в ledger, история транзакций остаётся консистентной (покажет и charge, и refund).
- `AppDelegate.didReceive` для `SNOOZE_ACTION` обновлён под новый async API: удерживает системный `completionHandler` пока коордорин не разрешит outcome, на `.scheduleFailed` отправляет локальный `UNNotificationRequest` ("Снуз не запланирован — установите запасной") с `.timeSensitive` interruption, чтобы пользователь увидел баннер даже если приложение в фоне.
- Логирование разнесено в `logSnoozeOutcome` helper (cyclomatic complexity), refund/log логика — в `handleScheduleResult` private helper.
- Коммент про дегенеративный случай "refund тоже упал" — `os_log .fault` со словом "wallet desync, manual reconciliation required" чтобы такие записи легко найти в логах.

## Verify
- `swiftlint`: 0 errors (warnings — лишь pre-existing line_length / file_length, не от моих изменений)
- `build_sim`: succeeded (simulator: iPhone 17 Pro Max)
- Тесты обновлены на async API (через `expectation`); добавлены два новых:
  - `testHandleSnooze_schedulerRejectsAdd_refundsBalanceAndReportsScheduleFailed` — stub UN.add возвращает error, проверяет outcome `.scheduleFailed(.system)` + balance восстановлен до pre-charge суммы.
  - `testHandleSnooze_schedulerHitsPendingLimit_refundsBalance` — pending-limit pre-flight отказ, проверяет outcome `.scheduleFailed(.pendingLimitReached)` + refund + что `add()` вообще не вызван.
- `test_sim` отключён по политике — тесты не запускались.