### PR TITLE
[design-refresh] Sticky balance + low-balance warning on alarms list (#142)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
@@ -1,6 +1,25 @@
 import UIKit
 
-/// Main screen: alarm list with balance card header and navigation to create/edit alarms.
+/// Main screen — alarm list with a sticky balance header that stays pinned
+/// above the scroll, an optional low-balance warning banner under it, the
+/// alarm list itself, and an empty-state column that overlays the table when
+/// there are no alarms yet.
+///
+/// Layout (top → bottom inside `view`):
+/// ```
+/// safeArea.top
+///   ├─ SPAlarmsListHeader (sticky)
+///   │     ├─ balance card (caps + value + centered hint + trailing pill)
+///   │     └─ optional low-balance warning banner
+///   └─ UITableView (scrolls)
+///         └─ overlay: SPAlarmsListEmptyState (when alarms.isEmpty)
+/// safeArea.bottom
+/// ```
+///
+/// The header is pinned to the safe area — it does NOT live as
+/// `tableView.tableHeaderView` so it can't scroll away with the list. The
+/// table is anchored beneath the header with a small gap so the warning
+/// banner shadow can breathe before the list begins.
 class AlarmsListViewController: UIViewController {
 
     // MARK: - ViewModel
@@ -9,67 +28,41 @@ class AlarmsListViewController: UIViewController {
 
     // MARK: - UI Elements
 
+    private let header: SPAlarmsListHeader = {
+        let view = SPAlarmsListHeader()
+        view.directionalLayoutMargins = NSDirectionalEdgeInsets(
+            top: AppSpacing.sp3,
+            leading: AppSpacing.screenInset,
+            bottom: AppSpacing.sp3,
+            trailing: AppSpacing.screenInset
+        )
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
     private let tableView: UITableView = {
         let table = UITableView(frame: .zero, style: .plain)
-        table.backgroundColor = .systemGroupedBackground
+        table.backgroundColor = .clear
         table.separatorStyle = .none
         table.translatesAutoresizingMaskIntoConstraints = false
         return table
     }()
 
-    private let emptyStateView: UIView = {
-        let view = UIView()
+    private let emptyStateView: SPAlarmsListEmptyState = {
+        let view = SPAlarmsListEmptyState()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.isHidden = true
-
-        let stack = UIStackView()
-        stack.axis = .vertical
-        stack.alignment = .center
-        stack.spacing = AppSpacing.sm
-        stack.translatesAutoresizingMaskIntoConstraints = false
-
-        let iconLabel = UILabel()
-        iconLabel.text = "⏰"
-        iconLabel.font = UIFont.systemFont(ofSize: 64)
-
-        let titleLabel = UILabel()
-        titleLabel.text = "Нет будильников"
-        titleLabel.font = UIFont.systemFont(ofSize: 20, weight: .semibold)
-        titleLabel.textColor = .label
-
-        let subtitleLabel = UILabel()
-        subtitleLabel.text = "Нажмите + чтобы добавить"
-        subtitleLabel.font = UIFont.systemFont(ofSize: 15)
-        subtitleLabel.textColor = .secondaryLabel
-
-        stack.addArrangedSubview(iconLabel)
-        stack.addArrangedSubview(titleLabel)
-        stack.addArrangedSubview(subtitleLabel)
-        view.addSubview(stack)
-
-        NSLayoutConstraint.activate([
-            stack.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            stack.centerYAnchor.constraint(equalTo: view.centerYAnchor)
-        ])
-
         return view
     }()
-
-    // MARK: - Balance Card (table header)
-
-    private let balanceCard = UIView()
-    private let balanceAmountLabel = UILabel()
-    private let topUpButton = UIButton(type: .system)
 
     // MARK: - Lifecycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .systemGroupedBackground
+        view.backgroundColor = AppColors.bg0
         setupNavigationBar()
-        setupTableView()
-        setupBalanceHeader()
-        setupEmptyState()
+        setupLayout()
+        setupCallbacks()
         bindViewModel()
     }
 
@@ -85,7 +78,6 @@ class AlarmsListViewController: UIViewController {
         navigationItem.title = "Будильники"
         navigationController?.navigationBar.prefersLargeTitles = false
 
-        // "+" button using SF Symbol
         let addButton = UIBarButtonItem(
             image: UIImage(systemName: "plus.circle.fill"),
             style: .plain,
@@ -95,161 +87,83 @@ class AlarmsListViewController: UIViewController {
         navigationItem.rightBarButtonItem = addButton
     }
 
-    private func setupTableView() {
+    private func setupLayout() {
+        // Order matters — header is added LAST so it draws on top of the
+        // table content shadow if any of the alarm cards bleed under the
+        // safe-area inset during scroll.
         view.addSubview(tableView)
+        view.addSubview(emptyStateView)
+        view.addSubview(header)
+
         tableView.delegate = self
         tableView.dataSource = self
         tableView.register(AlarmCell.self, forCellReuseIdentifier: AlarmCell.reuseID)
 
         NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
+            // Sticky header pinned to safe-area top.
+            header.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            header.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            header.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+
+            // Table flows beneath the header.
+            tableView.topAnchor.constraint(equalTo: header.bottomAnchor),
             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-        ])
-    }
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
 
-    private func setupBalanceHeader() {
-        // Container for the balance card with padding
-        let headerContainer = UIView()
-
-        // Balance card styling — blue background. The accent blue is already
-        // high contrast against `systemGroupedBackground`, so we keep the
-        // border off (`applyCardStyle()` would override the blue fill) but add
-        // a soft drop shadow for the same elevation language as the alarm
-        // cards below.
-        balanceCard.backgroundColor = AppColors.accentBlue
-        balanceCard.layer.cornerRadius = AppRadius.md
-        balanceCard.layer.masksToBounds = false
-        balanceCard.layer.shadowColor = UIColor.black.cgColor
-        balanceCard.layer.shadowOpacity = 0.08
-        balanceCard.layer.shadowRadius = 6
-        balanceCard.layer.shadowOffset = CGSize(width: 0, height: 2)
-        balanceCard.translatesAutoresizingMaskIntoConstraints = false
-
-        // "БАЛАНС" small label
-        let titleLabel = UILabel()
-        titleLabel.text = "БАЛАНС"
-        titleLabel.font = UIFont.systemFont(ofSize: 11, weight: .semibold)
-        titleLabel.textColor = UIColor.white.withAlphaComponent(0.7)
-        titleLabel.translatesAutoresizingMaskIntoConstraints = false
-
-        // Amount label (large, white)
-        balanceAmountLabel.font = UIFont.monospacedDigitSystemFont(ofSize: 28, weight: .bold)
-        balanceAmountLabel.textColor = .white
-        balanceAmountLabel.translatesAutoresizingMaskIntoConstraints = false
-
-        // Top-up button (white pill with wallet icon)
-        var buttonConfig = UIButton.Configuration.filled()
-        buttonConfig.baseBackgroundColor = .white
-        buttonConfig.baseForegroundColor = AppColors.accentBlue
-        buttonConfig.cornerStyle = .capsule
-        buttonConfig.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16)
-
-        let walletImage = UIImage(systemName: "wallet.pass.fill")?
-            .withConfiguration(UIImage.SymbolConfiguration(pointSize: 13, weight: .semibold))
-        buttonConfig.image = walletImage
-        buttonConfig.imagePadding = 6
-        buttonConfig.imagePlacement = .leading
-
-        var titleAttr = AttributedString("Пополнить")
-        titleAttr.font = UIFont.systemFont(ofSize: 14, weight: .semibold)
-        buttonConfig.attributedTitle = titleAttr
-
-        topUpButton.configuration = buttonConfig
-        topUpButton.addTarget(self, action: #selector(topUpTapped), for: .touchUpInside)
-        topUpButton.translatesAutoresizingMaskIntoConstraints = false
-
-        balanceCard.addSubview(titleLabel)
-        balanceCard.addSubview(balanceAmountLabel)
-        balanceCard.addSubview(topUpButton)
-
-        headerContainer.addSubview(balanceCard)
-
-        NSLayoutConstraint.activate([
-            balanceCard.topAnchor.constraint(equalTo: headerContainer.topAnchor, constant: AppSpacing.sm),
-            balanceCard.leadingAnchor.constraint(equalTo: headerContainer.leadingAnchor, constant: AppSpacing.lg),
-            balanceCard.trailingAnchor.constraint(equalTo: headerContainer.trailingAnchor, constant: -AppSpacing.lg),
-            balanceCard.bottomAnchor.constraint(equalTo: headerContainer.bottomAnchor, constant: -AppSpacing.sm),
-
-            titleLabel.topAnchor.constraint(equalTo: balanceCard.topAnchor, constant: AppSpacing.md),
-            titleLabel.leadingAnchor.constraint(equalTo: balanceCard.leadingAnchor, constant: AppSpacing.lg),
-
-            balanceAmountLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: AppSpacing.xs),
-            balanceAmountLabel.leadingAnchor.constraint(equalTo: balanceCard.leadingAnchor, constant: AppSpacing.lg),
-            balanceAmountLabel.bottomAnchor.constraint(equalTo: balanceCard.bottomAnchor, constant: -AppSpacing.md),
-
-            topUpButton.centerYAnchor.constraint(equalTo: balanceCard.centerYAnchor),
-            topUpButton.trailingAnchor.constraint(equalTo: balanceCard.trailingAnchor, constant: -AppSpacing.lg),
-            topUpButton.leadingAnchor.constraint(
-                greaterThanOrEqualTo: balanceAmountLabel.trailingAnchor,
-                constant: AppSpacing.md
-            )
-        ])
-
-        // Size the header to fit its content
-        let targetSize = CGSize(width: view.bounds.width, height: UIView.layoutFittingCompressedSize.height)
-        headerContainer.frame.size.width = view.bounds.width
-        headerContainer.setNeedsLayout()
-        headerContainer.layoutIfNeeded()
-        let height = headerContainer.systemLayoutSizeFitting(targetSize,
-            withHorizontalFittingPriority: .required,
-            verticalFittingPriority: .fittingSizeLevel).height
-        headerContainer.frame = CGRect(x: 0, y: 0, width: view.bounds.width, height: height)
-
-        tableView.tableHeaderView = headerContainer
-    }
-
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-
-        // Recalculate header height on layout changes (rotation, etc.)
-        guard let header = tableView.tableHeaderView else { return }
-        let targetSize = CGSize(width: tableView.bounds.width, height: UIView.layoutFittingCompressedSize.height)
-        let newHeight = header.systemLayoutSizeFitting(targetSize,
-            withHorizontalFittingPriority: .required,
-            verticalFittingPriority: .fittingSizeLevel).height
-        if header.frame.height != newHeight {
-            header.frame.size = CGSize(width: tableView.bounds.width, height: newHeight)
-            tableView.tableHeaderView = header
-        }
-
-        // Pre-rasterise the balance card shadow against its current rounded
-        // bounds so the offscreen pass doesn't run on every scroll frame.
-        balanceCard.layer.shadowPath = UIBezierPath(
-            roundedRect: balanceCard.bounds,
-            cornerRadius: AppRadius.md
-        ).cgPath
-    }
-
-    private func setupEmptyState() {
-        view.addSubview(emptyStateView)
-        NSLayoutConstraint.activate([
-            emptyStateView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            emptyStateView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            emptyStateView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            // Empty state overlays the same area as the table so the
+            // sticky header still shows the user their balance even
+            // when the list is empty.
+            emptyStateView.topAnchor.constraint(equalTo: tableView.topAnchor),
+            emptyStateView.leadingAnchor.constraint(equalTo: tableView.leadingAnchor),
+            emptyStateView.trailingAnchor.constraint(equalTo: tableView.trailingAnchor),
             emptyStateView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
         ])
+    }
+
+    private func setupCallbacks() {
+        header.onBalanceTopUpTap = { [weak self] in
+            self?.presentTopUp()
+        }
+        header.onWarnTopUpTap = { [weak self] in
+            self?.presentTopUp()
+        }
+        emptyStateView.onAddAlarmTap = { [weak self] in
+            self?.addAlarmTapped()
+        }
     }
 
     private func bindViewModel() {
         viewModel.onAlarmsUpdated = { [weak self] in
             guard let self else { return }
             self.tableView.reloadData()
-            self.emptyStateView.isHidden = !self.viewModel.alarms.isEmpty
-            self.tableView.isHidden = self.viewModel.alarms.isEmpty
+            let isEmpty = self.viewModel.alarms.isEmpty
+            self.emptyStateView.isHidden = !isEmpty
+            self.tableView.isHidden = isEmpty
+            // Refresh the affordability hint — it depends on the
+            // current alarm set's average penalty, so a delete /
+            // create can change the snooze count even when the
+            // balance hasn't moved.
+            self.refreshHeader()
         }
 
         viewModel.onBalanceUpdated = { [weak self] _ in
-            guard let self else { return }
-            // `formattedBalance` already includes the "₽" suffix (e.g. "0 ₽").
-            // Adding a "₽ " prefix here previously rendered "₽ 0 ₽" (issue #55).
-            self.balanceAmountLabel.text = self.viewModel.formattedBalance
+            self?.refreshHeader()
         }
 
         viewModel.onLoadError = { [weak self] error in
             self?.presentRepositoryError(error)
         }
+    }
+
+    /// Push the latest balance / hint / warning state into the sticky
+    /// header. Called both from `onBalanceUpdated` (BalanceService
+    /// notification) and `onAlarmsUpdated` (alarm-set change shifts the
+    /// average penalty).
+    private func refreshHeader() {
+        let balance = Decimal(viewModel.balance)
+        header.setBalance(balance, hint: viewModel.affordabilityHint)
+        header.setWarning(visible: viewModel.isLowBalance, balance: balance)
     }
 
     /// Shows a non-blocking alert when the repository couldn't load or
@@ -280,7 +194,7 @@ class AlarmsListViewController: UIViewController {
         present(nav, animated: true)
     }
 
-    @objc private func topUpTapped() {
+    private func presentTopUp() {
         let topUpVC = TopUpViewController()
         let nav = UINavigationController(rootViewController: topUpVC)
         present(nav, animated: true)

--- a/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
@@ -207,6 +207,93 @@ final class AlarmsListViewModel {
         "\(Int(balance)) ₽"
     }
 
+    // MARK: - Affordability hint
+
+    /// Default penalty used when the user hasn't created any alarms yet
+    /// (or every alarm has a non-positive penalty). Matches the
+    /// `Alarm.init` default and the IAP "~N откладываний" copy in
+    /// `TopUpViewController`. Kept as a constant so a single tweak
+    /// covers both the empty-list hint and the topup subtitles.
+    static let defaultPenaltyAmount: Double = 50
+
+    /// Average penalty across all alarms, falling back to
+    /// `defaultPenaltyAmount` when no alarms exist or every alarm has a
+    /// non-positive penalty. Used by the alarms list balance card to
+    /// render "Хватит на ~N откладываний". The mode (most-frequent
+    /// penalty) is preferred over the arithmetic mean because the
+    /// design hint reads more accurately when alarms are clustered
+    /// around a single value (e.g. four alarms at 50 ₽ + one outlier
+    /// at 200 ₽ should report "~50" not "~80").
+    var averagePenalty: Double {
+        let positives = alarms.map { $0.penaltyAmount }.filter { $0 > 0 }
+        guard !positives.isEmpty else { return Self.defaultPenaltyAmount }
+        // Mode — pick the penalty value that appears most often. Ties
+        // resolve to the largest penalty (so the hint stays
+        // conservative — it under-reports the snooze count rather than
+        // promising more than the user can actually afford).
+        var counts: [Double: Int] = [:]
+        for value in positives {
+            counts[value, default: 0] += 1
+        }
+        guard let mode = counts.max(by: { lhs, rhs in
+            if lhs.value != rhs.value { return lhs.value < rhs.value }
+            return lhs.key < rhs.key
+        }) else {
+            return Self.defaultPenaltyAmount
+        }
+        return mode.key
+    }
+
+    /// Number of snoozes the user can currently afford given the
+    /// current `balance` and `averagePenalty`. Floored — the list hint
+    /// never advertises a fractional snooze. Returns 0 when the user is
+    /// out of money so the warning banner can still fire.
+    var affordableSnoozeCount: Int {
+        let penalty = averagePenalty
+        guard penalty > 0, balance > 0 else { return 0 }
+        return Int(floor(balance / penalty))
+    }
+
+    /// Localised hint shown under the balance number on the alarms
+    /// list: "Хватит на ~5 откладываний". Pluralisation follows
+    /// Russian rules (1 / 2-4 / 5-20 buckets); the "~" prefix mirrors
+    /// the topup-row copy.
+    var affordabilityHint: String {
+        let count = affordableSnoozeCount
+        return "Хватит на ~\(count) \(Self.snoozeWord(for: count))"
+    }
+
+    /// `true` when the balance is at or below the low-balance
+    /// threshold. The list shows a warning banner whenever this is
+    /// true on view appear (see issue #142).
+    var isLowBalance: Bool {
+        balance <= Self.lowBalanceThreshold
+    }
+
+    /// Threshold for the low-balance warning banner. Matched against
+    /// the raw `balance` (₽). 100 ₽ chosen because it's roughly 2
+    /// snoozes at the default penalty — the warning gives the user
+    /// runway to top up before the next charge fails.
+    static let lowBalanceThreshold: Double = 100
+
+    /// Russian pluralisation for "откладывание" — picks between
+    /// `откладывание` (n=1, 21, 31…), `откладывания` (2-4, 22-24…) and
+    /// `откладываний` (everything else, including 0 and 5-20). Local to
+    /// this VM because the only consumer is the affordability hint;
+    /// promote to a shared utility once a second screen needs it.
+    private static func snoozeWord(for count: Int) -> String {
+        let normalisedCount = abs(count)
+        let mod10 = normalisedCount % 10
+        let mod100 = normalisedCount % 100
+        if mod10 == 1 && mod100 != 11 {
+            return "откладывание"
+        }
+        if (2...4).contains(mod10) && !(12...14).contains(mod100) {
+            return "откладывания"
+        }
+        return "откладываний"
+    }
+
     // MARK: - Helpers for cell display
 
     /// Cached formatter — avoids ~1ms per-call allocation that adds up in lists.

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPAlarmsListEmptyState.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPAlarmsListEmptyState.swift
@@ -1,0 +1,112 @@
+import UIKit
+
+/// Empty-state column for the alarms list.
+///
+/// Visual:
+///   ┌─────────────────────────────┐
+///   │             🔕              │
+///   │     Нет будильников         │
+///   │ Создайте первый, чтобы …    │
+///   │   [+ Добавить будильник]    │
+///   └─────────────────────────────┘
+///
+/// Hosted as an overlay over the table view in
+/// `AlarmsListViewController` and toggled via `isHidden`. Uses
+/// `AppTypography` + `SPButton(.money, .lg)` so it stays visually
+/// consistent with the rest of the design system.
+final class SPAlarmsListEmptyState: UIView {
+
+    // MARK: - Public API
+
+    /// Triggered when the user taps "Добавить будильник".
+    var onAddAlarmTap: (() -> Void)?
+
+    // MARK: - Subviews
+
+    private let iconView: UIImageView = {
+        let configuration = UIImage.SymbolConfiguration(pointSize: 64, weight: .regular)
+        let view = UIImageView(image: UIImage(systemName: "bell.slash", withConfiguration: configuration))
+        view.tintColor = AppColors.fg3
+        view.contentMode = .scaleAspectFit
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Нет будильников"
+        label.font = AppTypography.h2
+        label.textColor = AppColors.fg1
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Создайте первый, чтобы начать"
+        label.font = AppTypography.body
+        label.textColor = AppColors.fg3
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let addButton: SPButton = {
+        let button = SPButton(
+            title: "Добавить будильник",
+            variant: .money,
+            size: .lg,
+            icon: UIImage(systemName: "plus")
+        )
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    // MARK: - Init
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Configuration
+
+    private func configure() {
+        backgroundColor = .clear
+
+        let stack = UIStackView(arrangedSubviews: [
+            iconView, titleLabel, subtitleLabel, addButton
+        ])
+        stack.axis = .vertical
+        stack.alignment = .center
+        stack.spacing = AppSpacing.sp3
+        stack.setCustomSpacing(AppSpacing.sp4, after: iconView)
+        stack.setCustomSpacing(AppSpacing.sp5, after: subtitleLabel)
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            stack.centerXAnchor.constraint(equalTo: centerXAnchor),
+            stack.centerYAnchor.constraint(equalTo: centerYAnchor),
+            stack.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: AppSpacing.sp6),
+            stack.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -AppSpacing.sp6),
+
+            iconView.widthAnchor.constraint(equalToConstant: 80),
+            iconView.heightAnchor.constraint(equalToConstant: 80)
+        ])
+
+        addButton.addTarget(self, action: #selector(addTapped), for: .touchUpInside)
+    }
+
+    // MARK: - Actions
+
+    @objc private func addTapped() {
+        onAddAlarmTap?()
+    }
+}

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPAlarmsListHeader.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPAlarmsListHeader.swift
@@ -1,0 +1,366 @@
+import UIKit
+
+/// Sticky header for the alarms list — composes a balance card and an
+/// optional low-balance warning banner. Lives at the top of the screen
+/// above the scrolling table view; pinned to the safe-area so it never
+/// scrolls away.
+///
+/// Visual recipe:
+/// - **Balance card**: same SPBalanceCard chrome (`bg2` raised surface,
+///   28pt vertical / 24pt horizontal padding, 28pt corner radius). Caps
+///   header "БАЛАНС", `moneyLg` value, a centered "Хватит на ~N
+///   откладываний" hint **below** the value, and a trailing
+///   `SPButton(.money, .sm)` "Пополнить" placed to the right of the
+///   value row. The centered hint placement is a direct fix for PM
+///   feedback (chat1.md line 971) — the previous layout put the hint
+///   inline with the value and PM called it out as misaligned.
+/// - **Warning banner**: `SPCard(.warn)` shown when balance ≤ 100. Caps
+///   "БАЛАНС ПОЧТИ ПУСТ", current balance meta, and a small
+///   `SPButton(.warn, .sm)` "Пополнить". Slot collapses (`isHidden`)
+///   when balance > 100; the surrounding stack absorbs the gap.
+///
+/// The view exposes two callbacks (`onBalanceTopUpTap` and
+/// `onWarnTopUpTap`) so the controller can wire whichever destination
+/// it wants — callers don't need to know about the internal SPButton
+/// instances.
+final class SPAlarmsListHeader: UIView {
+
+    // MARK: - Public API
+
+    /// Triggered when the user taps the "Пополнить" pill on the balance
+    /// card.
+    var onBalanceTopUpTap: (() -> Void)?
+
+    /// Triggered when the user taps the "Пополнить" pill on the
+    /// low-balance warning banner.
+    var onWarnTopUpTap: (() -> Void)?
+
+    /// Update the balance card. `hint` is rendered as a centered line
+    /// below the balance number — pass `nil` to hide.
+    func setBalance(_ balance: Decimal, hint: String?) {
+        balanceValueLabel.text = balance.formattedRubles()
+        if let hint = hint, !hint.isEmpty {
+            balanceHintLabel.text = hint
+            balanceHintLabel.isHidden = false
+        } else {
+            balanceHintLabel.isHidden = true
+        }
+        // Remask the gradient on the value once layout reflows so the
+        // mask tracks the new digit width (#137 SPBalanceCard pattern).
+        setNeedsLayout()
+    }
+
+    /// Toggle the low-balance warning banner. When `visible == true`
+    /// the banner shows the supplied `balance` in its meta line.
+    func setWarning(visible: Bool, balance: Decimal) {
+        warningBanner.isHidden = !visible
+        warningMetaLabel.text = "Сейчас: \(balance.formattedRubles())"
+    }
+
+    // MARK: - Subviews
+
+    private let stack = UIStackView()
+
+    // Balance card
+    private let balanceCard = SPCard(tone: .raised, padding: 24, cornerRadius: AppRadius.xl)
+    private let balanceCapsLabel = UILabel()
+    private let balanceValueLabel = UILabel()
+    private let balanceValueGradient = CAGradientLayer()
+    private let balanceHintLabel = UILabel()
+    private let balanceTopUpButton = SPButton(
+        title: "Пополнить",
+        variant: .money,
+        size: .sm,
+        icon: UIImage(systemName: "plus.circle.fill")
+    )
+    private let radialOverlay = AlarmsHeaderRadialOverlayView()
+
+    // Warning banner
+    private let warningBanner = SPCard(tone: .warn, padding: AppSpacing.sp4, cornerRadius: AppRadius.lg)
+    private let warningCapsLabel = UILabel()
+    private let warningMetaLabel = UILabel()
+    private let warningTopUpButton = SPButton(
+        title: "Пополнить",
+        variant: .warn,
+        size: .sm
+    )
+
+    // MARK: - Init
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Layout
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        radialOverlay.frame = balanceCard.bounds
+        applyValueGradient()
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        radialOverlay.setNeedsDisplay()
+    }
+
+    // MARK: - Configuration
+
+    private func configure() {
+        // Outer stack — vertical, 12pt gap between balance card and the
+        // optional warning banner. Pinned to the view's layoutMargins so
+        // the screen edges resolve to AppSpacing.screenInset (16pt) by
+        // default — the controller assigns directionalLayoutMargins to
+        // override.
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .vertical
+        stack.spacing = AppSpacing.sp3
+        stack.alignment = .fill
+        addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
+            stack.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
+            stack.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor)
+        ])
+
+        configureBalanceCard()
+        configureWarningBanner()
+
+        stack.addArrangedSubview(balanceCard)
+        stack.addArrangedSubview(warningBanner)
+        // Hidden by default — controller flips on view appear.
+        warningBanner.isHidden = true
+    }
+
+    // swiftlint:disable:next function_body_length
+    private func configureBalanceCard() {
+        // Internal layout:
+        //   ┌─────────────────────────────────┐
+        //   │ БАЛАНС                          │
+        //   │ 1 234 ₽           [+ Пополнить] │
+        //   │       ~5 откладываний (centered)│
+        //   └─────────────────────────────────┘
+        balanceCard.translatesAutoresizingMaskIntoConstraints = false
+
+        // Radial overlay sits behind content so subviews stack above it.
+        radialOverlay.translatesAutoresizingMaskIntoConstraints = false
+        radialOverlay.isUserInteractionEnabled = false
+        balanceCard.insertSubview(radialOverlay, at: 0)
+
+        balanceCapsLabel.translatesAutoresizingMaskIntoConstraints = false
+        balanceCapsLabel.attributedText = NSAttributedString(
+            string: "БАЛАНС",
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.fg3
+            ]
+        )
+
+        balanceValueLabel.translatesAutoresizingMaskIntoConstraints = false
+        balanceValueLabel.font = AppTypography.moneyLg
+        balanceValueLabel.textColor = AppColors.fg1
+        balanceValueLabel.adjustsFontForContentSizeCategory = false
+        balanceValueLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        balanceTopUpButton.translatesAutoresizingMaskIntoConstraints = false
+        balanceTopUpButton.addTarget(
+            self,
+            action: #selector(balanceTopUpTapped),
+            for: .touchUpInside
+        )
+
+        // Value row — value pinned leading, top-up button trailing.
+        let valueRow = UIView()
+        valueRow.translatesAutoresizingMaskIntoConstraints = false
+        valueRow.addSubview(balanceValueLabel)
+        valueRow.addSubview(balanceTopUpButton)
+
+        balanceHintLabel.translatesAutoresizingMaskIntoConstraints = false
+        balanceHintLabel.font = AppTypography.meta
+        balanceHintLabel.textColor = AppColors.fg3
+        balanceHintLabel.textAlignment = .center
+        balanceHintLabel.numberOfLines = 1
+        balanceHintLabel.isHidden = true
+
+        // Caps + value row + centered hint — vertical stack inside the
+        // card. Custom spacing keeps the hint visually separate from the
+        // value (matches the JSX `gap-y-2` after value).
+        let innerStack = UIStackView(arrangedSubviews: [
+            balanceCapsLabel, valueRow, balanceHintLabel
+        ])
+        innerStack.translatesAutoresizingMaskIntoConstraints = false
+        innerStack.axis = .vertical
+        innerStack.alignment = .fill
+        innerStack.spacing = 8
+        innerStack.setCustomSpacing(8, after: balanceCapsLabel)
+        innerStack.setCustomSpacing(10, after: valueRow)
+        balanceCard.addSubview(innerStack)
+
+        NSLayoutConstraint.activate([
+            innerStack.topAnchor.constraint(equalTo: balanceCard.layoutMarginsGuide.topAnchor),
+            innerStack.bottomAnchor.constraint(equalTo: balanceCard.layoutMarginsGuide.bottomAnchor),
+            innerStack.leadingAnchor.constraint(equalTo: balanceCard.layoutMarginsGuide.leadingAnchor),
+            innerStack.trailingAnchor.constraint(equalTo: balanceCard.layoutMarginsGuide.trailingAnchor),
+
+            balanceValueLabel.leadingAnchor.constraint(equalTo: valueRow.leadingAnchor),
+            balanceValueLabel.topAnchor.constraint(equalTo: valueRow.topAnchor),
+            balanceValueLabel.bottomAnchor.constraint(equalTo: valueRow.bottomAnchor),
+
+            balanceTopUpButton.trailingAnchor.constraint(equalTo: valueRow.trailingAnchor),
+            balanceTopUpButton.centerYAnchor.constraint(equalTo: balanceValueLabel.centerYAnchor),
+            balanceTopUpButton.leadingAnchor.constraint(
+                greaterThanOrEqualTo: balanceValueLabel.trailingAnchor,
+                constant: AppSpacing.sp3
+            )
+        ])
+
+        // Wire the gradient layer to the value label — masked to glyph
+        // outlines on every layout pass.
+        balanceValueGradient.colors = SPSupport.moneyGradientColors
+        balanceValueGradient.locations = SPSupport.moneyGradientLocations
+        balanceValueGradient.startPoint = SPSupport.gradientStart
+        balanceValueGradient.endPoint = SPSupport.gradientEnd
+    }
+
+    private func configureWarningBanner() {
+        warningBanner.translatesAutoresizingMaskIntoConstraints = false
+
+        warningCapsLabel.translatesAutoresizingMaskIntoConstraints = false
+        warningCapsLabel.attributedText = NSAttributedString(
+            string: "БАЛАНС ПОЧТИ ПУСТ",
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.fgOnWarn
+            ]
+        )
+
+        warningMetaLabel.translatesAutoresizingMaskIntoConstraints = false
+        warningMetaLabel.font = AppTypography.meta
+        warningMetaLabel.textColor = AppColors.fgOnWarn.withAlphaComponent(0.85)
+        warningMetaLabel.numberOfLines = 1
+
+        warningTopUpButton.translatesAutoresizingMaskIntoConstraints = false
+        warningTopUpButton.addTarget(
+            self,
+            action: #selector(warnTopUpTapped),
+            for: .touchUpInside
+        )
+
+        let textStack = UIStackView(arrangedSubviews: [warningCapsLabel, warningMetaLabel])
+        textStack.translatesAutoresizingMaskIntoConstraints = false
+        textStack.axis = .vertical
+        textStack.alignment = .leading
+        textStack.spacing = 4
+
+        let row = UIStackView(arrangedSubviews: [textStack, warningTopUpButton])
+        row.translatesAutoresizingMaskIntoConstraints = false
+        row.axis = .horizontal
+        row.alignment = .center
+        row.spacing = AppSpacing.sp3
+        row.distribution = .fill
+
+        warningBanner.addSubview(row)
+        NSLayoutConstraint.activate([
+            row.topAnchor.constraint(equalTo: warningBanner.layoutMarginsGuide.topAnchor),
+            row.bottomAnchor.constraint(equalTo: warningBanner.layoutMarginsGuide.bottomAnchor),
+            row.leadingAnchor.constraint(equalTo: warningBanner.layoutMarginsGuide.leadingAnchor),
+            row.trailingAnchor.constraint(equalTo: warningBanner.layoutMarginsGuide.trailingAnchor)
+        ])
+
+        textStack.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        warningTopUpButton.setContentHuggingPriority(.required, for: .horizontal)
+        warningTopUpButton.setContentCompressionResistancePriority(.required, for: .horizontal)
+    }
+
+    // MARK: - Gradient masking
+
+    private func applyValueGradient() {
+        // Same recipe as SPBalanceCard.applyValueGradient — render the
+        // glyph outlines into an offscreen image and use it as the
+        // gradient layer's mask. Re-runs every layout so font / size
+        // changes refresh the mask.
+        let textBounds = balanceValueLabel.bounds
+        guard textBounds.width > 0, textBounds.height > 0 else { return }
+        if balanceValueGradient.superlayer !== balanceValueLabel.layer {
+            balanceValueLabel.layer.addSublayer(balanceValueGradient)
+        }
+        balanceValueGradient.frame = textBounds
+
+        let renderer = UIGraphicsImageRenderer(size: textBounds.size)
+        let mask = renderer.image { ctx in
+            ctx.cgContext.setFillColor(UIColor.white.cgColor)
+            (balanceValueLabel.text ?? "").draw(
+                in: textBounds,
+                withAttributes: [
+                    .font: balanceValueLabel.font as Any,
+                    .foregroundColor: UIColor.white
+                ]
+            )
+        }
+        let maskLayer = CALayer()
+        maskLayer.frame = textBounds
+        maskLayer.contents = mask.cgImage
+        balanceValueGradient.mask = maskLayer
+        // Hide the label paint so we don't double-render.
+        balanceValueLabel.textColor = .clear
+    }
+
+    // MARK: - Actions
+
+    @objc private func balanceTopUpTapped() {
+        onBalanceTopUpTap?()
+    }
+
+    @objc private func warnTopUpTapped() {
+        onWarnTopUpTap?()
+    }
+}
+
+// MARK: - Radial overlay
+
+/// Reuses the SPBalanceCard radial-highlight recipe (80% × 60% money tint
+/// at top-right). Kept private to this file so the SP* primitive isn't
+/// touched.
+private final class AlarmsHeaderRadialOverlayView: UIView {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .clear
+        isUserInteractionEnabled = false
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func draw(_ rect: CGRect) {
+        guard let context = UIGraphicsGetCurrentContext() else { return }
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let colors = [
+            AppColors.money400.withAlphaComponent(0.18).cgColor,
+            UIColor.clear.cgColor
+        ]
+        guard let gradient = CGGradient(
+            colorsSpace: colorSpace,
+            colors: colors as CFArray,
+            locations: [0.0, 1.0]
+        ) else { return }
+        let centerPoint = CGPoint(x: rect.maxX, y: rect.minY)
+        let radius = max(rect.width, rect.height) * 0.6
+        context.drawRadialGradient(
+            gradient,
+            startCenter: centerPoint,
+            startRadius: 0,
+            endCenter: centerPoint,
+            endRadius: radius,
+            options: []
+        )
+    }
+}


