### PR TITLE
[design-refresh] Onboarding Dawn refresh + later button (#145)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController.swift
@@ -1,13 +1,33 @@
 import UIKit
 
-/// Onboarding flow shown on first launch.
-/// Three fullscreen pages with swipe navigation and pagination dots.
+/// First-launch onboarding — Dawn redesign (#145).
+///
+/// Three full-screen pages on a single horizontally-paged `UIScrollView`:
+/// 1. "Что такое SnoozePay" — concept explainer.
+/// 2. "Как работает" — snooze → penalty mechanic.
+/// 3. "Стартовый депозит" — three preset tiles (200 / 500 / 1000 ₽) plus an
+///    Apple Pay primary CTA *and* a ghost "Позже" button so the user can
+///    skip the first top-up (per PM directive in `chat1.md` line 747).
+///
+/// Visual treatment is the shared design-refresh "Dawn" surface: a vertical
+/// 4-stop atmospheric gradient (`--sp-grad-dawn`), Manrope/JetBrains Mono
+/// typography, brand-token foregrounds. Behaviour preserves the existing
+/// `UserDefaults` key (`onboarding_completed`) so the SceneDelegate root
+/// re-init flow keeps working unchanged.
 final class OnboardingViewController: UIViewController {
 
-    // MARK: - Constants
+    // MARK: - Persistence keys
 
     private static let completedKey = "onboarding_completed"
+    /// Set to `false` when the user finishes step 3 via "Позже" so future
+    /// analytics / re-engagement can distinguish "user opted out of the
+    /// first deposit" from "user paid". Stays absent until the user actually
+    /// reaches step 3.
+    private static let firstTopUpDoneKey = "first_top_up_done"
 
+    /// `true` once the user has finished onboarding (either Apple Pay path
+    /// or "Позже" path). Read by `SceneDelegate` to decide whether to mount
+    /// the onboarding flow on launch.
     static var isCompleted: Bool {
         UserDefaults.standard.bool(forKey: completedKey)
     }
@@ -15,109 +35,190 @@ final class OnboardingViewController: UIViewController {
     // MARK: - Page Data
 
     private struct Page {
-        let emoji: String
         let title: String
-        let description: String
-        let buttonTitle: String
+        let body: String
     }
 
     private let pages: [Page] = [
         Page(
-            emoji: "\u{23F0}",
-            title: "Откладывание стоит денег",
-            description: "Каждый раз, когда вы откладываете будильник, с вашего баланса списывается штраф. Это мотивирует просыпаться вовремя.",
-            buttonTitle: "Далее"
+            title: "Что такое SnoozePay",
+            body: """
+            Будильник, за который вы платите рублём. \
+            Каждое откладывание списывает деньги с депозита — \
+            поэтому вставать вовремя проще, чем переспать.
+            """
         ),
         Page(
-            emoji: "\u{1F4B0}",
-            title: "Штраф 10–1000\u{20BD}",
-            description: "Вы устанавливаете размер штрафа сами. Если баланс = 0, откладывание блокируется.",
-            buttonTitle: "Далее"
+            title: "Как работает",
+            body: """
+            Вы кладёте депозит и ставите будильник. \
+            Жмёте «Отложить» — со счёта списывается штраф. \
+            Дисмиссите будильник вовремя — депозит остаётся при вас.
+            """
         ),
         Page(
-            emoji: "\u{1F525}",
-            title: "Статистика и streak",
-            description: "Следите за своими успехами и экономьте деньги. Каждый день без откладывания увеличивает ваш streak!",
-            buttonTitle: "Начать"
+            title: "Стартовый депозит",
+            body: """
+            Положите небольшую сумму, чтобы старт был ощутимым. \
+            Меньше денег на счёте — слабее мотивация; \
+            больше — выше цена утреннего «ещё пять минут».
+            """
         )
     ]
 
+    /// Preset amounts on step 3. Default selection is the middle tile (500 ₽).
+    private let presetAmounts: [Decimal] = [200, 500, 1000]
+    private let defaultPresetIndex: Int = 1
+
     // MARK: - Callback
 
+    /// Invoked once the user finishes (or skips) onboarding. SceneDelegate
+    /// uses this to swap the root from the onboarding flow to the tab bar.
     var onFinished: (() -> Void)?
+
+    // MARK: - Background (Dawn)
+
+    /// Vertical 4-stop atmospheric gradient. Same recipe as
+    /// `AlarmFiringViewController`'s `dawnGradientLayer` — sourced from
+    /// `--sp-grad-dawn` in `tokens.css` (#14122A → #0F1A2E → #0A1320 → #050912).
+    private let dawnGradientLayer: CAGradientLayer = {
+        let gradient = CAGradientLayer()
+        gradient.colors = [
+            UIColor(rgb: 0x14122A).cgColor,
+            UIColor(rgb: 0x0F1A2E).cgColor,
+            UIColor(rgb: 0x0A1320).cgColor,
+            UIColor(rgb: 0x050912).cgColor
+        ]
+        gradient.locations = [0.0, 0.4, 0.7, 1.0]
+        gradient.startPoint = CGPoint(x: 0.5, y: 0.0)
+        gradient.endPoint = CGPoint(x: 0.5, y: 1.0)
+        return gradient
+    }()
 
     // MARK: - UI Elements
 
     private let scrollView: UIScrollView = {
-        let sv = UIScrollView()
-        sv.isPagingEnabled = true
-        sv.showsHorizontalScrollIndicator = false
-        sv.showsVerticalScrollIndicator = false
-        sv.bounces = false
-        sv.translatesAutoresizingMaskIntoConstraints = false
-        return sv
+        let scrollView = UIScrollView()
+        scrollView.isPagingEnabled = true
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.bounces = false
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        return scrollView
     }()
 
+    /// Page dots — kept as `UIPageControl` so the existing test
+    /// (`OnboardingTests.testOnboardingPages_count`) keeps reaching for the
+    /// same view kind. Tinted with brand tokens: `money500` for the active
+    /// dot (matches the deposit hero), `fg3` for the rest.
     private let pageControl: UIPageControl = {
-        let pc = UIPageControl()
-        pc.currentPageIndicatorTintColor = .systemBlue
-        pc.pageIndicatorTintColor = UIColor.systemGray.withAlphaComponent(0.5)
-        pc.translatesAutoresizingMaskIntoConstraints = false
-        pc.isUserInteractionEnabled = false
-        return pc
+        let pageControl = UIPageControl()
+        pageControl.currentPageIndicatorTintColor = AppColors.money500
+        pageControl.pageIndicatorTintColor = AppColors.fg3
+        pageControl.translatesAutoresizingMaskIntoConstraints = false
+        pageControl.isUserInteractionEnabled = false
+        return pageControl
     }()
 
-    private let skipButton: UIButton = {
-        let button = UIButton(type: .system)
-        button.setTitle("Пропустить", for: .normal)
-        button.setTitleColor(.systemBlue, for: .normal)
-        button.titleLabel?.font = UIFont.systemFont(ofSize: 15, weight: .regular)
-        button.translatesAutoresizingMaskIntoConstraints = false
-        return button
-    }()
+    /// Top-right "Пропустить" — restyled as `SPButton(.quiet, .sm)`.
+    private let skipButton = SPButton(
+        title: "Пропустить",
+        variant: .quiet,
+        size: .sm
+    )
 
-    private let actionButton: UIButton = {
-        var config = UIButton.Configuration.filled()
-        config.baseBackgroundColor = .systemBlue
-        config.baseForegroundColor = .white
-        config.cornerStyle = .large
-        config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { attrs in
-            var modified = attrs
-            modified.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
-            return modified
-        }
-        let button = UIButton(configuration: config)
-        button.translatesAutoresizingMaskIntoConstraints = false
-        return button
+    /// Primary CTA. On steps 1-2 this reads "Далее" and advances the pager;
+    /// on step 3 the VC swaps it for an Apple Pay-flavoured money button
+    /// (`actionButton` is the step-1/2 instance only; step-3 uses
+    /// `applePayButton` mounted inside the page).
+    private let actionButton = SPButton(
+        title: "Далее",
+        variant: .money,
+        size: .lg,
+        fullWidth: true
+    )
+
+    /// Step-3 Apple Pay primary CTA — mounted inside the third page so it
+    /// scrolls in/out with the page. SPButton has no public title setter, so
+    /// the title-change-on-preset-change path replaces the whole button via
+    /// `rebuildApplePayButton()` (same pattern as FiringTopUpBottomSheet).
+    private var applePayButton: SPButton = SPButton(
+        title: "Начать с 500 ₽",
+        variant: .money,
+        size: .lg,
+        fullWidth: true
+    )
+
+    /// Step-3 "Позже" — ghost CTA stacked right under `applePayButton`. Tap
+    /// finishes onboarding without triggering an IAP and stamps
+    /// `first_top_up_done = false` so future analytics can attribute the
+    /// opt-out.
+    private let laterButton = SPButton(
+        title: "Позже",
+        variant: .ghost,
+        size: .lg,
+        fullWidth: true
+    )
+
+    /// CTA stack on step 3 — owns the (re-creatable) Apple Pay button as its
+    /// first arranged subview so `rebuildApplePayButton()` can swap the
+    /// instance without re-pinning constraints.
+    private let ctaStack: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = AppSpacing.sp3
+        stackView.alignment = .fill
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
     }()
 
     private var pageViews: [UIView] = []
+    private var presetTiles: [SPAmountPreset] = []
+
+    /// Currently-selected preset index on step 3. Initialised to
+    /// `defaultPresetIndex` (500 ₽). Drives both the Apple Pay CTA title and
+    /// which tile renders selected.
+    private lazy var selectedPresetIndex: Int = defaultPresetIndex
 
     // MARK: - Lifecycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .black
+        view.backgroundColor = UIColor(rgb: 0x050912)
+        view.layer.insertSublayer(dawnGradientLayer, at: 0)
         setupUI()
-        updateActionButton(forPage: 0)
+        updatePagerState(forPage: 0)
     }
 
     override var prefersStatusBarHidden: Bool { true }
 
+    /// Force dark UI so the Dawn gradient + brand foregrounds read correctly
+    /// regardless of the user's system theme. Same approach as
+    /// AlarmFiringViewController so onboarding doesn't flash light-mode tiles
+    /// on first launch.
+    override var preferredStatusBarStyle: UIStatusBarStyle { .lightContent }
+
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        // Recalculate page widths after layout
+        // Recalculate page widths after layout.
         let width = scrollView.bounds.width
-        guard width > 0 else { return }
+        let height = scrollView.bounds.height
+        guard width > 0, height > 0 else { return }
         for (index, pageView) in pageViews.enumerated() {
             pageView.frame = CGRect(
                 x: width * CGFloat(index),
                 y: 0,
                 width: width,
-                height: scrollView.bounds.height
+                height: height
             )
         }
-        scrollView.contentSize = CGSize(width: width * CGFloat(pages.count), height: scrollView.bounds.height)
+        scrollView.contentSize = CGSize(width: width * CGFloat(pages.count), height: height)
+        // Disable implicit animation so the gradient layer doesn't crossfade
+        // on each rotation / size-class change.
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        dawnGradientLayer.frame = view.bounds
+        CATransaction.commit()
     }
 
     // MARK: - Setup
@@ -132,108 +233,254 @@ final class OnboardingViewController: UIViewController {
         pageControl.currentPage = 0
 
         NSLayoutConstraint.activate([
-            // Skip button — top right
-            skipButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 8),
-            skipButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+            // Skip button — top right.
+            skipButton.topAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.topAnchor,
+                constant: AppSpacing.sp2
+            ),
+            skipButton.trailingAnchor.constraint(
+                equalTo: view.trailingAnchor,
+                constant: -AppSpacing.screenInset
+            ),
 
-            // Scroll view — full screen behind everything
+            // Scroll view — full screen behind everything.
             scrollView.topAnchor.constraint(equalTo: view.topAnchor),
             scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
 
-            // Action button — bottom, full width with margins
-            actionButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
-            actionButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
-            actionButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -24),
-            actionButton.heightAnchor.constraint(equalToConstant: 50),
+            // Action button — bottom, full width with margins.
+            actionButton.leadingAnchor.constraint(
+                equalTo: view.leadingAnchor,
+                constant: AppSpacing.screenInset
+            ),
+            actionButton.trailingAnchor.constraint(
+                equalTo: view.trailingAnchor,
+                constant: -AppSpacing.screenInset
+            ),
+            actionButton.bottomAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.bottomAnchor,
+                constant: -AppSpacing.sp6
+            ),
 
