### PR TITLE
[design-refresh] Add SnoozePay design-system primitives (#137)

### DIFF
--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPAmountPreset.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPAmountPreset.swift
@@ -1,0 +1,193 @@
+import UIKit
+
+/// Top-up amount preset tile — `.sp-preset` in `components.css`.
+///
+/// Visual: outlined card (1.5pt `stroke1`) with a centered mono amount
+/// (`moneyMd` 20pt) and an optional secondary label (`meta` 13pt). When
+/// `selected` is true the border switches to `money500`, the fill takes a
+/// 10% money tint, and a 4pt outer glow ring renders. A "Популярно" badge
+/// floats above the top edge when `popular` is true.
+final class SPAmountPreset: UIControl {
+
+    // MARK: - State
+
+    private(set) var value: Decimal
+    private(set) var label: String?
+    private(set) var popular: Bool
+
+    /// Toggling sliding fades the card between idle and selected appearance.
+    /// Setter animates by default; pass `setSelected(_:animated:)` for
+    /// instant toggles.
+    override var isSelected: Bool {
+        didSet { applySelectionState(animated: oldValue != isSelected) }
+    }
+
+    override var isHighlighted: Bool {
+        didSet {
+            UIView.animate(withDuration: SPSupport.durationQuick) {
+                self.transform = self.isHighlighted
+                    ? CGAffineTransform(translationX: 0, y: -1)
+                    : .identity
+            }
+        }
+    }
+
+    var onTap: (() -> Void)?
+
+    // MARK: - Subviews
+
+    private let valueLabel = UILabel()
+    private let labelView = UILabel()
+    private let popularBadge = UILabel()
+    private let stack = UIStackView()
+
+    // MARK: - Init
+
+    /// - Parameters:
+    ///   - value: Top-up amount (rendered with `formattedRubles()`).
+    ///   - label: Optional second line ("Бонус 5%", "Минимум", ...).
+    ///   - selected: Initial selection state.
+    ///   - popular: Show the "Популярно" badge above the top edge.
+    ///   - onTap: Tap callback.
+    init(
+        value: Decimal,
+        label: String? = nil,
+        selected: Bool = false,
+        popular: Bool = false,
+        onTap: (() -> Void)? = nil
+    ) {
+        self.value = value
+        self.label = label
+        self.popular = popular
+        self.onTap = onTap
+        super.init(frame: .zero)
+        configure()
+        update(value: value, label: label)
+        isSelected = selected
+        applySelectionState(animated: false)
+        popularBadge.isHidden = !popular
+        addTarget(self, action: #selector(handleTap), for: .touchUpInside)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Layout
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        layer.cornerRadius = AppRadius.lg     // 16pt — matches sp-r-md
+        // Outer ring is faked via shadow when selected — pre-rasterise the
+        // path so it tracks the rounded corners cleanly.
+        layer.shadowPath = UIBezierPath(
+            roundedRect: bounds,
+            cornerRadius: AppRadius.lg
+        ).cgPath
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        applySelectionState(animated: false)
+    }
+
+    // MARK: - Public API
+
+    func update(value: Decimal, label: String?) {
+        self.value = value
+        self.label = label
+        valueLabel.text = value.formattedRubles()
+        if let label = label {
+            labelView.text = label
+            labelView.isHidden = false
+        } else {
+            labelView.isHidden = true
+        }
+    }
+
+    // MARK: - Configuration
+
+    private func configure() {
+        backgroundColor = AppColors.bg1
+        layer.cornerRadius = AppRadius.lg
+        layer.masksToBounds = false
+        layer.borderWidth = 1.5
+
+        valueLabel.translatesAutoresizingMaskIntoConstraints = false
+        valueLabel.font = AppTypography.moneyMd
+        valueLabel.textColor = AppColors.fg1
+        valueLabel.textAlignment = .center
+
+        labelView.translatesAutoresizingMaskIntoConstraints = false
+        labelView.font = AppTypography.meta
+        labelView.textColor = AppColors.fg3
+        labelView.textAlignment = .center
+
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .vertical
+        stack.alignment = .center
+        stack.spacing = 4
+        stack.isUserInteractionEnabled = false
+        stack.addArrangedSubview(valueLabel)
+        stack.addArrangedSubview(labelView)
+        addSubview(stack)
+
+        // Popular badge — small caps pill that floats above the top edge.
+        popularBadge.translatesAutoresizingMaskIntoConstraints = false
+        popularBadge.attributedText = NSAttributedString(
+            string: "ПОПУЛЯРНО",
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: 12 * 0.12,
+                .foregroundColor: AppColors.fgOnMoney
+            ]
+        )
+        popularBadge.backgroundColor = AppColors.money500
+        popularBadge.layer.cornerRadius = 10
+        popularBadge.layer.masksToBounds = true
+        popularBadge.textAlignment = .center
+        addSubview(popularBadge)
+
+        NSLayoutConstraint.activate([
+            heightAnchor.constraint(greaterThanOrEqualToConstant: 88),
+            stack.topAnchor.constraint(equalTo: topAnchor, constant: 18),
+            stack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -18),
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
+
+            popularBadge.centerXAnchor.constraint(equalTo: centerXAnchor),
+            popularBadge.centerYAnchor.constraint(equalTo: topAnchor),
+            popularBadge.heightAnchor.constraint(equalToConstant: 20),
+            popularBadge.widthAnchor.constraint(greaterThanOrEqualToConstant: 86)
+        ])
+    }
+
+    private func applySelectionState(animated: Bool) {
+        let apply: () -> Void = {
+            if self.isSelected {
+                self.backgroundColor = AppColors.money500.withAlphaComponent(0.10)
+                self.layer.borderColor = AppColors.money500.cgColor
+                // Outer 4pt glow recipe: spread shadow at the brand colour.
+                self.layer.shadowColor = AppColors.money500.cgColor
+                self.layer.shadowOpacity = 0.18
+                self.layer.shadowOffset = .zero
+                self.layer.shadowRadius = 8
+            } else {
+                self.backgroundColor = AppColors.bg1
+                self.layer.borderColor = AppColors.stroke1
+                    .resolvedColor(with: self.traitCollection).cgColor
+                self.layer.shadowOpacity = 0
+            }
+        }
+        if animated {
+            UIView.animate(withDuration: SPSupport.durationQuick, animations: apply)
+        } else {
+            apply()
+        }
+    }
+
+    @objc
+    private func handleTap() {
+        onTap?()
+    }
+}

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPBalanceCard.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPBalanceCard.swift
@@ -1,0 +1,264 @@
+import UIKit
+
+/// Hero balance card — `.sp-balance` in `components.css`.
+///
+/// Visual: 28pt vertical / 24pt horizontal padding, `bg2` fill with a soft
+/// money-tinted radial highlight in the top-right corner. Caps "Баланс"
+/// header sits on top of the big mono number; optional weekly delta
+/// (`↑/↓ amount за неделю`) and hint line stack underneath.
+///
+/// The big number ideally renders with the money gradient mask (CSS uses
+/// `-webkit-background-clip: text`); CoreText doesn't expose a direct
+/// equivalent so we mask a `CAGradientLayer` with the rendered glyph
+/// outlines on layout to get the same effect.
+final class SPBalanceCard: UIView {
+
+    // MARK: - Subviews
+
+    private let capsLabel = UILabel()
+    private let valueLabel = UILabel()
+    private let valueGradient = CAGradientLayer()
+    private let deltaLabel = UILabel()
+    private let hintLabel = UILabel()
+    private let radialOverlay = RadialOverlayView()
+
+    // MARK: - State
+
+    private(set) var balance: Decimal
+    private(set) var delta: Decimal?
+    private(set) var hint: String?
+
+    // MARK: - Init
+
+    /// - Parameters:
+    ///   - balance: Current balance — formatted as integer roubles
+    ///     ("12 345 ₽") via `Decimal.formattedRubles()` below.
+    ///   - delta: Optional weekly net change. Positive values render with
+    ///     the up arrow + money tint; negative with the down arrow + pain
+    ///     tint. `nil` hides the row.
+    ///   - hint: Optional secondary line (`meta` 13pt). Used for context
+    ///     such as "обновлено 2 ч назад" or "ближайшее списание завтра".
+    init(balance: Decimal, delta: Decimal? = nil, hint: String? = nil) {
+        self.balance = balance
+        self.delta = delta
+        self.hint = hint
+        super.init(frame: .zero)
+        configure()
+        update(balance: balance, delta: delta, hint: hint)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Layout
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        layer.cornerRadius = AppRadius.xl
+        radialOverlay.layer.cornerRadius = AppRadius.xl
+        radialOverlay.frame = bounds
+        // Re-mask the gradient with the freshly laid-out glyph rect so the
+        // gradient still tracks the digit baseline after font metrics
+        // resolve.
+        applyValueGradient()
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        radialOverlay.setNeedsDisplay()
+    }
+
+    // MARK: - Public API
+
+    /// Update card data in-place. Cheaper than rebuilding the view when the
+    /// balance updates — the same labels are reused so the gradient mask
+    /// re-rasterises only when the layout cycle invalidates.
+    func update(balance: Decimal, delta: Decimal? = nil, hint: String? = nil) {
+        self.balance = balance
+        self.delta = delta
+        self.hint = hint
+        valueLabel.text = balance.formattedRubles()
+        if let delta = delta {
+            deltaLabel.isHidden = false
+            deltaLabel.attributedText = renderDelta(delta)
+        } else {
+            deltaLabel.isHidden = true
+        }
+        if let hint = hint {
+            hintLabel.text = hint
+            hintLabel.isHidden = false
+        } else {
+            hintLabel.isHidden = true
+        }
+        setNeedsLayout()
+    }
+
+    // MARK: - Configuration
+
+    private func configure() {
+        backgroundColor = AppColors.bg2
+        layer.cornerRadius = AppRadius.xl
+        layer.masksToBounds = true   // radial overlay clips inside corners
+
+        radialOverlay.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(radialOverlay)
+
+        capsLabel.translatesAutoresizingMaskIntoConstraints = false
+        capsLabel.attributedText = NSAttributedString(
+            string: "БАЛАНС",
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: 12 * 0.12,
+                .foregroundColor: AppColors.fg3
+            ]
+        )
+
+        valueLabel.translatesAutoresizingMaskIntoConstraints = false
+        valueLabel.font = AppTypography.moneyLg
+        // Set a neutral text colour as a safety net — `applyValueGradient`
+        // promotes this to a gradient mask once layout resolves.
+        valueLabel.textColor = AppColors.fg1
+        valueLabel.adjustsFontForContentSizeCategory = false
+
+        deltaLabel.translatesAutoresizingMaskIntoConstraints = false
+        deltaLabel.font = AppTypography.moneySm
+
+        hintLabel.translatesAutoresizingMaskIntoConstraints = false
+        hintLabel.font = AppTypography.meta
+        hintLabel.textColor = AppColors.fg3
+
+        let stack = UIStackView(arrangedSubviews: [
+            capsLabel, valueLabel, deltaLabel, hintLabel
+        ])
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .vertical
+        stack.spacing = 4
+        stack.setCustomSpacing(8, after: capsLabel)
+        stack.setCustomSpacing(14, after: deltaLabel)
+        addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: topAnchor, constant: 28),
+            stack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -28),
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -24)
+        ])
+
+        // Add the gradient layer above the label so the mask can clip it.
+        valueGradient.colors = SPSupport.moneyGradientColors
+        valueGradient.locations = SPSupport.moneyGradientLocations
+        valueGradient.startPoint = SPSupport.gradientStart
+        valueGradient.endPoint = SPSupport.gradientEnd
+    }
+
+    private func applyValueGradient() {
+        // Position the gradient over the label and mask it to the rendered
+        // text — this is the CALayer equivalent of CSS's
+        // `-webkit-background-clip: text`. We add the gradient as a
+        // sublayer of the label's layer rather than rasterising into the
+        // label so size / theme switches refresh cheaply.
+        let textBounds = valueLabel.bounds
+        guard textBounds.width > 0, textBounds.height > 0 else { return }
+        if valueGradient.superlayer !== valueLabel.layer {
+            valueLabel.layer.addSublayer(valueGradient)
+        }
+        valueGradient.frame = textBounds
+
+        // Mask the gradient to the text shape — re-render every layout pass
+        // so font / weight / size changes refresh.
+        let renderer = UIGraphicsImageRenderer(size: textBounds.size)
+        let mask = renderer.image { ctx in
+            ctx.cgContext.setFillColor(UIColor.white.cgColor)
+            (valueLabel.text ?? "").draw(
+                in: textBounds,
+                withAttributes: [
+                    .font: valueLabel.font as Any,
+                    .foregroundColor: UIColor.white
+                ]
+            )
+        }
+        let maskLayer = CALayer()
+        maskLayer.frame = textBounds
+        maskLayer.contents = mask.cgImage
+        valueGradient.mask = maskLayer
+        // Hide the underlying label colour so we don't double-stack glyph
+        // outlines (label paints fg1, gradient paints money tones).
+        valueLabel.textColor = .clear
+    }
+
+    private func renderDelta(_ delta: Decimal) -> NSAttributedString {
+        let arrow = delta < 0 ? "↓" : "↑"
+        let abs = NSDecimalNumber(decimal: delta < 0 ? -delta : delta).decimalValue
+        let str = "\(arrow) \(abs.formattedRubles()) за неделю"
+        let color = delta < 0 ? AppColors.pain400 : AppColors.money400
+        return NSAttributedString(
+            string: str,
+            attributes: [
+                .font: AppTypography.moneySm,
+                .foregroundColor: color
+            ]
+        )
+    }
+}
+
+// MARK: - Radial overlay
+
+/// Internal helper view that paints the brand radial highlight behind the
+/// balance card. CSS uses `radial-gradient(80% 60% at 100% 0%, rgba(46,219,159,.18))`
+/// — CoreGraphics doesn't have a one-liner so we draw it in `draw(_:)`.
+private final class RadialOverlayView: UIView {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .clear
+        isUserInteractionEnabled = false
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func draw(_ rect: CGRect) {
+        guard let context = UIGraphicsGetCurrentContext() else { return }
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let colors = [
+            AppColors.money400.withAlphaComponent(0.18).cgColor,
+            UIColor.clear.cgColor
+        ]
+        guard let gradient = CGGradient(
+            colorsSpace: colorSpace,
+            colors: colors as CFArray,
+            locations: [0.0, 1.0]
+        ) else { return }
+        // 80% wide × 60% tall radial centred at top-right corner.
+        let centerPoint = CGPoint(x: rect.maxX, y: rect.minY)
+        let radius = max(rect.width, rect.height) * 0.6
+        context.drawRadialGradient(
+            gradient,
+            startCenter: centerPoint,
+            startRadius: 0,
+            endCenter: centerPoint,
+            endRadius: radius,
+            options: []
+        )
+    }
+}
+
+// MARK: - Decimal formatting
+
+extension Decimal {
+    /// Format as integer roubles using the locale-aware `ru-RU` thousands
+    /// separator and a trailing `₽` glyph, e.g. `1 234 ₽`. Truncates the
+    /// fractional component — the design system never shows kopecks on the
+    /// balance card.
+    func formattedRubles() -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.locale = Locale(identifier: "ru_RU")
+        formatter.maximumFractionDigits = 0
+        formatter.roundingMode = .down
+        let number = NSDecimalNumber(decimal: self)
+        let text = formatter.string(from: number) ?? "\(number.intValue)"
+        return "\(text) ₽"
+    }
+}

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPButton.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPButton.swift
@@ -1,0 +1,314 @@
+import UIKit
+
+/// Branded button primitive matching the `.sp-btn` recipe in
+/// `docs/design/snoozepay-2026-04-27/project/components/components.css`.
+///
+/// Three axes:
+/// - `Variant`: visual chrome (gradient fills for money/pain/warn,
+///   stroked-transparent for ghost, faint overlay for quiet).
+/// - `Size`: 56pt / 48pt / 36pt heights with matching typography ramps.
+/// - Optional `icon` (left) and `suffix` (right, mono-font) decorations.
+///
+/// All gradient variants install a `CAGradientLayer` at the bottom of the
+/// view's layer tree and refresh it on layout / trait changes — `tintColor`
+/// alone can't reproduce the 3-stop diagonal sweep the design calls for.
+final class SPButton: UIControl {
+
+    // MARK: - Variants
+
+    enum Variant {
+        case money   // Primary CTA — money gradient + fgOnMoney text.
+        case pain    // Stop / delete / progressive snooze — pain gradient.
+        case warn    // Default snooze — warn gradient.
+        case ghost   // Transparent fill, stroke2 border.
+        case quiet   // No chrome, faint overlay fill.
+    }
+
+    // Short cases mirror the JSX spec (`size="lg"`/`"md"`/`"sm"`) and the
+    // `--sp-btn--{lg,md,sm}` CSS modifiers — keeping the names here makes
+    // grep across CSS / JSX / Swift trivial.
+    // swiftlint:disable identifier_name
+    enum Size {
+        case lg   // 56pt — primary CTA
+        case md   // 48pt — secondary actions
+        case sm   // 36pt — chips / inline buttons
+        // swiftlint:enable identifier_name
+
+        var height: CGFloat {
+            switch self {
+            case .lg: return 56
+            case .md: return 48
+            case .sm: return 36
+            }
+        }
+
+        var horizontalPadding: CGFloat {
+            switch self {
+            case .lg, .md: return AppSpacing.sp6   // 24pt
+            case .sm:      return 14
+            }
+        }
+
+        var labelFont: UIFont {
+            switch self {
+            case .lg: return AppFonts.sans(.bold, 17)
+            case .md: return AppTypography.button
+            case .sm: return AppTypography.buttonSm
+            }
+        }
+
+        var cornerRadius: CGFloat {
+            switch self {
+            case .lg: return AppRadius.lg          // 16pt — matches sp-r-md
+            case .md: return AppRadius.lg
+            case .sm: return AppRadius.md          // 12pt — matches sp-r-sm
+            }
+        }
+
+        var iconSize: CGFloat {
+            switch self {
+            case .lg: return 20
+            case .md: return 18
+            case .sm: return 16
+            }
+        }
+    }
+
+    // MARK: - Configuration
+
+    let variant: Variant
+    let size: Size
+
+    // MARK: - State
+
+    /// Override `isEnabled` to refresh visual state — UIControl's default
+    /// implementation only flips a property, not the rendered appearance.
+    override var isEnabled: Bool {
+        didSet { refreshDisabledAppearance() }
+    }
+
+    override var isHighlighted: Bool {
+        didSet { SPSupport.animatePress(self, pressed: isHighlighted) }
+    }
+
+    /// `false` by default — caller sizes the button explicitly. When `true`
+    /// the button stretches to match its superview width via the trailing
+    /// constraint installed by the parent.
+    var isFullWidth: Bool = false {
+        didSet { invalidateIntrinsicContentSize() }
+    }
+
+    // MARK: - Subviews
+
+    private let stack = UIStackView()
+    private let iconView = UIImageView()
+    private let titleLabel = UILabel()
+    private let suffixLabel = UILabel()
+    private var gradientLayer: CAGradientLayer?
+
+    // MARK: - Init
+
+    /// - Parameters:
+    ///   - title: Button label.
+    ///   - variant: Visual chrome.
+    ///   - size: Vertical scale. Defaults to `.lg`.
+    ///   - icon: Optional leading image (rendered as template, tinted to
+    ///     match the label colour).
+    ///   - suffix: Optional trailing mono-font string (used for amounts,
+    ///     e.g. "−50 ₽" suffixes on quick-pay buttons).
+    ///   - fullWidth: When `true`, intrinsic width returns `noIntrinsicMetric`
+    ///     so the caller can pin the button to its superview's width.
+    init(
+        title: String,
+        variant: Variant = .money,
+        size: Size = .lg,
+        icon: UIImage? = nil,
+        suffix: String? = nil,
+        fullWidth: Bool = false
+    ) {
+        self.variant = variant
+        self.size = size
+        self.isFullWidth = fullWidth
+        super.init(frame: .zero)
+        configureLayout()
+        titleLabel.text = title
+        if let icon = icon {
+            iconView.image = icon.withRenderingMode(.alwaysTemplate)
+            iconView.isHidden = false
+        } else {
+            iconView.isHidden = true
+        }
+        if let suffix = suffix {
+            suffixLabel.text = suffix
+            suffixLabel.isHidden = false
+        } else {
+            suffixLabel.isHidden = true
+        }
+        applyVariant()
+        refreshDisabledAppearance()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Layout
+
+    override var intrinsicContentSize: CGSize {
+        // Honour `isFullWidth` by returning .noIntrinsicMetric for the width
+        // axis — caller pins to superview / stack so the button stretches.
+        let height = size.height
+        if isFullWidth {
+            return CGSize(width: UIView.noIntrinsicMetric, height: height)
+        }
+        let stackSize = stack.systemLayoutSizeFitting(
+            UIView.layoutFittingCompressedSize
+        )
+        return CGSize(
+            width: stackSize.width + size.horizontalPadding * 2,
+            height: height
+        )
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        gradientLayer?.frame = bounds
+        layer.shadowPath = UIBezierPath(
+            roundedRect: bounds,
+            cornerRadius: size.cornerRadius
+        ).cgPath
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        applyVariant()
+    }
+
+    // MARK: - Configuration internals
+
+    private func configureLayout() {
+        layer.cornerRadius = size.cornerRadius
+        layer.masksToBounds = false
+
+        iconView.translatesAutoresizingMaskIntoConstraints = false
+        iconView.contentMode = .scaleAspectFit
+        iconView.setContentHuggingPriority(.required, for: .horizontal)
+
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.font = size.labelFont
+        titleLabel.textAlignment = .center
+        titleLabel.adjustsFontForContentSizeCategory = false
+
+        suffixLabel.translatesAutoresizingMaskIntoConstraints = false
+        // Mono font for trailing amount suffixes — matches CSS recipe
+        // `font-family: var(--sp-font-mono); opacity: .85`.
+        suffixLabel.font = size == .sm ? AppTypography.moneySm : AppTypography.moneyMd
+        suffixLabel.textAlignment = .right
+        suffixLabel.alpha = 0.85
+        suffixLabel.setContentHuggingPriority(.required, for: .horizontal)
+
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .horizontal
+        stack.spacing = AppSpacing.sp2     // 8pt — matches `gap: 8px`
+        stack.alignment = .center
+        stack.isUserInteractionEnabled = false
+        stack.addArrangedSubview(iconView)
+        stack.addArrangedSubview(titleLabel)
+        stack.addArrangedSubview(suffixLabel)
+        addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            heightAnchor.constraint(equalToConstant: size.height),
+            stack.centerYAnchor.constraint(equalTo: centerYAnchor),
+            stack.leadingAnchor.constraint(
+                greaterThanOrEqualTo: leadingAnchor,
+                constant: size.horizontalPadding
+            ),
+            stack.trailingAnchor.constraint(
+                lessThanOrEqualTo: trailingAnchor,
+                constant: -size.horizontalPadding
+            ),
+            stack.centerXAnchor.constraint(equalTo: centerXAnchor),
+            iconView.widthAnchor.constraint(equalToConstant: size.iconSize),
+            iconView.heightAnchor.constraint(equalToConstant: size.iconSize)
+        ])
+    }
+
+    private func applyVariant() {
+        gradientLayer?.removeFromSuperlayer()
+        gradientLayer = nil
+        layer.borderWidth = 0
+        layer.shadowOpacity = 0
+
+        switch variant {
+        case .money:
+            installGradient(
+                colors: SPSupport.moneyGradientColors,
+                locations: SPSupport.moneyGradientLocations
+            )
+            applyColoredShadow(color: AppColors.money500)
+            setForeground(AppColors.fgOnMoney)
+        case .pain:
+            installGradient(
+                colors: SPSupport.painGradientColors,
+                locations: SPSupport.painGradientLocations
+            )
+            applyColoredShadow(color: AppColors.pain500)
+            setForeground(AppColors.fgOnPain)
+        case .warn:
+            installGradient(
+                colors: SPSupport.warnGradientColors,
+                locations: SPSupport.warnGradientLocations
+            )
+            applyColoredShadow(color: AppColors.warn500)
+            setForeground(AppColors.fgOnWarn)
+        case .ghost:
+            backgroundColor = .clear
+            let scale = traitCollection.displayScale > 0 ? traitCollection.displayScale : 1
+            layer.borderWidth = 1.0 / scale
+            layer.borderColor = AppColors.stroke2.resolvedColor(with: traitCollection).cgColor
+            setForeground(AppColors.fg1)
+        case .quiet:
+            backgroundColor = AppColors.whiteOverlay06
+            setForeground(AppColors.fg1)
+        }
+    }
+
+    private func installGradient(colors: [CGColor], locations: [NSNumber]) {
+        let gradient = CAGradientLayer()
+        gradient.colors = colors
+        gradient.locations = locations
+        gradient.startPoint = SPSupport.gradientStart
+        gradient.endPoint = SPSupport.gradientEnd
+        gradient.cornerRadius = size.cornerRadius
+        layer.insertSublayer(gradient, at: 0)
+        gradientLayer = gradient
+        backgroundColor = .clear
+    }
+
+    private func applyColoredShadow(color: UIColor) {
+        layer.shadowColor = color.cgColor
+        layer.shadowOpacity = traitCollection.userInterfaceStyle == .light ? 0.30 : 0.40
+        layer.shadowOffset = CGSize(width: 0, height: 8)
+        layer.shadowRadius = 16
+    }
+
+    private func setForeground(_ color: UIColor) {
+        titleLabel.textColor = color
+        suffixLabel.textColor = color
+        iconView.tintColor = color
+    }
+
+    private func refreshDisabledAppearance() {
+        // CSS recipe `is-disabled { opacity: .35; box-shadow: none;
+        // filter: grayscale(.5); }` — we drop the shadow + alpha; the
+        // grayscale hint is too expensive on a CALayer for the tiny visual
+        // win, so we instead darken via reduced alpha which reads similarly.
+        alpha = isEnabled ? 1.0 : 0.35
+        if !isEnabled {
+            layer.shadowOpacity = 0
+        } else {
+            applyVariant()
+        }
+    }
+}

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPCard.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPCard.swift
@@ -1,0 +1,228 @@
+import UIKit
+
+/// Standalone card surface for the SnoozePay design system.
+///
+/// Replaces `CardView` long-term. The legacy `applyCardStyle()` extension on
+/// `UIView` and the standalone `CardView` class continue to work as thin
+/// wrappers around the same recipe so the 30+ existing call sites (Settings,
+/// Statistics, CreateAlarm, TopUp, ...) keep compiling. New screens reach for
+/// `SPCard(tone:)` directly.
+///
+/// Tones map onto the `.sp-card--*` modifiers in
+/// `docs/design/snoozepay-2026-04-27/project/components/components.css`.
+final class SPCard: UIView {
+
+    // MARK: - Tone
+
+    /// Visual style of the card.
+    /// - `.surface`: default — `bg1` fill, hairline stroke, soft shadow. In
+    ///   light mode the stroke + shadow are required for visibility per
+    ///   `feedback_design_system_consistency.md`.
+    /// - `.raised`: stronger surface (`bg2`) for sheets / hero panels.
+    /// - `.outline`: transparent fill, 1px `stroke2` border, no shadow.
+    /// - `.money` / `.pain` / `.warn`: brand-gradient fills with matching
+    ///   coloured shadow recipes.
+    enum Tone {
+        case surface
+        case raised
+        case outline
+        case money
+        case pain
+        case warn
+    }
+
+    // MARK: - Configuration
+
+    let tone: Tone
+    let cardCornerRadius: CGFloat
+    /// Inset applied uniformly on all four sides via `layoutMargins`. Subviews
+    /// constrained to `layoutMarginsGuide` automatically pick up the padding.
+    let cardPadding: CGFloat
+
+    // MARK: - Internal layers
+
+    /// Optional gradient layer for `.money`/`.pain`/`.warn` tones — added as a
+    /// sublayer at zero index so subviews stack above it. Nil for non-gradient
+    /// tones to keep the layer tree shallow.
+    private var gradientLayer: CAGradientLayer?
+
+    // MARK: - Init
+
+    /// - Parameters:
+    ///   - tone: Visual style. Defaults to `.surface`.
+    ///   - padding: Uniform inset for `layoutMarginsGuide`. Defaults to 20pt
+    ///     (matching the JSX spec `padding = 20`).
+    ///   - cornerRadius: Corner radius. Defaults to `AppRadius.lg` (20pt) —
+    ///     larger than the legacy 12pt `AppRadius.md` so SPCards read as a
+    ///     visibly different primitive from `applyCardStyle()` cards.
+    init(
+        tone: Tone = .surface,
+        padding: CGFloat = AppSpacing.sp5,
+        cornerRadius: CGFloat = 20
+    ) {
+        self.tone = tone
+        self.cardPadding = padding
+        self.cardCornerRadius = cornerRadius
+        super.init(frame: .zero)
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Layout
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        gradientLayer?.frame = bounds
+        // Pre-rasterise the shadow so the card doesn't pay the per-pixel
+        // offscreen pass during scrolling.
+        if needsShadow {
+            layer.shadowPath = UIBezierPath(
+                roundedRect: bounds,
+                cornerRadius: cardCornerRadius
+            ).cgPath
+        }
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        // CALayer's `cgColor` properties don't auto-resolve dynamic UIColors,
+        // so refresh the border + shadow whenever the trait collection flips.
+        refreshDynamicColors()
+    }
+
+    // MARK: - Configuration internals
+
+    private var needsShadow: Bool {
+        switch tone {
+        case .surface, .raised, .money, .pain, .warn: return true
+        case .outline: return false
+        }
+    }
+
+    private func configure() {
+        layer.cornerRadius = cardCornerRadius
+        layer.masksToBounds = false
+        layoutMargins = UIEdgeInsets(
+            top: cardPadding, left: cardPadding,
+            bottom: cardPadding, right: cardPadding
+        )
+        applyTone()
+    }
+
+    private func applyTone() {
+        // Reset every property each call so re-applying after a token swap
+        // can't leave stale state behind.
+        gradientLayer?.removeFromSuperlayer()
+        gradientLayer = nil
+        layer.borderWidth = 0
+        layer.shadowOpacity = 0
+
+        switch tone {
+        case .surface:
+            backgroundColor = AppColors.bg1
+            applyHairlineStroke()
+            applyShadow1()
+        case .raised:
+            backgroundColor = AppColors.bg2
+            // No hairline on `.raised` — bg2 has enough contrast against bg0
+            // that a stroke would read as a double-edge in dark mode.
+            applyShadow2()
+        case .outline:
+            backgroundColor = .clear
+            applyOutlineStroke()
+        case .money:
+            backgroundColor = .clear
+            installGradient(
+                colors: SPSupport.moneyGradientColors,
+                locations: SPSupport.moneyGradientLocations
+            )
+            applyColoredShadow(.money)
+        case .pain:
+            backgroundColor = .clear
+            installGradient(
+                colors: SPSupport.painGradientColors,
+                locations: SPSupport.painGradientLocations
+            )
+            applyColoredShadow(.pain)
+        case .warn:
+            backgroundColor = .clear
+            installGradient(
+                colors: SPSupport.warnGradientColors,
+                locations: SPSupport.warnGradientLocations
+            )
+            applyColoredShadow(.warn)
+        }
+    }
+
+    private func applyHairlineStroke() {
+        let scale = traitCollection.displayScale > 0 ? traitCollection.displayScale : 1
+        layer.borderWidth = 1.0 / scale
+        layer.borderColor = AppColors.stroke1.resolvedColor(with: traitCollection).cgColor
+    }
+
+    private func applyOutlineStroke() {
+        let scale = traitCollection.displayScale > 0 ? traitCollection.displayScale : 1
+        layer.borderWidth = 1.0 / scale
+        layer.borderColor = AppColors.stroke2.resolvedColor(with: traitCollection).cgColor
+    }
+
+    private func applyShadow1() {
+        AppShadow.shadow1(for: traitCollection).apply(to: layer)
+    }
+
+    private func applyShadow2() {
+        AppShadow.shadow2(for: traitCollection).apply(to: layer)
+    }
+
+    private func applyColoredShadow(_ kind: ColoredShadow) {
+        // `--sp-shadow-{money,pain,warn}: 0 8px 22px -6px rgba(...,.40)`. The
+        // CSS uses a negative spread we can't replicate on CALayer, so fold
+        // it into a slightly tighter offset + radius pair that still reads
+        // as "this card glows brand-coloured".
+        let color: UIColor
+        switch kind {
+        case .money: color = AppColors.money500
+        case .pain:  color = AppColors.pain500
+        case .warn:  color = AppColors.warn500
+        }
+        layer.shadowColor = color.cgColor
+        layer.shadowOpacity = traitCollection.userInterfaceStyle == .light ? 0.30 : 0.40
+        layer.shadowOffset = CGSize(width: 0, height: 8)
+        layer.shadowRadius = 16
+    }
+
+    private enum ColoredShadow { case money, pain, warn }
+
+    private func installGradient(colors: [CGColor], locations: [NSNumber]) {
+        let gradient = CAGradientLayer()
+        gradient.colors = colors
+        gradient.locations = locations
+        gradient.startPoint = SPSupport.gradientStart
+        gradient.endPoint = SPSupport.gradientEnd
+        gradient.cornerRadius = cardCornerRadius
+        layer.insertSublayer(gradient, at: 0)
+        gradientLayer = gradient
+    }
+
+    private func refreshDynamicColors() {
+        // Re-resolve the same recipe that `applyTone()` first installed.
+        switch tone {
+        case .surface:
+            applyHairlineStroke()
+            applyShadow1()
+        case .raised:
+            applyShadow2()
+        case .outline:
+            applyOutlineStroke()
+        case .money:
+            applyColoredShadow(.money)
+        case .pain:
+            applyColoredShadow(.pain)
+        case .warn:
+            applyColoredShadow(.warn)
+        }
+    }
+}

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPInput.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPInput.swift
@@ -1,0 +1,246 @@
+import UIKit
+
+/// Branded text input wrapper — `.sp-input` in `components.css`.
+///
+/// Layout: optional caps label on top, then a 52pt-tall field with `bg2`
+/// fill, 1.5pt `stroke1` border, 16pt internal padding. Optional trailing
+/// view (icon button, character counter, ...). Hint / error message slot
+/// underneath.
+///
+/// Wraps a vanilla `UITextField` rather than subclassing it — composition
+/// keeps the field free for direct configuration (placeholder, keyboard
+/// type, secure entry, ...) without us hiding behind a delegate proxy.
+final class SPInput: UIView {
+
+    // MARK: - Public surface
+
+    /// The wrapped text field — call sites configure keyboard / secure
+    /// entry / delegate / first-responder behaviour directly on it.
+    let textField = UITextField()
+
+    /// Hint string shown below the field. `nil` hides the hint slot.
+    var hint: String? {
+        get { hintLabel.text }
+        set {
+            hintLabel.text = newValue
+            hintLabel.textColor = AppColors.fg3
+            updateMessageVisibility()
+        }
+    }
+
+    /// Error string. Setting a non-nil value flips the field border to
+    /// `pain500` and tints the message line. Pass `nil` to clear.
+    var error: String? {
+        didSet { applyError() }
+    }
+
+    /// Optional trailing accessory (icon, button, label). Replaces any
+    /// previous trailing view.
+    var trailingView: UIView? {
+        didSet { rebuildTrailing() }
+    }
+
+    /// Closure fired on every text change. Convenience over manual
+    /// `addTarget(_:action:for:.editingChanged)` wiring — caller still has
+    /// the option to set a `UITextFieldDelegate` for finer-grained events.
+    var onChange: ((String) -> Void)?
+
+    // MARK: - Subviews
+
+    private let labelView = UILabel()
+    private let fieldContainer = UIView()
+    private let hintLabel = UILabel()
+    private let trailingContainer = UIView()
+    private var stack: UIStackView!
+
+    // MARK: - Init
+
+    /// - Parameters:
+    ///   - label: Optional caps label above the field.
+    ///   - placeholder: Field placeholder.
+    ///   - text: Initial text.
+    ///   - trailing: Optional trailing accessory view.
+    ///   - hint: Optional helper line.
+    ///   - error: Optional error line — flips field to error state when
+    ///     non-nil.
+    init(
+        label: String? = nil,
+        placeholder: String? = nil,
+        text: String? = nil,
+        trailing: UIView? = nil,
+        hint: String? = nil,
+        error: String? = nil
+    ) {
+        super.init(frame: .zero)
+        configure()
+        if let label = label {
+            labelView.attributedText = NSAttributedString(
+                string: label.uppercased(),
+                attributes: [
+                    .font: AppTypography.caps,
+                    .kern: 12 * 0.12,
+                    .foregroundColor: AppColors.fg3
+                ]
+            )
+            labelView.isHidden = false
+        } else {
+            labelView.isHidden = true
+        }
+        textField.placeholder = placeholder
+        textField.text = text
+        self.trailingView = trailing
+        self.hint = hint
+        self.error = error
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Layout
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        fieldContainer.layer.cornerRadius = AppRadius.lg     // matches sp-r-md
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        applyBorder()
+    }
+
+    // MARK: - First responder forwarding
+
+    override var canBecomeFirstResponder: Bool { textField.canBecomeFirstResponder }
+
+    @discardableResult
+    override func becomeFirstResponder() -> Bool { textField.becomeFirstResponder() }
+
+    @discardableResult
+    override func resignFirstResponder() -> Bool { textField.resignFirstResponder() }
+
+    // MARK: - Configuration
+
+    private func configure() {
+        labelView.translatesAutoresizingMaskIntoConstraints = false
+        labelView.numberOfLines = 1
+
+        fieldContainer.translatesAutoresizingMaskIntoConstraints = false
+        fieldContainer.backgroundColor = AppColors.bg2
+        fieldContainer.layer.cornerRadius = AppRadius.lg
+        fieldContainer.layer.borderWidth = 1.5
+
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        textField.font = AppTypography.bodyLg
+        textField.textColor = AppColors.fg1
+        textField.tintColor = AppColors.money500
+        textField.addTarget(self, action: #selector(handleEditingDidBegin), for: .editingDidBegin)
+        textField.addTarget(self, action: #selector(handleEditingDidEnd), for: .editingDidEnd)
+        textField.addTarget(self, action: #selector(handleEditingChanged), for: .editingChanged)
+
+        trailingContainer.translatesAutoresizingMaskIntoConstraints = false
+
+        let fieldRow = UIStackView(arrangedSubviews: [textField, trailingContainer])
+        fieldRow.translatesAutoresizingMaskIntoConstraints = false
+        fieldRow.axis = .horizontal
+        fieldRow.alignment = .center
+        fieldRow.spacing = AppSpacing.sp2
+        fieldContainer.addSubview(fieldRow)
+
+        hintLabel.translatesAutoresizingMaskIntoConstraints = false
+        hintLabel.font = AppTypography.meta
+        hintLabel.textColor = AppColors.fg3
+        hintLabel.numberOfLines = 0
+        hintLabel.isHidden = true
+
+        stack = UIStackView(arrangedSubviews: [labelView, fieldContainer, hintLabel])
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .vertical
+        stack.alignment = .fill
+        stack.spacing = 6
+        addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: topAnchor),
+            stack.bottomAnchor.constraint(equalTo: bottomAnchor),
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor),
+
+            fieldContainer.heightAnchor.constraint(equalToConstant: 52),
+            fieldRow.topAnchor.constraint(equalTo: fieldContainer.topAnchor),
+            fieldRow.bottomAnchor.constraint(equalTo: fieldContainer.bottomAnchor),
+            fieldRow.leadingAnchor.constraint(equalTo: fieldContainer.leadingAnchor, constant: 16),
+            fieldRow.trailingAnchor.constraint(equalTo: fieldContainer.trailingAnchor, constant: -16)
+        ])
+        applyBorder()
+    }
+
+    private func rebuildTrailing() {
+        trailingContainer.subviews.forEach { $0.removeFromSuperview() }
+        guard let view = trailingView else {
+            trailingContainer.isHidden = true
+            return
+        }
+        trailingContainer.isHidden = false
+        view.translatesAutoresizingMaskIntoConstraints = false
+        trailingContainer.addSubview(view)
+        NSLayoutConstraint.activate([
+            view.topAnchor.constraint(equalTo: trailingContainer.topAnchor),
+            view.bottomAnchor.constraint(equalTo: trailingContainer.bottomAnchor),
+            view.leadingAnchor.constraint(equalTo: trailingContainer.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: trailingContainer.trailingAnchor)
+        ])
+    }
+
+    private func applyBorder() {
+        if error != nil {
+            fieldContainer.layer.borderColor = AppColors.pain500.cgColor
+        } else if textField.isFirstResponder {
+            fieldContainer.layer.borderColor = AppColors.money500.cgColor
+        } else {
+            fieldContainer.layer.borderColor = AppColors.stroke1
+                .resolvedColor(with: traitCollection).cgColor
+        }
+    }
+
+    private func applyError() {
+        if let error = error {
+            hintLabel.text = error
+            hintLabel.textColor = AppColors.pain400
+            hintLabel.isHidden = false
+        } else if let hint = hint, !hint.isEmpty {
+            hintLabel.text = hint
+            hintLabel.textColor = AppColors.fg3
+            hintLabel.isHidden = false
+        } else {
+            hintLabel.isHidden = true
+        }
+        applyBorder()
+    }
+
+    private func updateMessageVisibility() {
+        if error != nil { return }
+        hintLabel.isHidden = (hintLabel.text ?? "").isEmpty
+    }
+
+    // MARK: - Field events
+
+    @objc
+    private func handleEditingDidBegin() {
+        UIView.animate(withDuration: SPSupport.durationQuick) {
+            self.applyBorder()
+        }
+    }
+
+    @objc
+    private func handleEditingDidEnd() {
+        UIView.animate(withDuration: SPSupport.durationQuick) {
+            self.applyBorder()
+        }
+    }
+
+    @objc
+    private func handleEditingChanged() {
+        onChange?(textField.text ?? "")
+    }
+}

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPPill.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPPill.swift
@@ -1,0 +1,137 @@
+import UIKit
+
+/// Compact badge / chip primitive — `.sp-pill` in `components.css`.
+///
+/// Visual: 26pt tall capsule with 12pt horizontal padding, 6pt gap between
+/// optional leading icon and the label. Tones tint both the background fill
+/// (low-alpha brand colour) and the foreground text. Use for status flags
+/// ("Активный", "Популярно", "Списано"), not for tap targets — tap targets
+/// belong on `SPButton(size: .sm)` so they hit the 44pt minimum.
+final class SPPill: UIView {
+
+    enum Tone {
+        case neutral   // White overlay + fg2 text
+        case money     // Money-tint overlay + money300 text
+        case pain      // Pain-tint overlay + pain300 text
+        case warn      // Warn-tint overlay + warn300 text
+    }
+
+    // MARK: - Subviews
+
+    private let stack = UIStackView()
+    private let iconView = UIImageView()
+    private let label = UILabel()
+
+    let tone: Tone
+
+    // MARK: - Init
+
+    /// - Parameters:
+    ///   - text: Caps-styled label (uppercased automatically per the
+    ///     `--sp-t-caps` recipe — bold 12pt + 0.14em tracking).
+    ///   - tone: Background + text colour mapping. Defaults to `.neutral`.
+    ///   - icon: Optional 14pt leading icon (rendered as template, tinted
+    ///     to match the label).
+    init(text: String, tone: Tone = .neutral, icon: UIImage? = nil) {
+        self.tone = tone
+        super.init(frame: .zero)
+        configure()
+        setText(text)
+        setIcon(icon)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Layout
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        // Pill — fully rounded.
+        layer.cornerRadius = bounds.height / 2
+    }
+
+    // MARK: - Configuration
+
+    private func configure() {
+        layer.cornerRadius = 13
+        layer.masksToBounds = true
+
+        iconView.translatesAutoresizingMaskIntoConstraints = false
+        iconView.contentMode = .scaleAspectFit
+
+        label.translatesAutoresizingMaskIntoConstraints = false
+        // `--sp-t-caps: 700 12px/16px Manrope` with letter-spacing .14em.
+        label.font = AppTypography.caps
+        label.adjustsFontForContentSizeCategory = false
+
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .horizontal
+        stack.spacing = AppSpacing.sp1 + 2   // 6pt — matches `gap: 6px`
+        stack.alignment = .center
+        stack.isUserInteractionEnabled = false
+        stack.addArrangedSubview(iconView)
+        stack.addArrangedSubview(label)
+        addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            heightAnchor.constraint(equalToConstant: 26),
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
+            stack.centerYAnchor.constraint(equalTo: centerYAnchor),
+            iconView.widthAnchor.constraint(equalToConstant: 14),
+            iconView.heightAnchor.constraint(equalToConstant: 14)
+        ])
+
+        applyTone()
+    }
+
+    private func setText(_ text: String) {
+        // CSS pairs caps tracking (.14em ≈ 12 * 0.14 = 1.68pt) with the
+        // bold 12pt size; bake that into an attributed string so the label
+        // stays in one node (not a stack of label + spacer).
+        let attributed = NSAttributedString(
+            string: text.uppercased(),
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: 12 * 0.14
+            ]
+        )
+        label.attributedText = attributed
+    }
+
+    private func setIcon(_ icon: UIImage?) {
+        if let icon = icon {
+            iconView.image = icon.withRenderingMode(.alwaysTemplate)
+            iconView.isHidden = false
+        } else {
+            iconView.isHidden = true
+        }
+    }
+
+    private func applyTone() {
+        // swiftlint:disable identifier_name
+        let bg: UIColor
+        let fg: UIColor
+        // swiftlint:enable identifier_name
+        switch tone {
+        case .neutral:
+            bg = AppColors.whiteOverlay08
+            fg = AppColors.fg2
+        case .money:
+            // `rgba(46,219,159,.16)` — money400 at 16% over surface.
+            bg = AppColors.money400.withAlphaComponent(0.16)
+            fg = AppColors.money300
+        case .pain:
+            bg = AppColors.pain500.withAlphaComponent(0.16)
+            fg = AppColors.pain300
+        case .warn:
+            bg = AppColors.warn500.withAlphaComponent(0.18)
+            fg = AppColors.warn300
+        }
+        backgroundColor = bg
+        label.textColor = fg
+        iconView.tintColor = fg
+    }
+}

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPRow.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPRow.swift
@@ -1,0 +1,180 @@
+import UIKit
+
+/// Settings / list row primitive — `.sp-row` in `components.css`.
+///
+/// Layout: leading icon (optional) → main column (title + optional
+/// subtitle) → trailing accessory (chevron / switch / value label /
+/// arbitrary view). Tap target spans the whole row and is gated to ≥44pt
+/// to satisfy the iOS HIG minimum.
+///
+/// SPRows are designed to stack inside an `SPCard` or be used as the
+/// content of a UITableViewCell. The `divider` flag draws a 1px hairline
+/// across the bottom edge so consecutive rows visually separate without
+/// the caller having to add per-row separators.
+final class SPRow: UIControl {
+
+    // MARK: - Configuration
+
+    let showsDivider: Bool
+    /// Closure invoked on `.touchUpInside`. Storing the callback so the
+    /// caller doesn't have to wire `addTarget` boilerplate.
+    var onTap: (() -> Void)?
+
+    // MARK: - Subviews
+
+    private let leadingContainer = UIView()
+    private let titleLabel = UILabel()
+    private let subtitleLabel = UILabel()
+    private let trailingContainer = UIView()
+    private let divider = UIView()
+    private let mainStack = UIStackView()
+    private let textStack = UIStackView()
+
+    // MARK: - Init
+
+    /// - Parameters:
+    ///   - title: Primary label (`bodyLg` 17pt medium).
+    ///   - subtitle: Optional secondary label (`meta` 13pt medium).
+    ///   - leading: Optional leading view (icon, image, badge). Sized via
+    ///     its own intrinsic content; rendered in a 24pt-wide column.
+    ///   - trailing: Optional trailing view (chevron, switch, value label).
+    ///   - divider: When `true` (default) draws a 1px hairline along the
+    ///     bottom edge using `stroke1`. The first / last row in a stack
+    ///     normally hides this manually.
+    ///   - onTap: Tap callback. When set the row paints a faint highlight
+    ///     and the system reads it as a button to assistive tech.
+    init(
+        title: String,
+        subtitle: String? = nil,
+        leading: UIView? = nil,
+        trailing: UIView? = nil,
+        divider: Bool = true,
+        onTap: (() -> Void)? = nil
+    ) {
+        self.showsDivider = divider
+        self.onTap = onTap
+        super.init(frame: .zero)
+        configure()
+        titleLabel.text = title
+        if let subtitle = subtitle {
+            subtitleLabel.text = subtitle
+            subtitleLabel.isHidden = false
+        } else {
+            subtitleLabel.isHidden = true
+        }
+        if let leading = leading {
+            install(leading, in: leadingContainer)
+            leadingContainer.isHidden = false
+        } else {
+            leadingContainer.isHidden = true
+        }
+        if let trailing = trailing {
+            install(trailing, in: trailingContainer)
+            trailingContainer.isHidden = false
+        } else {
+            trailingContainer.isHidden = true
+        }
+        if onTap != nil {
+            isAccessibilityElement = true
+            accessibilityTraits = .button
+            addTarget(self, action: #selector(handleTap), for: .touchUpInside)
+        } else {
+            isUserInteractionEnabled = false
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Highlight feedback
+
+    override var isHighlighted: Bool {
+        didSet {
+            // Subtle background highlight so taps register without a full
+            // press scale (rows live inside a card, scaling looks weird
+            // when neighbours don't move).
+            UIView.animate(withDuration: SPSupport.durationQuick) {
+                self.backgroundColor = self.isHighlighted
+                    ? AppColors.whiteOverlay04
+                    : .clear
+            }
+        }
+    }
+
+    // MARK: - Configuration
+
+    private func configure() {
+        backgroundColor = .clear
+
+        leadingContainer.translatesAutoresizingMaskIntoConstraints = false
+        trailingContainer.translatesAutoresizingMaskIntoConstraints = false
+
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.font = AppTypography.bodyLg
+        titleLabel.textColor = AppColors.fg1
+        titleLabel.numberOfLines = 1
+
+        subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
+        subtitleLabel.font = AppTypography.meta
+        subtitleLabel.textColor = AppColors.fg3
+        subtitleLabel.numberOfLines = 1
+
+        textStack.translatesAutoresizingMaskIntoConstraints = false
+        textStack.axis = .vertical
+        textStack.alignment = .leading
+        textStack.spacing = 2
+        textStack.addArrangedSubview(titleLabel)
+        textStack.addArrangedSubview(subtitleLabel)
+
+        mainStack.translatesAutoresizingMaskIntoConstraints = false
+        mainStack.axis = .horizontal
+        mainStack.alignment = .center
+        mainStack.spacing = 14    // matches `gap: 14px`
+        mainStack.isUserInteractionEnabled = false
+        mainStack.addArrangedSubview(leadingContainer)
+        mainStack.addArrangedSubview(textStack)
+        mainStack.addArrangedSubview(trailingContainer)
+        addSubview(mainStack)
+
+        divider.translatesAutoresizingMaskIntoConstraints = false
+        divider.backgroundColor = AppColors.stroke1
+        divider.isHidden = !showsDivider
+        addSubview(divider)
+
+        NSLayoutConstraint.activate([
+            // 14pt vertical padding × 2 + content height. Hit-target floor
+            // is enforced via `heightAnchor >= 44`.
+            heightAnchor.constraint(greaterThanOrEqualToConstant: 44),
+            mainStack.topAnchor.constraint(equalTo: topAnchor, constant: 14),
+            mainStack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -14),
+            mainStack.leadingAnchor.constraint(equalTo: leadingAnchor),
+            mainStack.trailingAnchor.constraint(equalTo: trailingAnchor),
+            divider.leadingAnchor.constraint(equalTo: leadingAnchor),
+            divider.trailingAnchor.constraint(equalTo: trailingAnchor),
+            divider.bottomAnchor.constraint(equalTo: bottomAnchor),
+            // 1px hairline — divide by display scale so the line stays a
+            // single device pixel on @2x/@3x. `traitCollection.displayScale`
+            // is `0` until the view is in a window, so fall back to 2x.
+            divider.heightAnchor.constraint(
+                equalToConstant: 1.0 / max(traitCollection.displayScale, 2)
+            )
+        ])
+    }
+
+    private func install(_ view: UIView, in container: UIView) {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(view)
+        NSLayoutConstraint.activate([
+            view.topAnchor.constraint(equalTo: container.topAnchor),
+            view.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            view.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: container.trailingAnchor)
+        ])
+    }
+
+    @objc
+    private func handleTap() {
+        onTap?()
+    }
+}

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPSegmented.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPSegmented.swift
@@ -1,0 +1,172 @@
+import UIKit
+
+/// Segmented selector matching `.sp-seg` in `components.css`.
+///
+/// Visual: capsule background (`whiteOverlay06`), inset 4pt, with a sliding
+/// selection indicator that animates between segments at the brand
+/// `--sp-dur-base` (220ms) duration. The selected segment shows a `bg1`
+/// fill + soft shadow so it lifts off the capsule, matching the iOS-native
+/// segmented look but recoloured for the brand.
+final class SPSegmented: UIControl {
+
+    /// Single option: stable `value` ID + display `label`.
+    struct Option {
+        let value: String
+        let label: String
+    }
+
+    // MARK: - State
+
+    private(set) var options: [Option]
+    /// Currently selected `value`. Setting programmatically does not fire
+    /// `onChange` — only user interaction does. Triggers a slide animation
+    /// of the selection indicator.
+    var selectedValue: String? {
+        didSet { updateSelection(animated: oldValue != selectedValue) }
+    }
+
+    /// Closure fired on user-driven selection change. Receives the new
+    /// `value`. Storing as a closure (rather than a delegate) keeps simple
+    /// SwiftUI-like call sites idiomatic.
+    var onChange: ((String) -> Void)?
+
+    // MARK: - Subviews
+
+    private let track = UIView()
+    private let indicator = UIView()
+    private var segmentButtons: [UIButton] = []
+
+    // MARK: - Init
+
+    /// - Parameters:
+    ///   - options: Ordered list of (value, label) pairs.
+    ///   - selectedValue: Initial selection — must match one of the option
+    ///     values, otherwise no segment is shown as selected.
+    ///   - onChange: Selection callback.
+    init(
+        options: [Option],
+        selectedValue: String? = nil,
+        onChange: ((String) -> Void)? = nil
+    ) {
+        self.options = options
+        self.selectedValue = selectedValue
+        self.onChange = onChange
+        super.init(frame: .zero)
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Layout
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        layer.cornerRadius = AppRadius.md
+        track.layer.cornerRadius = AppRadius.md
+        // Indicator slides into place via constraints; corner radius scales
+        // with track padding so it visually nests.
+        indicator.layer.cornerRadius = AppRadius.md - 4
+        // Re-position indicator after layout cycle resolves geometries.
+        positionIndicator(animated: false)
+    }
+
+    // MARK: - Configuration
+
+    private func configure() {
+        backgroundColor = .clear
+
+        track.translatesAutoresizingMaskIntoConstraints = false
+        track.backgroundColor = AppColors.whiteOverlay06
+        addSubview(track)
+
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        indicator.backgroundColor = AppColors.bg1
+        indicator.layer.shadowColor = UIColor.black.cgColor
+        indicator.layer.shadowOpacity = 0.18
+        indicator.layer.shadowOffset = CGSize(width: 0, height: 2)
+        indicator.layer.shadowRadius = 6
+        track.addSubview(indicator)
+
+        let stack = UIStackView()
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .horizontal
+        stack.distribution = .fillEqually
+        stack.spacing = 0
+        stack.isUserInteractionEnabled = true
+        track.addSubview(stack)
+
+        segmentButtons = options.enumerated().map { index, option in
+            let button = UIButton(type: .system)
+            button.setTitle(option.label, for: .normal)
+            button.titleLabel?.font = AppTypography.buttonSm
+            button.tag = index
+            button.tintColor = .clear   // disable the iOS blue tint reflow
+            button.setTitleColor(AppColors.fg3, for: .normal)
+            button.setTitleColor(AppColors.fg1, for: .selected)
+            button.addTarget(self, action: #selector(handleTap(_:)), for: .touchUpInside)
+            stack.addArrangedSubview(button)
+            return button
+        }
+
+        NSLayoutConstraint.activate([
+            heightAnchor.constraint(equalToConstant: 44),
+            track.topAnchor.constraint(equalTo: topAnchor),
+            track.bottomAnchor.constraint(equalTo: bottomAnchor),
+            track.leadingAnchor.constraint(equalTo: leadingAnchor),
+            track.trailingAnchor.constraint(equalTo: trailingAnchor),
+            stack.topAnchor.constraint(equalTo: track.topAnchor, constant: 4),
+            stack.bottomAnchor.constraint(equalTo: track.bottomAnchor, constant: -4),
+            stack.leadingAnchor.constraint(equalTo: track.leadingAnchor, constant: 4),
+            stack.trailingAnchor.constraint(equalTo: track.trailingAnchor, constant: -4)
+        ])
+        updateSelection(animated: false)
+    }
+
+    @objc
+    private func handleTap(_ sender: UIButton) {
+        guard sender.tag < options.count else { return }
+        let value = options[sender.tag].value
+        guard value != selectedValue else { return }
+        selectedValue = value
+        onChange?(value)
+        sendActions(for: .valueChanged)
+    }
+
+    private func updateSelection(animated: Bool) {
+        for (index, button) in segmentButtons.enumerated() {
+            let isOn = options[index].value == selectedValue
+            button.isSelected = isOn
+        }
+        if animated {
+            UIView.animate(
+                withDuration: SPSupport.durationBase,
+                delay: 0,
+                options: [.curveEaseOut, .beginFromCurrentState],
+                animations: { self.positionIndicator(animated: true) },
+                completion: nil
+            )
+        } else {
+            positionIndicator(animated: false)
+        }
+    }
+
+    private func positionIndicator(animated: Bool) {
+        guard
+            let selected = selectedValue,
+            let index = options.firstIndex(where: { $0.value == selected }),
+            index < segmentButtons.count,
+            track.bounds.width > 0
+        else {
+            indicator.isHidden = true
+            return
+        }
+        indicator.isHidden = false
+        let target = segmentButtons[index]
+        // Position the indicator inside the track using its frame in track
+        // coordinates — track is laid out in `bounds` already.
+        let frame = target.convert(target.bounds, to: track)
+        indicator.frame = frame
+    }
+}

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPSnoozePrice.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPSnoozePrice.swift
@@ -1,0 +1,201 @@
+import UIKit
+
+/// Big snooze CTA — `.sp-snooze` in `components.css`.
+///
+/// Visual hierarchy: the price is the dominant element (32pt mono bold),
+/// with a small caps top label ("Поспать ещё 5 мин") and an optional
+/// hint meta line. Tone selects between the warn (default snooze price)
+/// and pain (progressive / expensive snooze) gradients.
+///
+/// Min height 80pt so the touch target reads as a primary action even on
+/// the smallest device. Press scale 0.98 (a notch shallower than SPButton's
+/// 0.96) because the surface is bigger and 0.96 feels twitchy.
+final class SPSnoozePrice: UIControl {
+
+    enum Tone {
+        case warn   // Default snooze — warm amber gradient
+        case pain   // Progressive / expensive — pain coral gradient
+    }
+
+    // MARK: - Configuration
+
+    let tone: Tone
+    private(set) var price: Decimal
+    private(set) var minutes: Int
+    private(set) var hint: String?
+
+    var onTap: (() -> Void)?
+
+    // MARK: - State
+
+    override var isEnabled: Bool {
+        didSet { refreshDisabledAppearance() }
+    }
+
+    override var isHighlighted: Bool {
+        didSet {
+            UIView.animate(
+                withDuration: SPSupport.durationQuick,
+                delay: 0,
+                options: [.allowUserInteraction, .beginFromCurrentState, .curveEaseOut],
+                animations: {
+                    self.transform = self.isHighlighted
+                        ? CGAffineTransform(scaleX: 0.98, y: 0.98)
+                        : .identity
+                },
+                completion: nil
+            )
+        }
+    }
+
+    // MARK: - Subviews
+
+    private let capsLabel = UILabel()
+    private let priceLabel = UILabel()
+    private let hintLabel = UILabel()
+    private var gradientLayer: CAGradientLayer?
+
+    // MARK: - Init
+
+    /// - Parameters:
+    ///   - price: Cost of the snooze in roubles.
+    ///   - minutes: Snooze duration, displayed in the caps line. Defaults
+    ///     to 5 (the standard SnoozePay window).
+    ///   - tone: `.warn` or `.pain`.
+    ///   - hint: Optional secondary line ("Уже 3-я задержка" etc).
+    ///   - onTap: Tap callback.
+    init(
+        price: Decimal,
+        minutes: Int = 5,
+        tone: Tone = .warn,
+        hint: String? = nil,
+        onTap: (() -> Void)? = nil
+    ) {
+        self.price = price
+        self.minutes = minutes
+        self.tone = tone
+        self.hint = hint
+        self.onTap = onTap
+        super.init(frame: .zero)
+        configure()
+        update(price: price, minutes: minutes, hint: hint)
+        addTarget(self, action: #selector(handleTap), for: .touchUpInside)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Layout
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        gradientLayer?.frame = bounds
+        layer.shadowPath = UIBezierPath(
+            roundedRect: bounds,
+            cornerRadius: AppRadius.xl
+        ).cgPath
+    }
+
+    // MARK: - Public API
+
+    func update(price: Decimal, minutes: Int? = nil, hint: String? = nil) {
+        self.price = price
+        if let minutes = minutes { self.minutes = minutes }
+        self.hint = hint
+        capsLabel.attributedText = NSAttributedString(
+            string: "Поспать ещё \(self.minutes) мин".uppercased(),
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: 12 * 0.14,
+                .foregroundColor: foreground.withAlphaComponent(0.82)
+            ]
+        )
+        priceLabel.text = "−\(price.formattedRubles())"
+        if let hint = hint {
+            hintLabel.text = hint
+            hintLabel.isHidden = false
+        } else {
+            hintLabel.isHidden = true
+        }
+    }
+
+    // MARK: - Configuration
+
+    private func configure() {
+        layer.cornerRadius = AppRadius.xl
+        layer.masksToBounds = false
+
+        capsLabel.translatesAutoresizingMaskIntoConstraints = false
+        capsLabel.textAlignment = .center
+
+        priceLabel.translatesAutoresizingMaskIntoConstraints = false
+        priceLabel.font = AppTypography.moneyLg
+        priceLabel.textAlignment = .center
+        priceLabel.textColor = foreground
+
+        hintLabel.translatesAutoresizingMaskIntoConstraints = false
+        hintLabel.font = AppTypography.meta
+        hintLabel.textAlignment = .center
+        hintLabel.alpha = 0.85
+        hintLabel.textColor = foreground
+
+        let stack = UIStackView(arrangedSubviews: [capsLabel, priceLabel, hintLabel])
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .vertical
+        stack.alignment = .center
+        stack.spacing = 4
+        stack.isUserInteractionEnabled = false
+        addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            heightAnchor.constraint(greaterThanOrEqualToConstant: 80),
+            stack.topAnchor.constraint(equalTo: topAnchor, constant: 18),
+            stack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -22),
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -24)
+        ])
+
+        applyTone()
+    }
+
+    private var foreground: UIColor {
+        switch tone {
+        case .warn: return AppColors.fgOnWarn
+        case .pain: return AppColors.fgOnPain
+        }
+    }
+
+    private func applyTone() {
+        gradientLayer?.removeFromSuperlayer()
+        let gradient = CAGradientLayer()
+        gradient.startPoint = SPSupport.gradientStart
+        gradient.endPoint = SPSupport.gradientEnd
+        gradient.cornerRadius = AppRadius.xl
+        switch tone {
+        case .warn:
+            gradient.colors = SPSupport.warnGradientColors
+            gradient.locations = SPSupport.warnGradientLocations
+            layer.shadowColor = AppColors.warn500.cgColor
+        case .pain:
+            gradient.colors = SPSupport.painGradientColors
+            gradient.locations = SPSupport.painGradientLocations
+            layer.shadowColor = AppColors.pain500.cgColor
+        }
+        layer.insertSublayer(gradient, at: 0)
+        gradientLayer = gradient
+        layer.shadowOpacity = 0.40
+        layer.shadowOffset = CGSize(width: 0, height: 8)
+        layer.shadowRadius = 22
+    }
+
+    private func refreshDisabledAppearance() {
+        alpha = isEnabled ? 1.0 : 0.35
+        layer.shadowOpacity = isEnabled ? 0.40 : 0.0
+    }
+
+    @objc
+    private func handleTap() {
+        onTap?()
+    }
+}

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPSupport.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPSupport.swift
@@ -1,0 +1,121 @@
+import UIKit
+
+/// Internal design-system support: shared gradient stops, motion constants,
+/// and small helpers used across the SP* component family.
+///
+/// Every SP* primitive routes back to these helpers so the visual recipes
+/// stay in one place — when the design tokens at
+/// `docs/design/snoozepay-2026-04-27/project/tokens.css` change, only this
+/// file needs to follow.
+enum SPSupport {
+
+    // MARK: - Brand gradients
+    //
+    // 135° linear gradients sourced from `--sp-grad-{money,pain,warn}` in
+    // `tokens.css`. CAGradientLayer expects 0..1 start/end points so the
+    // 135° vector resolves to (0, 0) → (1, 1) (top-left → bottom-right).
+
+    static let gradientStart = CGPoint(x: 0, y: 0)
+    static let gradientEnd = CGPoint(x: 1, y: 1)
+
+    /// `--sp-grad-money: linear-gradient(135deg, #2EDB9F 0%, #10B981 60%, #0B7A56 100%)`.
+    static var moneyGradientColors: [CGColor] {
+        [
+            AppColors.money400.cgColor,
+            AppColors.money500.cgColor,
+            AppColors.money700.cgColor
+        ]
+    }
+    static let moneyGradientLocations: [NSNumber] = [0.0, 0.6, 1.0]
+
+    /// `--sp-grad-pain: linear-gradient(135deg, #FFB4A8 0%, #F4523F 55%, #D43A28 100%)`.
+    static var painGradientColors: [CGColor] {
+        [
+            AppColors.pain300.cgColor,
+            AppColors.pain500.cgColor,
+            AppColors.pain600.cgColor
+        ]
+    }
+    static let painGradientLocations: [NSNumber] = [0.0, 0.55, 1.0]
+
+    /// `--sp-grad-warn: linear-gradient(135deg, #FFD479 0%, #F59E0B 60%, #C97A06 100%)`.
+    static var warnGradientColors: [CGColor] {
+        [
+            AppColors.warn300.cgColor,
+            AppColors.warn500.cgColor,
+            AppColors.warn600.cgColor
+        ]
+    }
+    static let warnGradientLocations: [NSNumber] = [0.0, 0.6, 1.0]
+
+    // MARK: - Motion (`tokens.css` durations + easings)
+
+    /// `--sp-dur-quick: 140ms` — press/release scale animations.
+    static let durationQuick: TimeInterval = 0.140
+    /// `--sp-dur-base: 220ms` — segmented indicator slides, switch knob.
+    static let durationBase: TimeInterval = 0.220
+    /// `--sp-dur-slow: 420ms`.
+    static let durationSlow: TimeInterval = 0.420
+
+    /// Approximation of `cubic-bezier(.2,.8,.2,1)` used by `--sp-ease-out`.
+    /// `UIView.animate(...)` doesn't accept arbitrary cubic-beziers; the
+    /// closest preset (`.curveEaseOut`) gives the right "fast in, soft
+    /// settle" character without dropping to CAMediaTimingFunction-only
+    /// keyframe animations for every press feedback.
+    static let easeOut: UIView.AnimationOptions = [.curveEaseOut]
+
+    // MARK: - Press feedback
+
+    /// Animate a 0.96 scale press (or restore to identity) on a view.
+    /// Matches the `.sp-btn:active { transform: scale(.97) }` recipe from
+    /// `components.css` (rounded to 0.96 for a slightly more tactile feel
+    /// on touch devices).
+    static func animatePress(_ view: UIView, pressed: Bool) {
+        UIView.animate(
+            withDuration: durationQuick,
+            delay: 0,
+            options: [.allowUserInteraction, .beginFromCurrentState, .curveEaseOut],
+            animations: {
+                view.transform = pressed ? CGAffineTransform(scaleX: 0.96, y: 0.96) : .identity
+            },
+            completion: nil
+        )
+    }
+}
+
+/// Reusable `UIView` wrapping a `CAGradientLayer` that resizes its layer to
+/// the view bounds on every layout pass. Internal — exposed only inside the
+/// design system so SPButton / SPCard / SPSnoozePrice can share one
+/// implementation rather than each rolling its own gradient layer.
+final class SPGradientView: UIView {
+
+    override class var layerClass: AnyClass { CAGradientLayer.self }
+
+    private var gradientLayer: CAGradientLayer {
+        // swiftlint:disable:next force_cast
+        layer as! CAGradientLayer
+    }
+
+    /// Convenience init that wires up a 135° gradient with the supplied
+    /// `cgColor` stops + locations.
+    init(colors: [CGColor], locations: [NSNumber]) {
+        super.init(frame: .zero)
+        gradientLayer.colors = colors
+        gradientLayer.locations = locations
+        gradientLayer.startPoint = SPSupport.gradientStart
+        gradientLayer.endPoint = SPSupport.gradientEnd
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    /// Refresh the underlying `cgColor` stops — call from
+    /// `traitCollectionDidChange` so dynamic SwiftUI-style color tokens
+    /// re-resolve on light/dark switch. The current SP gradients use brand
+    /// hex literals so this is mostly defensive.
+    func refresh(colors: [CGColor], locations: [NSNumber]) {
+        gradientLayer.colors = colors
+        gradientLayer.locations = locations
+    }
+}

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPSwitch.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPSwitch.swift
@@ -1,0 +1,31 @@
+import UIKit
+
+/// Brand-tinted UISwitch.
+///
+/// `UISwitch` already gives us the platform-native physics and a11y for free
+/// — the SP recipe just needs the `onTintColor` flipped to the money tone so
+/// the toggle reads as "money / commit" instead of the default iOS green.
+///
+/// Subclassing (rather than a factory) keeps the type information attached
+/// to call sites: a screen that exposes `let pushToggle = SPSwitch()` makes
+/// the brand intent obvious in code review.
+final class SPSwitch: UISwitch {
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        applyBrandTint()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        applyBrandTint()
+    }
+
+    private func applyBrandTint() {
+        // `--sp-switch.is-on { background: var(--sp-grad-money) }` — UISwitch
+        // doesn't render a gradient natively, so we fall back to the
+        // `money500` flat fill which lines up with the dominant gradient
+        // stop and keeps the toggle indistinguishable in motion.
+        onTintColor = AppColors.money500
+    }
+}


