### PR TITLE
[design-refresh] Add splash + permissions screens (#149)

### DIFF
--- a/SnoozePay/SnoozePay/AppDelegate.swift
+++ b/SnoozePay/SnoozePay/AppDelegate.swift
@@ -14,12 +14,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
-        // Register notification categories and request permission
+        // Register notification categories on every cold launch so the alarm
+        // notification's actions stay wired up regardless of permission state.
         AlarmScheduler.shared.registerCategories()
-        AlarmScheduler.shared.requestPermission { [weak self] granted in
-            if !granted {
-                AppLogger.appDelegate.notice("notification permission denied — alarms may not fire")
-                self?.presentNotificationsDisabledAlert()
+        // Defer the notification permission prompt until the dedicated
+        // PermissionsViewController has had a chance to drive it (#149) —
+        // otherwise the OS dialog would race the splash → onboarding →
+        // permissions UI and the user sees the system prompt before the
+        // explanatory screen. Once Permissions has been shown at least once,
+        // the auto-request resumes for subsequent launches so the existing
+        // "permission revoked from Settings" alert keeps firing.
+        if PermissionsViewController.hasBeenShown {
+            AlarmScheduler.shared.requestPermission { [weak self] granted in
+                if !granted {
+                    AppLogger.appDelegate.notice("notification permission denied — alarms may not fire")
+                    self?.presentNotificationsDisabledAlert()
+                }
             }
         }
 

--- a/SnoozePay/SnoozePay/SceneDelegate.swift
+++ b/SnoozePay/SnoozePay/SceneDelegate.swift
@@ -24,24 +24,73 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // would skip it.
         ThemeService.shared.apply(to: window)
 
-        if OnboardingViewController.isCompleted {
-            window.rootViewController = makeRootViewController()
-        } else {
-            let onboarding = OnboardingViewController()
-            onboarding.onFinished = { [weak self] in
-                self?.transitionToMainApp()
-            }
-            window.rootViewController = onboarding
+        // Always mount the branded Splash first — it owns the first ~200ms of
+        // perceived launch and crossfades into whichever real root the user
+        // state requires (Onboarding → Permissions → TabBar).
+        let splash = SplashViewController()
+        splash.onFinished = { [weak self] in
+            self?.transitionToInitialRoot()
         }
-
+        window.rootViewController = splash
         window.makeKeyAndVisible()
     }
 
-    // MARK: - Onboarding transition
+    // MARK: - Root selection
+
+    /// Decide which "real" root to present after the splash finishes.
+    /// Order: Onboarding (if not completed) → Permissions (if not yet shown)
+    /// → TabBar.
+    private func transitionToInitialRoot() {
+        guard let window = window else { return }
+        let nextRoot = makeNextRootViewController()
+        UIView.transition(with: window, duration: 0.3, options: .transitionCrossDissolve) {
+            window.rootViewController = nextRoot
+        }
+    }
+
+    /// Build the appropriate root VC for the current launch state. Extracted
+    /// so the post-onboarding / post-permissions transitions can reuse the
+    /// same selector without duplicating the precedence logic.
+    private func makeNextRootViewController() -> UIViewController {
+        if !OnboardingViewController.isCompleted {
+            let onboarding = OnboardingViewController()
+            onboarding.onFinished = { [weak self] in
+                self?.transitionAfterOnboarding()
+            }
+            return onboarding
+        }
+        if !PermissionsViewController.hasBeenShown {
+            return makePermissionsViewController()
+        }
+        return makeTabBarController()
+    }
+
+    private func makePermissionsViewController() -> UIViewController {
+        let permissions = PermissionsViewController()
+        permissions.onFinished = { [weak self] in
+            self?.transitionToMainApp()
+        }
+        return permissions
+    }
+
+    // MARK: - Onboarding / Permissions transitions
+
+    private func transitionAfterOnboarding() {
+        guard let window = window else { return }
+        // Onboarding finished — Permissions is the natural next step on a
+        // fresh install. If for some reason the flag was already flipped
+        // (e.g. test fixture), fall straight through to the tab bar.
+        let nextRoot: UIViewController = PermissionsViewController.hasBeenShown
+            ? makeTabBarController()
+            : makePermissionsViewController()
+        UIView.transition(with: window, duration: 0.4, options: .transitionCrossDissolve) {
+            window.rootViewController = nextRoot
+        }
+    }
 
     private func transitionToMainApp() {
         guard let window = window else { return }
-        let tabBar = makeRootViewController()
+        let tabBar = makeTabBarController()
         UIView.transition(with: window, duration: 0.4, options: .transitionCrossDissolve) {
             window.rootViewController = tabBar
         }
@@ -49,7 +98,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     // MARK: - Root UI setup
 
-    private func makeRootViewController() -> UIViewController {
+    private func makeTabBarController() -> UIViewController {
         let tabBar = UITabBarController()
 
         // Alarms tab

--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/PermissionCardView.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/PermissionCardView.swift
@@ -1,0 +1,190 @@
+import UIKit
+
+/// Single permission row mounted inside `PermissionsViewController` (#149).
+/// Visually a `.surface` SPCard with a leading SF-Symbol icon, a title +
+/// body copy stack, and a trailing affordance (SPButton or SPPill) that the
+/// parent VC swaps via `apply(status:)`.
+///
+/// Kept in its own file so the parent VC stays under SwiftLint's 400-line
+/// file-length budget.
+enum PermissionKind {
+    case notifications
+    case criticalAlerts
+    case sound
+
+    var iconName: String {
+        switch self {
+        case .notifications: return "bell.fill"
+        case .criticalAlerts: return "exclamationmark.triangle.fill"
+        case .sound: return "speaker.wave.2.fill"
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .notifications: return "Уведомления"
+        case .criticalAlerts: return "Критические оповещения"
+        case .sound: return "Звук в беззвучном режиме"
+        }
+    }
+
+    var body: String {
+        switch self {
+        case .notifications:
+            return "Чтобы будильник звонил даже когда телефон в фоне"
+        case .criticalAlerts:
+            return "Чтобы будильник звонил даже в режиме «Не беспокоить»"
+        case .sound:
+            return "Чтобы будильник звонил вслух даже если выключен звук"
+        }
+    }
+}
+
+/// Visual state of a permission card's trailing affordance.
+enum PermissionStatus {
+    /// Show "Разрешить" SPButton. Tap triggers a real grant.
+    case actionable
+    /// Show "Разрешено" pill — granted by the user.
+    case granted
+    /// Show "Включено" pill — auto-configured (no user action needed),
+    /// e.g. AVAudioSession `.playback + .duckOthers`.
+    case enabled
+    /// Show "Недоступно" pill — entitlement / capability missing. The
+    /// user can't fix this from the app.
+    case unavailable
+}
+
+final class PermissionCardView: UIView {
+
+    // MARK: - Public API
+
+    var onPrimaryTap: (() -> Void)?
+
+    // MARK: - Subviews
+
+    private let card = SPCard(tone: .surface)
+    private let iconView = UIImageView()
+    private let titleLabel = UILabel()
+    private let bodyLabel = UILabel()
+    /// Container for the trailing affordance — either an SPButton (actionable)
+    /// or an SPPill (granted / enabled / unavailable). We keep a stable host
+    /// view and replace its subview on `apply(status:)` so the surrounding
+    /// constraints don't churn.
+    private let trailingHost = UIView()
+
+    // MARK: - Init
+
+    init(kind: PermissionKind) {
+        super.init(frame: .zero)
+        translatesAutoresizingMaskIntoConstraints = false
+        configure(kind: kind)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Configuration
+
+    private func configure(kind: PermissionKind) {
+        card.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(card)
+        NSLayoutConstraint.activate([
+            card.topAnchor.constraint(equalTo: topAnchor),
+            card.bottomAnchor.constraint(equalTo: bottomAnchor),
+            card.leadingAnchor.constraint(equalTo: leadingAnchor),
+            card.trailingAnchor.constraint(equalTo: trailingAnchor)
+        ])
+
+        iconView.translatesAutoresizingMaskIntoConstraints = false
+        iconView.image = UIImage(systemName: kind.iconName)?.withRenderingMode(.alwaysTemplate)
+        iconView.tintColor = AppColors.money500
+        iconView.contentMode = .scaleAspectFit
+
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.text = kind.title
+        titleLabel.font = AppTypography.h4
+        titleLabel.textColor = AppColors.fg1
+        titleLabel.numberOfLines = 0
+
+        bodyLabel.translatesAutoresizingMaskIntoConstraints = false
+        bodyLabel.text = kind.body
+        bodyLabel.font = AppTypography.meta
+        bodyLabel.textColor = AppColors.fg3
+        bodyLabel.numberOfLines = 0
+
+        trailingHost.translatesAutoresizingMaskIntoConstraints = false
+        // Ensure the trailing column reserves visual room even before the
+        // first `apply(status:)` call lands.
+        trailingHost.setContentHuggingPriority(.required, for: .horizontal)
+        trailingHost.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+        let copyStack = UIStackView(arrangedSubviews: [titleLabel, bodyLabel])
+        copyStack.translatesAutoresizingMaskIntoConstraints = false
+        copyStack.axis = .vertical
+        copyStack.alignment = .fill
+        copyStack.spacing = AppSpacing.sp1
+
+        let cardContent = card.layoutMarginsGuide
+        card.addSubview(iconView)
+        card.addSubview(copyStack)
+        card.addSubview(trailingHost)
+
+        NSLayoutConstraint.activate([
+            iconView.leadingAnchor.constraint(equalTo: cardContent.leadingAnchor),
+            iconView.topAnchor.constraint(equalTo: cardContent.topAnchor, constant: 2),
+            iconView.widthAnchor.constraint(equalToConstant: 28),
+            iconView.heightAnchor.constraint(equalToConstant: 28),
+
+            copyStack.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: AppSpacing.sp3),
+            copyStack.topAnchor.constraint(equalTo: cardContent.topAnchor),
+            copyStack.bottomAnchor.constraint(equalTo: cardContent.bottomAnchor),
+            copyStack.trailingAnchor.constraint(
+                lessThanOrEqualTo: trailingHost.leadingAnchor,
+                constant: -AppSpacing.sp3
+            ),
+
+            trailingHost.trailingAnchor.constraint(equalTo: cardContent.trailingAnchor),
+            trailingHost.centerYAnchor.constraint(equalTo: cardContent.centerYAnchor)
+        ])
+    }
+
+    // MARK: - Status rendering
+
+    /// Replace the trailing affordance to match the supplied status. Idempotent
+    /// — re-application with the same status simply rebuilds the trailing
+    /// view (cheap; max 3 swaps over the screen's lifetime).
+    func apply(status: PermissionStatus) {
+        // Remove the previous trailing view first so multi-call sequences
+        // don't stack.
+        trailingHost.subviews.forEach { $0.removeFromSuperview() }
+
+        let trailingView: UIView
+        switch status {
+        case .actionable:
+            let button = SPButton(title: "Разрешить", variant: .money, size: .sm)
+            button.addTarget(self, action: #selector(primaryTapped), for: .touchUpInside)
+            trailingView = button
+        case .granted:
+            trailingView = SPPill(text: "Разрешено", tone: .money)
+        case .enabled:
+            trailingView = SPPill(text: "Включено", tone: .money)
+        case .unavailable:
+            trailingView = SPPill(text: "Недоступно", tone: .neutral)
+        }
+
+        trailingView.translatesAutoresizingMaskIntoConstraints = false
+        trailingHost.addSubview(trailingView)
+        NSLayoutConstraint.activate([
+            trailingView.leadingAnchor.constraint(equalTo: trailingHost.leadingAnchor),
+            trailingView.trailingAnchor.constraint(equalTo: trailingHost.trailingAnchor),
+            trailingView.topAnchor.constraint(equalTo: trailingHost.topAnchor),
+            trailingView.bottomAnchor.constraint(equalTo: trailingHost.bottomAnchor)
+        ])
+    }
+
+    @objc
+    private func primaryTapped() {
+        onPrimaryTap?()
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/PermissionsViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/PermissionsViewController.swift
@@ -1,0 +1,349 @@
+import UIKit
+import UserNotifications
+
+/// Permissions screen — shown once after Onboarding finishes, before the main
+/// alarms list. Three permission cards (Notifications, Critical Alerts, Sound
+/// in silent mode) plus a "Позже" footer.
+///
+/// Flow:
+/// 1. Notifications card → tapping "Разрешить" calls
+///    `UNUserNotificationCenter.requestAuthorization` with the same option set
+///    `AlarmScheduler.requestPermission` uses (`alert + sound + badge +
+///    criticalAlert`). On result the cards refresh.
+/// 2. Critical Alerts — hard-gated on the entitlement living in
+///    `SnoozePay.entitlements`. The entitlement is currently commented out
+///    (PM-only), so the card surfaces a neutral "Недоступно" pill until it
+///    lands. Once flipped, the same notification authorisation grant covers
+///    both, so this card mirrors notifications status.
+/// 3. Sound — `AVAudioSession` `.playback + .duckOthers`, no system permission
+///    needed. `AudioService.configureAudioSession` already installs that
+///    recipe on every alarm, so this card is informational ("Включено").
+///
+/// Persistence: `permissions_screen_shown` UserDefaults key prevents re-show
+/// on subsequent launches even when the user picks "Позже". Future grants /
+/// revocations happen through Settings; the screen does not nag.
+final class PermissionsViewController: UIViewController {
+
+    // MARK: - Persistence keys
+
+    private static let shownKey = "permissions_screen_shown"
+
+    /// `true` once the user has dismissed the permissions screen at least
+    /// once (either by granting or via "Позже"). Read by SceneDelegate to
+    /// decide whether to present the screen on a given launch.
+    static var hasBeenShown: Bool {
+        UserDefaults.standard.bool(forKey: shownKey)
+    }
+
+    // MARK: - Callback
+
+    /// Invoked once the user finishes (grant complete or "Позже"). SceneDelegate
+    /// uses this to swap the root from this VC to the tab bar.
+    var onFinished: (() -> Void)?
+
+    // MARK: - Background (Dawn)
+
+    private let dawnGradientLayer: CAGradientLayer = {
+        let gradient = CAGradientLayer()
+        gradient.colors = [
+            UIColor(permRGB: 0x14122A).cgColor,
+            UIColor(permRGB: 0x0F1A2E).cgColor,
+            UIColor(permRGB: 0x0A1320).cgColor,
+            UIColor(permRGB: 0x050912).cgColor
+        ]
+        gradient.locations = [0.0, 0.4, 0.7, 1.0]
+        gradient.startPoint = CGPoint(x: 0.5, y: 0.0)
+        gradient.endPoint = CGPoint(x: 0.5, y: 1.0)
+        return gradient
+    }()
+
+    // MARK: - State
+
+    /// Latest `UNNotificationSettings.authorizationStatus`. Drives the
+    /// Notifications + Critical Alerts cards. Refreshed in `viewWillAppear`
+    /// so a return-from-Settings flips the cards without manual re-launch.
+    private var notificationStatus: UNAuthorizationStatus = .notDetermined
+
+    /// Whether the Critical Alerts entitlement is *available* at all (i.e.
+    /// the entitlement key is present in `.entitlements`). Detected via the
+    /// `criticalAlertSetting` field on `UNNotificationSettings` — `.notSupported`
+    /// means the entitlement isn't there, anything else means it is.
+    ///
+    /// Currently the entitlement is commented out in `SnoozePay.entitlements`
+    /// (PM-only edit), so we expect `.notSupported` at runtime. Once PM
+    /// uncomments the key, this will start tracking the actual grant state.
+    private var criticalAlertsAvailable: Bool = false
+    private var criticalAlertsGranted: Bool = false
+
+    // MARK: - UI Elements
+
+    private let scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.alwaysBounceVertical = true
+        scrollView.showsVerticalScrollIndicator = false
+        return scrollView
+    }()
+
+    private let contentStack: UIStackView = {
+        let stack = UIStackView()
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .vertical
+        stack.spacing = AppSpacing.sp4
+        stack.alignment = .fill
+        return stack
+    }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Разрешения"
+        label.font = AppTypography.h1
+        label.textColor = AppColors.fg1
+        label.textAlignment = .left
+        label.numberOfLines = 0
+        return label
+    }()
+
+    private let subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Чтобы будильник работал — нужны несколько разрешений"
+        label.font = AppTypography.bodyLg
+        label.textColor = AppColors.fg2
+        label.textAlignment = .left
+        label.numberOfLines = 0
+        return label
+    }()
+
+    /// Footer "Позже" — keeps the screen escapable even if the user never
+    /// grants. Same persistence as the grant path so the screen does not
+    /// re-show on next launch.
+    private let laterButton = SPButton(
+        title: "Позже",
+        variant: .ghost,
+        size: .lg,
+        fullWidth: true
+    )
+
+    /// One card per `PermissionKind`, owned so we can re-render trailing
+    /// affordances after a grant without rebuilding the view tree.
+    private var cardViews: [PermissionKind: PermissionCardView] = [:]
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = UIColor(permRGB: 0x050912)
+        view.layer.insertSublayer(dawnGradientLayer, at: 0)
+        setupUI()
+        // Detect whether the Critical Alerts entitlement is even present
+        // before we start fetching settings — `criticalAlertSetting` on a
+        // missing entitlement is `.notSupported`.
+        refreshNotificationSettings()
+        laterButton.addTarget(self, action: #selector(laterTapped), for: .touchUpInside)
+    }
+
+    override var prefersStatusBarHidden: Bool { false }
+    override var preferredStatusBarStyle: UIStatusBarStyle { .lightContent }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        // Refresh on every appear so a return-from-Settings flips the cards
+        // without the user having to relaunch the app.
+        refreshNotificationSettings()
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        dawnGradientLayer.frame = view.bounds
+        CATransaction.commit()
+    }
+
+    // MARK: - Setup
+
+    private func setupUI() {
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentStack)
+        view.addSubview(laterButton)
+        laterButton.translatesAutoresizingMaskIntoConstraints = false
+        installLayoutConstraints()
+        populateContent()
+    }
+
+    private func installLayoutConstraints() {
+        let inset = AppSpacing.sp5
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: laterButton.topAnchor, constant: -AppSpacing.sp4),
+
+            contentStack.topAnchor.constraint(
+                equalTo: scrollView.contentLayoutGuide.topAnchor,
+                constant: AppSpacing.sp6
+            ),
+            contentStack.leadingAnchor.constraint(
+                equalTo: scrollView.contentLayoutGuide.leadingAnchor,
+                constant: inset
+            ),
+            contentStack.trailingAnchor.constraint(
+                equalTo: scrollView.contentLayoutGuide.trailingAnchor,
+                constant: -inset
+            ),
+            contentStack.bottomAnchor.constraint(
+                equalTo: scrollView.contentLayoutGuide.bottomAnchor,
+                constant: -AppSpacing.sp6
+            ),
+            contentStack.widthAnchor.constraint(
+                equalTo: scrollView.frameLayoutGuide.widthAnchor,
+                constant: -inset * 2
+            ),
+
+            laterButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
+            laterButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
+            laterButton.bottomAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.bottomAnchor,
+                constant: -inset
+            )
+        ])
+    }
+
+    private func populateContent() {
+        contentStack.addArrangedSubview(titleLabel)
+        contentStack.addArrangedSubview(subtitleLabel)
+        contentStack.setCustomSpacing(AppSpacing.sp2, after: titleLabel)
+        contentStack.setCustomSpacing(AppSpacing.sp6, after: subtitleLabel)
+
+        for kind in [PermissionKind.notifications, .criticalAlerts, .sound] {
+            let card = PermissionCardView(kind: kind)
+            card.onPrimaryTap = { [weak self] in self?.handleGrantTap(for: kind) }
+            cardViews[kind] = card
+            contentStack.addArrangedSubview(card)
+        }
+    }
+
+    // MARK: - State refresh
+
+    /// Fetch the current `UNNotificationSettings` and re-render every card.
+    /// Always dispatches back to main — UN settings callbacks fire on a
+    /// background queue.
+    private func refreshNotificationSettings() {
+        UNUserNotificationCenter.current().getNotificationSettings { [weak self] settings in
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                self.notificationStatus = settings.authorizationStatus
+                // `.notSupported` means the Critical Alerts entitlement is
+                // absent (e.g. it's commented out in `.entitlements`). Any
+                // other value means the capability is wired and reflects the
+                // actual user-grant state.
+                self.criticalAlertsAvailable = settings.criticalAlertSetting != .notSupported
+                self.criticalAlertsGranted = settings.criticalAlertSetting == .enabled
+                self.applyStatusToCards()
+            }
+        }
+    }
+
+    private func applyStatusToCards() {
+        cardViews[.notifications]?.apply(status: notificationsStatus())
+        cardViews[.criticalAlerts]?.apply(status: criticalAlertsStatus())
+        cardViews[.sound]?.apply(status: soundStatus())
+    }
+
+    private func notificationsStatus() -> PermissionStatus {
+        switch notificationStatus {
+        case .authorized, .provisional, .ephemeral:
+            return .granted
+        case .denied:
+            // Once denied, the OS won't show the prompt again — the user
+            // must flip the toggle in Settings. Surface the "Разрешить"
+            // affordance anyway; the tap handler routes to Settings.
+            return .actionable
+        case .notDetermined:
+            return .actionable
+        @unknown default:
+            return .actionable
+        }
+    }
+
+    private func criticalAlertsStatus() -> PermissionStatus {
+        guard criticalAlertsAvailable else {
+            // Entitlement is missing from `.entitlements` — user cannot grant
+            // this from the app. Documented in the PR description as a
+            // follow-up for PM to flip the entitlement key.
+            return .unavailable
+        }
+        return criticalAlertsGranted ? .granted : .actionable
+    }
+
+    private func soundStatus() -> PermissionStatus {
+        // `AudioService.configureAudioSession` installs `.playback` +
+        // `.duckOthers` every time an alarm starts ringing, so this is
+        // always-on for the user. No system permission lives behind it.
+        .enabled
+    }
+
+    // MARK: - Grant flow
+
+    private func handleGrantTap(for kind: PermissionKind) {
+        switch kind {
+        case .notifications, .criticalAlerts:
+            handleNotificationsTap()
+        case .sound:
+            // Sound card is informational — no tap path. `actionable` never
+            // resolves for `.sound`, but guard defensively.
+            break
+        }
+    }
+
+    private func handleNotificationsTap() {
+        // If the user already denied once, iOS won't re-prompt — open
+        // Settings instead so they have a way to flip the toggle.
+        if notificationStatus == .denied {
+            openAppSettings()
+            return
+        }
+
+        // Route through `AlarmScheduler.requestPermission` so the same
+        // critical-alert-with-fallback request ladder runs as on AppDelegate
+        // launch — and the `AlarmScheduler.criticalAlertsAvailable` static
+        // flag stays in sync (it's `private(set)` so only the scheduler can
+        // mutate it).
+        AlarmScheduler.shared.requestPermission { [weak self] _ in
+            // Refresh from settings rather than trusting the `granted` flag
+            // alone — `criticalAlertSetting` may resolve differently from
+            // the headline grant on legacy iOS versions.
+            self?.refreshNotificationSettings()
+        }
+    }
+
+    private func openAppSettings() {
+        guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+        UIApplication.shared.open(url)
+    }
+
+    // MARK: - Footer actions
+
+    @objc
+    private func laterTapped() {
+        finish()
+    }
+
+    private func finish() {
+        UserDefaults.standard.set(true, forKey: Self.shownKey)
+        onFinished?()
+    }
+}
+
+// MARK: - Hex helper
+
+private extension UIColor {
+    /// `0xRRGGBB` literal initialiser, file-prefixed name to avoid collisions
+    /// with the same helper inside Onboarding / Splash.
+    convenience init(permRGB: UInt32, alpha: CGFloat = 1) {
+        let red = CGFloat((permRGB >> 16) & 0xFF) / 255.0
+        let green = CGFloat((permRGB >> 8) & 0xFF) / 255.0
+        let blue = CGFloat(permRGB & 0xFF) / 255.0
+        self.init(red: red, green: green, blue: blue, alpha: alpha)
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/SplashViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/SplashViewController.swift
@@ -1,0 +1,173 @@
+import UIKit
+
+/// First-frame splash — covers the gap between `LaunchScreen.storyboard` (which
+/// is the system-controlled static frame iOS shows during process bring-up) and
+/// the real root SceneDelegate installs (Onboarding / Permissions / TabBar).
+///
+/// Visual: full-screen Dawn gradient (`--sp-grad-dawn`) with the SnoozePay text
+/// logo masked by the money brand gradient, mirroring the
+/// `SPBalanceCard.applyValueGradient` recipe so the wordmark reads as the same
+/// "money-glow" primitive used on the balance hero.
+///
+/// We deliberately keep `LaunchScreen.storyboard` unchanged (it is part of the
+/// signing/Info.plist contract and the no-touch contract treats storyboard +
+/// signing related files as PM-owned). Instead this VC is shown for ~`displayDuration`
+/// before SceneDelegate calls `onFinished` and crossfades to the real root.
+/// That keeps the "branded launch" outcome without touching the static
+/// storyboard.
+final class SplashViewController: UIViewController {
+
+    // MARK: - Configuration
+
+    /// How long the splash is shown after the scene becomes active before the
+    /// root is replaced. 200ms matches the spec; long enough for the gradient
+    /// + wordmark to register, short enough not to feel like an explicit
+    /// loading screen.
+    private static let displayDuration: TimeInterval = 0.20
+
+    /// Invoked after `displayDuration` elapses. SceneDelegate uses this to
+    /// crossfade into Onboarding / Permissions / TabBar depending on user
+    /// state. `nil` is safe — without a callback the splash simply sits.
+    var onFinished: (() -> Void)?
+
+    // MARK: - Background (Dawn)
+
+    /// Same 4-stop atmospheric gradient as `OnboardingViewController` so the
+    /// crossfade between the two screens has no perceptible seam.
+    private let dawnGradientLayer: CAGradientLayer = {
+        let gradient = CAGradientLayer()
+        gradient.colors = [
+            UIColor(splashRGB: 0x14122A).cgColor,
+            UIColor(splashRGB: 0x0F1A2E).cgColor,
+            UIColor(splashRGB: 0x0A1320).cgColor,
+            UIColor(splashRGB: 0x050912).cgColor
+        ]
+        gradient.locations = [0.0, 0.4, 0.7, 1.0]
+        gradient.startPoint = CGPoint(x: 0.5, y: 0.0)
+        gradient.endPoint = CGPoint(x: 0.5, y: 1.0)
+        return gradient
+    }()
+
+    // MARK: - Wordmark
+
+    /// "SnoozePay" rendered with the money gradient mask. The label paints
+    /// `clear` once `applyWordmarkGradient()` runs (same pattern as
+    /// `SPBalanceCard.applyValueGradient`) so we don't double-stack the
+    /// solid label colour under the gradient.
+    private let wordmarkLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "SnoozePay"
+        label.font = AppTypography.h1
+        label.textColor = AppColors.fg1
+        label.textAlignment = .center
+        label.adjustsFontForContentSizeCategory = false
+        return label
+    }()
+
+    /// Gradient layer that the wordmark glyphs mask — installed as a sublayer
+    /// of `wordmarkLabel.layer` once layout resolves so size / theme switches
+    /// re-rasterise cheaply.
+    private let wordmarkGradient: CAGradientLayer = {
+        let gradient = CAGradientLayer()
+        gradient.colors = SPSupport.moneyGradientColors
+        gradient.locations = SPSupport.moneyGradientLocations
+        gradient.startPoint = SPSupport.gradientStart
+        gradient.endPoint = SPSupport.gradientEnd
+        return gradient
+    }()
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Solid base under the gradient so any flash before CALayer commits
+        // matches the bottom stop instead of the system bg.
+        view.backgroundColor = UIColor(splashRGB: 0x050912)
+        view.layer.insertSublayer(dawnGradientLayer, at: 0)
+        view.addSubview(wordmarkLabel)
+        NSLayoutConstraint.activate([
+            wordmarkLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            wordmarkLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            wordmarkLabel.leadingAnchor.constraint(
+                greaterThanOrEqualTo: view.leadingAnchor,
+                constant: AppSpacing.screenInset
+            ),
+            wordmarkLabel.trailingAnchor.constraint(
+                lessThanOrEqualTo: view.trailingAnchor,
+                constant: -AppSpacing.screenInset
+            )
+        ])
+    }
+
+    override var prefersStatusBarHidden: Bool { true }
+
+    /// Force light status bar so the dark Dawn gradient reads correctly
+    /// regardless of the user's system appearance.
+    override var preferredStatusBarStyle: UIStatusBarStyle { .lightContent }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        // Disable implicit animation so size / orientation changes don't
+        // crossfade the gradient stops.
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        dawnGradientLayer.frame = view.bounds
+        CATransaction.commit()
+        applyWordmarkGradient()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        // Schedule the handoff once the view is on-screen — viewDidLoad would
+        // fire `onFinished` before the user's first frame has even composited.
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.displayDuration) { [weak self] in
+            self?.onFinished?()
+        }
+    }
+
+    // MARK: - Wordmark gradient mask
+
+    /// Mask `wordmarkGradient` to the rendered glyph outline — CSS equivalent
+    /// of `-webkit-background-clip: text`. Lifted from
+    /// `SPBalanceCard.applyValueGradient` so the visual treatment between the
+    /// hero balance and the splash wordmark stays in sync.
+    private func applyWordmarkGradient() {
+        let textBounds = wordmarkLabel.bounds
+        guard textBounds.width > 0, textBounds.height > 0 else { return }
+        if wordmarkGradient.superlayer !== wordmarkLabel.layer {
+            wordmarkLabel.layer.addSublayer(wordmarkGradient)
+        }
+        wordmarkGradient.frame = textBounds
+
+        let renderer = UIGraphicsImageRenderer(size: textBounds.size)
+        let mask = renderer.image { _ in
+            (wordmarkLabel.text ?? "").draw(
+                in: textBounds,
+                withAttributes: [
+                    .font: wordmarkLabel.font as Any,
+                    .foregroundColor: UIColor.white
+                ]
+            )
+        }
+        let maskLayer = CALayer()
+        maskLayer.frame = textBounds
+        maskLayer.contents = mask.cgImage
+        wordmarkGradient.mask = maskLayer
+        wordmarkLabel.textColor = .clear
+    }
+}
+
+// MARK: - Hex helper
+
+private extension UIColor {
+    /// `0xRRGGBB` literal initialiser — local copy mirroring the (private)
+    /// helpers in AppColors / OnboardingViewController. File-prefixed so it
+    /// can't collide with the other private extensions in the module.
+    convenience init(splashRGB: UInt32, alpha: CGFloat = 1) {
+        let red = CGFloat((splashRGB >> 16) & 0xFF) / 255.0
+        let green = CGFloat((splashRGB >> 8) & 0xFF) / 255.0
+        let blue = CGFloat(splashRGB & 0xFF) / 255.0
+        self.init(red: red, green: green, blue: blue, alpha: alpha)
+    }
+}


