### PR TITLE
[design-refresh] Refresh Statistics with heatmap + bars + streak (#147)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsEmptyStateView.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsEmptyStateView.swift
@@ -1,0 +1,106 @@
+import UIKit
+
+/// Empty-state column shown on the statistics screen when the selected
+/// period has no transactions. Mirrors the alarms-list empty state in
+/// shape (icon + heading + body + primary CTA) but uses a chart icon and
+/// "Создать будильник" copy so the user lands on the alarm-creation flow
+/// rather than the top-up flow.
+///
+/// Hosted by `StatisticsViewController`; the controller listens to
+/// `onCreateAlarmTap` to push `CreateAlarmViewController(alarm: nil)`.
+final class StatisticsEmptyStateView: UIView {
+
+    // MARK: - Public API
+
+    /// Triggered when the user taps "Создать будильник".
+    var onCreateAlarmTap: (() -> Void)?
+
+    // MARK: - Subviews
+
+    private let iconView: UIImageView = {
+        let configuration = UIImage.SymbolConfiguration(pointSize: 64, weight: .regular)
+        let view = UIImageView(image: UIImage(systemName: "chart.bar.xaxis", withConfiguration: configuration))
+        view.tintColor = AppColors.fg3
+        view.contentMode = .scaleAspectFit
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Пока нет данных"
+        label.font = AppTypography.h3
+        label.textColor = AppColors.fg1
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let bodyLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Создайте будильник, чтобы отслеживать серии"
+        label.font = AppTypography.body
+        label.textColor = AppColors.fg3
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let createButton: SPButton = {
+        let button = SPButton(
+            title: "Создать будильник",
+            variant: .money,
+            size: .lg,
+            icon: UIImage(systemName: "plus"),
+            fullWidth: true
+        )
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    // MARK: - Init
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Configuration
+
+    private func configure() {
+        backgroundColor = .clear
+
+        let stack = UIStackView(arrangedSubviews: [iconView, titleLabel, bodyLabel, createButton])
+        stack.axis = .vertical
+        stack.alignment = .center
+        stack.spacing = AppSpacing.sp3
+        stack.setCustomSpacing(AppSpacing.sp4, after: iconView)
+        stack.setCustomSpacing(AppSpacing.sp5, after: bodyLabel)
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            iconView.widthAnchor.constraint(equalToConstant: 80),
+            iconView.heightAnchor.constraint(equalToConstant: 80),
+
+            stack.topAnchor.constraint(equalTo: topAnchor, constant: AppSpacing.sp7),
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor),
+            stack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -AppSpacing.sp5),
+
+            createButton.leadingAnchor.constraint(equalTo: stack.leadingAnchor, constant: AppSpacing.sp4),
+            createButton.trailingAnchor.constraint(equalTo: stack.trailingAnchor, constant: -AppSpacing.sp4)
+        ])
+
+        createButton.addTarget(self, action: #selector(createTapped), for: .touchUpInside)
+    }
+
+    @objc private func createTapped() {
+        onCreateAlarmTap?()
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsHeatmapView.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsHeatmapView.swift
@@ -1,0 +1,186 @@
+import UIKit
+
+/// GitHub-style heatmap calendar for the statistics screen.
+///
+/// Renders a 7-column × N-row grid of small squares (12pt at the smallest
+/// scale, growing to fill horizontal space) where each square's tint encodes
+/// the day's penalty total. The intensity bucket (0..4) comes pre-computed
+/// from `StatisticsViewModel.HeatmapCell` so the view stays a pure renderer.
+///
+/// We use `UICollectionView` with a compositional layout instead of a hand-
+/// rolled stack-of-stacks because:
+///   1. Tap targets need cells (toast-on-tap surfaces date + amount).
+///   2. The grid scales smoothly from 7 cells (week) → 84 cells (all-time)
+///      without re-laying out an arbitrary stack tree on every period change.
+///
+/// The cell size is derived from the available width inside `layoutSubviews`
+/// so a 7-cell wide row always packs flush; the height grows with row count.
+final class StatisticsHeatmapView: UIView {
+
+    // MARK: - Public API
+
+    /// Replace the rendered cells. Triggers a collection-view reload and
+    /// (since rows depend on cell count) a layout pass via
+    /// `invalidateIntrinsicContentSize`.
+    var cells: [StatisticsViewModel.HeatmapCell] = [] {
+        didSet {
+            collectionView.reloadData()
+            invalidateIntrinsicContentSize()
+            setNeedsLayout()
+        }
+    }
+
+    /// Triggered when the user taps a cell — caller surfaces a toast / alert.
+    var onCellTap: ((StatisticsViewModel.HeatmapCell) -> Void)?
+
+    // MARK: - Constants
+
+    /// Number of columns. The spec is GitHub-style — Monday → Sunday.
+    private static let columnCount = 7
+    /// Inner spacing between squares (matches `--sp-r-xs` / 4px gutter).
+    private static let cellSpacing: CGFloat = 4
+    /// Square corner radius — the spec calls for 3pt.
+    static let cellCornerRadius: CGFloat = 3
+
+    // MARK: - Subviews
+
+    private let collectionView: UICollectionView
+    private let flowLayout = UICollectionViewFlowLayout()
+
+    // MARK: - Init
+
+    override init(frame: CGRect) {
+        flowLayout.scrollDirection = .vertical
+        flowLayout.minimumInteritemSpacing = Self.cellSpacing
+        flowLayout.minimumLineSpacing = Self.cellSpacing
+        flowLayout.sectionInset = .zero
+        collectionView = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
+        super.init(frame: frame)
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Layout
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        // Compute cell side from current width — 7 columns + 6 gutters.
+        let availableWidth = bounds.width
+        let totalGutter = Self.cellSpacing * CGFloat(Self.columnCount - 1)
+        let side = max(8, floor((availableWidth - totalGutter) / CGFloat(Self.columnCount)))
+        if flowLayout.itemSize.width != side {
+            flowLayout.itemSize = CGSize(width: side, height: side)
+            flowLayout.invalidateLayout()
+            invalidateIntrinsicContentSize()
+        }
+    }
+
+    override var intrinsicContentSize: CGSize {
+        guard !cells.isEmpty else {
+            return CGSize(width: UIView.noIntrinsicMetric, height: 0)
+        }
+        let rowCount = Int(ceil(Double(cells.count) / Double(Self.columnCount)))
+        let side = flowLayout.itemSize.height > 0 ? flowLayout.itemSize.height : 12
+        let height = side * CGFloat(rowCount) + Self.cellSpacing * CGFloat(max(0, rowCount - 1))
+        return CGSize(width: UIView.noIntrinsicMetric, height: height)
+    }
+
+    // MARK: - Configuration
+
+    private func configure() {
+        backgroundColor = .clear
+        collectionView.backgroundColor = .clear
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        collectionView.delegate = self
+        collectionView.dataSource = self
+        collectionView.isScrollEnabled = false
+        collectionView.register(HeatmapCellView.self, forCellWithReuseIdentifier: HeatmapCellView.reuseID)
+        addSubview(collectionView)
+
+        NSLayoutConstraint.activate([
+            collectionView.topAnchor.constraint(equalTo: topAnchor),
+            collectionView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            collectionView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            collectionView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+}
+
+// MARK: - Data + Delegate
+
+extension StatisticsHeatmapView: UICollectionViewDataSource, UICollectionViewDelegate {
+
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        cells.count
+    }
+
+    func collectionView(
+        _ collectionView: UICollectionView,
+        cellForItemAt indexPath: IndexPath
+    ) -> UICollectionViewCell {
+        guard
+            let cell = collectionView.dequeueReusableCell(
+                withReuseIdentifier: HeatmapCellView.reuseID,
+                for: indexPath
+            ) as? HeatmapCellView,
+            indexPath.item < cells.count
+        else { return UICollectionViewCell() }
+        cell.apply(intensity: cells[indexPath.item].intensity)
+        return cell
+    }
+
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard indexPath.item < cells.count else { return }
+        onCellTap?(cells[indexPath.item])
+    }
+}
+
+// MARK: - Heatmap cell
+
+/// Single square in the heatmap grid. Maps `intensity` (0..4) onto a tint
+/// from the money palette so a denser day reads as a "more saved" colour.
+/// Bucket 0 is the empty `whiteOverlay06` token — same affordance the
+/// streak-modal uses for future / muted days.
+private final class HeatmapCellView: UICollectionViewCell {
+
+    static let reuseID = "HeatmapCellView"
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        contentView.layer.cornerRadius = StatisticsHeatmapView.cellCornerRadius
+        contentView.layer.cornerCurve = .continuous
+        contentView.layer.masksToBounds = true
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        // Re-resolve dynamic colours so a light/dark switch re-tints buckets
+        // 0 (whiteOverlay06) without leaving the previous theme baked in.
+        contentView.backgroundColor = contentView.backgroundColor?.resolvedColor(with: traitCollection)
+    }
+
+    func apply(intensity: Int) {
+        contentView.backgroundColor = Self.color(for: intensity)
+    }
+
+    /// Map a 0..4 bucket onto the money palette. 0 is the empty cell —
+    /// `whiteOverlay06` so it matches the streak-modal "future / muted"
+    /// affordance. 1..4 lerp between `money300` and `money700` so the
+    /// gradient reads as "more saved → deeper green".
+    private static func color(for intensity: Int) -> UIColor {
+        switch intensity {
+        case 0: return AppColors.whiteOverlay06
+        case 1: return SPSupport.lerpColor(AppColors.money300, AppColors.money700, progress: 0.0)
+        case 2: return SPSupport.lerpColor(AppColors.money300, AppColors.money700, progress: 0.33)
+        case 3: return SPSupport.lerpColor(AppColors.money300, AppColors.money700, progress: 0.66)
+        default: return AppColors.money700
+        }
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsViewController+Cards.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsViewController+Cards.swift
@@ -1,0 +1,184 @@
+import UIKit
+import SwiftUI
+
+/// Card-builder helpers for `StatisticsViewController`.
+///
+/// Lifted into an extension so the main type body stays under SwiftLint's
+/// `type_body_length` ceiling. Each `make…()` returns a fully-laid-out
+/// `SPCard`-rooted view ready for insertion into `dataStack`. The factories
+/// are non-private so the controller can call them from another file —
+/// internal access is enough to keep them out of the module's public surface.
+extension StatisticsViewController {
+
+    // MARK: - Summary row
+
+    /// Two-column summary row: pain-tinted "Потрачено" + neutral "Откладываний".
+    /// Returns a horizontal `UIStackView` rather than a single SPCard so the
+    /// two values can sit side-by-side without nesting cards inside cards.
+    func makeSummaryRow() -> UIView {
+        let leftCard = makeSummaryTile(caption: "Потрачено", valueLabel: spentAmountLabel)
+        let rightCard = makeSummaryTile(caption: "Откладываний", valueLabel: snoozeCountLabel)
+        let row = UIStackView(arrangedSubviews: [leftCard, rightCard])
+        row.axis = .horizontal
+        row.spacing = AppSpacing.sp3
+        row.distribution = .fillEqually
+        row.translatesAutoresizingMaskIntoConstraints = false
+        return row
+    }
+
+    /// One tile inside the summary row — caps caption above a `moneyMd`
+    /// numeric value, both inside an `SPCard(.surface)` with the standard
+    /// 16pt internal padding.
+    func makeSummaryTile(caption: String, valueLabel: UILabel) -> UIView {
+        let card = SPCard(tone: .surface, padding: AppSpacing.sp4)
+
+        let captionLabel = UILabel()
+        captionLabel.attributedText = NSAttributedString(
+            string: caption.uppercased(),
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.fg3
+            ]
+        )
+        captionLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        let stack = UIStackView(arrangedSubviews: [captionLabel, valueLabel])
+        stack.axis = .vertical
+        stack.spacing = AppSpacing.sp2
+        stack.alignment = .leading
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: card.layoutMarginsGuide.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: card.layoutMarginsGuide.trailingAnchor),
+            stack.topAnchor.constraint(equalTo: card.layoutMarginsGuide.topAnchor),
+            stack.bottomAnchor.constraint(equalTo: card.layoutMarginsGuide.bottomAnchor)
+        ])
+        return card
+    }
+
+    // MARK: - Heatmap
+
+    /// Heatmap card — title + 7-column heatmap grid wrapped in an SPCard.
+    func makeHeatmapCard() -> UIView {
+        let card = SPCard(tone: .surface, padding: AppSpacing.sp4)
+        let titleLabel = UILabel()
+        titleLabel.text = "Календарь"
+        titleLabel.font = AppTypography.h4
+        titleLabel.textColor = AppColors.fg1
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        let stack = UIStackView(arrangedSubviews: [titleLabel, heatmapView])
+        stack.axis = .vertical
+        stack.spacing = AppSpacing.sp3
+        stack.alignment = .fill
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        card.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: card.layoutMarginsGuide.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: card.layoutMarginsGuide.trailingAnchor),
+            stack.topAnchor.constraint(equalTo: card.layoutMarginsGuide.topAnchor),
+            stack.bottomAnchor.constraint(equalTo: card.layoutMarginsGuide.bottomAnchor)
+        ])
+        return card
+    }
+
+    // MARK: - Chart
+
+    /// Chart card — title + Apple-Charts bar chart wrapped in an SPCard.
+    /// Stores the hosting controller on the VC so `refresh()` can swap the
+    /// rootView when the period changes without re-building the SwiftUI
+    /// hierarchy.
+    func makeChartCard() -> UIView {
+        let card = SPCard(tone: .surface, padding: AppSpacing.sp4)
+        let titleLabel = UILabel()
+        titleLabel.text = "Средний штраф по дням"
+        titleLabel.font = AppTypography.h4
+        titleLabel.textColor = AppColors.fg1
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        let chartView = WeekdayChartView(bars: [])
+        let hosting = UIHostingController(rootView: chartView)
+        hosting.view.translatesAutoresizingMaskIntoConstraints = false
+        hosting.view.backgroundColor = .clear
+        addChild(hosting)
+        hosting.didMove(toParent: self)
+        chartHostingController = hosting
+
+        let stack = UIStackView(arrangedSubviews: [titleLabel, hosting.view])
+        stack.axis = .vertical
+        stack.spacing = AppSpacing.sp3
+        stack.alignment = .fill
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        card.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: card.layoutMarginsGuide.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: card.layoutMarginsGuide.trailingAnchor),
+            stack.topAnchor.constraint(equalTo: card.layoutMarginsGuide.topAnchor),
+            stack.bottomAnchor.constraint(equalTo: card.layoutMarginsGuide.bottomAnchor),
+            hosting.view.heightAnchor.constraint(equalToConstant: 200)
+        ])
+        return card
+    }
+
+    // MARK: - Streak
+
+    /// Tappable streak card — flame icon + caption + current/best lines +
+    /// trailing chevron. Tapping anywhere on the card triggers
+    /// `streakTapped()` which presents `StreakModalViewController`.
+    func makeStreakCard() -> UIView {
+        let card = SPCard(tone: .surface, padding: AppSpacing.sp4)
+
+        let flameConfig = UIImage.SymbolConfiguration(pointSize: 24, weight: .semibold)
+        let flameView = UIImageView(image: UIImage(systemName: "flame.fill", withConfiguration: flameConfig))
+        flameView.tintColor = AppColors.warn500
+        flameView.translatesAutoresizingMaskIntoConstraints = false
+        flameView.setContentHuggingPriority(.required, for: .horizontal)
+
+        let titleCaption = UILabel()
+        titleCaption.attributedText = NSAttributedString(
+            string: "ТЕКУЩАЯ СЕРИЯ",
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.fg3
+            ]
+        )
+        titleCaption.translatesAutoresizingMaskIntoConstraints = false
+
+        let textStack = UIStackView(arrangedSubviews: [titleCaption, streakValueLabel, streakBestLabel])
+        textStack.axis = .vertical
+        textStack.spacing = AppSpacing.sp1
+        textStack.alignment = .leading
+        textStack.translatesAutoresizingMaskIntoConstraints = false
+
+        let chevron = UIImageView(image: UIImage(systemName: "chevron.right"))
+        chevron.tintColor = AppColors.fg3
+        chevron.translatesAutoresizingMaskIntoConstraints = false
+        chevron.setContentHuggingPriority(.required, for: .horizontal)
+
+        let row = UIStackView(arrangedSubviews: [flameView, textStack, chevron])
+        row.axis = .horizontal
+        row.spacing = AppSpacing.sp3
+        row.alignment = .center
+        row.translatesAutoresizingMaskIntoConstraints = false
+
+        card.addSubview(row)
+        NSLayoutConstraint.activate([
+            row.leadingAnchor.constraint(equalTo: card.layoutMarginsGuide.leadingAnchor),
+            row.trailingAnchor.constraint(equalTo: card.layoutMarginsGuide.trailingAnchor),
+            row.topAnchor.constraint(equalTo: card.layoutMarginsGuide.topAnchor),
+            row.bottomAnchor.constraint(equalTo: card.layoutMarginsGuide.bottomAnchor),
+            flameView.widthAnchor.constraint(equalToConstant: 32),
+            flameView.heightAnchor.constraint(equalToConstant: 32)
+        ])
+
+        let tap = UITapGestureRecognizer(target: self, action: #selector(streakTapped))
+        card.addGestureRecognizer(tap)
+        card.isUserInteractionEnabled = true
+        return card
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsViewController.swift
@@ -2,180 +2,124 @@ import UIKit
 import SwiftUI
 import Charts
 
-/// Statistics screen: spending summary, bar chart, streak, motivation.
-class StatisticsViewController: UIViewController {
+/// Statistics screen — design-refresh 2026-04-27 rewrite (#147).
+///
+/// Vertical stack of:
+///   1. Period segmented (Неделя / Месяц / Всё время) — drives the VM.
+///   2. Two-column summary (Потрачено · Откладываний) on `SPCard(.surface)`s
+///      with caps + moneyMd typography.
+///   3. GitHub-style heatmap calendar — 7 columns × N rows of money-tinted
+///      squares. Tap a square → toast with date + amount.
+///   4. Apple-Charts bar chart of average penalty by weekday (Пн → Вс).
+///   5. Streak SPCard with 🔥 + current days + lifetime best — tap to open
+///      `StreakModalViewController`.
+///   6. Empty state when there are no transactions in the selected period.
+///
+/// Backed by the existing `StatisticsViewModel`; new heatmap / weekday-bar /
+/// `hasData` accessors land in the same file so the chart, heatmap, streak
+/// card, and empty state all read from one source of truth.
+///
+/// Card-building helpers (`makeSummaryRow()`, `makeHeatmapCard()`, ...) live
+/// in `StatisticsViewController+Cards.swift` so the main type body stays
+/// under SwiftLint's `type_body_length` ceiling.
+final class StatisticsViewController: UIViewController {
 
     // MARK: - ViewModel
 
-    private let viewModel = StatisticsViewModel()
+    let viewModel = StatisticsViewModel()
 
-    // MARK: - UI
+    // MARK: - Layout containers
 
-    private let scrollView: UIScrollView = {
-        let sv = UIScrollView()
-        sv.translatesAutoresizingMaskIntoConstraints = false
-        return sv
+    let scrollView = UIScrollView()
+    let contentStack = UIStackView()
+    /// Stack of "data" sections (summary + heatmap + chart + streak).
+    /// Hidden as a unit when the empty state takes over.
+    let dataStack = UIStackView()
+    var emptyStateView: StatisticsEmptyStateView?
+
+    // MARK: - Period selector
+
+    lazy var periodSegment: SPSegmented = {
+        let options = StatisticsViewModel.Period.allCases.map { period in
+            SPSegmented.Option(value: String(period.rawValue), label: period.title)
+        }
+        let segment = SPSegmented(
+            options: options,
+            selectedValue: String(StatisticsViewModel.Period.week.rawValue)
+        ) { [weak self] value in
+            guard let raw = Int(value), let period = StatisticsViewModel.Period(rawValue: raw) else { return }
+            self?.viewModel.loadData(period: period)
+        }
+        segment.translatesAutoresizingMaskIntoConstraints = false
+        return segment
     }()
 
-    private let contentStack: UIStackView = {
-        let sv = UIStackView()
-        sv.axis = .vertical
-        sv.spacing = AppSpacing.lg
-        sv.translatesAutoresizingMaskIntoConstraints = false
-        return sv
-    }()
+    // MARK: - Summary tiles
 
-    private let periodSegment: UISegmentedControl = {
-        let items = StatisticsViewModel.Period.allCases.map { $0.title }
-        let sc = UISegmentedControl(items: items)
-        sc.selectedSegmentIndex = 0
-        sc.translatesAutoresizingMaskIntoConstraints = false
-        return sc
-    }()
-
-    // MARK: Two-column summary
-
-    private let spentTitleLabel: UILabel = {
+    /// Pain-tinted "Потрачено" amount. Drawn with the pain-text gradient via
+    /// `UILabel.applyGradientMask(_:)` so the value glyphs track the brand
+    /// red sweep.
+    let spentAmountLabel: UILabel = {
         let label = UILabel()
-        label.text = "Потрачено"
-        label.font = UIFont.systemFont(ofSize: 13)
-        label.textColor = .secondaryLabel
+        label.font = AppTypography.moneyMd
+        label.textColor = AppColors.fg1
+        label.adjustsFontForContentSizeCategory = false
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    let spentGradientLayer = CAGradientLayer()
+
+    let snoozeCountLabel: UILabel = {
+        let label = UILabel()
+        label.font = AppTypography.moneyMd
+        label.textColor = AppColors.fg1
+        label.adjustsFontForContentSizeCategory = false
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
 
-    private let spentAmountLabel: UILabel = {
-        let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 32, weight: .bold)
-        label.textColor = AppColors.accentOrange
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
-    }()
+    // MARK: - Heatmap
 
-    private let snoozeTitleLabel: UILabel = {
-        let label = UILabel()
-        label.text = "Откладываний"
-        label.font = UIFont.systemFont(ofSize: 13)
-        label.textColor = .secondaryLabel
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
-    }()
-
-    private let snoozeCountLabel: UILabel = {
-        let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 32, weight: .bold)
-        label.textColor = .label
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
-    }()
-
-    // MARK: Average card
-
-    private let averageTitleLabel: UILabel = {
-        let label = UILabel()
-        label.text = "Среднее"
-        label.font = UIFont.systemFont(ofSize: 13)
-        label.textColor = .secondaryLabel
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
-    }()
-
-    private let averageValueLabel: UILabel = {
-        let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 28, weight: .bold)
-        label.textColor = .label
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
-    }()
-
-    // MARK: Chart
-
-    private let chartTitleLabel: UILabel = {
-        let label = UILabel()
-        label.text = "График по дням"
-        label.font = UIFont.systemFont(ofSize: 15, weight: .semibold)
-        label.textColor = .label
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
-    }()
-
-    private var chartHostingController: UIHostingController<StatisticsChartView>?
-
-    /// Explicit reference to the streak card so `refresh()` can toggle its
-    /// visibility without walking the view-hierarchy via `superview?.superview`.
-    private var streakCard: UIView?
-
-    // MARK: Streak
-
-    private let streakIconView: UIView = {
-        let container = UIView()
-        container.backgroundColor = AppColors.accentOrange.withAlphaComponent(0.15)
-        container.layer.cornerRadius = 22
-        container.translatesAutoresizingMaskIntoConstraints = false
-
-        let label = UILabel()
-        label.text = "🔥"
-        label.font = UIFont.systemFont(ofSize: 22)
-        label.translatesAutoresizingMaskIntoConstraints = false
-        container.addSubview(label)
-
-        NSLayoutConstraint.activate([
-            container.widthAnchor.constraint(equalToConstant: 44),
-            container.heightAnchor.constraint(equalToConstant: 44),
-            label.centerXAnchor.constraint(equalTo: container.centerXAnchor),
-            label.centerYAnchor.constraint(equalTo: container.centerYAnchor)
-        ])
-        return container
-    }()
-
-    private let streakLabel: UILabel = {
-        let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 20, weight: .bold)
-        label.textColor = .label
-        label.numberOfLines = 0
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
-    }()
-
-    private let bestStreakLabel: UILabel = {
-        let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 13)
-        label.textColor = .secondaryLabel
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
-    }()
-
-    // MARK: Motivation banner
-
-    private let motivationCard: UIView = {
-        let view = UIView()
-        view.backgroundColor = AppColors.accentOrange
-        view.layer.cornerRadius = AppRadius.md
+    let heatmapView: StatisticsHeatmapView = {
+        let view = StatisticsHeatmapView()
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
 
-    private let motivationIconLabel: UILabel = {
+    /// Toast banner used for tap feedback on heatmap cells. Hidden by default;
+    /// `showToast(_:)` slides it in for ~2 s.
+    let toastLabel: UILabel = {
         let label = UILabel()
-        label.text = "↗️"
-        label.font = UIFont.systemFont(ofSize: 24)
+        label.font = AppTypography.body
+        label.textColor = AppColors.fg1
+        label.backgroundColor = AppColors.bg2
+        label.layer.cornerRadius = AppRadius.md
+        label.layer.masksToBounds = true
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.alpha = 0
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
 
-    private let motivationTitleLabel: UILabel = {
+    // MARK: - Bar chart
+
+    var chartHostingController: UIHostingController<WeekdayChartView>?
+
+    // MARK: - Streak card
+
+    let streakValueLabel: UILabel = {
         let label = UILabel()
-        label.text = "Мотивация"
-        label.font = UIFont.systemFont(ofSize: 15, weight: .bold)
-        label.textColor = .white
+        label.font = AppTypography.moneyMd
+        label.textColor = AppColors.fg1
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
 
-    private let motivationMessageLabel: UILabel = {
+    let streakBestLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 14)
-        label.textColor = UIColor.white.withAlphaComponent(0.9)
+        label.font = AppTypography.meta
+        label.textColor = AppColors.fg3
         label.numberOfLines = 0
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
@@ -187,221 +131,102 @@ class StatisticsViewController: UIViewController {
         super.viewDidLoad()
         title = "Статистика"
         navigationController?.navigationBar.prefersLargeTitles = true
-        view.backgroundColor = .systemGroupedBackground
-        setupUI()
+        view.backgroundColor = AppColors.bg0
+        configureGradientLayers()
+        setupLayout()
         bindViewModel()
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        let period = StatisticsViewModel.Period(rawValue: periodSegment.selectedSegmentIndex) ?? .week
+        let raw = Int(periodSegment.selectedValue ?? "") ?? 0
+        let period = StatisticsViewModel.Period(rawValue: raw) ?? .week
         viewModel.loadData(period: period)
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        spentAmountLabel.applyGradientMask(spentGradientLayer)
     }
 
     // MARK: - Setup
 
-    private func setupUI() {
+    private func configureGradientLayers() {
+        spentGradientLayer.colors = SPSupport.painGradientColors
+        spentGradientLayer.locations = SPSupport.painGradientLocations
+        spentGradientLayer.startPoint = SPSupport.gradientStart
+        spentGradientLayer.endPoint = SPSupport.gradientEnd
+    }
+
+    private func setupLayout() {
+        configureContainers()
+        installContainerConstraints()
+        installToastConstraints()
+        contentStack.addArrangedSubview(periodSegment)
+        contentStack.addArrangedSubview(dataStack)
+        dataStack.addArrangedSubview(makeSummaryRow())
+        dataStack.addArrangedSubview(makeHeatmapCard())
+        dataStack.addArrangedSubview(makeChartCard())
+        dataStack.addArrangedSubview(makeStreakCard())
+        heatmapView.onCellTap = { [weak self] cell in
+            self?.presentHeatmapToast(for: cell)
+        }
+    }
+
+    private func configureContainers() {
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        contentStack.axis = .vertical
+        contentStack.spacing = AppSpacing.sp5
+        contentStack.translatesAutoresizingMaskIntoConstraints = false
+        dataStack.axis = .vertical
+        dataStack.spacing = AppSpacing.sp5
+        dataStack.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(scrollView)
         scrollView.addSubview(contentStack)
+        view.addSubview(toastLabel)
+    }
 
+    private func installContainerConstraints() {
         NSLayoutConstraint.activate([
             scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
 
-            contentStack.topAnchor.constraint(equalTo: scrollView.topAnchor, constant: AppSpacing.lg),
-            contentStack.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor, constant: AppSpacing.lg),
-            contentStack.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor, constant: -AppSpacing.lg),
-            contentStack.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor, constant: -AppSpacing.lg),
-            contentStack.widthAnchor.constraint(equalTo: scrollView.widthAnchor, constant: -AppSpacing.xxl)
+            contentStack.topAnchor.constraint(equalTo: scrollView.topAnchor, constant: AppSpacing.sp5),
+            contentStack.leadingAnchor.constraint(
+                equalTo: scrollView.leadingAnchor,
+                constant: AppSpacing.screenInset
+            ),
+            contentStack.trailingAnchor.constraint(
+                equalTo: scrollView.trailingAnchor,
+                constant: -AppSpacing.screenInset
+            ),
+            contentStack.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor, constant: -AppSpacing.sp7),
+            contentStack.widthAnchor.constraint(
+                equalTo: scrollView.widthAnchor,
+                constant: -AppSpacing.screenInset * 2
+            )
         ])
-
-        // Period selector
-        periodSegment.addTarget(self, action: #selector(periodChanged), for: .valueChanged)
-        contentStack.addArrangedSubview(periodSegment)
-
-        // Two-column summary (Spent + Snooze Count)
-        contentStack.addArrangedSubview(makeTwoColumnSummary())
-
-        // Average card
-        contentStack.addArrangedSubview(makeAverageCard())
-
-        // Chart card
-        contentStack.addArrangedSubview(makeChartCard())
-
-        // Streak card
-        let streakCardView = makeStreakCard()
-        streakCard = streakCardView
-        contentStack.addArrangedSubview(streakCardView)
-
-        // Motivation banner
-        contentStack.addArrangedSubview(makeMotivationBanner())
     }
 
-    // MARK: - Card Builders
-
-    private func makeTwoColumnSummary() -> UIView {
-        // Left card — amount spent
-        let leftCard = makeCard()
-        let leftStack = UIStackView(arrangedSubviews: [spentTitleLabel, spentAmountLabel])
-        leftStack.axis = .vertical
-        leftStack.spacing = AppSpacing.xs
-        leftStack.translatesAutoresizingMaskIntoConstraints = false
-        leftCard.addSubview(leftStack)
+    private func installToastConstraints() {
         NSLayoutConstraint.activate([
-            leftStack.leadingAnchor.constraint(equalTo: leftCard.leadingAnchor, constant: AppSpacing.lg),
-            leftStack.trailingAnchor.constraint(equalTo: leftCard.trailingAnchor, constant: -AppSpacing.lg),
-            leftStack.topAnchor.constraint(equalTo: leftCard.topAnchor, constant: AppSpacing.lg),
-            leftStack.bottomAnchor.constraint(equalTo: leftCard.bottomAnchor, constant: -AppSpacing.lg)
+            toastLabel.bottomAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.bottomAnchor,
+                constant: -AppSpacing.sp5
+            ),
+            toastLabel.leadingAnchor.constraint(
+                greaterThanOrEqualTo: view.leadingAnchor,
+                constant: AppSpacing.screenInset
+            ),
+            toastLabel.trailingAnchor.constraint(
+                lessThanOrEqualTo: view.trailingAnchor,
+                constant: -AppSpacing.screenInset
+            ),
+            toastLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            toastLabel.heightAnchor.constraint(greaterThanOrEqualToConstant: 44)
         ])
-
-        // Right card — snooze count
-        let rightCard = makeCard()
-        let rightStack = UIStackView(arrangedSubviews: [snoozeTitleLabel, snoozeCountLabel])
-        rightStack.axis = .vertical
-        rightStack.spacing = AppSpacing.xs
-        rightStack.translatesAutoresizingMaskIntoConstraints = false
-        rightCard.addSubview(rightStack)
-        NSLayoutConstraint.activate([
-            rightStack.leadingAnchor.constraint(equalTo: rightCard.leadingAnchor, constant: AppSpacing.lg),
-            rightStack.trailingAnchor.constraint(equalTo: rightCard.trailingAnchor, constant: -AppSpacing.lg),
-            rightStack.topAnchor.constraint(equalTo: rightCard.topAnchor, constant: AppSpacing.lg),
-            rightStack.bottomAnchor.constraint(equalTo: rightCard.bottomAnchor, constant: -AppSpacing.lg)
-        ])
-
-        // Horizontal row
-        let row = UIStackView(arrangedSubviews: [leftCard, rightCard])
-        row.axis = .horizontal
-        row.spacing = AppSpacing.sm
-        row.distribution = .fillEqually
-        row.translatesAutoresizingMaskIntoConstraints = false
-        return row
-    }
-
-    private func makeAverageCard() -> UIView {
-        let card = makeCard()
-        let stack = UIStackView(arrangedSubviews: [averageTitleLabel, averageValueLabel])
-        stack.axis = .vertical
-        stack.spacing = AppSpacing.xs
-        stack.translatesAutoresizingMaskIntoConstraints = false
-        card.addSubview(stack)
-        NSLayoutConstraint.activate([
-            stack.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: AppSpacing.lg),
-            stack.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -AppSpacing.lg),
-            stack.topAnchor.constraint(equalTo: card.topAnchor, constant: AppSpacing.lg),
-            stack.bottomAnchor.constraint(equalTo: card.bottomAnchor, constant: -AppSpacing.lg)
-        ])
-        return card
-    }
-
-    private func makeChartCard() -> UIView {
-        let card = makeCard()
-        // Don't clip — `applyCardStyle()` needs `masksToBounds = false` so the
-        // drop shadow renders. Chart subviews are constrained inside `card`
-        // via Auto Layout below, so they won't visually overflow without the
-        // clip.
-
-        // Title label
-        card.addSubview(chartTitleLabel)
-
-        // SwiftUI chart
-        let chartSwiftUIView = StatisticsChartView(data: [])
-        let hostingController = UIHostingController(rootView: chartSwiftUIView)
-        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
-        hostingController.view.backgroundColor = .clear
-
-        addChild(hostingController)
-        card.addSubview(hostingController.view)
-        hostingController.didMove(toParent: self)
-
-        NSLayoutConstraint.activate([
-            chartTitleLabel.topAnchor.constraint(equalTo: card.topAnchor, constant: AppSpacing.lg),
-            chartTitleLabel.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: AppSpacing.lg),
-            chartTitleLabel.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -AppSpacing.lg),
-
-            hostingController.view.topAnchor.constraint(equalTo: chartTitleLabel.bottomAnchor, constant: AppSpacing.sm),
-            hostingController.view.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: AppSpacing.md),
-            hostingController.view.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -AppSpacing.md),
-            hostingController.view.bottomAnchor.constraint(equalTo: card.bottomAnchor, constant: -AppSpacing.md),
-            hostingController.view.heightAnchor.constraint(equalToConstant: 200)
-        ])
-
-        chartHostingController = hostingController
-        return card
-    }
-
-    private func makeStreakCard() -> UIView {
-        let card = makeCard()
-
-        // Text stack (title + subtitle)
-        let textStack = UIStackView(arrangedSubviews: [streakLabel, bestStreakLabel])
-        textStack.axis = .vertical
-        textStack.spacing = AppSpacing.xs
-        textStack.translatesAutoresizingMaskIntoConstraints = false
-
-        // Horizontal layout: icon | text
-        let hStack = UIStackView(arrangedSubviews: [streakIconView, textStack])
-        hStack.axis = .horizontal
-        hStack.spacing = AppSpacing.md
-        hStack.alignment = .center
-        hStack.translatesAutoresizingMaskIntoConstraints = false
-
-        card.addSubview(hStack)
-        NSLayoutConstraint.activate([
-            hStack.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: AppSpacing.lg),
-            hStack.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -AppSpacing.lg),
-            hStack.topAnchor.constraint(equalTo: card.topAnchor, constant: AppSpacing.lg),
-            hStack.bottomAnchor.constraint(equalTo: card.bottomAnchor, constant: -AppSpacing.lg)
-        ])
-
-        return card
-    }
-
-    private func makeMotivationBanner() -> UIView {
-        // Icon container
-        let iconContainer = UIView()
-        iconContainer.translatesAutoresizingMaskIntoConstraints = false
-        iconContainer.addSubview(motivationIconLabel)
-        NSLayoutConstraint.activate([
-            motivationIconLabel.topAnchor.constraint(equalTo: iconContainer.topAnchor),
-            motivationIconLabel.leadingAnchor.constraint(equalTo: iconContainer.leadingAnchor),
-            motivationIconLabel.trailingAnchor.constraint(equalTo: iconContainer.trailingAnchor),
-            iconContainer.widthAnchor.constraint(equalToConstant: 32)
-        ])
-
-        // Text stack
-        let textStack = UIStackView(arrangedSubviews: [motivationTitleLabel, motivationMessageLabel])
-        textStack.axis = .vertical
-        textStack.spacing = AppSpacing.xs
-        textStack.translatesAutoresizingMaskIntoConstraints = false
-
-        // Horizontal layout: icon | text
-        let hStack = UIStackView(arrangedSubviews: [iconContainer, textStack])
-        hStack.axis = .horizontal
-        hStack.spacing = AppSpacing.md
-        hStack.alignment = .top
-        hStack.translatesAutoresizingMaskIntoConstraints = false
-
-        motivationCard.addSubview(hStack)
-        NSLayoutConstraint.activate([
-            hStack.leadingAnchor.constraint(equalTo: motivationCard.leadingAnchor, constant: AppSpacing.lg),
-            hStack.trailingAnchor.constraint(equalTo: motivationCard.trailingAnchor, constant: -AppSpacing.lg),
-            hStack.topAnchor.constraint(equalTo: motivationCard.topAnchor, constant: AppSpacing.lg),
-            hStack.bottomAnchor.constraint(equalTo: motivationCard.bottomAnchor, constant: -AppSpacing.lg)
-        ])
-
-        return motivationCard
-    }
-
-    /// Standard widget card — surface colour, hairline border, subtle shadow.
-    /// Without the border + shadow these widgets dissolve into
-    /// `systemGroupedBackground` in light mode. `CardView` owns its shadow-path
-    /// rasterisation and trait-change refresh so the call site doesn't have to.
-    private func makeCard() -> CardView {
-        let view = CardView()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        return view
     }
 
     // MARK: - Binding