-            // Page control — above button
+            // Page control — above the action button.
             pageControl.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            pageControl.bottomAnchor.constraint(equalTo: actionButton.topAnchor, constant: -24)
+            pageControl.bottomAnchor.constraint(
+                equalTo: actionButton.topAnchor,
+                constant: -AppSpacing.sp4
+            )
         ])
 
         scrollView.delegate = self
-        skipButton.addTarget(self, action: #selector(finishOnboarding), for: .touchUpInside)
+        skipButton.addTarget(self, action: #selector(skipTapped), for: .touchUpInside)
         actionButton.addTarget(self, action: #selector(actionTapped), for: .touchUpInside)
+        applePayButton.addTarget(self, action: #selector(applePayTapped), for: .touchUpInside)
+        laterButton.addTarget(self, action: #selector(laterTapped), for: .touchUpInside)
 
-        // Create page content views
-        for page in pages {
-            let pageView = makePageView(page: page)
+        ctaStack.addArrangedSubview(applePayButton)
+        ctaStack.addArrangedSubview(laterButton)
+
+        // Build page content — first two pages share one layout, step 3 is a
+        // bespoke "deposit" page with preset tiles + dual CTAs.
+        for (index, page) in pages.enumerated() {
+            let pageView: UIView
+            if index == pages.count - 1 {
+                pageView = makeDepositPageView(page: page)
+            } else {
+                pageView = makeTextPageView(page: page)
+            }
             scrollView.addSubview(pageView)
             pageViews.append(pageView)
         }
     }
 
-    private func makePageView(page: Page) -> UIView {
+    /// Steps 1 & 2 — `h1` heading + `bodyLg` body, vertically centred and
+    /// inset by 32pt so the text wraps naturally without hugging the edges.
+    private func makeTextPageView(page: Page) -> UIView {
         let container = UIView()
+        let stack = makeCopyStack(title: page.title, body: page.body)
+        container.addSubview(stack)
+        NSLayoutConstraint.activate([
+            // Slightly above centre so the action button + page dots don't
+            // optically crowd the body copy.
+            stack.centerYAnchor.constraint(equalTo: container.centerYAnchor, constant: -AppSpacing.sp9),
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: AppSpacing.sp7),
+            stack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -AppSpacing.sp7)
+        ])
+        return container
+    }
 
-        let emojiLabel = UILabel()
-        emojiLabel.text = page.emoji
-        emojiLabel.font = UIFont.systemFont(ofSize: 64)
-        emojiLabel.textAlignment = .center
-        emojiLabel.translatesAutoresizingMaskIntoConstraints = false
+    /// Step 3 — heading, body, three preset tiles, Apple Pay CTA, ghost
+    /// "Позже". The CTAs live inside the page (rather than the shared
+    /// `actionButton`) so the page-3 controls feel cohesive with the preset
+    /// tiles instead of appearing detached at the screen bottom.
+    private func makeDepositPageView(page: Page) -> UIView {
+        let container = UIView()
+        let copyStack = makeCopyStack(title: page.title, body: page.body)
+        let presetsStack = makePresetsStack()
+        container.addSubview(copyStack)
+        container.addSubview(presetsStack)
+        container.addSubview(ctaStack)
+        let inset = AppSpacing.screenInset
+        let outerInset = AppSpacing.sp7
+        NSLayoutConstraint.activate([
+            copyStack.topAnchor.constraint(
+                equalTo: container.safeAreaLayoutGuide.topAnchor,
+                constant: AppSpacing.sp10
+            ),
+            copyStack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: outerInset),
+            copyStack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -outerInset),
 
+            presetsStack.topAnchor.constraint(equalTo: copyStack.bottomAnchor, constant: outerInset),
+            presetsStack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: inset),
+            presetsStack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -inset),
+
+            ctaStack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: inset),
+            ctaStack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -inset),
+            ctaStack.bottomAnchor.constraint(
+                equalTo: container.safeAreaLayoutGuide.bottomAnchor,
+                constant: -AppSpacing.sp6
+            )
+        ])
+        return container
+    }
+
+    private func makeCopyStack(title: String, body: String) -> UIStackView {
         let titleLabel = UILabel()
-        titleLabel.text = page.title
-        titleLabel.font = UIFont.systemFont(ofSize: 24, weight: .bold)
-        titleLabel.textColor = .white
+        titleLabel.text = title
+        titleLabel.font = AppTypography.h1
+        titleLabel.textColor = AppColors.fg1
         titleLabel.textAlignment = .center
         titleLabel.numberOfLines = 0
-        titleLabel.translatesAutoresizingMaskIntoConstraints = false
 
-        let descLabel = UILabel()
-        descLabel.text = page.description
-        descLabel.font = UIFont.systemFont(ofSize: 15, weight: .regular)
-        descLabel.textColor = UIColor.white.withAlphaComponent(0.6)
-        descLabel.textAlignment = .center
-        descLabel.numberOfLines = 0
-        descLabel.translatesAutoresizingMaskIntoConstraints = false
+        let bodyLabel = UILabel()
+        bodyLabel.text = body
+        bodyLabel.font = AppTypography.bodyLg
+        bodyLabel.textColor = AppColors.fg2
+        bodyLabel.textAlignment = .center
+        bodyLabel.numberOfLines = 0
 
-        let stack = UIStackView(arrangedSubviews: [emojiLabel, titleLabel, descLabel])
+        let stack = UIStackView(arrangedSubviews: [titleLabel, bodyLabel])
         stack.axis = .vertical
-        stack.spacing = 16
-        stack.alignment = .center
+        stack.spacing = AppSpacing.sp4
+        stack.alignment = .fill
         stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }
 