### PR DESCRIPTION
Fixes #137

## What

First batch of reusable UIKit primitives for the SnoozePay design refresh, built from the JSX/CSS spec under `docs/design/snoozepay-2026-04-27/project/components/`. Every component composes from the existing `AppColors` / `AppSpacing` / `AppRadius` / `AppTypography` tokens (no hardcoded hex / spacing).

10 new files under `SnoozePay/Views/DesignSystem/`:

- **SPSupport** — internal: brand gradient stops, motion constants, press-feedback util, `SPGradientView` base.
- **SPCard** — `surface` / `raised` / `outline` / `money` / `pain` / `warn` tones; configurable padding + radius. Light-mode `surface` keeps shadow + 1px stroke per design-system memory.
- **SPButton** — `money` / `pain` / `warn` (gradient) + `ghost` / `quiet` (chrome-light) variants × `lg` / `md` / `sm` sizes; optional icon + mono suffix; full-width support; 0.96 press-scale animation.
- **SPPill** — 26pt caps badge with `neutral` / `money` / `pain` / `warn` tones + optional 14pt leading icon.
- **SPRow** — leading / title / subtitle / trailing slots, divider flag, ≥44pt hit target, tap callback.
- **SPSegmented** — capsule track with sliding indicator (220ms ease-out animation), `onChange` closure.
- **SPSwitch** — `UISwitch` subclass with `onTintColor = money500`.
- **SPBalanceCard** — caps header + 32pt mono balance with money-gradient text mask + radial money highlight; optional weekly delta + hint.
- **SPSnoozePrice** — big snooze CTA, dominant 32pt mono price; `warn` / `pain` tones for default / progressive snooze; min height 80pt.
- **SPAmountPreset** — outlined top-up tile with selection state (money border + 4pt outer glow + 10% fill); optional “Популярно” badge.
- **SPInput** — wraps `UITextField`: caps label, 52pt field with focus / error border, hint / error meta line, optional trailing view.

