### PR TITLE
[design-refresh] Add referral section to settings (#144)

### DIFF
--- a/SnoozePay/SnoozePay/Models/Transaction.swift
+++ b/SnoozePay/SnoozePay/Models/Transaction.swift
@@ -1,9 +1,17 @@
 import Foundation
 
-/// Type of balance transaction
+/// Type of balance transaction.
+///
+/// `topup` is reserved for IAP / paid-money credits that flow through Apple's
+/// StoreKit pipeline — Statistics revenue accounting and any future receipt-
+/// reconciliation logic keys off this case. `promotion` covers free credits
+/// granted by in-app marketing flows (referrals, daily bonuses, etc.) so they
+/// stay segregated from purchases the user actually paid for. `charge` is a
+/// debit (snooze penalty).
 enum TransactionType: String, Codable {
     case topup = "topup"
     case charge = "charge"
+    case promotion = "promotion"
 }
 
 /// Domain model for a balance transaction

--- a/SnoozePay/SnoozePay/Services/BalanceService.swift
+++ b/SnoozePay/SnoozePay/Services/BalanceService.swift
@@ -170,6 +170,40 @@ final class BalanceService {
         return result.recorded
     }
 
+    // MARK: - Promotional credit (referral, daily bonus, ...)
+
+    /// Credits the wallet from a non-monetary source (referral bonus, daily
+    /// streak reward, ...) and records a `.promotion` ledger entry. Behaves
+    /// like `topUp` w.r.t. corruption gating and ledger-first ordering, but
+    /// the dedicated `TransactionType.promotion` case keeps these credits out
+    /// of any future StoreKit receipt-reconciliation / revenue accounting
+    /// logic that keys off `.topup` (issue #144).
+    @discardableResult
+    func creditPromotion(amount: Double) -> Bool {
+        guard amount.isFinite, amount > 0 else { return false }
+
+        let result: (recorded: Bool, newBalance: Double) = queue.sync {
+            let current = readRawBalance()
+            guard !_balanceCorrupted else { return (false, current) }
+
+            let transaction = Transaction(
+                type: .promotion,
+                amount: amount
+            )
+            guard transactionRepository.record(transaction) else {
+                return (false, current)
+            }
+            let updated = current + amount
+            defaults.set(updated, forKey: balanceKey)
+            return (true, updated)
+        }
+
+        if result.recorded {
+            notifyBalanceChanged(result.newBalance)
+        }
+        return result.recorded
+    }
+
     // MARK: - Validation
 
     func canAfford(_ amount: Double) -> Bool {

--- a/SnoozePay/SnoozePay/Services/ReferralService.swift
+++ b/SnoozePay/SnoozePay/Services/ReferralService.swift
@@ -1,0 +1,189 @@
+import Foundation
+import os
+
+/// Offline-first referral service backing the Settings → "Пригласить друга"
+/// section (issue #144).
+///
+/// Stores the user's own 6-character code and the friend's code (if applied)
+/// in `UserDefaults`. Bonus credits land via `BalanceService.creditPromotion`
+/// so they get a dedicated `.promotion` ledger entry rather than masquerading
+/// as a paid `.topup` (which would pollute any future revenue accounting that
+/// reads the StoreKit-credit history).
+///
+/// MVP scope: there is no server, so we cannot actually verify a friend's
+/// code belongs to a real user — the validation surface is intentionally
+/// minimal (format + self-apply + already-applied) and the service exists
+/// mainly to give the screen a clean seam for the eventual real backend.
+final class ReferralService {
+
+    static let shared = ReferralService()
+
+    /// Bonus awarded on a successful friend-code apply, in rubles. Matches the
+    /// caption text rendered in the Settings section so the two stay in sync
+    /// — change here, change the caption.
+    static let referralBonusAmount: Double = 200
+
+    /// Errors surfaced to the UI from `applyFriendCode`.
+    enum ApplyError: LocalizedError, Equatable {
+        /// Code wasn't 6 characters or contained non-alphanumeric symbols
+        /// (after normalisation to upper-case).
+        case invalidFormat
+        /// User has already redeemed a friend-code on this device — bonus
+        /// is one-shot.
+        case alreadyApplied
+        /// User entered their own code.
+        case cannotApplyOwnCode
+        /// Balance store is locked (corruption — issue #119) so we can't
+        /// safely credit. Surfaces the gate to the UI.
+        case balanceLocked
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidFormat:
+                return "Код должен содержать 6 символов (буквы и цифры)."
+            case .alreadyApplied:
+                return "Бонус по реферальному коду уже получен."
+            case .cannotApplyOwnCode:
+                return "Нельзя применить собственный код."
+            case .balanceLocked:
+                return "Не удалось зачислить бонус. Попробуйте позже."
+            }
+        }
+    }
+
+    // MARK: - Storage keys
+
+    private let myCodeKey = "referral_my_code"
+    private let appliedCodeKey = "referral_applied_code"
+
+    private let defaults: UserDefaults
+    private let balanceService: BalanceService
+    /// Serial queue protecting the read-then-write on `appliedCodeKey` —
+    /// without this two `applyFriendCode` calls racing from different
+    /// threads could both observe "not applied yet" and credit the bonus
+    /// twice.
+    private let queue = DispatchQueue(label: "com.snoozepay.referral.serial")
+    private static let log = OSLog(
+        subsystem: "Ivan-Emelyanov.SnoozePay",
+        category: "ReferralService"
+    )
+
+    /// Production code MUST use `ReferralService.shared`. Tests inject custom
+    /// `UserDefaults` + `BalanceService` to stay isolated.
+    init(defaults: UserDefaults, balanceService: BalanceService) {
+        self.defaults = defaults
+        self.balanceService = balanceService
+    }
+
+    private convenience init() {
+        self.init(defaults: .standard, balanceService: .shared)
+    }
+
+    // MARK: - Public API
+
+    /// Returns the user's referral code, generating one on first call.
+    /// Stable across launches once generated — the code IS the user's
+    /// long-term identity in the referral graph.
+    func getMyCode() -> String {
+        queue.sync {
+            if let existing = defaults.string(forKey: myCodeKey),
+               isValidFormat(existing) {
+                return existing
+            }
+            let fresh = Self.generateCode()
+            defaults.set(fresh, forKey: myCodeKey)
+            return fresh
+        }
+    }
+
+    /// Returns the friend code the user has already redeemed on this device,
+    /// if any. The Settings input row uses this to short-circuit re-apply
+    /// without round-tripping through the validator.
+    var appliedFriendCode: String? {
+        queue.sync { defaults.string(forKey: appliedCodeKey) }
+    }
+
+    /// Validates `rawCode` and credits the referral bonus on success.
+    ///
+    /// - Parameter rawCode: User-entered string. Trimmed and upper-cased
+    ///   internally so the caller doesn't have to normalise.
+    /// - Throws: `ApplyError` describing why the apply was rejected.
+    /// - Returns: The amount of rubles credited (matches
+    ///   `referralBonusAmount` on the happy path).
+    @discardableResult
+    func applyFriendCode(_ rawCode: String) throws -> Double {
+        let normalised = rawCode
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .uppercased()
+
+        guard isValidFormat(normalised) else {
+            throw ApplyError.invalidFormat
+        }
+
+        // Read-then-write under serial queue so concurrent applies cannot
+        // both observe "not applied yet" and double-credit the bonus.
+        try queue.sync {
+            if defaults.string(forKey: appliedCodeKey) != nil {
+                throw ApplyError.alreadyApplied
+            }
+            let myCode = defaults.string(forKey: myCodeKey)
+            if let myCode, myCode == normalised {
+                throw ApplyError.cannotApplyOwnCode
+            }
+            // Persist FIRST, then credit. If the credit fails (corrupt
+            // balance store) we roll back the persisted code so the user
+            // can retry once the corruption is acknowledged. Without this
+            // a balance lockout would permanently consume the user's
+            // single referral apply slot with no bonus to show for it.
+            defaults.set(normalised, forKey: appliedCodeKey)
+            let credited = balanceService.creditPromotion(
+                amount: Self.referralBonusAmount
+            )
+            if !credited {
+                defaults.removeObject(forKey: appliedCodeKey)
+                os_log(
+                    "Referral apply rolled back: balance credit refused (likely corruption gate)",
+                    log: Self.log, type: .error
+                )
+                throw ApplyError.balanceLocked
+            }
+        }
+        return Self.referralBonusAmount
+    }
+
+    // MARK: - Validation
+
+    /// Letters + digits, 6 chars long, exclude `O`/`0`/`I`/`1` to avoid
+    /// hand-copy ambiguity (matches `generateCode`'s alphabet so a code
+    /// we generate always validates here).
+    private func isValidFormat(_ code: String) -> Bool {
+        guard code.count == 6 else { return false }
+        return code.unicodeScalars.allSatisfy(Self.alphabetSet.contains)
+    }
+
+    // MARK: - Generation
+
+    /// Alphabet excluding visually ambiguous glyphs (`0`/`O`, `1`/`I`).
+    /// Lowered to a `Set<Unicode.Scalar>` so `isValidFormat` runs in
+    /// O(n) over the input.
+    private static let alphabetString = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+    private static let alphabetSet: Set<Unicode.Scalar> = {
+        Set(alphabetString.unicodeScalars)
+    }()
+
+    private static func generateCode() -> String {
+        let alphabet = Array(alphabetString)
+        var code = ""
+        for _ in 0..<6 {
+            // `randomElement()` on a non-empty array can only return nil
+            // for empty collections, but we still guard so a future edit
+            // that empties `alphabetString` fails loudly in tests.
+            guard let char = alphabet.randomElement() else {
+                assertionFailure("Referral alphabet is empty — fix alphabetString")
+                return "AAAAAA"
+            }
+            code.append(char)
+        }
+        return code
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController+Referral.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController+Referral.swift
@@ -1,0 +1,313 @@
+import UIKit
+
+// MARK: - Referral cells & actions
+//
+// Lifted out of `SettingsViewController.swift` so the parent file stays under
+// the swiftlint file_length error threshold (issue #144). The stored-property
+// surface (`friendCodeInput`, `referralService`, `ReferralRow`) lives on the
+// main class because Swift forbids stored properties in extensions; everything
+// else is a pure function over those properties and slots into this file.
+
+extension SettingsViewController {
+
+    /// Dispatches to one of three layouts (`myCode`, `friendInput`, `caption`).
+    /// Centralising the switch keeps `cellForRowAt:` short and the row-index
+    /// math next to the enum it indexes into.
+    func makeReferralCell(at indexPath: IndexPath) -> UITableViewCell {
+        guard let row = ReferralRow(rawValue: indexPath.row) else { return UITableViewCell() }
+        switch row {
+        case .myCode:      return makeMyCodeCell()
+        case .friendInput: return makeFriendInputCell()
+        case .caption:     return makeReferralCaptionCell()
+        }
+    }
+
+    /// Row 1 — "Ваш код" with the user's 6-char code and a copy icon.
+    /// Tapping anywhere on the row copies the code (we forward the tap from
+    /// `didSelectRowAt:` rather than wiring an inner tap-target so a bigger
+    /// hit area falls out for free).
+    func makeMyCodeCell() -> UITableViewCell {
+        let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
+        cell.backgroundColor = .secondarySystemBackground
+
+        let titleLabel = UILabel()
+        titleLabel.text = "Ваш код"
+        titleLabel.font = UIFont.systemFont(ofSize: 17)
+        titleLabel.textColor = .label
+
+        let codeLabel = UILabel()
+        codeLabel.text = referralService.getMyCode()
+        codeLabel.font = AppTypography.moneySm
+        codeLabel.textColor = AppColors.money500
+        codeLabel.setContentHuggingPriority(.required, for: .horizontal)
+
+        let copyIcon = UIImageView(image: UIImage(systemName: "doc.on.clipboard"))
+        copyIcon.tintColor = .secondaryLabel
+        copyIcon.contentMode = .scaleAspectFit
+        copyIcon.translatesAutoresizingMaskIntoConstraints = false
+        copyIcon.widthAnchor.constraint(equalToConstant: 18).isActive = true
+        copyIcon.heightAnchor.constraint(equalToConstant: 18).isActive = true
+
+        let trailingStack = UIStackView(arrangedSubviews: [codeLabel, copyIcon])
+        trailingStack.axis = .horizontal
+        trailingStack.alignment = .center
+        trailingStack.spacing = AppSpacing.sm
+        trailingStack.translatesAutoresizingMaskIntoConstraints = false
+
+        let mainStack = UIStackView(arrangedSubviews: [titleLabel, trailingStack])
+        mainStack.axis = .horizontal
+        mainStack.alignment = .center
+        mainStack.translatesAutoresizingMaskIntoConstraints = false
+        cell.contentView.addSubview(mainStack)
+
+        NSLayoutConstraint.activate([
+            mainStack.leadingAnchor.constraint(
+                equalTo: cell.contentView.leadingAnchor,
+                constant: AppSpacing.lg
+            ),
+            mainStack.trailingAnchor.constraint(
+                equalTo: cell.contentView.trailingAnchor,
+                constant: -AppSpacing.lg
+            ),
+            mainStack.centerYAnchor.constraint(equalTo: cell.contentView.centerYAnchor)
+        ])
+
+        cell.accessoryType = .none
+        return cell
+    }
+
+    /// Row 2 — `SPInput` for the friend's code + small "Применить" SPButton.
+    /// We disable selection on the cell because the interactive controls are
+    /// inside it; otherwise the cell would highlight on every tap inside the
+    /// text field.
+    func makeFriendInputCell() -> UITableViewCell {
+        let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
+        cell.backgroundColor = .secondarySystemBackground
+        cell.selectionStyle = .none
+
+        let input = SPInput(
+            label: "Код друга",
+            placeholder: "Введите 6 символов"
+        )
+        input.textField.autocapitalizationType = .allCharacters
+        input.textField.autocorrectionType = .no
+        input.textField.returnKeyType = .done
+        input.textField.delegate = self
+        input.translatesAutoresizingMaskIntoConstraints = false
+
+        // If the user has already redeemed a code, render it as the
+        // pre-filled value and freeze further edits — the bonus is one-shot,
+        // and showing the code keeps support able to ask the user what they
+        // entered.
+        if let applied = referralService.appliedFriendCode {
+            input.textField.text = applied
+            input.textField.isEnabled = false
+            input.hint = "Код уже применён"
+        }
+        self.friendCodeInput = input
+
+        let applyButton = SPButton(title: "Применить", variant: .money, size: .sm)
+        applyButton.translatesAutoresizingMaskIntoConstraints = false
+        applyButton.isEnabled = referralService.appliedFriendCode == nil
+        applyButton.addTarget(
+            self,
+            action: #selector(handleApplyFriendCodeTapped),
+            for: .touchUpInside
+        )
+
+        let stack = UIStackView(arrangedSubviews: [input, applyButton])
+        stack.axis = .horizontal
+        stack.alignment = .top
+        stack.spacing = AppSpacing.sm
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        cell.contentView.addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(
+                equalTo: cell.contentView.leadingAnchor,
+                constant: AppSpacing.lg
+            ),
+            stack.trailingAnchor.constraint(
+                equalTo: cell.contentView.trailingAnchor,
+                constant: -AppSpacing.lg
+            ),
+            stack.topAnchor.constraint(
+                equalTo: cell.contentView.topAnchor,
+                constant: AppSpacing.md
+            ),
+            stack.bottomAnchor.constraint(
+                equalTo: cell.contentView.bottomAnchor,
+                constant: -AppSpacing.md
+            )
+        ])
+
+        return cell
+    }
+
+    /// Row 3 — small grey caption line. Modeled as a real cell rather than a
+    /// section footer so it inherits the card-row styling applied in
+    /// `willDisplay`.
+    func makeReferralCaptionCell() -> UITableViewCell {
+        let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
+        cell.backgroundColor = .secondarySystemBackground
+        cell.selectionStyle = .none
+
+        let label = UILabel()
+        label.text = "За каждого друга — +200 ₽ на ваш баланс"
+        label.font = AppTypography.meta
+        label.textColor = .secondaryLabel
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        cell.contentView.addSubview(label)
+
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(
+                equalTo: cell.contentView.leadingAnchor,
+                constant: AppSpacing.lg
+            ),
+            label.trailingAnchor.constraint(
+                equalTo: cell.contentView.trailingAnchor,
+                constant: -AppSpacing.lg
+            ),
+            label.topAnchor.constraint(
+                equalTo: cell.contentView.topAnchor,
+                constant: AppSpacing.md
+            ),
+            label.bottomAnchor.constraint(
+                equalTo: cell.contentView.bottomAnchor,
+                constant: -AppSpacing.md
+            )
+        ])
+
+        return cell
+    }
+
+    // MARK: - Actions
+
+    /// Copies the user's referral code to the system pasteboard and shows a
+    /// 1.5-second toast at the bottom-safe area. Chosen over a UIAlertController
+    /// because a modal alert for "Скопировано" is too heavy a UX hit for an
+    /// action this minor.
+    func copyMyCodeToPasteboard() {
+        let code = referralService.getMyCode()
+        UIPasteboard.general.string = code
+        showToast(message: "Скопировано")
+    }
+
+    @objc
+    func handleApplyFriendCodeTapped() {
+        guard let input = friendCodeInput else { return }
+        let raw = input.textField.text ?? ""
+        do {
+            let credited = try referralService.applyFriendCode(raw)
+            input.error = nil
+            input.hint = "Бонус +\(Int(credited)) ₽ зачислен"
+            input.textField.isEnabled = false
+            input.textField.resignFirstResponder()
+            // Friend-input cell needs a re-layout to flip the apply button
+            // to disabled — the simplest path is a section reload.
+            tableView.reloadSections(IndexSet(integer: Section.referral.rawValue), with: .automatic)
+            showToast(message: "Бонус начислен")
+        } catch let error as ReferralService.ApplyError {
+            input.error = error.errorDescription
+        } catch {
+            input.error = "Не удалось применить код"
+        }
+    }
+
+    /// Presents a brief auto-dismissing toast pinned to the bottom safe-area.
+    /// Lives on the keyWindow so it survives a pushed VC transition and can't
+    /// be cropped by the navigation bar.
+    func showToast(message: String) {
+        let candidateWindow = view.window ?? UIApplication.shared.connectedScenes
+            .compactMap { ($0 as? UIWindowScene)?.keyWindow }
+            .first
+        guard let window = candidateWindow else { return }
+
+        let toast = SettingsToastLabel()
+        toast.text = message
+        toast.font = AppTypography.body
+        toast.textColor = .white
+        toast.backgroundColor = UIColor.label.withAlphaComponent(0.9)
+        toast.textAlignment = .center
+        toast.layer.cornerRadius = AppRadius.md
+        toast.layer.masksToBounds = true
+        toast.alpha = 0
+        toast.translatesAutoresizingMaskIntoConstraints = false
+        window.addSubview(toast)
+
+        NSLayoutConstraint.activate([
+            toast.centerXAnchor.constraint(equalTo: window.centerXAnchor),
+            toast.bottomAnchor.constraint(
+                equalTo: window.safeAreaLayoutGuide.bottomAnchor,
+                constant: -AppSpacing.xl
+            ),
+            toast.heightAnchor.constraint(greaterThanOrEqualToConstant: 36)
+        ])
+
+        UIView.animate(
+            withDuration: 0.2,
+            animations: { toast.alpha = 1 },
+            completion: { _ in
+                UIView.animate(
+                    withDuration: 0.3,
+                    delay: 1.1,
+                    options: [],
+                    animations: { toast.alpha = 0 },
+                    completion: { _ in toast.removeFromSuperview() }
+                )
+            }
+        )
+    }
+}
+
+// MARK: - UITextFieldDelegate (referral input)
+
+extension SettingsViewController: UITextFieldDelegate {
+
+    /// "Done" key dismisses the keyboard rather than triggering Apply — the
+    /// user typically wants to review their input before committing.
+    public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
+    }
+
+    /// Force-uppercase + cap at 6 chars as the user types so the value
+    /// displayed always matches what `applyFriendCode` will see post-
+    /// normalisation. Without the cap nothing prevents pasting a 30-char
+    /// blob that would later fail validation with no visible cause.
+    public func textField(
+        _ textField: UITextField,
+        shouldChangeCharactersIn range: NSRange,
+        replacementString string: String
+    ) -> Bool {
+        let current = textField.text ?? ""
+        guard let swiftRange = Range(range, in: current) else { return false }
+        let proposed = current.replacingCharacters(in: swiftRange, with: string).uppercased()
+        if proposed.count > 6 { return false }
+        textField.text = proposed
+        return false
+    }
+}
+
+// MARK: - SettingsToastLabel
+
+/// Small UILabel subclass that bakes 16/8 padding into its intrinsic size so
+/// the toast pill renders without an external container. Inline because no
+/// other screen uses it yet — promote to its own file if a second caller
+/// shows up.
+final class SettingsToastLabel: UILabel {
+    private let inset = UIEdgeInsets(top: 8, left: 16, bottom: 8, right: 16)
+
+    override func drawText(in rect: CGRect) {
+        super.drawText(in: rect.inset(by: inset))
+    }
+
+    override var intrinsicContentSize: CGSize {
+        let size = super.intrinsicContentSize
+        return CGSize(
+            width: size.width + inset.left + inset.right,
+            height: size.height + inset.top + inset.bottom
+        )
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController.swift
@@ -10,7 +10,9 @@ class SettingsViewController: UIViewController {
 
     // MARK: - UI
 
-    private let tableView: UITableView = {
+    /// Internal so `SettingsViewController+Referral` can call
+    /// `reloadSections` after a successful friend-code apply (issue #144).
+    let tableView: UITableView = {
         let table = UITableView(frame: .zero, style: .insetGrouped)
         table.translatesAutoresizingMaskIntoConstraints = false
         return table
@@ -36,12 +38,32 @@ class SettingsViewController: UIViewController {
 
     // MARK: - Sections
 
-    private enum Section: Int, CaseIterable {
+    /// `internal` so the cross-file `SettingsViewController+Referral`
+    /// extension can read `Section.referral` for the `reloadSections`
+    /// call (issue #144).
+    enum Section: Int, CaseIterable {
         case account    // Transaction history + Balance
+        case referral   // My code (copyable) + friend's code input + caption
         case appearance // Theme selector (system / light / dark)
         case info       // Privacy policy + Terms
         case contact    // Contact us
     }
+
+    /// Row layout inside `.referral`. Indexed positions stay readable when
+    /// the table calls `cellForRowAt:` — the alternative (raw `0/1/2`)
+    /// trades a static enum mismatch error for a runtime off-by-one.
+    enum ReferralRow: Int, CaseIterable {
+        case myCode       // "Ваш код" + 6-char code + copy icon
+        case friendInput  // SPInput "Код друга" + Применить button
+        case caption      // "За каждого друга — +200 ₽ ..." footer text
+    }
+
+    let referralService = ReferralService.shared
+
+    /// Held weak so the cell may be recycled without a dangling reference.
+    /// Used to surface inline validation messages from
+    /// `handleApplyFriendCodeTapped` without a full `reloadData`.
+    weak var friendCodeInput: SPInput?
 
     // MARK: - Lifecycle
 
@@ -133,6 +155,7 @@ extension SettingsViewController: UITableViewDataSource {
         guard let sec = Section(rawValue: section) else { return 0 }
         switch sec {
         case .account: return 2    // Transaction history, Balance
+        case .referral: return ReferralRow.allCases.count
         case .appearance: return 1 // Dark theme
         case .info: return 2       // Privacy, Terms
         case .contact: return 1    // Contact us
@@ -143,6 +166,7 @@ extension SettingsViewController: UITableViewDataSource {
         guard let sec = Section(rawValue: section) else { return nil }
         switch sec {
         case .account: return "АККАУНТ"
+        case .referral: return "ПРИГЛАСИТЬ ДРУГА"
         case .appearance: return "ОФОРМЛЕНИЕ"
         case .info: return "ИНФОРМАЦИЯ"
         case .contact: return "СВЯЗАТЬСЯ"
@@ -194,6 +218,9 @@ extension SettingsViewController: UITableViewDataSource {
                 cell.selectionStyle = .none
                 return cell
             }
+
+        case .referral:
+            return makeReferralCell(at: indexPath)
 
         case .appearance:
             // Dedicated cell type owns the segment control — avoids the previous
@@ -331,7 +358,31 @@ extension SettingsViewController: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         guard let section = Section(rawValue: indexPath.section) else { return 52 }
-        return section == .appearance ? 56 : 52
+        switch section {
+        case .appearance:
+            return 56
+        case .referral:
+            // Friend-input row hosts an SPInput (52pt field + label + hint);
+            // the caption row wraps to two lines on small screens — let
+            // self-sizing handle both rather than guessing.
+            guard let row = ReferralRow(rawValue: indexPath.row) else { return 52 }
+            switch row {
+            case .myCode:      return 52
+            case .friendInput: return UITableView.automaticDimension
+            case .caption:     return UITableView.automaticDimension
+            }
+        default:
+            return 52
+        }
+    }
+
+    func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+        // `automaticDimension` paths above need an estimate or the table
+        // collapses on first layout pass. 52pt matches the rest of the
+        // settings rows for visual continuity.
+        guard let section = Section(rawValue: indexPath.section),
+              section == .referral else { return 52 }
+        return 80
     }
 
     /// Apply the shared card-style background to every row so each
@@ -353,6 +404,14 @@ extension SettingsViewController: UITableViewDelegate {
             if indexPath.row == 0 {
                 let historyVC = TransactionHistoryViewController()
                 navigationController?.pushViewController(historyVC, animated: true)
+            }
+
+        case .referral:
+            // Only the "Ваш код" row has a tap behaviour — the input row owns
+            // its own controls (SPInput / SPButton) and the caption row is
+            // non-interactive.
+            if ReferralRow(rawValue: indexPath.row) == .myCode {
+                copyMyCodeToPasteboard()
             }
 
         case .appearance:
@@ -594,20 +653,34 @@ final class TransactionCell: UITableViewCell {
     // MARK: - Configure
 
     func configure(with transaction: Transaction, alarmName: String?) {
-        let isTopup = transaction.type == .topup
+        let isCredit = transaction.type != .charge
 
-        // Icon
-        iconContainer.backgroundColor = isTopup ? AppColors.accentGreen : AppColors.destructiveRed
-        iconImageView.image = UIImage(systemName: isTopup ? "arrow.up" : "arrow.down")?.withConfiguration(
+        // Icon — credits (topup, promotion) read green/up; charges red/down.
+        // Promotion gets a distinct gift glyph so the user can tell a
+        // referral bonus apart from an IAP top-up at a glance (issue #144).
+        iconContainer.backgroundColor = isCredit ? AppColors.accentGreen : AppColors.destructiveRed
+        let iconName: String
+        switch transaction.type {
+        case .topup:     iconName = "arrow.up"
+        case .charge:    iconName = "arrow.down"
+        case .promotion: iconName = "gift.fill"
+        }
+        iconImageView.image = UIImage(systemName: iconName)?.withConfiguration(
             UIImage.SymbolConfiguration(pointSize: 14, weight: .bold)
         )
 
-        // Title
-        titleLabel.text = isTopup ? "Пополнение" : "Откладывание"
+        // Title — promotion reads "Бонус" so the row doesn't claim the user
+        // paid for the credit (which would mislead anyone scanning their
+        // history for IAP receipts).
+        switch transaction.type {
+        case .topup:     titleLabel.text = "Пополнение"
+        case .charge:    titleLabel.text = "Откладывание"
+        case .promotion: titleLabel.text = "Бонус"
+        }
 
-        // Subtitle: alarm name + date
+        // Subtitle: alarm name + date for charges; just the date otherwise.
         let dateString = Self.formatDate(transaction.createdAt)
-        if let name = alarmName, !isTopup {
+        if let name = alarmName, transaction.type == .charge {
             subtitleLabel.text = "\(name) \u{00B7} \(dateString)"
         } else {
             subtitleLabel.text = dateString
@@ -615,7 +688,7 @@ final class TransactionCell: UITableViewCell {
 
         // Amount
         let amount = Int(transaction.amount)
-        if isTopup {
+        if isCredit {
             amountLabel.text = "+₽\(amount)"
             amountLabel.textColor = AppColors.accentGreen
         } else {


### PR DESCRIPTION
Fixes #144

Base: `design-refresh-2026-04-27` (integration branch — NOT main).

## Что сделано
- New "Пригласить друга" section in `SettingsViewController` between `account` and `appearance`:
  - Row 1 — "Ваш код" + 6-char generated code (JetBrainsMono `moneySm`) + `doc.on.clipboard` icon. Tap copies to `UIPasteboard` and shows a 1.5s toast pinned to bottom safe-area.
  - Row 2 — `SPInput(label: "Код друга")` + `SPButton(.money, .sm)` "Применить". Validates 6-char alphanumeric, force-uppercases as the user types, surfaces inline `error`/`hint` states, freezes after a successful apply.
  - Row 3 — `AppTypography.meta` caption "За каждого друга — +200 ₽ на ваш баланс".
- New `Services/ReferralService.swift` — `getMyCode()` (UserDefaults-backed, generates on first call from a confusion-free alphabet excluding `0/O/1/I`), `applyFriendCode(_:)` with `.invalidFormat` / `.alreadyApplied` / `.cannotApplyOwnCode` / `.balanceLocked` errors. Serial queue prevents double-credit on concurrent apply.
- New `BalanceService.creditPromotion(amount:)` — records a dedicated `TransactionType.promotion` ledger entry instead of `.topup`, so the referral bonus stays out of any future StoreKit revenue/receipt accounting.
- New `TransactionType.promotion` case + `TransactionCell` rendering ("Бонус", `gift.fill` icon, green `+₽X`) so the history view doesn't claim the user paid for the credit.
- Existing settings sections (Privacy, Terms, Contact, Theme, Balance, History) unchanged behaviourally — only renumbered downstream of the new section.

## Promotional credit accounting (per spec)
The referral bonus uses a dedicated `TransactionType.promotion` instead of overloading `.topup`. `StatisticsViewModel` only filters on `.charge`, so neither change pollutes the spent / streak metrics. `.topup` stays exclusively for StoreKit-backed paid credits, which keeps the door open for future receipt reconciliation that needs to distinguish paid revenue from promotional grants.

## Files added/modified
- `M` `SnoozePay/Models/Transaction.swift` — adds `.promotion` case (back-compat string raw value).
- `M` `SnoozePay/Services/BalanceService.swift` — `creditPromotion(amount:)` gated by corruption flag, ledger-first ordering.
- `A` `SnoozePay/Services/ReferralService.swift` — referral code lifecycle.
- `M` `SnoozePay/ViewControllers/Settings/SettingsViewController.swift` — new `.referral` section, `TransactionCell` handles `.promotion`. Stored properties / `Section` / `ReferralRow` flipped to internal so the cross-file extension can reach them.
- `A` `SnoozePay/ViewControllers/Settings/SettingsViewController+Referral.swift` — cell builders, copy / apply handlers, toast, `UITextFieldDelegate` conformance. Lifted out of the parent file to keep it under the swiftlint `file_length` error threshold (1000 lines).

## Verify
- swiftlint: 0 errors (`Done linting! Found 69 violations, 0 serious in 64 files.` — all warnings pre-exist in the codebase)
- build_sim (iPhone 16 Pro): succeeded
- test_sim: skipped per spec
- screenshot: skipped per spec

## Deviations from spec
- Toast helper is implemented as `SettingsToastLabel` (a tiny `UILabel` subclass with baked-in padding) hosted on the keyWindow rather than the spec's "or use UIAlertController .actionSheet" suggestion — a 1.5-second fade-in/out pill is the simpler / less intrusive UX for a "Скопировано" confirmation.
- The friend-code input row uses `UITableView.automaticDimension` for height because the SPInput grows when an `error`/`hint` line shows up; the spec didn't pin a specific row height.
- The referral caption is rendered as a real `.referral` row (not a `tableView(_:titleForFooterInSection:)` footer) so it inherits the same `styleAsCardRow` treatment as the other rows in the section — visually consistent with the rest of the settings cards.