### PR DESCRIPTION
Fixes #149

## What's added

### A) Splash / Launch
- New `SplashViewController` mounted as the first scene root. Full-screen dawn gradient (`--sp-grad-dawn`) with the SnoozePay wordmark rendered through a money-gradient mask (same recipe as `SPBalanceCard.applyValueGradient`).
- `LaunchScreen.storyboard` is intentionally left untouched — the existing static frame is part of the signing/Info.plist contract; we own the branded launch story from the `SplashViewController` instead, which crossfades into the real root after ~200ms.

### B) Permissions
- New `PermissionsViewController` shown after `OnboardingViewController` finishes, before the alarms list, gated by `permissions_screen_shown` UserDefaults flag so it doesn't re-show on subsequent launches.
- Three `SPCard` rows: Notifications, Critical Alerts, Sound (silent-mode), each with title/body and a trailing `SPButton(.money, .sm)` "Разрешить" or `SPPill` status (Разрешено / Включено / Недоступно).
- "Разрешить" routes through `AlarmScheduler.requestPermission` so the existing critical-alert-with-fallback ladder runs and the `criticalAlertsAvailable` static stays in sync. If the user has previously denied, the tap routes to Settings.
- "Позже" footer (`SPButton(.ghost, .lg)`) finishes the flow without granting and stamps the same flag.