-        container.addSubview(stack)
-
-        NSLayoutConstraint.activate([
-            stack.centerYAnchor.constraint(equalTo: container.centerYAnchor, constant: -60),
-            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 32),
-            stack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -32)
-        ])
-
-        return container
+    private func makePresetsStack() -> UIStackView {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.alignment = .fill
+        stack.distribution = .fillEqually
+        stack.spacing = AppSpacing.sp3
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        for (index, amount) in presetAmounts.enumerated() {
+            let tile = SPAmountPreset(value: amount, selected: index == defaultPresetIndex)
+            tile.onTap = { [weak self] in self?.handlePresetTap(index: index) }
+            presetTiles.append(tile)
+            stack.addArrangedSubview(tile)
+        }
+        return stack
     }
 
     // MARK: - Actions
 
-    @objc private func actionTapped() {
+    @objc
+    private func actionTapped() {
+        // `actionTapped` only fires while the shared CTA is visible (steps
+        // 1-2). Step 3 uses `applePayButton` / `laterButton` instead.
         let currentPage = pageControl.currentPage
-        if currentPage < pages.count - 1 {
-            // Advance to next page
-            let nextPage = currentPage + 1
-            let offsetX = scrollView.bounds.width * CGFloat(nextPage)
-            scrollView.setContentOffset(CGPoint(x: offsetX, y: 0), animated: true)
-            pageControl.currentPage = nextPage
-            updateActionButton(forPage: nextPage)
-        } else {
-            // Last page — finish
-            finishOnboarding()
-        }
+        guard currentPage < pages.count - 1 else { return }
+        let nextPage = currentPage + 1
+        let offsetX = scrollView.bounds.width * CGFloat(nextPage)
+        scrollView.setContentOffset(CGPoint(x: offsetX, y: 0), animated: true)
+        pageControl.currentPage = nextPage
+        updatePagerState(forPage: nextPage)
     }
 
-    @objc private func finishOnboarding() {
+    @objc
+    private func applePayTapped() {
+        // Apple Pay path — mark onboarding completed and let the parent
+        // SceneDelegate swap the root. The actual IAP is handled from the
+        // main app's TopUp flow; the onboarding stays a pure UI layer so the
+        // SceneDelegate transition isn't blocked on a StoreKit round-trip.
+        // (PR #145 ships the visual + flag wiring; the StoreKit hook-up is a
+        // follow-up issue.)
+        UserDefaults.standard.set(true, forKey: Self.completedKey)
+        UserDefaults.standard.set(false, forKey: Self.firstTopUpDoneKey)
+        onFinished?()
+    }
+
+    @objc
+    private func laterTapped() {
+        // "Позже" path — finish without IAP. Same persistence as the Apple
+        // Pay path so SceneDelegate doesn't re-mount onboarding next launch.
+        UserDefaults.standard.set(true, forKey: Self.completedKey)
+        UserDefaults.standard.set(false, forKey: Self.firstTopUpDoneKey)
+        onFinished?()
+    }
+
+    @objc
+    private func skipTapped() {
+        // Top-right "Пропустить" — completes onboarding from any page; balance
+        // stays at 0 (the existing default in `BalanceService`).
         UserDefaults.standard.set(true, forKey: Self.completedKey)
         onFinished?()
     }
 
-    private func updateActionButton(forPage page: Int) {
-        actionButton.setTitle(pages[page].buttonTitle, for: .normal)
+    // MARK: - State
 
-        // Hide skip on last page
-        skipButton.isHidden = (page == pages.count - 1)
+    private func handlePresetTap(index: Int) {
+        guard index < presetTiles.count else { return }
+        selectedPresetIndex = index
+        for (tileIndex, tile) in presetTiles.enumerated() {
+            tile.isSelected = tileIndex == index
+        }
+        updateApplePayTitle()
+    }
+
+    /// Replace the Apple Pay button instance with a fresh one whose title
+    /// reflects the currently-selected preset amount. SPButton has no public
+    /// title setter (its label is private), so the cheapest faithful path is
+    /// a full re-create — same trade-off `FiringTopUpBottomSheet` accepts
+    /// (one extra alloc per preset tap; max 3 swaps).
+    private func updateApplePayTitle() {
+        guard let oldButton = ctaStack.arrangedSubviews.first as? SPButton else { return }
+        let amount = presetAmounts[selectedPresetIndex]
+        let newButton = SPButton(
+            title: "Начать с \(amount.formattedRubles())",
+            variant: .money,
+            size: .lg,
+            fullWidth: true
+        )
+        newButton.addTarget(self, action: #selector(applePayTapped), for: .touchUpInside)
+        ctaStack.removeArrangedSubview(oldButton)
+        oldButton.removeFromSuperview()
+        ctaStack.insertArrangedSubview(newButton, at: 0)
+        applePayButton = newButton
+    }
+
+    /// Drive the shared CTA (steps 1-2) and page-control state on every
+    /// scroll settle. Step 3 hides the shared CTA + page dots so the
+    /// page-3 layout owns the bottom edge.
+    private func updatePagerState(forPage page: Int) {
+        let isLastPage = page == pages.count - 1
+
+        // Hide the shared action button on step 3 — that page mounts its own
+        // Apple Pay + "Позже" CTAs inside its content view. Likewise hide the
+        // page dots so they don't visually compete with the preset tiles.
+        actionButton.isHidden = isLastPage
+        pageControl.isHidden = isLastPage
+
+        // Step 3 controls focus on the deposit decision; "Пропустить" stays
+        // visible everywhere (including step 3) per spec — it's the global
+        // escape hatch, distinct from "Позже" which still records the
+        // first-top-up flag.
+        skipButton.isHidden = false
+
+        // The shared action button title is always "Далее" on steps 1-2 (no
+        // per-page copy) so there's nothing to update beyond visibility.
     }
 }
 
@@ -243,6 +490,20 @@ extension OnboardingViewController: UIScrollViewDelegate {
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         let page = Int(round(scrollView.contentOffset.x / scrollView.bounds.width))
         pageControl.currentPage = page
-        updateActionButton(forPage: page)
+        updatePagerState(forPage: page)
+    }
+}
+
+// MARK: - Hex helper
+
+private extension UIColor {
+    /// `0xRRGGBB` literal initializer so the Dawn gradient stops read as in
+    /// `tokens.css`. Local copy mirroring the (private) helper in AppColors —
+    /// kept file-local to match the AlarmFiringViewController convention.
+    convenience init(rgb: UInt32, alpha: CGFloat = 1) {
+        let red = CGFloat((rgb >> 16) & 0xFF) / 255.0
+        let green = CGFloat((rgb >> 8) & 0xFF) / 255.0
+        let blue = CGFloat(rgb & 0xFF) / 255.0
+        self.init(red: red, green: green, blue: blue, alpha: alpha)
     }
 }


### PR DESCRIPTION
Fixes #145

## Что сделано
- Перерисован `OnboardingViewController` под design-refresh Dawn-стиль: 4-стоповый атмосферный CAGradientLayer (#14122A → #050912, тот же `--sp-grad-dawn`, что и в `AlarmFiringViewController`), `AppTypography.h1` / `bodyLg`, foregrounds через `AppColors.fg1` / `fg2`.
- Шаг 3 «Стартовый депозит» получил три `SPAmountPreset` тайла (200 / 500 / 1000 ₽, default — 500), Apple Pay primary `SPButton(.money, .lg, fullWidth: true)` «Начать с {N} ₽» и **новый** ghost `SPButton(.ghost, .lg, fullWidth: true)` «Позже» прямо под Apple Pay (PM directive `chat1.md:747`). Тап «Позже» завершает онбординг без IAP и пишет `UserDefaults.first_top_up_done = false` для будущей аналитики.
- Top-right «Пропустить» перестроен как `SPButton(.quiet, .sm)` (раньше был plain `UIButton`).
- `UIPageControl` сохранён (важен для `OnboardingTests.testOnboardingPages_count`), но перетонирован: `money500` для активной точки, `fg3` для остальных.
- Существующая `UserDefaults`-персистентность (`onboarding_completed`) и `onFinished` callback не тронуты — `SceneDelegate` root re-init работает без изменений.

## Verify
- swiftlint: 0 errors (3 warnings: file_length / function_body / type_body — non-blocking, под общим стилем кодбейзы)
- build_sim: succeeded (simulator: iPhone 17 Pro)
- test_sim: пропущен (по правилам команды)
- screenshot: пропущен (по правилам команды)

## Base
Базируется на `design-refresh-2026-04-27` (integration-ветка батча #135-#143). Финальный merge в `main` — отдельным большим PR когда весь батч готов.