### PR TITLE
[design-refresh] Add progressive snooze visual escalation (#139)

### DIFF
--- a/SnoozePay/SnoozePay/Utilities/AppFonts.swift
+++ b/SnoozePay/SnoozePay/Utilities/AppFonts.swift
@@ -134,3 +134,32 @@ enum AppFonts {
         return UIFont(name: name, size: size)
     }
 }
+
+// MARK: - Tabular numeric helper
+
+extension UIFont {
+    /// Tabular-figures variant of the font — every digit glyph occupies the
+    /// same advance width, so columns of numbers (clock ticks, balance
+    /// rows, the firing-screen history ticker) stop reflowing every time a
+    /// `1` swaps with a `4`. Mirrors SwiftUI's `Font.monospacedDigit()`
+    /// using the UIKit feature-settings descriptor (Apple flags
+    /// `kNumberSpacingType` + `kMonospacedNumbersSelector`).
+    ///
+    /// Lives in `AppFonts.swift` because the design-system fonts compose
+    /// into UIFont via `AppFonts.font(...)`, and several call sites
+    /// (`AlarmFiringViewController.timeLabel`, the new `historyTicker`
+    /// in #139, future money-row labels) chain `.monospacedDigit()` on
+    /// the resulting `UIFont`. `UIFont` itself does not ship the SwiftUI
+    /// instance method, so we add it here.
+    func monospacedDigit() -> UIFont {
+        let descriptor = fontDescriptor.addingAttributes([
+            .featureSettings: [
+                [
+                    UIFontDescriptor.FeatureKey.type: kNumberSpacingType,
+                    UIFontDescriptor.FeatureKey.selector: kMonospacedNumbersSelector
+                ]
+            ]
+        ])
+        return UIFont(descriptor: descriptor, size: pointSize)
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Progressive.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Progressive.swift
@@ -1,0 +1,121 @@
+import UIKit
+
+/// Progressive-snooze UI for the firing screen — extracted from
+/// `AlarmFiringViewController` so the main type stays under SwiftLint's
+/// `type_body_length` cap (mirrors the same pattern used by the +Audio file).
+///
+/// Issue #139 — when `alarm.progressiveScale == true` the firing screen mounts
+/// an indicator pill ("Прогрессив · N-й снуз") above the snooze CTA, a single
+/// line history ticker ("сегодня: −50 → −100 → −200 ₽") below it, and
+/// cross-fades the snooze gradient from warn → pain as the user keeps
+/// snoozing. None of this is touched for default alarms — the +Progressive
+/// installer is a no-op via guard at the call site.
+extension AlarmFiringViewController {
+
+    /// Build the progressive-snooze indicator pill + history ticker stack
+    /// and pin it horizontally to the screen-inset. Pulse animation on the
+    /// dot is started here once — no need to restart on `updateUI()`.
+    /// Returns the stack so `setupUI` can wire it into the bottom layout.
+    func installProgressiveStack(inset: CGFloat) -> UIStackView {
+        // Pill: caps text. The leading dot is drawn as a sibling 8pt circle
+        // view inside a horizontal wrapper rather than via `SPPill(icon:)`,
+        // because we need the dot to host its own pulse animation while the
+        // pill keeps its background/text styling.
+        let pill = SPPill(text: "Прогрессив · 1-й снуз", tone: .warn)
+        pill.translatesAutoresizingMaskIntoConstraints = false
+        progressivePill = pill
+
+        let dot = UIView()
+        dot.translatesAutoresizingMaskIntoConstraints = false
+        dot.backgroundColor = AppColors.warn300
+        dot.layer.cornerRadius = 4
+        dot.isUserInteractionEnabled = false
+        progressivePulseDot = dot
+
+        // Wrap pill + dot so the dot sits 6pt to the leading edge of the
+        // pill while staying centered horizontally as a group.
+        let pillRow = UIStackView(arrangedSubviews: [dot, pill])
+        pillRow.axis = .horizontal
+        pillRow.spacing = AppSpacing.sp1 + 2   // 6pt — matches SPPill's internal gap recipe
+        pillRow.alignment = .center
+
+        let ticker = UILabel()
+        ticker.translatesAutoresizingMaskIntoConstraints = false
+        ticker.font = AppTypography.meta.monospacedDigit()
+        ticker.textColor = AppColors.fg3
+        ticker.textAlignment = .center
+        ticker.numberOfLines = 1
+        ticker.lineBreakMode = .byTruncatingHead
+        ticker.adjustsFontSizeToFitWidth = true
+        ticker.minimumScaleFactor = 0.7
+        ticker.isHidden = true
+        historyTicker = ticker
+
+        let stack = UIStackView(arrangedSubviews: [pillRow, ticker])
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .vertical
+        stack.alignment = .center
+        stack.spacing = AppSpacing.sp2
+        view.addSubview(stack)
+        progressiveStack = stack
+
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
+            stack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
+            dot.widthAnchor.constraint(equalToConstant: 8),
+            dot.heightAnchor.constraint(equalToConstant: 8)
+        ])
+
+        startPulseAnimation(on: dot)
+        return stack
+    }
+
+    /// Refresh the indicator pill text + the history ticker. Called from
+    /// `updateUI()` so the indicator counts up (`1-й` → `2-й` → ...) and
+    /// the ticker grows as the user keeps snoozing.
+    func updateProgressiveChrome() {
+        let nextIndex = viewModel.snoozeCount + 1
+        progressivePill?.setText("Прогрессив · \(nextIndex)-й снуз")
+
+        guard let ticker = historyTicker else { return }
+        let past = viewModel.pastPenalties
+        if past.isEmpty {
+            // No history yet — keep the pill, hide the ticker.
+            ticker.isHidden = true
+            ticker.text = nil
+            return
+        }
+        var parts = past.map { "−\(Self.formatPenalty($0))" }
+        parts.append("−\(Self.formatPenalty(viewModel.currentPenalty))")
+        // Trailing currency glyph after the last amount only — keeps the
+        // arrow chain visually balanced ("−50 → −100 → −200 ₽").
+        if let last = parts.last {
+            parts[parts.count - 1] = "\(last) ₽"
+        }
+        ticker.text = "сегодня: \(parts.joined(separator: " → "))"
+        ticker.isHidden = false
+    }
+
+    /// 0.4 → 1.0 opacity autoreverse pulse, 900ms each leg. Driven via
+    /// CABasicAnimation rather than UIView.animate so the layer pulse keeps
+    /// running while UIKit runs touch / scroll animations elsewhere.
+    private func startPulseAnimation(on dot: UIView) {
+        let pulse = CABasicAnimation(keyPath: "opacity")
+        pulse.fromValue = 0.4
+        pulse.toValue = 1.0
+        pulse.duration = SPSupport.durationAnxious
+        pulse.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+        pulse.autoreverses = true
+        pulse.repeatCount = .infinity
+        dot.layer.add(pulse, forKey: "progressivePulse")
+    }
+
+    /// Format a penalty amount for the history ticker. The ticker is a
+    /// glanceable single-line summary, so we strip thousand separators and
+    /// the currency glyph (`formattedRubles` adds " ₽" to each value).
+    /// Trailing fraction is dropped — the doubling rule produces integers.
+    private static func formatPenalty(_ amount: Double) -> String {
+        let intValue = Int(amount.rounded())
+        return "\(intValue)"
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
@@ -18,7 +18,9 @@ class AlarmFiringViewController: UIViewController {
 
     // MARK: - ViewModel
 
-    private let viewModel: AlarmFiringViewModel
+    /// `internal` so the +Audio and +Progressive extensions in sibling files
+    /// can read VM state during their UI updates.
+    let viewModel: AlarmFiringViewModel
 
     // MARK: - Background layers
 
@@ -81,9 +83,11 @@ class AlarmFiringViewController: UIViewController {
 
     /// Big snooze CTA. Built in `setupUI` because its constructor needs
     /// VM-derived price + minutes that aren't valid at property-init time.
-    /// Tone is `.warn` for the default path; the progressive `.pain`
-    /// variant ships in #139.
-    private var snoozeCTA: SPSnoozePrice?
+    /// Tone defaults to `.warn`; for `progressiveScale == true` alarms the
+    /// VC swaps it to `.progressive(intensity:)` and bumps the intensity on
+    /// every snooze tap (#139). `internal` so the +Progressive extension
+    /// can re-tone it on `updateUI()`.
+    var snoozeCTA: SPSnoozePrice?
 
     private let dismissButton = SPButton(
         title: "Я встал",
@@ -91,6 +95,30 @@ class AlarmFiringViewController: UIViewController {
         size: .lg,
         fullWidth: true
     )
+
+    // MARK: - Progressive UI (#139) — only mounted when `alarm.progressiveScale`.
+    //
+    // Layout + animation logic lives in `AlarmFiringViewController+Progressive.swift`;
+    // these stored handles are accessed from the extension via `internal` so the
+    // type body of the main VC stays under SwiftLint's `type_body_length` cap.
+
+    /// Container holding the indicator pill + history ticker. Built lazily
+    /// inside `setupUI` so the default firing flow (#138) skips both views
+    /// entirely — they never enter the layout pass.
+    var progressiveStack: UIStackView?
+
+    /// "Прогрессив · N-й снуз" pill above the snooze CTA. Re-titled on every
+    /// `updateUI()` so the label tracks `snoozeCount + 1` (the next snooze).
+    var progressivePill: SPPill?
+
+    /// Pulsing dot rendered inside `progressivePill`. CABasicAnimation lives
+    /// on its `layer.opacity` (autoreverse, infinite, 900ms — `--sp-dur-anxious`).
+    var progressivePulseDot: UIView?
+
+    /// Single-line ticker rendered between the pill and the snooze CTA.
+    /// `meta` typography, fg-3, mono digits — "сегодня: −50 → −100 → ..."
+    /// Hidden when `snoozeCount == 0` (no history to show yet).
+    var historyTicker: UILabel?
 
     /// Banner shown when AudioService falls back to vibration / silent mode.
     /// Hidden by default; surfaces only on `.silentBecauseConfigFailed` or `.vibrationOnly`.
@@ -199,10 +227,16 @@ class AlarmFiringViewController: UIViewController {
 
         // VM exposes `currentPenalty` as `Double`; wrap in `Decimal` so
         // `SPSnoozePrice.formattedRubles()` does the locale-aware format.
+        // Pick the initial tone based on the alarm config — progressive
+        // alarms start at intensity 0 (still pure warn) and ramp up as the
+        // user snoozes.
+        let initialTone: SPSnoozePrice.Tone = viewModel.isProgressiveActive
+            ? .progressive(intensity: viewModel.progressiveIntensity)
+            : .warn
         let snooze = SPSnoozePrice(
             price: Decimal(viewModel.currentPenalty),
             minutes: viewModel.alarm.snoozeMinutes,
-            tone: .warn,
+            tone: initialTone,
             hint: nil
         )
         snooze.translatesAutoresizingMaskIntoConstraints = false
@@ -221,6 +255,21 @@ class AlarmFiringViewController: UIViewController {
         let inset: CGFloat = AppSpacing.sp5      // 20pt — Dawn spec
         let gap: CGFloat = AppSpacing.sp3         // 12pt — Dawn spec
 
+        // Progressive escalation chrome — only mounted for alarms with the
+        // doubling-penalty toggle. The default flow stays exactly as #138.
+        // Anchor the audio-fallback banner to the chrome's top so the banner
+        // never overlaps the indicator when both are on screen.
+        let bannerBottomAnchor: NSLayoutYAxisAnchor
+        if viewModel.isProgressiveActive {
+            let stack = installProgressiveStack(inset: inset)
+            NSLayoutConstraint.activate([
+                stack.bottomAnchor.constraint(equalTo: snooze.topAnchor, constant: -AppSpacing.sp3)
+            ])
+            bannerBottomAnchor = stack.topAnchor
+        } else {
+            bannerBottomAnchor = snooze.topAnchor
+        }
+
         NSLayoutConstraint.activate([
             timeLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             timeLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: -80),
@@ -234,7 +283,7 @@ class AlarmFiringViewController: UIViewController {
 
             audioWarningBanner.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
             audioWarningBanner.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
-            audioWarningBanner.bottomAnchor.constraint(equalTo: snooze.topAnchor, constant: -AppSpacing.sp4),
+            audioWarningBanner.bottomAnchor.constraint(equalTo: bannerBottomAnchor, constant: -AppSpacing.sp4),
 
             snooze.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
             snooze.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
@@ -273,7 +322,7 @@ class AlarmFiringViewController: UIViewController {
         }
     }
 
-    private func updateUI() {
+    func updateUI() {
         nameLabel.text = viewModel.alarmName
 
         // Refresh snooze CTA — VM may have bumped `snoozeCount` (progressive
@@ -285,6 +334,16 @@ class AlarmFiringViewController: UIViewController {
                 hint: nil
             )
             snooze.isEnabled = viewModel.canSnooze
+            if viewModel.isProgressiveActive {
+                // Cross-fade the gradient toward pain as snoozeCount climbs.
+                // SPSnoozePrice.setTone is a no-op when intensity hasn't
+                // moved, so calling it on every updateUI() is cheap.
+                snooze.setTone(.progressive(intensity: viewModel.progressiveIntensity))
+            }
+        }
+
+        if viewModel.isProgressiveActive {
+            updateProgressiveChrome()
         }
     }
 

--- a/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
@@ -42,6 +42,35 @@ final class AlarmFiringViewModel {
         alarm.penalty(forSnoozeCount: snoozeCount + 1)
     }
 
+    // MARK: - Progressive escalation (#139)
+
+    /// `true` when the firing screen should render the progressive escalation
+    /// chrome: the warn → pain gradient cross-fade on the snooze CTA, the
+    /// "Прогрессив · N-й снуз" indicator pill, and the history ticker.
+    /// Mirrors the underlying alarm setting so default alarms keep the plain
+    /// warn-tone Dawn treatment from #138.
+    var isProgressiveActive: Bool { alarm.progressiveScale }
+
+    /// Cross-fade weight between the warn and pain gradient stops. `0.0` on
+    /// the very first snooze (snoozeCount == 0), reaching `1.0` once the
+    /// user has hit the 6th snooze of the morning. Linear ramp because the
+    /// PM brief reads as "gradually redden" — easing curves muddied which
+    /// snooze count produced which colour during prototyping.
+    var progressiveIntensity: Double {
+        guard isProgressiveActive else { return 0 }
+        return max(0.0, min(1.0, Double(snoozeCount) / 5.0))
+    }
+
+    /// Past penalty amounts charged today, in chronological order, derived
+    /// from the same doubling rule as `currentPenalty`. Used by the firing
+    /// screen's history ticker to render "сегодня: −50 → −100 → ..." without
+    /// hitting the balance ledger (the in-VC string is purely informational).
+    /// Returns `[]` until the user has snoozed at least once.
+    var pastPenalties: [Double] {
+        guard snoozeCount > 0 else { return [] }
+        return (1...snoozeCount).map { alarm.penalty(forSnoozeCount: $0) }
+    }
+
     var canSnooze: Bool {
         balanceService.canAfford(currentPenalty)
     }

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPPill.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPPill.swift
@@ -87,7 +87,10 @@ final class SPPill: UIView {
         applyTone()
     }
 
-    private func setText(_ text: String) {
+    /// Update the pill's caps label in place. Used by callers that re-title
+    /// a long-lived pill instance (e.g. the progressive-snooze indicator on
+    /// the firing screen counts up "1-й снуз" → "2-й снуз" → ...).
+    func setText(_ text: String) {
         // CSS pairs caps tracking (.14em ≈ 12 * 0.14 = 1.68pt) with the
         // bold 12pt size; bake that into an attributed string so the label
         // stays in one node (not a stack of label + spacer).

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPSnoozePrice.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPSnoozePrice.swift
@@ -12,14 +12,20 @@ import UIKit
 /// 0.96) because the surface is bigger and 0.96 feels twitchy.
 final class SPSnoozePrice: UIControl {
 
-    enum Tone {
+    enum Tone: Equatable {
         case warn   // Default snooze — warm amber gradient
         case pain   // Progressive / expensive — pain coral gradient
+        /// Progressive escalation — interpolates linearly between the warn
+        /// and pain gradients. `intensity` is clamped to `0...1`; 0 renders
+        /// pure warn (snooze #1), 1 renders pure pain (snooze #6+). The
+        /// shadow tint blends the same way so the surrounding glow tracks
+        /// the fill colour as the user keeps snoozing.
+        case progressive(intensity: Double)
     }
 
     // MARK: - Configuration
 
-    let tone: Tone
+    private(set) var tone: Tone
     private(set) var price: Decimal
     private(set) var minutes: Int
     private(set) var hint: String?
@@ -120,6 +126,27 @@ final class SPSnoozePrice: UIControl {
         }
     }
 
+    /// Re-tone the surface in place. Used by the progressive-firing flow
+    /// (#139) to bump the snooze CTA's redness as `snoozeCount` grows
+    /// without rebuilding the control.
+    func setTone(_ newTone: Tone) {
+        guard tone != newTone else { return }
+        tone = newTone
+        applyTone()
+        priceLabel.textColor = foreground
+        hintLabel.textColor = foreground
+        // Re-render the caps label so its tinted attributedString picks up
+        // the new foreground.
+        capsLabel.attributedText = NSAttributedString(
+            string: "Поспать ещё \(self.minutes) мин".uppercased(),
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: 12 * 0.14,
+                .foregroundColor: foreground.withAlphaComponent(0.82)
+            ]
+        )
+    }
+
     // MARK: - Configuration
 
     private func configure() {
@@ -163,6 +190,17 @@ final class SPSnoozePrice: UIControl {
         switch tone {
         case .warn: return AppColors.fgOnWarn
         case .pain: return AppColors.fgOnPain
+        case .progressive(let intensity):
+            // Cross-fade the on-fill text colour the same way the gradient
+            // is interpolated. At intensity 0 the surface is pure amber so
+            // we want the warn ink (near-black); at intensity 1 it's coral
+            // and the pain ink (white) gives 4.5:1 contrast.
+            let clamped = max(0.0, min(1.0, intensity))
+            return SPSupport.lerpColor(
+                AppColors.fgOnWarn,
+                AppColors.fgOnPain,
+                progress: clamped
+            )
         }
     }
 
@@ -181,6 +219,15 @@ final class SPSnoozePrice: UIControl {
             gradient.colors = SPSupport.painGradientColors
             gradient.locations = SPSupport.painGradientLocations
             layer.shadowColor = AppColors.pain500.cgColor
+        case .progressive(let intensity):
+            let clamped = max(0.0, min(1.0, intensity))
+            gradient.colors = SPSupport.progressiveGradientColors(intensity: clamped)
+            gradient.locations = SPSupport.warnGradientLocations
+            layer.shadowColor = SPSupport.lerpColor(
+                AppColors.warn500,
+                AppColors.pain500,
+                progress: clamped
+            ).cgColor
         }
         layer.insertSublayer(gradient, at: 0)
         gradientLayer = gradient

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPSupport.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPSupport.swift
@@ -48,6 +48,41 @@ enum SPSupport {
     }
     static let warnGradientLocations: [NSNumber] = [0.0, 0.6, 1.0]
 
+    // MARK: - Progressive (warn → pain) interpolation
+
+    /// Linear-interpolate between the warn and pain gradient stops to render
+    /// the "the human keeps snoozing, surface keeps reddening" treatment
+    /// from #139. `intensity` 0 returns pure warn, 1 returns pure pain; the
+    /// shared `warnGradientLocations` are reused so the visual rhythm of the
+    /// stops doesn't shift mid-fade.
+    static func progressiveGradientColors(intensity: Double) -> [CGColor] {
+        let clamped = max(0.0, min(1.0, intensity))
+        return [
+            lerpColor(AppColors.warn300, AppColors.pain300, progress: clamped).cgColor,
+            lerpColor(AppColors.warn500, AppColors.pain500, progress: clamped).cgColor,
+            lerpColor(AppColors.warn600, AppColors.pain600, progress: clamped).cgColor
+        ]
+    }
+
+    /// Linear interpolation between two `UIColor` instances in sRGB.
+    /// `t` is clamped to `0...1` — out-of-range inputs collapse to the
+    /// nearest endpoint. Internal helper for the progressive snooze treatment;
+    /// also re-used by the on-fill text colour so the typography contrast
+    /// tracks the gradient.
+    static func lerpColor(_ from: UIColor, _ toColor: UIColor, progress: Double) -> UIColor {
+        let clamped = CGFloat(max(0.0, min(1.0, progress)))
+        var fromR: CGFloat = 0, fromG: CGFloat = 0, fromB: CGFloat = 0, fromA: CGFloat = 0
+        var toR: CGFloat = 0, toG: CGFloat = 0, toB: CGFloat = 0, toA: CGFloat = 0
+        from.getRed(&fromR, green: &fromG, blue: &fromB, alpha: &fromA)
+        toColor.getRed(&toR, green: &toG, blue: &toB, alpha: &toA)
+        return UIColor(
+            red: fromR + (toR - fromR) * clamped,
+            green: fromG + (toG - fromG) * clamped,
+            blue: fromB + (toB - fromB) * clamped,
+            alpha: fromA + (toA - fromA) * clamped
+        )
+    }
+
     // MARK: - Motion (`tokens.css` durations + easings)
 
     /// `--sp-dur-quick: 140ms` — press/release scale animations.
@@ -56,6 +91,10 @@ enum SPSupport {
     static let durationBase: TimeInterval = 0.220
     /// `--sp-dur-slow: 420ms`.
     static let durationSlow: TimeInterval = 0.420
+    /// `--sp-dur-anxious: 900ms` — pulse cadence for "things are escalating"
+    /// affordances (progressive-snooze indicator dot, low-balance flicker).
+    /// Slower than a heartbeat so it reads as worry, not panic.
+    static let durationAnxious: TimeInterval = 0.900
 
     /// Approximation of `cubic-bezier(.2,.8,.2,1)` used by `--sp-ease-out`.
     /// `UIView.animate(...)` doesn't accept arbitrary cubic-beziers; the


### PR DESCRIPTION
Fixes #139

## Summary

Progressive escalation chrome for the firing screen — only mounts when `alarm.progressiveScale == true`, so the default Dawn flow from #138 stays intact.

- **Indicator pill** "Прогрессив · {N}-й снуз" (warn-tone `SPPill`) with leading 8pt dot pulsing 0.4 ↔ 1.0 over 900ms (`--sp-dur-anxious`, autoreverse, infinite). Re-titled on every `updateUI()` so the count tracks `snoozeCount + 1`.
- **History ticker** below the pill, `meta` typography with mono digits, fg-3: `сегодня: −50 → −100 → −200 ₽`. Hidden when `snoozeCount == 0`.
- **Gradient cross-fade** on the `SPSnoozePrice` CTA — new `.progressive(intensity:)` tone linearly interpolates the warn↔pain gradient stops, the on-fill text colour, and the shadow tint. `intensity = min(1, snoozeCount / 5)`, so snooze #6+ renders pure pain.

## Implementation notes

- `SPSnoozePrice.Tone.progressive(intensity:)` is the new public entry point. `setTone(_:)` lets the VC re-tone the long-lived control without rebuilding it.
- Lerp + progressive gradient helpers live in `SPSupport` (sRGB linear interpolation), so they're reusable for future SP* components.
- `SPPill.setText(_:)` promoted from `private` to `internal` — re-titling without rebuilding fits the long-lived indicator's lifecycle.
- VM exposes `isProgressiveActive`, `progressiveIntensity`, and `pastPenalties` derived from the existing `Alarm.penalty(forSnoozeCount:)` doubling rule. No persistence change.
- Layout extracted to `AlarmFiringViewController+Progressive.swift` so the main type stays under SwiftLint's `type_body_length` cap (mirrors the +Audio extension pattern).
- **Drive-by fix:** `UIFont.monospacedDigit()` extension via the `kNumberSpacingType` feature setting in `AppFonts.swift`. The design-refresh base (#138) already calls `clockXl.monospacedDigit()` on the firing-screen clock, but UIFont doesn't ship that method (only SwiftUI's `Font` does). Without this fix the base branch doesn't compile — confirmed by checking out `origin/design-refresh-2026-04-27` cleanly.

## Verify

- swiftlint: 0 errors (warnings unchanged from base)
- build_sim: succeeded (iPhone 17 simulator)
- test_sim: skipped per issue instructions
- screenshot: skipped per issue instructions

## Out of scope

- No-balance state (#140)
- Top-up bottom sheet (#141)