### Wiring
- `SceneDelegate` mounts Splash first and routes Splash → Onboarding (if needed) → Permissions (if needed) → TabBar based on UserDefaults.
- `AppDelegate.application(_:didFinishLaunchingWithOptions:)` defers its automatic `requestPermission` call until `PermissionsViewController.hasBeenShown == true` so the OS prompt doesn't race the splash → onboarding → permissions UI on a fresh install. Subsequent launches keep the existing "permission revoked" alert path.

## Critical Alerts entitlement (PM follow-up)

`SnoozePay.entitlements` keeps the `com.apple.developer.usernotifications.critical-alerts` key commented out, exactly as on `design-refresh-2026-04-27`. The Permissions screen detects this at runtime via `UNNotificationSettings.criticalAlertSetting == .notSupported` and surfaces a neutral "Недоступно" pill on that card. Once PM uncomments the entitlement key (Apple-approval gated), the same card will start tracking actual grant state.

## Sound card

`AudioService.configureAudioSession` already installs `.playback + .duckOthers`, which is the iOS recipe for "alarm rings even with the silent switch on" — no system permission lives behind it. The card therefore renders a static "Включено" pill informationally.

## Verify
- swiftlint: 0 errors (5 pre-existing AppDelegate warnings, no new ones)
- build_sim: succeeded (simulator: iPhone 17 Pro)
- test_sim: skipped per instructions
- screenshot: skipped per instructions

## No-touch zones respected
- `Info.plist`: untouched
- `SnoozePay.entitlements`: untouched
- `LaunchScreen.storyboard`: untouched
- `project.pbxproj`: untouched (project uses `fileSystemSynchronizedGroups`, new files auto-detected)