### PR TITLE
[design-refresh] Add brand light/dark theme tokens (#136)

### DIFF
--- a/SnoozePay/SnoozePay/Utilities/AppColors.swift
+++ b/SnoozePay/SnoozePay/Utilities/AppColors.swift
@@ -38,6 +38,81 @@ enum AppColors {
     static let warn500 = UIColor(hex: 0xF59E0B)
     static let warn600 = UIColor(hex: 0xC97A06)
 
+    // MARK: - Brand · Info
+    /// Informational links only — `--sp-info-500` in `tokens.css`.
+    static let info500 = UIColor(hex: 0x4F8BFF)
+
+    // MARK: - Theme-aware surfaces (`bg0`...`bg4`)
+    //
+    // Five-step surface elevation per `tokens.css`. `bg0` is the deepest /
+    // app background, `bg4` the top hover/focus surface. Values resolve via
+    // `UIColor(dynamicProvider:)` so each token auto-adapts when the system
+    // toggles between light and dark, *and* when a single VC overrides its
+    // `userInterfaceStyle` (e.g. AlarmFiringViewController forcing dark).
+    /// App background — deepest. Dark `#060912`, Light `#F4F6FB`.
+    static let bg0 = dynamicColor(dark: 0x060912, light: 0xF4F6FB)
+    /// Card / sheet base. Dark `#0E1320`, Light `#FFFFFF`.
+    static let bg1 = dynamicColor(dark: 0x0E1320, light: 0xFFFFFF)
+    /// Raised card. Dark `#161C2E`, Light `#ECEEF6`.
+    static let bg2 = dynamicColor(dark: 0x161C2E, light: 0xECEEF6)
+    /// Active chip / sheet header. Dark `#1F2740`, Light `#DFE3F0`.
+    static let bg3 = dynamicColor(dark: 0x1F2740, light: 0xDFE3F0)
+    /// Hover / focus surface. Dark `#2A3354`, Light `#C9D0E3`.
+    static let bg4 = dynamicColor(dark: 0x2A3354, light: 0xC9D0E3)
+
+    // MARK: - Theme-aware foregrounds (`fg1`...`fg4`)
+    //
+    // Primary → disabled scale. Dark mode tints `#EBEDF5` (near-white) at
+    // 1.0 / 0.86 / 0.58 / 0.32 alpha; light mode tints `#0A0F1F` (brand
+    // near-black ink) at 1.0 / 0.82 / 0.56 / 0.32. Step scale matches
+    // `tokens.css`.
+    /// Primary headings & hero numbers.
+    static let fg1 = foreground(darkAlpha: 1.0, lightAlpha: 1.0, darkIsPureWhite: true)
+    /// Body copy. Dark 86% white-ish, Light 82% near-black.
+    static let fg2 = foreground(darkAlpha: 0.86, lightAlpha: 0.82)
+    /// Meta. Dark 58%, Light 56%.
+    static let fg3 = foreground(darkAlpha: 0.58, lightAlpha: 0.56)
+    /// Disabled / placeholder. Dark 32%, Light 32%.
+    static let fg4 = foreground(darkAlpha: 0.32, lightAlpha: 0.32)
+
+    /// Text rendered ON top of `money500` fills. Dark mint hue.
+    static let fgOnMoney = UIColor(hex: 0x052016)
+    /// Text rendered ON top of `pain500` fills.
+    static let fgOnPain = UIColor.white
+    /// Text rendered ON top of `warn500` fills.
+    static let fgOnWarn = UIColor(hex: 0x1A0F00)
+
+    // MARK: - Theme-aware overlays (alpha on white / near-black ink)
+    //
+    // Dark mode lays white over surfaces (`rgba(255,255,255,X)`); light mode
+    // lays the near-black ink (`#080E1E`) at the same alpha so an overlay
+    // chip "darkens" on light and "brightens" on dark.
+    static let whiteOverlay04 = overlay(alpha: 0.04)
+    static let whiteOverlay06 = overlay(alpha: 0.06)
+    static let whiteOverlay08 = overlay(alpha: 0.08)
+    static let whiteOverlay12 = overlay(alpha: 0.12)
+    static let whiteOverlay16 = overlay(alpha: 0.16)
+    static let whiteOverlay24 = overlay(alpha: 0.24)
+
+    // MARK: - Theme-aware strokes
+    //
+    // 1px hairlines for cards and dividers. Same alpha values, opposite ink:
+    // white on dark / near-black on light.
+    /// 8% hairline.
+    static let stroke1 = overlay(alpha: 0.08)
+    /// 14% stronger hairline (active state, focus ring).
+    static let stroke2 = overlay(alpha: 0.14)
+    /// Money-tinted stroke. Dark 45% / Light 55% (per `tokens.css`).
+    static let strokeMoney = UIColor { trait in
+        let alpha: CGFloat = trait.userInterfaceStyle == .light ? 0.55 : 0.45
+        return UIColor(red: 46.0 / 255.0, green: 219.0 / 255.0, blue: 159.0 / 255.0, alpha: alpha)
+    }
+    /// Pain-tinted stroke. Dark 45% / Light 55%.
+    static let strokePain = UIColor { trait in
+        let alpha: CGFloat = trait.userInterfaceStyle == .light ? 0.55 : 0.45
+        return UIColor(red: 244.0 / 255.0, green: 82.0 / 255.0, blue: 63.0 / 255.0, alpha: alpha)
+    }
+
     // MARK: - Separator
     static let separator = UIColor.separator
 
@@ -69,6 +144,50 @@ enum AppColors {
     /// slightly warmer hue than `warn500` (#79); migrating it onto a brand
     /// token is its own UI-issue decision.
     static let alarmFiringSnooze = UIColor(red: 0.91, green: 0.66, blue: 0.22, alpha: 1) // #E8A838
+
+    // MARK: - Theme-aware helpers
+
+    /// Resolve a token to either the light or dark hex literal based on the
+    /// current trait collection. Used for the surface scale.
+    private static func dynamicColor(dark: UInt32, light: UInt32) -> UIColor {
+        UIColor { trait in
+            trait.userInterfaceStyle == .light ? UIColor(hex: light) : UIColor(hex: dark)
+        }
+    }
+
+    /// Resolve a foreground token. Dark mode tints `#EBEDF5` (or pure white
+    /// for `fg1`) at `darkAlpha`; light mode tints the brand near-black ink
+    /// `#0A0F1F` at `lightAlpha`. Pure white in dark is needed only for
+    /// `fg1` so hero numbers don't acquire a slight off-white cast against
+    /// the deepest `bg0` surface.
+    private static func foreground(
+        darkAlpha: CGFloat,
+        lightAlpha: CGFloat,
+        darkIsPureWhite: Bool = false
+    ) -> UIColor {
+        UIColor { trait in
+            if trait.userInterfaceStyle == .light {
+                return UIColor(red: 10.0 / 255.0, green: 15.0 / 255.0, blue: 31.0 / 255.0, alpha: lightAlpha)
+            }
+            if darkIsPureWhite {
+                return UIColor(white: 1.0, alpha: darkAlpha)
+            }
+            return UIColor(red: 235.0 / 255.0, green: 237.0 / 255.0, blue: 245.0 / 255.0, alpha: darkAlpha)
+        }
+    }
+
+    /// Tint overlay used for `whiteOverlayXX` and `strokeN`. Dark mode lays
+    /// `rgba(255,255,255,alpha)`; light mode lays `rgba(10,15,31,alpha)`
+    /// (the near-black brand ink) so the same call produces a "darkening"
+    /// chip on light and a "brightening" chip on dark.
+    private static func overlay(alpha: CGFloat) -> UIColor {
+        UIColor { trait in
+            if trait.userInterfaceStyle == .light {
+                return UIColor(red: 10.0 / 255.0, green: 15.0 / 255.0, blue: 31.0 / 255.0, alpha: alpha)
+            }
+            return UIColor(white: 1.0, alpha: alpha)
+        }
+    }
 }
 
 /// App-wide spacing constants. The 4px grid (`sp1`...`sp10`) is the underlying

--- a/SnoozePay/SnoozePay/Utilities/AppShadow.swift
+++ b/SnoozePay/SnoozePay/Utilities/AppShadow.swift
@@ -1,0 +1,64 @@
+import UIKit
+
+/// Shadow recipes from `tokens.css` (`--sp-shadow-1` / `--sp-shadow-2`). The
+/// dark variant is a single drop shadow; the light variant is a two-stop
+/// drop shadow (`0 1px 3px / 0 4px 14px rgba(8,14,30,.06)`) that fakes the
+/// ambient + key light a flat single shadow can't reproduce. CALayer renders
+/// one stop natively, so we use the wider stop for visibility on light
+/// surfaces. Apply via `apply(to: layer)` from `traitCollectionDidChange`
+/// so the shadow re-resolves on theme switch.
+struct AppShadow {
+    let color: UIColor
+    let opacity: Float
+    let offset: CGSize
+    let radius: CGFloat
+
+    /// Default card shadow. Dark `0 2px 8px rgba(0,0,0,.35)`. Light is the
+    /// dominant stop of `0 1px 3px / 0 4px 14px rgba(8,14,30,.06)` — we use
+    /// the wider 14pt radius for legibility on near-white surfaces.
+    static func shadow1(for trait: UITraitCollection) -> AppShadow {
+        if trait.userInterfaceStyle == .light {
+            return AppShadow(
+                color: UIColor(red: 8.0 / 255.0, green: 14.0 / 255.0, blue: 30.0 / 255.0, alpha: 1.0),
+                opacity: 0.06,
+                offset: CGSize(width: 0, height: 4),
+                radius: 14
+            )
+        }
+        return AppShadow(
+            color: .black,
+            opacity: 0.35,
+            offset: CGSize(width: 0, height: 2),
+            radius: 8
+        )
+    }
+
+    /// Stronger card shadow — modal sheets, hero panels.
+    /// Dark `0 8px 24px rgba(0,0,0,.45)`, Light `0 6px 20px rgba(8,14,30,.10)`.
+    static func shadow2(for trait: UITraitCollection) -> AppShadow {
+        if trait.userInterfaceStyle == .light {
+            return AppShadow(
+                color: UIColor(red: 8.0 / 255.0, green: 14.0 / 255.0, blue: 30.0 / 255.0, alpha: 1.0),
+                opacity: 0.10,
+                offset: CGSize(width: 0, height: 6),
+                radius: 20
+            )
+        }
+        return AppShadow(
+            color: .black,
+            opacity: 0.45,
+            offset: CGSize(width: 0, height: 8),
+            radius: 24
+        )
+    }
+
+    /// Apply this shadow recipe to a `CALayer`. Caller must ensure
+    /// `masksToBounds = false` and (ideally) provide a `shadowPath` so the
+    /// rasterised shadow doesn't pay the offscreen pass cost.
+    func apply(to layer: CALayer) {
+        layer.shadowColor = color.cgColor
+        layer.shadowOpacity = opacity
+        layer.shadowOffset = offset
+        layer.shadowRadius = radius
+    }
+}

--- a/SnoozePay/SnoozePay/Utilities/UIView+CardStyle.swift
+++ b/SnoozePay/SnoozePay/Utilities/UIView+CardStyle.swift
@@ -22,23 +22,34 @@ extension UIView {
         backgroundColor = AppColors.surface
         layer.cornerRadius = cornerRadius
         layer.masksToBounds = false
-        // Drop shadow lifts the card off the background. Light values keep it
-        // subtle so we don't read as elevated above accent banners.
-        layer.shadowColor = UIColor.black.cgColor
-        layer.shadowOpacity = 0.06
-        layer.shadowRadius = 4
-        layer.shadowOffset = CGSize(width: 0, height: 1)
-        // Hairline border reinforces the edge in light mode (UIColor.separator
-        // is fully opaque grey in light, very faint in dark — auto-adapts).
-        layer.borderWidth = 0.5
-        layer.borderColor = UIColor.separator.cgColor
+        // Brand `shadow1` is theme-aware: dark mode gets a single deep stop
+        // (`rgba(0,0,0,.35)`); light mode gets a wider, softer stop pulled
+        // from the two-stop `0 1px 3px / 0 4px 14px` recipe in `tokens.css`
+        // so cards lift cleanly off the near-white surface instead of
+        // reading as a flat slab.
+        AppShadow.shadow1(for: traitCollection).apply(to: layer)
+        // Hairline border reinforces the edge — `stroke1` is theme-aware
+        // (8% white on dark, 8% near-black ink on light), so the border has
+        // visible weight in light mode where the system's grey separator
+        // washes out against the brand ink.
+        // Hairline width — `traitCollection.displayScale` resolves to the
+        // current screen's scale (1×, 2× or 3×). Falls back to 1× if the
+        // view isn't yet in a window (`displayScale == 0`).
+        let scale = traitCollection.displayScale > 0 ? traitCollection.displayScale : 1
+        layer.borderWidth = 1.0 / scale
+        layer.borderColor = AppColors.stroke1.resolvedColor(with: traitCollection).cgColor
     }
 
-    /// Refresh the cached `cgColor` border with the current trait collection so
-    /// dynamic colours re-resolve after a light/dark switch. Call from
-    /// `traitCollectionDidChange` or via `registerForTraitChanges` on iOS 17+.
+    /// Refresh the cached `cgColor` border + shadow with the current trait
+    /// collection so dynamic colours re-resolve after a light/dark switch.
+    /// Call from `traitCollectionDidChange` or via `registerForTraitChanges`
+    /// on iOS 17+.
     func refreshCardBorderForTraitChange() {
-        layer.borderColor = UIColor.separator.resolvedColor(with: traitCollection).cgColor
+        layer.borderColor = AppColors.stroke1.resolvedColor(with: traitCollection).cgColor
+        // Re-resolve the shadow recipe — dark and light use different
+        // colours, opacities, offsets and radii (single-stop deep shadow vs
+        // wider soft shadow), so it isn't enough to just refresh `cgColor`.
+        AppShadow.shadow1(for: traitCollection).apply(to: layer)
     }
 
     /// Pre-rasterise the shadow against the rounded card frame so scrolling
@@ -146,11 +157,10 @@ extension UITableViewCell {
 
         // Drop shadow only on the rows that paint the section's outer top or
         // bottom — middle rows would otherwise overlap into neighbours.
+        // Re-uses the theme-aware brand `shadow1` so the row lift matches
+        // free-standing CardViews on the same screen.
         if position != .middle {
-            surface.layer.shadowColor = UIColor.black.cgColor
-            surface.layer.shadowOpacity = 0.05
-            surface.layer.shadowRadius = 4
-            surface.layer.shadowOffset = CGSize(width: 0, height: 1)
+            AppShadow.shadow1(for: traitCollection).apply(to: surface.layer)
         }
 
         backgroundView = surface

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
@@ -169,6 +169,12 @@ class AlarmFiringViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        // Per `tokens.css` lines 109–112: the firing screen is intentionally
+        // exempt from the brand light theme. The decorative purple gradient
+        // circles, blurred lock-screen-style backdrop and the white-on-dark
+        // numerals are designed against `--sp-grad-night`, so we pin
+        // `.dark` here rather than letting the system theme bleed through.
+        overrideUserInterfaceStyle = .dark
         setupUI()
         bindViewModel()
         observeAudioState()


### PR DESCRIPTION
Fixes #136

## What

Surface, foreground, overlay, stroke and shadow tokens for the brand theme — both light and dark variants exposed through a single dynamic-provider API.

- **`AppColors.bg0`...`bg4`** — five-step elevation per `tokens.css`. Dark `#060912 → #2A3354`, Light `#F4F6FB → #C9D0E3`.
- **`AppColors.fg1`...`fg4`** — primary → disabled scale. Dark tints `#EBEDF5` (or pure white for `fg1`); light tints brand near-black ink `#0A0F1F` at `1.0 / 0.82 / 0.56 / 0.32` alpha.
- **`AppColors.whiteOverlay04/06/08/12/16/24`** — alpha overlays. White on dark, near-black ink on light.
- **`AppColors.stroke1` / `stroke2` / `strokeMoney` / `strokePain`** — theme-aware hairlines.
- **`AppColors.fgOnMoney / fgOnPain / fgOnWarn`** — text-on-fill helpers.
- **`AppShadow.shadow1 / shadow2`** — single-stop drop-shadow descriptors that re-resolve from a `UITraitCollection`. Light mode picks the dominant stop of the two-stop CSS shadow because `CALayer` only renders one stop natively.
- **`AlarmFiringViewController`** sets `overrideUserInterfaceStyle = .dark` in `viewDidLoad` per `tokens.css` lines 109–112 (firing screen pinned to night palette).
- **`UIView+CardStyle` / `CardView` / `styleAsCardRow`** now reach for `AppColors.stroke1` + `AppShadow.shadow1`, and the trait-change handler refreshes both border `cgColor` and shadow recipe so a light/dark switch updates the full card decoration in one pass.

No existing call sites are migrated to `bg0…bg4` / `fg1…fg4` — per the issue, that's later issues' job. Existing screens still resolve through the legacy `surface` / `textPrimary` aliases.

## Verify

- swiftlint: 0 errors (warnings unchanged from base — all pre-existing identifier_name on AppSpacing/AppRadius and the AlarmFiringViewController file_length warning).
- build_sim: succeeded (iPhone 17, iOS 26.2).
- test_sim: skipped per memory `feedback_test_gate_disabled.md`.

## Files

- `SnoozePay/Utilities/AppColors.swift` — new theme-aware token API + private helpers.
- `SnoozePay/Utilities/AppShadow.swift` — new file with `shadow1`/`shadow2` recipes and `apply(to:)`.
- `SnoozePay/Utilities/UIView+CardStyle.swift` — uses new shadow + stroke; `refreshCardBorderForTraitChange` now re-applies shadow too.
- `SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift` — forces dark.