@@ -415,11 +240,6 @@ class StatisticsViewController: UIViewController {
         }
     }
 
-    /// Alerts the user when the transaction ledger can't be decoded.
-    /// Empty stats look identical to a brand-new user, so without this
-    /// banner a corrupt blob hides itself behind "ноль откладываний"
-    /// (issue #72). Guarded against double-presentation in case load is
-    /// triggered repeatedly while the alert is still on screen.
     private func presentRepositoryError(_ error: LocalizedError) {
         guard presentedViewController == nil else { return }
         let alert = UIAlertController(
@@ -432,140 +252,105 @@ class StatisticsViewController: UIViewController {
     }
 
     private func refresh() {
-        // Two-column summary — colour and text both come from the VM so the
-        // empty-state vs has-data branching lives in one place.
-        spentAmountLabel.textColor = viewModel.spentColor
+        // Summary row.
         spentAmountLabel.text = viewModel.totalSpentFormatted
-
-        snoozeCountLabel.textColor = viewModel.snoozeCountColor
         snoozeCountLabel.text = viewModel.snoozeCountFormatted
+        // The pain-gradient mask renders the "spent" value glyph-by-glyph;
+        // refresh after text updates so the mask matches the new string.
+        view.setNeedsLayout()
 
-        // Average
-        averageValueLabel.text = viewModel.averagePerDayFormatted
+        // Heatmap.
+        heatmapView.cells = viewModel.heatmapCells
 
-        // Streak — when no active streak we show the zero-state caption but
-        // keep the card visible so the layout doesn't jump. The card is
-        // never hidden anywhere, so no `isHidden = false` reset is needed.
-        if viewModel.streakActive {
-            streakLabel.text = viewModel.streakMessage
-            bestStreakLabel.text = viewModel.bestStreakFormatted
+        // Bar chart.
+        let chartBars = viewModel.weekdayBars.map { bar in
+            WeekdayBarPoint(label: bar.label, amount: bar.amount, weekday: bar.weekday)
+        }
+        chartHostingController?.rootView = WeekdayChartView(bars: chartBars)
+
+        // Streak card.
+        streakValueLabel.text = "\(viewModel.streak) \(StreakModalViewController.dayWord(for: viewModel.streak))"
+        streakBestLabel.text = "Лучший результат: \(viewModel.bestStreak) "
+            + "\(StreakModalViewController.dayWord(for: viewModel.bestStreak))"
+
+        // Empty state — VM handles the empty-period detection.
+        setEmptyStateVisible(!viewModel.hasData)
+    }
+
+    // MARK: - Empty state
+
+    /// Toggle between the "we have data" stack and the empty-state column.
+    /// We keep both views allocated — flipping `isHidden` is cheap and avoids
+    /// re-running `addArrangedSubview` for every period switch.
+    func setEmptyStateVisible(_ visible: Bool) {
+        dataStack.isHidden = visible
+        if visible {
+            if emptyStateView == nil {
+                let view = StatisticsEmptyStateView()
+                view.translatesAutoresizingMaskIntoConstraints = false
+                view.onCreateAlarmTap = { [weak self] in self?.createAlarmTapped() }
+                emptyStateView = view
+                contentStack.addArrangedSubview(view)
+            }
+            emptyStateView?.isHidden = false
         } else {
-            streakLabel.text = viewModel.streakZeroMessage
-            bestStreakLabel.text = ""
+            emptyStateView?.isHidden = true
         }
-
-        // Motivation banner — VM decides whether there's anything to motivate
-        // against; view just toggles visibility off the bool.
-        motivationMessageLabel.text = viewModel.motivationalMessage
-        motivationCard.isHidden = !viewModel.motivationVisible
-
-        // Chart
-        let chartData = viewModel.dailyChartData.map {
-            ChartDataPoint(label: $0.label, amount: $0.amount)
-        }
-        chartHostingController?.rootView = StatisticsChartView(data: chartData)
     }
 
     // MARK: - Actions
 
-    @objc private func periodChanged() {
-        let period = StatisticsViewModel.Period(rawValue: periodSegment.selectedSegmentIndex) ?? .week
-        viewModel.loadData(period: period)
+    @objc func streakTapped() {
+        let alarms = (try? AlarmRepository.shared.fetchAllChecked()) ?? []
+        let saved = StreakModalViewController.estimatedSavings(
+            for: viewModel.streak,
+            alarms: alarms
+        )
+        let modal = StreakModalViewController(
+            streakDays: viewModel.streak,
+            savedAmount: saved
+        )
+        present(modal, animated: true)
     }
-}
 
-// MARK: - Swift Charts data model
+    private func createAlarmTapped() {
+        let createVC = CreateAlarmViewController(alarm: nil)
+        navigationController?.pushViewController(createVC, animated: true)
+    }
 
-/// Single data point for the bar chart.
-struct ChartDataPoint: Identifiable {
-    let id = UUID()
-    let label: String
-    let amount: Double
-}
+    // MARK: - Heatmap toast
 
-// MARK: - SwiftUI Chart View
-
-/// Bar chart built with Swift Charts framework, wrapped for UIKit embedding.
-struct StatisticsChartView: View {
-
-    let data: [ChartDataPoint]
-
-    @State private var animateChart = false
-
-    var body: some View {
-        if data.isEmpty || data.allSatisfy({ $0.amount == 0 }) {
-            // Empty state
-            VStack(spacing: 8) {
-                Image(systemName: "chart.bar")
-                    .font(.system(size: 32))
-                    .foregroundStyle(.secondary)
-                Text("Нет данных")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    private func presentHeatmapToast(for cell: StatisticsViewModel.HeatmapCell) {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ru_RU")
+        formatter.dateFormat = "d MMMM"
+        let dateText = formatter.string(from: cell.date)
+        let amountText: String
+        if cell.amount > 0 {
+            amountText = "−\(Int(cell.amount)) ₽"
         } else {
-            Chart(data) { point in
-                BarMark(
-                    x: .value("День", point.label),
-                    y: .value("Сумма", animateChart ? point.amount : 0)
-                )
-                .foregroundStyle(
-                    LinearGradient(
-                        colors: [Color.orange, Color.orange.opacity(0.6)],
-                        startPoint: .top,
-                        endPoint: .bottom
-                    )
-                )
-                .clipShape(RoundedRectangle(cornerRadius: 4))
-                .annotation(position: .top, spacing: 4) {
-                    if point.amount > 0 {
-                        Text("\(Int(point.amount)) ₽")
-                            .font(.caption2)
-                            .foregroundStyle(.secondary)
-                    }
-                }
-            }
-            .chartXAxis {
-                AxisMarks(values: .automatic) { _ in
-                    AxisValueLabel()
-                        .font(.caption)
-                }
-            }
-            .chartYAxis {
-                AxisMarks(position: .leading) { value in
-                    AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5, dash: [4, 4]))
-                        .foregroundStyle(Color.secondary.opacity(0.3))
-                    AxisValueLabel {
-                        if let amount = value.as(Double.self) {
-                            Text("\(Int(amount))")
-                                .font(.caption2)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                }
-            }
-            .chartYScale(domain: 0...(maxAmount * 1.2))
-            .animation(.easeOut(duration: 0.5), value: animateChart)
-            .onAppear {
-                // Trigger entrance animation
-                withAnimation(.easeOut(duration: 0.5)) {
-                    animateChart = true
-                }
-            }
-            .onChange(of: data.map(\.amount)) { oldValue, newValue in
-                // Re-animate when data changes
-                guard oldValue != newValue else { return }
-                animateChart = false
-                withAnimation(.easeOut(duration: 0.5)) {
-                    animateChart = true
-                }
-            }
+            amountText = "без штрафов"
         }
+        showToast("\(dateText) · \(amountText)")
     }
 
-    /// Maximum amount in the data set, at least 1 to avoid zero-range axis.
-    private var maxAmount: Double {
-        max(data.map(\.amount).max() ?? 1, 1)
+    private func showToast(_ message: String) {
+        // Pad the toast text — UILabel doesn't have intrinsic insets, so we
+        // wrap with non-breaking space so the visual padding stays simple
+        // while honouring `numberOfLines = 0` for long dates.
+        toastLabel.text = "  \(message)  "
+        UIView.animate(withDuration: SPSupport.durationBase, animations: {
+            self.toastLabel.alpha = 1
+        }, completion: { _ in
+            UIView.animate(
+                withDuration: SPSupport.durationSlow,
+                delay: 1.4,
+                options: [.curveEaseOut],
+                animations: {
+                    self.toastLabel.alpha = 0
+                },
+                completion: nil
+            )
+        })
     }
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Statistics/UILabel+GradientMask.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Statistics/UILabel+GradientMask.swift
@@ -1,0 +1,49 @@
+import UIKit
+
+/// Render the label's text with a CALayer gradient masked to the rendered
+/// glyphs — the iOS analogue of CSS's `-webkit-background-clip: text`.
+///
+/// Same recipe as `SPBalanceCard.applyValueGradient(...)` and
+/// `StreakModalViewController.applyAmountGradient(...)`. Lifted into a
+/// label-scoped helper here so `StatisticsViewController` can reuse it for
+/// the pain-tinted "Потрачено" amount without growing the VC past the
+/// SwiftLint type-body cap.
+extension UILabel {
+
+    /// Install (or refresh) the supplied gradient layer as a sublayer of the
+    /// label and mask it to the current glyph outlines. Caller is responsible
+    /// for keeping `gradient` alive (a stored property is the typical
+    /// pattern) and for invoking this from `viewDidLayoutSubviews` so the
+    /// mask stays in sync with text / size changes.
+    ///
+    /// `textColor` is set to `.clear` once the mask lands so the underlying
+    /// label paint doesn't double-stack with the gradient — the caller can
+    /// still set a non-clear `textColor` as a safety net before this runs.
+    func applyGradientMask(_ gradient: CAGradientLayer) {
+        let textBounds = bounds
+        guard textBounds.width > 0,
+              textBounds.height > 0,
+              text?.isEmpty == false else { return }
+
+        if gradient.superlayer !== layer {
+            layer.addSublayer(gradient)
+        }
+        gradient.frame = textBounds
+
+        let renderer = UIGraphicsImageRenderer(size: textBounds.size)
+        let mask = renderer.image { _ in
+            (text ?? "").draw(
+                in: textBounds,
+                withAttributes: [
+                    .font: font as Any,
+                    .foregroundColor: UIColor.white
+                ]
+            )
+        }
+        let maskLayer = CALayer()
+        maskLayer.frame = textBounds
+        maskLayer.contents = mask.cgImage
+        gradient.mask = maskLayer
+        textColor = .clear
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Statistics/WeekdayChartView.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Statistics/WeekdayChartView.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+import Charts
+import UIKit
+
+/// One bar in the statistics weekday chart. `weekday` is the calendar
+/// component (1 = Sunday … 7 = Saturday) so the SwiftUI chart can sort
+/// deterministically even when the input is shuffled.
+struct WeekdayBarPoint: Identifiable {
+    let id = UUID()
+    let label: String
+    let amount: Double
+    let weekday: Int
+}
+
+/// Apple-Charts bar chart for the statistics screen. Renders 7 bars
+/// (Mon → Sun) with the money gradient when the value is non-zero, and a
+/// muted overlay-only fill for empty days so the axis stays balanced.
+///
+/// Lives in its own file to keep `StatisticsViewController` under the
+/// SwiftLint `type_body_length` ceiling — the SwiftUI body alone runs
+/// 50+ lines once the axis configuration lands, and the VC otherwise
+/// trips the 350-line type body limit.
+struct WeekdayChartView: View {
+
+    let bars: [WeekdayBarPoint]
+
+    var body: some View {
+        Chart(bars) { bar in
+            BarMark(
+                x: .value("День", bar.label),
+                y: .value("Среднее", bar.amount)
+            )
+            .foregroundStyle(
+                bar.amount > 0
+                    ? AnyShapeStyle(
+                        LinearGradient(
+                            colors: [
+                                Color(uiColor: AppColors.money400),
+                                Color(uiColor: AppColors.money700)
+                            ],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    )
+                    : AnyShapeStyle(Color(uiColor: AppColors.whiteOverlay06))
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 4))
+        }
+        .chartXAxis {
+            AxisMarks(values: .automatic) { _ in
+                AxisValueLabel()
+                    .font(.caption)
+            }
+        }
+        .chartYAxis {
+            AxisMarks(position: .leading) { value in
+                AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5, dash: [4, 4]))
+                    .foregroundStyle(Color.secondary.opacity(0.3))
+                AxisValueLabel {
+                    if let amount = value.as(Double.self) {
+                        Text("\(Int(amount))")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+        .chartYScale(domain: 0...(maxAmount * 1.2))
+    }
+
+    /// Y-axis cap. Falls back to 1 so an all-zero bar set still renders an
+    /// axis with sane tick marks instead of collapsing to a 0...0 domain.
+    private var maxAmount: Double {
+        max(bars.map(\.amount).max() ?? 1, 1)
+    }
+}

--- a/SnoozePay/SnoozePay/ViewModels/StatisticsViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/StatisticsViewModel.swift
@@ -217,6 +217,128 @@ final class StatisticsViewModel {
         }
     }
 
+    // MARK: - Heatmap
+
+    /// Single square in the GitHub-style heatmap calendar.
+    /// `intensity` is bucketed 0..4 (5 buckets) so the view can pick a tint
+    /// from the money palette without re-running the bucket logic per cell.
+    struct HeatmapCell {
+        let date: Date
+        let amount: Double
+        let intensity: Int
+    }
+
+    /// 7-column grid of squares spanning the selected period. The order is
+    /// chronological (oldest → newest) so a flow-layout collection view fills
+    /// rows top-to-bottom, left-to-right with weekday alignment.
+    ///
+    /// Period sizing:
+    /// - `.week` → 7 cells (1 row).
+    /// - `.month` → ~35 cells (5 rows of 7).
+    /// - `.allTime` → 12 weeks back from today (84 cells).
+    /// The grid always begins on the configured calendar's "first weekday"
+    /// preceding the start date so columns line up with weekday labels.
+    var heatmapCells: [HeatmapCell] {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+
+        // How many calendar days does the heatmap span?
+        let dayCount: Int
+        switch selectedPeriod {
+        case .week:
+            dayCount = 7
+        case .month:
+            dayCount = 35
+        case .allTime:
+            dayCount = 84
+        }
+
+        // Per-day total, keyed by startOfDay so look-ups are O(1).
+        var totalByDay: [Date: Double] = [:]
+        for charge in charges {
+            let day = calendar.startOfDay(for: charge.createdAt)
+            totalByDay[day, default: 0] += charge.amount
+        }
+
+        // Pick a sensible bucket cap: highest single-day spend, fallback to 1
+        // so a flat-empty period doesn't divide by zero.
+        let maxDayTotal = max(totalByDay.values.max() ?? 0, 1)
+
+        return (0..<dayCount).reversed().map { daysAgo -> HeatmapCell in
+            let date = calendar.date(byAdding: .day, value: -daysAgo, to: today) ?? today
+            let amount = totalByDay[date] ?? 0
+            return HeatmapCell(
+                date: date,
+                amount: amount,
+                intensity: Self.bucketIntensity(amount: amount, max: maxDayTotal)
+            )
+        }
+    }
+
+    /// Buckets a per-day amount onto a 0..4 scale. 0 is reserved for the
+    /// "no penalty today" empty cell so the view can hand back the
+    /// `whiteOverlay06` token without a separate branch. The remaining
+    /// 1..4 buckets are evenly split across the observed range.
+    private static func bucketIntensity(amount: Double, max maxValue: Double) -> Int {
+        guard amount > 0 else { return 0 }
+        let ratio = amount / maxValue
+        if ratio < 0.25 { return 1 }
+        if ratio < 0.5 { return 2 }
+        if ratio < 0.75 { return 3 }
+        return 4
+    }
+
+    // MARK: - Bar chart by weekday
+
+    /// Single bar in the weekday chart.
+    struct WeekdayBar {
+        /// Short localised weekday label (e.g. `"Пн"`).
+        let label: String
+        /// Average penalty across all matching weekdays in the selected period.
+        let amount: Double
+        /// Calendar weekday (1 = Sunday … 7 = Saturday) so the view can sort
+        /// without re-deriving the order from the label.
+        let weekday: Int
+    }
+
+    /// Returns 7 bars in Mon → Sun order, each carrying the average penalty
+    /// for that weekday across the selected period. Empty days surface as 0
+    /// so the chart still renders 7 axis ticks.
+    var weekdayBars: [WeekdayBar] {
+        let calendar = Calendar.current
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ru_RU")
+        formatter.dateFormat = "EEEEEE" // "Пн", "Вт", ...
+
+        // Group charges by Calendar weekday (1-based Sun=1 … Sat=7).
+        var bucketTotals: [Int: Double] = [:]
+        var bucketDays: [Int: Set<Date>] = [:]
+        for charge in charges {
+            let weekday = calendar.component(.weekday, from: charge.createdAt)
+            let day = calendar.startOfDay(for: charge.createdAt)
+            bucketTotals[weekday, default: 0] += charge.amount
+            bucketDays[weekday, default: []].insert(day)
+        }
+
+        // Render Monday-first regardless of the user's locale calendar so the
+        // chart matches the heatmap column order in the spec.
+        let mondayFirst: [Int] = [2, 3, 4, 5, 6, 7, 1]
+        return mondayFirst.map { weekday -> WeekdayBar in
+            let total = bucketTotals[weekday] ?? 0
+            let dayCount = bucketDays[weekday]?.count ?? 0
+            let average = dayCount > 0 ? total / Double(dayCount) : 0
+            // Build a label off a known sample date that falls on this weekday.
+            // Calendar weekday 1 = Sunday → 2024-01-07, etc.
+            let sample = calendar.date(from: DateComponents(year: 2024, month: 1, day: 6 + weekday)) ?? Date()
+            return WeekdayBar(label: formatter.string(from: sample), amount: average, weekday: weekday)
+        }
+    }
+
+    /// `true` when there are no charge transactions in the selected period.
+    /// View uses this to swap the chart/heatmap stack for the empty-state
+    /// column.
+    var hasData: Bool { !charges.isEmpty }
+
     // MARK: - Helpers
 
     private func startDate(for period: Period) -> Date {


### PR DESCRIPTION
Fixes #147

## What changed
- **StatisticsViewController** rewritten around the 2026-04-27 design refresh:
  - `SPSegmented` period selector (Неделя / Месяц / Всё время) drives `StatisticsViewModel.Period`.
  - Two-column summary on `SPCard(.surface)` tiles — caps caption + `AppTypography.moneyMd`. The `Потрачено` value renders the pain-text gradient via a glyph-masked `CAGradientLayer`; `Откладываний` stays neutral `fg1`.
  - GitHub-style heatmap calendar (`StatisticsHeatmapView`, `UICollectionView` + flow layout). 7 columns × N rows where `N` scales by period (1 / 5 / 12). Squares tint by penalty intensity (5 buckets → `whiteOverlay06` → money palette). Tap → toast with `d MMMM · −X ₽`.
  - Apple-Charts bar chart of average penalty by weekday (Mon→Sun). Money-gradient bars when `amount > 0`, muted overlay otherwise.
  - Tappable streak `SPCard` with 🔥 + current/best lines → presents `StreakModalViewController` (from #146).
  - Empty state (`StatisticsEmptyStateView`) when the period has no transactions: `chart.bar.xaxis` icon, `h3 «Пока нет данных»`, body, full-width `SPButton(.money, .lg)` → pushes `CreateAlarmViewController(alarm: nil)`.

- **StatisticsViewModel** extended (no breaking API changes):
  - `HeatmapCell` + `heatmapCells` (chronological, bucketed 0..4 intensity).
  - `WeekdayBar` + `weekdayBars` (Mon-first, calendar-weekday grouped average).
  - `hasData` for the empty-state branch.

## Files
- `SnoozePay/ViewControllers/Statistics/StatisticsViewController.swift` — rewrite.
- `SnoozePay/ViewControllers/Statistics/StatisticsViewController+Cards.swift` — card builders (extension).
- `SnoozePay/ViewControllers/Statistics/StatisticsHeatmapView.swift` — new heatmap grid.
- `SnoozePay/ViewControllers/Statistics/StatisticsEmptyStateView.swift` — new empty state.
- `SnoozePay/ViewControllers/Statistics/WeekdayChartView.swift` — Apple-Charts bar view.
- `SnoozePay/ViewControllers/Statistics/UILabel+GradientMask.swift` — shared gradient text helper.
- `SnoozePay/ViewModels/StatisticsViewModel.swift` — heatmap + weekday-bar + hasData accessors.

## Verify
- swiftlint: 0 errors (61 pre-existing warnings, none in new files; `StatisticsViewController.swift` is 3 lines over the type-body warning ceiling but well under the serious 350-line cap)
- build_sim (iPhone 17 Pro): succeeded
- test_sim: skipped per task spec
- screenshot: skipped per task spec

## Constraints respected
- UIKit only (Apple Charts framework was already used).
- No Info.plist edits.
- No new SPM/CocoaPods.
- Existing `StatisticsViewModel` API extended, not broken.