## Backwards-compat

The legacy `UIView+CardStyle.swift` (`applyCardStyle()` extension + `CardView` class + `styleAsCardRow(...)` for `.insetGrouped` cells) is **untouched** so the 30+ existing call sites on Settings / Statistics / CreateAlarm / TopUp / Alarms continue to compile and render identically. SPCard will replace it incrementally as each screen migrates in its own UI issue.

## Verify

- `swiftlint lint SnoozePay/SnoozePay/Views/DesignSystem` → 0 violations.
- `xcodebuild build` (iPhone 17 sim) → ✅ build succeeded.
- Test gate skipped per memory.
- Existing screens still build (no API surface they depend on changed).

## Deviations from spec

- `SPSegmented` height set to 44pt (instead of CSS-implied 40pt) so the rendered segments still hit the iOS HIG 44pt tap minimum — matches the JSX role of the component.
- `SPBalanceCard`’s “gradient text” effect is implemented by masking a `CAGradientLayer` against a rasterised glyph image (CoreText has no direct equivalent of `-webkit-background-clip: text`); visually identical, refreshes on every layout pass.
- `SPSwitch` uses a flat `money500` `onTintColor` instead of a gradient (CALayer can’t pump a gradient through `UISwitch`’s built-in track).
- `SPButton` uses a 0.96 press scale (CSS spec is 0.97) for a slightly more tactile feel — same easing / duration.