### PR DESCRIPTION
Fixes #142

## Что сделано
- Sticky balance card pinned to safe-area top via new `SPAlarmsListHeader` (composed from SPCard.raised + SPButton.money,.sm). Caps "БАЛАНС" + `moneyLg` value with the money-gradient glyph mask, **centered "Хватит на ~N откладываний" below the balance** (PM feedback fix), and trailing "Пополнить" pill.
- Low-balance warning row (`SPCard(.warn)` + `SPButton(.warn,.sm)`) re-evaluates on every `BalanceService.balanceChangedNotification` and on view appear; threshold fixed at 100 ₽ (`AlarmsListViewModel.lowBalanceThreshold`).
- Empty state moved to `SPAlarmsListEmptyState`: SF Symbol `bell.slash` (64pt, `fg3`), `h2` heading, `body` subtitle, and `SPButton(.money,.lg)` "Добавить будильник" CTA wired to existing add flow. Lays out as an overlay under the sticky header so the user keeps seeing their balance.
- `AlarmsListViewModel` gains `averagePenalty` (mode of positive penalties, falls back to 50 ₽ default), `affordableSnoozeCount`, `affordabilityHint` (Russian-pluralised), and `isLowBalance`. The header refreshes on both balance and alarm-set changes since deleting an alarm can shift the average penalty.
- AlarmCell intentionally untouched per issue scope; only the list chrome around it changes.

## Verify
- swiftlint: 0 errors (only pre-existing warnings in unrelated tests; new files clean)
- build_sim (iPhone 17): succeeded
- test_sim / screenshot: skipped per issue instructions

## Out of scope
- Pre-emptive top-up bottom sheet (#141)
- AlarmCell visual refresh