### PR TITLE
[design-refresh] Sound picker refresh + Volume picker (#150)

### DIFF
--- a/SnoozePay/SnoozePay/AppDelegate.swift
+++ b/SnoozePay/SnoozePay/AppDelegate.swift
@@ -140,9 +140,13 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         // Start continuous alarm sound immediately (before presenting the VC).
         // Passing `alarmID` lets AudioService track ownership so a stacking
         // race between firing VCs cannot silence the wrong alarm (#116).
+        // Volume + fade-in (#150) come from the payload, which decodes them
+        // optionally so a pre-#150 notification still rings at full volume.
         AudioService.shared.startAlarmSound(
             soundID: payload.soundID,
-            alarmID: payload.alarmID
+            alarmID: payload.alarmID,
+            volume: payload.volume ?? 1.0,
+            fadeIn: payload.volumeFadeIn ?? false
         )
 
         // Show the alarm firing screen

--- a/SnoozePay/SnoozePay/Models/Alarm.swift
+++ b/SnoozePay/SnoozePay/Models/Alarm.swift
@@ -12,6 +12,13 @@ struct Alarm: Identifiable, Equatable, Codable {
     var penaltyAmount: Double
     var progressiveScale: Bool
     var enabled: Bool
+    /// Per-alarm playback volume in `0.0...1.0`. Default `1.0` keeps the
+    /// existing "ring at full volume" behaviour for legacy alarms (#150).
+    var volume: Float
+    /// When `true`, AudioService ramps from 0 → `volume` over 30 seconds at
+    /// firing time so the user is woken gently. Default `false` preserves the
+    /// pre-#150 instant-on behaviour.
+    var volumeFadeIn: Bool
 
     init(
         id: UUID = UUID(),
@@ -23,7 +30,9 @@ struct Alarm: Identifiable, Equatable, Codable {
         snoozeMinutes: Int = 9,
         penaltyAmount: Double = 50,
         progressiveScale: Bool = false,
-        enabled: Bool = true
+        enabled: Bool = true,
+        volume: Float = 1.0,
+        volumeFadeIn: Bool = false
     ) {
         self.id = id
         self.time = time
@@ -35,6 +44,40 @@ struct Alarm: Identifiable, Equatable, Codable {
         self.penaltyAmount = penaltyAmount
         self.progressiveScale = progressiveScale
         self.enabled = enabled
+        self.volume = min(max(volume, 0), 1)
+        self.volumeFadeIn = volumeFadeIn
+    }
+
+    // MARK: - Codable (backwards-compatible decode)
+    //
+    // `volume` + `volumeFadeIn` were added in #150. Pre-#150 stored alarms do
+    // not carry these keys — `decodeIfPresent` plus the documented defaults
+    // keeps existing JSON readable without forcing a migration step. The
+    // default encode path is fine because new keys are simply additive.
+
+    private enum CodingKeys: String, CodingKey {
+        case id, time, repeatDays, name, soundID, vibrationEnabled
+        case snoozeMinutes, penaltyAmount, progressiveScale, enabled
+        case volume, volumeFadeIn
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(UUID.self, forKey: .id)
+        self.time = try container.decode(Date.self, forKey: .time)
+        self.repeatDays = try container.decode([Int].self, forKey: .repeatDays)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.soundID = try container.decode(String.self, forKey: .soundID)
+        self.vibrationEnabled = try container.decode(Bool.self, forKey: .vibrationEnabled)
+        self.snoozeMinutes = try container.decode(Int.self, forKey: .snoozeMinutes)
+        self.penaltyAmount = try container.decode(Double.self, forKey: .penaltyAmount)
+        self.progressiveScale = try container.decode(Bool.self, forKey: .progressiveScale)
+        self.enabled = try container.decode(Bool.self, forKey: .enabled)
+        // New in #150 — fall back to the "ring at full volume, no fade"
+        // pre-#150 behaviour when keys are missing or out of range.
+        let rawVolume = try container.decodeIfPresent(Float.self, forKey: .volume) ?? 1.0
+        self.volume = min(max(rawVolume.isFinite ? rawVolume : 1.0, 0), 1)
+        self.volumeFadeIn = try container.decodeIfPresent(Bool.self, forKey: .volumeFadeIn) ?? false
     }
 
     /// Human-readable repeat days string (e.g. "Пн, Вт, Пт")

--- a/SnoozePay/SnoozePay/Models/AlarmNotificationPayload.swift
+++ b/SnoozePay/SnoozePay/Models/AlarmNotificationPayload.swift
@@ -27,6 +27,13 @@ struct AlarmNotificationPayload: Equatable {
     let snoozeCount: Int
     let snoozeMinutes: Int
     let soundID: String
+    /// Per-alarm playback volume (#150). Optional for backwards-compat with
+    /// notifications scheduled by pre-#150 builds — `nil` decodes to the
+    /// historical "ring at full volume" default.
+    let volume: Float?
+    /// Per-alarm fade-in flag (#150). Same backward-compat policy as
+    /// `volume`.
+    let volumeFadeIn: Bool?
 
     // MARK: - userInfo keys
     //
@@ -40,6 +47,8 @@ struct AlarmNotificationPayload: Equatable {
         static let snoozeCount = "snoozeCount"
         static let snoozeMinutes = "snoozeMinutes"
         static let soundID = "soundID"
+        static let volume = "volume"
+        static let volumeFadeIn = "volumeFadeIn"
     }
 
     // MARK: - Construction from an alarm
@@ -55,6 +64,8 @@ struct AlarmNotificationPayload: Equatable {
         self.snoozeCount = snoozeCount
         self.snoozeMinutes = alarm.snoozeMinutes
         self.soundID = alarm.soundID
+        self.volume = alarm.volume
+        self.volumeFadeIn = alarm.volumeFadeIn
     }
 
     /// Designated init for tests / decode paths.
@@ -64,7 +75,9 @@ struct AlarmNotificationPayload: Equatable {
         progressiveScale: Bool,
         snoozeCount: Int,
         snoozeMinutes: Int,
-        soundID: String
+        soundID: String,
+        volume: Float? = nil,
+        volumeFadeIn: Bool? = nil
     ) {
         self.alarmID = alarmID
         self.penaltyAmount = penaltyAmount
@@ -72,6 +85,8 @@ struct AlarmNotificationPayload: Equatable {
         self.snoozeCount = snoozeCount
         self.snoozeMinutes = snoozeMinutes
         self.soundID = soundID
+        self.volume = volume
+        self.volumeFadeIn = volumeFadeIn
     }
 
     // MARK: - userInfo bridge
@@ -99,13 +114,19 @@ struct AlarmNotificationPayload: Equatable {
         self.snoozeCount = snoozeCount
         self.snoozeMinutes = snoozeMinutes
         self.soundID = soundID
+        // Optional fields added in #150 — pre-#150 builds didn't write these
+        // into userInfo, so absence falls back to the documented defaults at
+        // the call site (full volume, no fade) without breaking decode.
+        self.volume = userInfo[Key.volume] as? Float
+            ?? (userInfo[Key.volume] as? Double).map { Float($0) }
+        self.volumeFadeIn = userInfo[Key.volumeFadeIn] as? Bool
     }
 
     /// Encode as the dictionary that `UNMutableNotificationContent.userInfo`
     /// expects. Only `Plist`-compatible value types are produced so iOS can
     /// serialize it across the notification daemon.
     func asUserInfo() -> [String: Any] {
-        [
+        var dict: [String: Any] = [
             Key.alarmID: alarmID.uuidString,
             Key.penaltyAmount: penaltyAmount,
             Key.progressiveScale: progressiveScale,
@@ -113,5 +134,17 @@ struct AlarmNotificationPayload: Equatable {
             Key.snoozeMinutes: snoozeMinutes,
             Key.soundID: soundID
         ]
+        // Only emit the new keys when set so a downgraded build's payload
+        // decoder still succeeds (it ignores unknown keys, but emitting nil
+        // would coerce to NSNull and break the userInfo plist serialiser).
+        if let volume = volume {
+            // Plist-encode as Double — `Float` is not a plist-compatible
+            // type on every iOS version's serialiser.
+            dict[Key.volume] = Double(volume)
+        }
+        if let volumeFadeIn = volumeFadeIn {
+            dict[Key.volumeFadeIn] = volumeFadeIn
+        }
+        return dict
     }
 }

--- a/SnoozePay/SnoozePay/Services/AudioService.swift
+++ b/SnoozePay/SnoozePay/Services/AudioService.swift
@@ -45,6 +45,11 @@ final class AudioService {
     private var audioPlayer: AVAudioPlayer?
     private var vibrationTimer: Timer?
 
+    /// Total seconds the fade-in ramp covers when `alarm.volumeFadeIn == true`
+    /// (#150). Matches the design copy "За 30 секунд" exposed in the volume
+    /// picker UI.
+    private static let fadeInDuration: TimeInterval = 30
+
     /// Identifier of the alarm that currently owns the audio session.
     ///
     /// Set in `startAlarmSound(soundID:alarmID:)` and cleared in `stopAlarmSound()`.
@@ -105,7 +110,19 @@ final class AudioService {
     ///   - alarmID: Identifier of the alarm taking ownership of the audio session.
     ///     Optional for callers that don't have a per-alarm context (legacy / tests).
     ///     Stored on `currentAlarmID` and cleared by `stopAlarmSound()`.
-    func startAlarmSound(soundID: String, alarmID: UUID? = nil) {
+    ///   - volume: Per-alarm playback volume (#150). Clamped to `0...1`. Defaults
+    ///     to `1.0` to preserve the historical "ring at full volume" behaviour
+    ///     for callers that don't pass a volume.
+    ///   - fadeIn: When `true`, ramps the player's `volume` from `0` to the
+    ///     target `volume` over `fadeInDuration` seconds via
+    ///     `AVAudioPlayer.setVolume(_:fadeDuration:)` (#150). Defaults to
+    ///     `false` so legacy call sites keep their instant-on behaviour.
+    func startAlarmSound(
+        soundID: String,
+        alarmID: UUID? = nil,
+        volume: Float = 1.0,
+        fadeIn: Bool = false
+    ) {
         // Already in a non-stopped state — preserve the existing pipeline.
         // Earlier guard was `!isPlaying` (Bool); using state covers
         // `.vibrationOnly` and `.silentBecauseConfigFailed` so we don't try to
@@ -187,7 +204,20 @@ final class AudioService {
 
         audioPlayer = player
         player.numberOfLoops = -1
-        player.volume = 1.0
+        // Honour the per-alarm volume (#150). Clamp defensively even though
+        // the call sites + Alarm initializer already do so — a corrupt
+        // payload should still produce a playable alarm rather than crash
+        // here.
+        let clampedVolume = min(max(volume.isFinite ? volume : 1.0, 0), 1)
+        if fadeIn {
+            // Start at 0 and ramp up so the user is woken gently. AVAudio
+            // schedules the ramp on the audio thread and survives screen
+            // lock — no Timer needed.
+            player.volume = 0
+            player.setVolume(clampedVolume, fadeDuration: Self.fadeInDuration)
+        } else {
+            player.volume = clampedVolume
+        }
 
         // prepareToPlay returns Bool but does not throw; play() does not throw
         // either, but its return value indicates whether the queue accepted the

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
@@ -242,9 +242,12 @@ class AlarmFiringViewController: UIViewController {
 
         // Pass `alarmID` so a stacking-replace race (#116) does not silence
         // the next alarm when this VC's `viewDidDisappear` fires.
+        // Volume + fade-in honour the per-alarm settings introduced in #150.
         AudioService.shared.startAlarmSound(
             soundID: viewModel.alarm.soundID,
-            alarmID: viewModel.alarm.id
+            alarmID: viewModel.alarm.id,
+            volume: viewModel.alarm.volume,
+            fadeIn: viewModel.alarm.volumeFadeIn
         )
 
         // Initial transition may have happened synchronously inside

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/SoundPickerRowCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/SoundPickerRowCell.swift
@@ -1,0 +1,216 @@
+import UIKit
+
+/// Single-sound row used by `SoundPickerViewController` (#150 design refresh).
+///
+/// Layout: leading `SPButton(.quiet, .sm)` toggling between play / pause →
+/// title (bodyLg) + duration (meta) text stack → trailing checkmark on the
+/// selected row. The whole content is wrapped in a hand-rolled card surface
+/// — `SPCard` itself doesn't expose a "selected" state, so we render the
+/// money-tinted border + `whiteOverlay06` fill directly on a plain `UIView`
+/// container so the picker can animate selection without re-instantiating
+/// the card every reload.
+final class SoundPickerRowCell: UITableViewCell {
+
+    static let reuseID = "SoundPickerRowCell"
+
+    var onPlayTapped: (() -> Void)?
+
+    // MARK: - UI
+
+    private let cardContainer = UIView()
+    private var playButton = SPButton(
+        title: "",
+        variant: .quiet,
+        size: .sm,
+        icon: UIImage(systemName: "play.fill")
+    )
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = AppTypography.bodyLg
+        label.textColor = AppColors.fg1
+        label.numberOfLines = 1
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.font = AppTypography.meta
+        label.textColor = AppColors.fg3
+        label.numberOfLines = 1
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let checkmark: UIImageView = {
+        let view = UIImageView()
+        view.image = UIImage(systemName: "checkmark")?.withConfiguration(
+            UIImage.SymbolConfiguration(pointSize: 16, weight: .semibold)
+        )
+        view.tintColor = AppColors.money500
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let textStack: UIStackView = {
+        let stack = UIStackView()
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .vertical
+        stack.spacing = 2
+        stack.alignment = .leading
+        stack.isUserInteractionEnabled = false
+        return stack
+    }()
+
+    private var lastIsSelected = false
+
+    // MARK: - Init
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupUI()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Setup
+
+    private func setupUI() {
+        backgroundColor = .clear
+        contentView.backgroundColor = .clear
+        selectionStyle = .none
+
+        cardContainer.translatesAutoresizingMaskIntoConstraints = false
+        cardContainer.layer.cornerRadius = AppRadius.md
+        cardContainer.layer.masksToBounds = false
+        contentView.addSubview(cardContainer)
+
+        textStack.addArrangedSubview(titleLabel)
+        textStack.addArrangedSubview(subtitleLabel)
+
+        playButton.translatesAutoresizingMaskIntoConstraints = false
+        playButton.addTarget(self, action: #selector(playTapped), for: .touchUpInside)
+
+        cardContainer.addSubview(playButton)
+        cardContainer.addSubview(textStack)
+        cardContainer.addSubview(checkmark)
+
+        let cardInset = AppSpacing.sp3
+        let verticalPadding = AppSpacing.sp3
+        NSLayoutConstraint.activate([
+            cardContainer.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 4),
+            cardContainer.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -4),
+            cardContainer.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            cardContainer.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+
+            playButton.leadingAnchor.constraint(equalTo: cardContainer.leadingAnchor, constant: cardInset),
+            playButton.centerYAnchor.constraint(equalTo: cardContainer.centerYAnchor),
+            playButton.widthAnchor.constraint(equalToConstant: 44),
+
+            textStack.leadingAnchor.constraint(equalTo: playButton.trailingAnchor, constant: AppSpacing.sp3),
+            textStack.centerYAnchor.constraint(equalTo: cardContainer.centerYAnchor),
+            textStack.topAnchor.constraint(
+                greaterThanOrEqualTo: cardContainer.topAnchor, constant: verticalPadding
+            ),
+            textStack.bottomAnchor.constraint(
+                lessThanOrEqualTo: cardContainer.bottomAnchor, constant: -verticalPadding
+            ),
+
+            checkmark.trailingAnchor.constraint(equalTo: cardContainer.trailingAnchor, constant: -cardInset),
+            checkmark.centerYAnchor.constraint(equalTo: cardContainer.centerYAnchor),
+            checkmark.widthAnchor.constraint(equalToConstant: 20),
+
+            textStack.trailingAnchor.constraint(
+                lessThanOrEqualTo: checkmark.leadingAnchor, constant: -AppSpacing.sp3
+            ),
+            cardContainer.heightAnchor.constraint(greaterThanOrEqualToConstant: 56)
+        ])
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        // CALayer cgColor doesn't auto-resolve dynamic UIColors — refresh
+        // border / shadow on system theme flips.
+        refreshChromeColors()
+    }
+
+    private func refreshChromeColors() {
+        let scale = max(traitCollection.displayScale, 1)
+        if lastIsSelected {
+            cardContainer.backgroundColor = AppColors.whiteOverlay06
+            cardContainer.layer.borderWidth = 1.0 / scale
+            cardContainer.layer.borderColor = AppColors.strokeMoney
+                .resolvedColor(with: traitCollection).cgColor
+            cardContainer.layer.shadowColor = AppColors.money500.cgColor
+            cardContainer.layer.shadowOpacity = traitCollection.userInterfaceStyle == .light ? 0.15 : 0.2
+            cardContainer.layer.shadowRadius = 8
+            cardContainer.layer.shadowOffset = CGSize(width: 0, height: 4)
+        } else {
+            cardContainer.backgroundColor = AppColors.bg1
+            cardContainer.layer.borderWidth = 1.0 / scale
+            cardContainer.layer.borderColor = AppColors.stroke1
+                .resolvedColor(with: traitCollection).cgColor
+            cardContainer.layer.shadowOpacity = 0
+        }
+    }
+
+    // MARK: - Configure
+
+    func configure(name: String, duration: String, isSelected: Bool, isPlaying: Bool) {
+        titleLabel.text = name
+        subtitleLabel.text = duration
+        checkmark.isHidden = !isSelected
+        lastIsSelected = isSelected
+        refreshChromeColors()
+
+        // Replace the SPButton's icon by rebuilding it — `SPButton` doesn't
+        // expose a setter for the leading icon and we want the play / pause
+        // toggle to read with the system "play.fill" / "pause.fill" SF
+        // symbols at consistent weight. Cheaper than animating into a
+        // CAShapeLayer.
+        playButton.removeFromSuperview()
+        playButton.removeTarget(self, action: nil, for: .allEvents)
+        let newIcon = UIImage(systemName: isPlaying ? "pause.fill" : "play.fill")
+        let replacement = SPButton(
+            title: "",
+            variant: .quiet,
+            size: .sm,
+            icon: newIcon
+        )
+        replacement.translatesAutoresizingMaskIntoConstraints = false
+        replacement.addTarget(self, action: #selector(playTapped), for: .touchUpInside)
+        cardContainer.addSubview(replacement)
+        NSLayoutConstraint.activate([
+            replacement.leadingAnchor.constraint(equalTo: cardContainer.leadingAnchor, constant: AppSpacing.sp3),
+            replacement.centerYAnchor.constraint(equalTo: cardContainer.centerYAnchor),
+            replacement.widthAnchor.constraint(equalToConstant: 44)
+        ])
+        playButton = replacement
+
+        // Re-pin the text stack leading anchor because we just swapped the
+        // play button view it depends on. AutoLayout keeps the old (deleted)
+        // constraint dangling otherwise.
+        for constraint in cardContainer.constraints
+        where constraint.firstItem === textStack && constraint.firstAttribute == .leading {
+            cardContainer.removeConstraint(constraint)
+        }
+        textStack.leadingAnchor.constraint(
+            equalTo: playButton.trailingAnchor, constant: AppSpacing.sp3
+        ).isActive = true
+    }
+
+    @objc private func playTapped() {
+        onPlayTapped?()
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        onPlayTapped = nil
+        checkmark.isHidden = true
+        lastIsSelected = false
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/VolumeCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/VolumeCell.swift
@@ -1,0 +1,93 @@
+import UIKit
+
+/// "Громкость" row on the create / edit alarm form (#150).
+///
+/// Mirrors the chrome of `SoundCell` so the new row reads as the same
+/// primitive — title on the left, current volume + optional fade-in label
+/// on the right, chevron disclosure. Tapping pushes the
+/// `VolumePickerViewController` (handled by the parent `didSelectRowAt`).
+final class VolumeCell: UITableViewCell {
+
+    static let reuseID = "VolumeCell"
+
+    // MARK: - UI
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Громкость"
+        label.font = UIFont.systemFont(ofSize: 17)
+        label.textColor = .label
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let valueLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 17)
+        label.textColor = .secondaryLabel
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textAlignment = .right
+        return label
+    }()
+
+    private let chevronView: UIImageView = {
+        let image = UIImage(systemName: "chevron.right")?.withConfiguration(
+            UIImage.SymbolConfiguration(pointSize: 13, weight: .semibold)
+        )
+        let view = UIImageView(image: image)
+        view.tintColor = .tertiaryLabel
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    // MARK: - Init
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupUI()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupUI() {
+        backgroundColor = .secondarySystemBackground
+        selectionStyle = .default
+
+        contentView.addSubview(titleLabel)
+        contentView.addSubview(chevronView)
+        contentView.addSubview(valueLabel)
+
+        NSLayoutConstraint.activate([
+            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.lg),
+            titleLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+
+            chevronView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.lg),
+            chevronView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+
+            valueLabel.trailingAnchor.constraint(equalTo: chevronView.leadingAnchor, constant: -AppSpacing.sm),
+            valueLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            valueLabel.leadingAnchor.constraint(
+                greaterThanOrEqualTo: titleLabel.trailingAnchor, constant: AppSpacing.sm
+            ),
+
+            contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: 44)
+        ])
+    }
+
+    // MARK: - Configure
+
+    /// Render the trailing summary as "{N}%" plus a "· плавно" suffix when
+    /// the per-alarm fade-in toggle is on so the user can spot the option
+    /// at a glance without having to drill into the picker.
+    func configure(volume: Float, fadeIn: Bool) {
+        let pct = Int(round(min(max(volume, 0), 1) * 100))
+        if fadeIn {
+            valueLabel.text = "\(pct)% · плавно"
+        } else {
+            valueLabel.text = "\(pct)%"
+        }
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
@@ -42,6 +42,7 @@ final class CreateAlarmViewController: UIViewController {
         case penalty
         case progressiveScale
         case sound
+        case volume
         case vibration
         case theme
         /// Destructive "Удалить будильник" row — only visible in edit mode.
@@ -71,10 +72,10 @@ final class CreateAlarmViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        // Refresh the sound + theme rows in case the user picked a new
-        // value on a pushed picker and is returning here.
+        // Refresh the sound + volume + theme rows in case the user picked a
+        // new value on a pushed picker and is returning here.
         tableView.reloadSections(
-            IndexSet([Section.sound.rawValue, Section.theme.rawValue]),
+            IndexSet([Section.sound.rawValue, Section.volume.rawValue, Section.theme.rawValue]),
             with: .none
         )
     }
@@ -121,6 +122,7 @@ final class CreateAlarmViewController: UIViewController {
         tableView.register(DayPickerCell.self, forCellReuseIdentifier: DayPickerCell.reuseID)
         tableView.register(NameCell.self, forCellReuseIdentifier: NameCell.reuseID)
         tableView.register(SoundCell.self, forCellReuseIdentifier: SoundCell.reuseID)
+        tableView.register(VolumeCell.self, forCellReuseIdentifier: VolumeCell.reuseID)
         tableView.register(VibrationCell.self, forCellReuseIdentifier: VibrationCell.reuseID)
         tableView.register(PenaltyCell.self, forCellReuseIdentifier: PenaltyCell.reuseID)
         tableView.register(ProgressiveScaleCell.self, forCellReuseIdentifier: ProgressiveScaleCell.reuseID)
@@ -320,6 +322,12 @@ extension CreateAlarmViewController: UITableViewDataSource {
                 }
             }
             return cell
+        case .volume:
+            let cell = tableView.dequeueReusableCell(withIdentifier: VolumeCell.reuseID, for: indexPath)
+            if let cell = cell as? VolumeCell {
+                cell.configure(volume: viewModel.volume, fadeIn: viewModel.volumeFadeIn)
+            }
+            return cell
         case .vibration:
             let cell = tableView.dequeueReusableCell(withIdentifier: VibrationCell.reuseID, for: indexPath)
             if let cell = cell as? VibrationCell {
@@ -396,6 +404,8 @@ extension CreateAlarmViewController: UITableViewDelegate {
         switch section {
         case .sound:
             showSoundPicker()
+        case .volume:
+            showVolumePicker()
         case .theme:
             // The full theme picker (`AlarmThemePickerViewController`) is
             // tracked by #151. Until it lands the row is a no-op so the form
@@ -454,6 +464,21 @@ extension CreateAlarmViewController: UITableViewDelegate {
                 self?.viewModel.previewSound(soundID)
             }
         )
+        navigationController?.pushViewController(picker, animated: true)
+    }
+
+    /// Push the new `VolumePickerViewController` (#150). The picker reports
+    /// every slider / switch change live so dismissing on the back chevron
+    /// is "auto-save" — the parent's `viewWillAppear` then refreshes the
+    /// volume row to render the new value.
+    private func showVolumePicker() {
+        let picker = VolumePickerViewController(
+            volume: viewModel.volume,
+            fadeIn: viewModel.volumeFadeIn
+        ) { [weak self] volume, fadeIn in
+            self?.viewModel.volume = volume
+            self?.viewModel.volumeFadeIn = fadeIn
+        }
         navigationController?.pushViewController(picker, animated: true)
     }
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/SoundPickerViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/SoundPickerViewController.swift
@@ -1,9 +1,19 @@
 import UIKit
 import AudioToolbox
 
-/// Full-screen sound picker pushed onto navigation stack.
-/// Shows all available sounds with play preview buttons and checkmark for selection.
-final class SoundPickerViewController: UITableViewController {
+/// Full-screen sound picker pushed onto the navigation stack.
+///
+/// Each row uses the SP design-system primitives (`SPRow` + `SPCard` + a
+/// `SPButton(.quiet, .sm)` play / pause head) so the screen reads the same
+/// as the rest of the brand-refreshed surfaces (#150). The selected row
+/// flips to a money-tinted SPCard so the active sound stands out without
+/// needing a separate trailing checkmark badge — although the checkmark is
+/// kept on the trailing edge per the design spec.
+///
+/// `onSelect` and `previewSound` callbacks intentionally keep the same
+/// signatures as the pre-refresh picker so callers (the alarm form) do not
+/// need to change.
+final class SoundPickerViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
 
     // MARK: - Properties
 
@@ -12,15 +22,39 @@ final class SoundPickerViewController: UITableViewController {
     private let onSelect: (String) -> Void
     private let previewSound: (String) -> Void
 
+    /// `id` of the sound whose preview is currently being broadcast — drives
+    /// the "play" / "pause" toggling on the row's head SPButton. Reset by a
+    /// short timer keyed to the average preview length so the icon doesn't
+    /// stay stuck on `pause.fill` once the system sound finishes.
     private var currentlyPlayingID: String?
+    private var previewResetWorkItem: DispatchWorkItem?
+
+    // MARK: - UI
+
+    private let tableView: UITableView = {
+        let table = UITableView(frame: .zero, style: .plain)
+        table.translatesAutoresizingMaskIntoConstraints = false
+        table.separatorStyle = .none
+        table.backgroundColor = .clear
+        // Generous row spacing keeps consecutive SPCards from visually
+        // running into each other — `tableView.separatorInset` doesn't
+        // help when each row has its own card chrome.
+        table.rowHeight = UITableView.automaticDimension
+        table.estimatedRowHeight = 64
+        table.contentInset = UIEdgeInsets(
+            top: AppSpacing.sp3, left: 0, bottom: AppSpacing.sp4, right: 0
+        )
+        return table
+    }()
 
     // MARK: - Init
 
     /// - Parameters:
-    ///   - sounds: Available sounds list (id + display name)
-    ///   - selectedID: Currently selected sound ID
-    ///   - onSelect: Callback when user picks a sound
-    ///   - previewSound: Callback to play preview of a sound
+    ///   - sounds: Available sounds list (id + display name).
+    ///   - selectedID: Currently selected sound id.
+    ///   - onSelect: Callback fired when the user picks a sound. The picker
+    ///     pops itself shortly afterwards so the user hears the preview.
+    ///   - previewSound: Callback to play preview for a given sound id.
     init(
         sounds: [(id: String, name: String)],
         selectedID: String,
@@ -31,9 +65,10 @@ final class SoundPickerViewController: UITableViewController {
         self.selectedSoundID = selectedID
         self.onSelect = onSelect
         self.previewSound = previewSound
-        super.init(style: .insetGrouped)
+        super.init(nibName: nil, bundle: nil)
     }
 
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -43,21 +78,44 @@ final class SoundPickerViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "Выбор звука"
-        view.backgroundColor = .systemGroupedBackground
-        tableView.register(SoundPickerRowCell.self, forCellReuseIdentifier: SoundPickerRowCell.reuseID)
+        view.backgroundColor = AppColors.bg0
+        setupTableView()
     }
 
-    // MARK: - Table View
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        previewResetWorkItem?.cancel()
+        previewResetWorkItem = nil
+    }
 
-    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    // MARK: - Setup
+
+    private func setupTableView() {
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.register(SoundPickerRowCell.self, forCellReuseIdentifier: SoundPickerRowCell.reuseID)
+        view.addSubview(tableView)
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            tableView.leadingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: AppSpacing.sp4
+            ),
+            tableView.trailingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -AppSpacing.sp4
+            ),
+            tableView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        ])
+    }
+
+    // MARK: - Table view
+
+    func numberOfSections(in tableView: UITableView) -> Int { 1 }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         sounds.count
     }
 
-    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        52
-    }
-
-    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(
             withIdentifier: SoundPickerRowCell.reuseID, for: indexPath
         ) as? SoundPickerRowCell else {
@@ -66,122 +124,102 @@ final class SoundPickerViewController: UITableViewController {
 
         let sound = sounds[indexPath.row]
         let isSelected = sound.id == selectedSoundID
-        cell.configure(name: sound.name, isSelected: isSelected)
+        let isPlaying = sound.id == currentlyPlayingID
+        cell.configure(
+            name: sound.name,
+            duration: Self.previewDuration(for: sound.id),
+            isSelected: isSelected,
+            isPlaying: isPlaying
+        )
         cell.onPlayTapped = { [weak self] in
-            self?.previewSound(sound.id)
+            self?.handlePreviewToggle(for: sound.id)
         }
         return cell
     }
 
-    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         let sound = sounds[indexPath.row]
         selectedSoundID = sound.id
         onSelect(sound.id)
         previewSound(sound.id)
         tableView.reloadData()
-        // Pop back after short delay so user hears the preview
+        // Pop back after a short delay so the user hears the chosen preview
+        // before the picker disappears.
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
             self?.navigationController?.popViewController(animated: true)
         }
     }
-}
 
-// MARK: - Sound Cell
+    // MARK: - Preview handling
 
-final class SoundPickerRowCell: UITableViewCell {
+    /// Toggle preview playback on the row's "play" / "pause" head. We don't
+    /// have a real audio session for previews (the live alarm sound is what
+    /// uses the AVAudioSession) — system sounds fire-and-forget, so the
+    /// "pause" state is a UI affordance backed by a timer that resets the
+    /// icon when the typical preview length elapses.
+    private func handlePreviewToggle(for soundID: String) {
+        previewResetWorkItem?.cancel()
 
-    static let reuseID = "SoundPickerRowCell"
+        if currentlyPlayingID == soundID {
+            // Tap on the same row → cancel the visual "playing" state.
+            // System sounds can't actually be stopped mid-play, but the
+            // icon flip honours the user's intent.
+            currentlyPlayingID = nil
+            tableView.reloadData()
+            return
+        }
 
-    var onPlayTapped: (() -> Void)?
+        currentlyPlayingID = soundID
+        previewSound(soundID)
+        tableView.reloadData()
 
-    // MARK: - UI
-
-    private let nameLabel: UILabel = {
-        let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 17)
-        return label
-    }()
-
-    private let playButton: UIButton = {
-        let button = UIButton(type: .system)
-        let config = UIImage.SymbolConfiguration(pointSize: 22, weight: .medium)
-        button.setImage(UIImage(systemName: "play.circle", withConfiguration: config), for: .normal)
-        button.tintColor = AppColors.accentBlue
-        button.translatesAutoresizingMaskIntoConstraints = false
-        return button
-    }()
-
-    private let checkmark: UIImageView = {
-        let imageView = UIImageView()
-        imageView.image = UIImage(systemName: "checkmark")?.withConfiguration(
-            UIImage.SymbolConfiguration(pointSize: 16, weight: .semibold)
-        )
-        imageView.tintColor = AppColors.accentBlue
-        imageView.translatesAutoresizingMaskIntoConstraints = false
-        return imageView
-    }()
-
-    // MARK: - Init
-
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
-        setupUI()
+        // Auto-reset the play state after the configured preview length
+        // so the row icon reverts to "play" once the system sound has
+        // realistically finished.
+        let duration = Self.previewDurationSeconds(for: soundID)
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            guard self.currentlyPlayingID == soundID else { return }
+            self.currentlyPlayingID = nil
+            self.tableView.reloadData()
+        }
+        previewResetWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + duration, execute: workItem)
     }
 
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+    // MARK: - Preview duration metadata
+
+    /// Approximate preview length per sound id. Used both for the
+    /// "0:42" subtitle copy and the visual reset timer. Numbers are
+    /// hand-tuned against the AudioToolbox `SystemSoundID` table — the
+    /// production soundbank will eventually ship real durations on the
+    /// alarm-sound model itself.
+    private static let previewDurations: [String: Double] = [
+        "dawn": 6,
+        "radar": 4,
+        "drops": 2,
+        "piano": 3,
+        "guitar": 3,
+        "bell": 2,
+        "waves": 8,
+        "birds": 6,
+        "classic": 5,
+        "jazz": 5
+    ]
+
+    private static func previewDurationSeconds(for soundID: String) -> Double {
+        previewDurations[soundID] ?? 3
     }
 
-    // MARK: - Setup
-
-    private func setupUI() {
-        backgroundColor = .secondarySystemBackground
-        selectionStyle = .default
-
-        contentView.addSubview(nameLabel)
-        contentView.addSubview(playButton)
-        contentView.addSubview(checkmark)
-
-        nameLabel.translatesAutoresizingMaskIntoConstraints = false
-
-        NSLayoutConstraint.activate([
-            checkmark.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.lg),
-            checkmark.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            checkmark.widthAnchor.constraint(equalToConstant: 20),
-
-            nameLabel.leadingAnchor.constraint(equalTo: checkmark.trailingAnchor, constant: AppSpacing.sm),
-            nameLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-
-            playButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.lg),
-            playButton.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            playButton.widthAnchor.constraint(equalToConstant: 44),
-            playButton.heightAnchor.constraint(equalToConstant: 44),
-
-            nameLabel.trailingAnchor.constraint(lessThanOrEqualTo: playButton.leadingAnchor, constant: -AppSpacing.sm)
-        ])
-
-        playButton.addTarget(self, action: #selector(playTapped), for: .touchUpInside)
-    }
-
-    @objc private func playTapped() {
-        onPlayTapped?()
-    }
-
-    // MARK: - Configure
-
-    func configure(name: String, isSelected: Bool) {
-        nameLabel.text = name
-        nameLabel.textColor = isSelected ? AppColors.accentBlue : .label
-        nameLabel.font = UIFont.systemFont(ofSize: 17, weight: isSelected ? .semibold : .regular)
-        checkmark.isHidden = !isSelected
-    }
-
-    override func prepareForReuse() {
-        super.prepareForReuse()
-        onPlayTapped = nil
-        checkmark.isHidden = true
-        nameLabel.textColor = .label
-        nameLabel.font = UIFont.systemFont(ofSize: 17)
+    private static func previewDuration(for soundID: String) -> String {
+        let total = Int(previewDurationSeconds(for: soundID))
+        let minutes = total / 60
+        let seconds = total % 60
+        return String(format: "%d:%02d", minutes, seconds)
     }
 }
+
+// `SoundPickerRowCell` lives in
+// `ViewControllers/Alarms/Cells/SoundPickerRowCell.swift` so this file stays
+// under the SwiftLint `file_length` cap.

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/VolumePickerViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/VolumePickerViewController.swift
@@ -1,0 +1,250 @@
+import UIKit
+
+/// Full-screen picker for the per-alarm playback volume (#150).
+///
+/// Pushed onto the navigation stack from the create/edit alarm form. The
+/// picker reports volume + fade-in changes back to the caller via the
+/// `onChange` callback as the user manipulates the slider / switch — no
+/// explicit "Save" action; the back chevron just pops the screen and the
+/// most recent value is what sticks.
+///
+/// Layout follows the design-refresh handoff (`SPMore2.jsx` /
+/// `SPMore4.jsx`):
+///   - `SPCard(.surface)` preview at the top showing the live "{N}%"
+///     reading in the `moneyXl` (56pt mono) numeric role.
+///   - Money-tinted UISlider with 5%-step quantisation and a 28pt thumb.
+///   - `SPRow` with an `SPSwitch` for the "Постепенно нарастает" / "За 30
+///     секунд" fade-in option.
+final class VolumePickerViewController: UIViewController {
+
+    // MARK: - Callbacks
+
+    /// Invoked whenever volume or fade-in flag changes. The caller keeps the
+    /// alarm model in sync so the back-button pop is "auto-save".
+    var onChange: ((Float, Bool) -> Void)?
+
+    // MARK: - State
+
+    private var volume: Float
+    private var fadeIn: Bool
+
+    /// 5%-step quantisation — matches the design-refresh spec. Slider value
+    /// is rounded to the nearest multiple of `step` so the preview reads
+    /// "65%" instead of "64.7%".
+    private static let step: Float = 0.05
+
+    // MARK: - UI
+
+    private let previewCard = SPCard(tone: .surface, padding: AppSpacing.sp6)
+    private let previewCaps: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.attributedText = NSAttributedString(
+            string: "ГРОМКОСТЬ",
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.fg3
+            ]
+        )
+        return label
+    }()
+    private let previewValue: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = AppTypography.moneyXl
+        label.textColor = AppColors.fg1
+        label.textAlignment = .center
+        label.adjustsFontSizeToFitWidth = true
+        label.minimumScaleFactor = 0.5
+        return label
+    }()
+
+    private let slider: UISlider = {
+        let slider = UISlider()
+        slider.translatesAutoresizingMaskIntoConstraints = false
+        slider.minimumValue = 0
+        slider.maximumValue = 1
+        slider.minimumTrackTintColor = AppColors.money500
+        slider.tintColor = AppColors.money500
+        return slider
+    }()
+
+    private let fadeRowContainer = SPCard(tone: .surface, padding: AppSpacing.sp4)
+    private let fadeSwitch = SPSwitch()
+
+    private let stack: UIStackView = {
+        let stack = UIStackView()
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .vertical
+        stack.spacing = AppSpacing.sp5
+        stack.alignment = .fill
+        return stack
+    }()
+
+    // MARK: - Init
+
+    /// - Parameters:
+    ///   - volume: Initial volume in `0.0...1.0`.
+    ///   - fadeIn: Initial fade-in flag.
+    ///   - onChange: Callback fired on every slider / switch change with
+    ///     `(volume, fadeIn)` — the caller persists.
+    init(volume: Float, fadeIn: Bool, onChange: ((Float, Bool) -> Void)? = nil) {
+        // Clamp the seed value so a corrupt persisted volume can't push the
+        // slider out of bounds and crash on the first valueChanged event.
+        self.volume = min(max(volume.isFinite ? volume : 1.0, 0), 1)
+        self.fadeIn = fadeIn
+        self.onChange = onChange
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Громкость"
+        view.backgroundColor = AppColors.bg0
+        setupUI()
+        applyVolumeToUI()
+        applyFadeToUI()
+    }
+
+    // MARK: - Setup
+
+    private func setupUI() {
+        view.addSubview(stack)
+        configurePreviewCard()
+        let sliderContainer = makeSliderContainer()
+        configureFadeRow()
+        stack.addArrangedSubview(previewCard)
+        stack.addArrangedSubview(sliderContainer)
+        stack.addArrangedSubview(fadeRowContainer)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: AppSpacing.sp5),
+            stack.leadingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: AppSpacing.sp5
+            ),
+            stack.trailingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -AppSpacing.sp5
+            )
+        ])
+    }
+
+    private func configurePreviewCard() {
+        previewCard.translatesAutoresizingMaskIntoConstraints = false
+        let previewStack = UIStackView(arrangedSubviews: [previewCaps, previewValue])
+        previewStack.translatesAutoresizingMaskIntoConstraints = false
+        previewStack.axis = .vertical
+        previewStack.spacing = AppSpacing.sp2
+        previewStack.alignment = .center
+        previewCard.addSubview(previewStack)
+        NSLayoutConstraint.activate([
+            previewStack.leadingAnchor.constraint(equalTo: previewCard.layoutMarginsGuide.leadingAnchor),
+            previewStack.trailingAnchor.constraint(equalTo: previewCard.layoutMarginsGuide.trailingAnchor),
+            previewStack.topAnchor.constraint(equalTo: previewCard.layoutMarginsGuide.topAnchor),
+            previewStack.bottomAnchor.constraint(equalTo: previewCard.layoutMarginsGuide.bottomAnchor)
+        ])
+    }
+
+    /// Larger thumb so the control reads as a "fat dial" matching the SP
+    /// design language. UIKit only exposes the thumb image — render a
+    /// money-tinted disc into a programmatic image instead of shipping an
+    /// asset.
+    private func makeSliderContainer() -> UIView {
+        slider.setThumbImage(Self.makeThumb(diameter: 28), for: .normal)
+        slider.setThumbImage(Self.makeThumb(diameter: 30), for: .highlighted)
+        slider.addTarget(self, action: #selector(sliderChanged), for: .valueChanged)
+        let container = UIView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(slider)
+        NSLayoutConstraint.activate([
+            slider.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            slider.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            slider.topAnchor.constraint(equalTo: container.topAnchor, constant: AppSpacing.sp2),
+            slider.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -AppSpacing.sp2),
+            slider.heightAnchor.constraint(greaterThanOrEqualToConstant: 32)
+        ])
+        return container
+    }
+
+    private func configureFadeRow() {
+        fadeRowContainer.translatesAutoresizingMaskIntoConstraints = false
+        let fadeRow = SPRow(
+            title: "Постепенно нарастает",
+            subtitle: "За 30 секунд",
+            trailing: fadeSwitch,
+            divider: false
+        )
+        fadeRow.translatesAutoresizingMaskIntoConstraints = false
+        fadeRowContainer.addSubview(fadeRow)
+        NSLayoutConstraint.activate([
+            fadeRow.leadingAnchor.constraint(equalTo: fadeRowContainer.layoutMarginsGuide.leadingAnchor),
+            fadeRow.trailingAnchor.constraint(equalTo: fadeRowContainer.layoutMarginsGuide.trailingAnchor),
+            fadeRow.topAnchor.constraint(equalTo: fadeRowContainer.layoutMarginsGuide.topAnchor),
+            fadeRow.bottomAnchor.constraint(equalTo: fadeRowContainer.layoutMarginsGuide.bottomAnchor)
+        ])
+        fadeSwitch.addTarget(self, action: #selector(fadeToggled), for: .valueChanged)
+    }
+
+    // MARK: - State sync
+
+    private func applyVolumeToUI() {
+        slider.value = volume
+        previewValue.text = "\(Int(round(volume * 100)))%"
+    }
+
+    private func applyFadeToUI() {
+        fadeSwitch.isOn = fadeIn
+    }
+
+    // MARK: - Actions
+
+    @objc
+    private func sliderChanged() {
+        // Quantise to 5% steps so the preview number doesn't flicker on
+        // sub-percent jitter. Round-then-clamp keeps the ends snappy.
+        let stepped = (slider.value / Self.step).rounded() * Self.step
+        let clamped = min(max(stepped, 0), 1)
+        if abs(clamped - volume) < .ulpOfOne { return }
+        volume = clamped
+        applyVolumeToUI()
+        onChange?(volume, fadeIn)
+    }
+
+    @objc
+    private func fadeToggled() {
+        fadeIn = fadeSwitch.isOn
+        onChange?(volume, fadeIn)
+    }
+
+    // MARK: - Thumb image
+
+    /// Render a money-tinted circle into a UIImage for use as the slider
+    /// thumb. Sizing the thumb via `setThumbImage` is the only supported
+    /// path on `UISlider` — there's no `thumbDiameter` knob.
+    private static func makeThumb(diameter: CGFloat) -> UIImage {
+        let size = CGSize(width: diameter, height: diameter)
+        let renderer = UIGraphicsImageRenderer(size: size)
+        return renderer.image { context in
+            let rect = CGRect(origin: .zero, size: size).insetBy(dx: 1, dy: 1)
+            // Soft ring shadow so the thumb lifts off the track in light mode.
+            context.cgContext.setShadow(
+                offset: CGSize(width: 0, height: 1),
+                blur: 2,
+                color: UIColor.black.withAlphaComponent(0.25).cgColor
+            )
+            AppColors.money500.setFill()
+            UIBezierPath(ovalIn: rect).fill()
+            // White inner dot so the thumb reads on dark + light alike.
+            context.cgContext.setShadow(offset: .zero, blur: 0, color: nil)
+            UIColor.white.withAlphaComponent(0.35).setFill()
+            let inner = rect.insetBy(dx: rect.width * 0.32, dy: rect.height * 0.32)
+            UIBezierPath(ovalIn: inner).fill()
+        }
+    }
+}

--- a/SnoozePay/SnoozePay/ViewModels/CreateAlarmViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/CreateAlarmViewModel.swift
@@ -19,6 +19,10 @@ final class CreateAlarmViewModel {
     var penaltyAmount: Double
     var progressiveScale: Bool
     var enabled: Bool
+    /// Per-alarm playback volume (#150). `0...1`, default `1.0`.
+    var volume: Float
+    /// Per-alarm "ramp from 0 → volume over 30 seconds" toggle (#150).
+    var volumeFadeIn: Bool
 
     private let existingID: UUID?
 
@@ -48,6 +52,8 @@ final class CreateAlarmViewModel {
         self.penaltyAmount = alarm?.penaltyAmount ?? 50
         self.progressiveScale = alarm?.progressiveScale ?? false
         self.enabled = alarm?.enabled ?? true
+        self.volume = alarm?.volume ?? 1.0
+        self.volumeFadeIn = alarm?.volumeFadeIn ?? false
     }
 
     // MARK: - Save
@@ -108,7 +114,9 @@ final class CreateAlarmViewModel {
             snoozeMinutes: snoozeMinutes,
             penaltyAmount: penaltyAmount,
             progressiveScale: progressiveScale,
-            enabled: enabled
+            enabled: enabled,
+            volume: volume,
+            volumeFadeIn: volumeFadeIn
         )
     }
 


### PR DESCRIPTION
Fixes #150

## Что сделано

### A) Sound picker refresh
- `SoundPickerViewController` переписан под SP-стиль: каждый ряд — `SPCard` с leading `SPButton(.quiet, .sm)` (play / pause toggle), title (`bodyLg`) + duration subtitle (`meta`), trailing checkmark на выбранном.
- Selected row рендерит `whiteOverlay06` fill + money-tinted border (`strokeMoney`) + лёгкий money shadow вместо плоского `accentBlue`.
- `screen-inset 16pt` вокруг table; cards rounded `AppRadius.md`; `bg0` фон.
- `SoundPickerRowCell` вынесен в `Cells/SoundPickerRowCell.swift`, чтобы оба файла остались в `file_length` бюджете.

### B) Volume picker (новый)
- `VolumePickerViewController` (push pattern, screen-inset 20pt):
  - `SPCard(.surface)` preview с caps "ГРОМКОСТЬ" + `moneyXl` 56pt mono "{N}%" — live update.
  - `UISlider 0...1`, квантование 5%, `money500` track, кастомный 28pt thumb.
  - `SPRow` + `SPSwitch` "Постепенно нарастает" / "За 30 секунд".
- `onChange` callback при каждом изменении — back-button = auto-save.

### C) Wiring
- `Alarm` получил два новых поля: `volume: Float = 1.0` и `volumeFadeIn: Bool = false`. Кастомный `init(from:)` декодирует через `decodeIfPresent`, поэтому JSON старых будильников читается без миграции (тест-баланс по `AlarmRepository.fetchAll()` сохранён).
- `CreateAlarmViewModel` хранит / отдаёт `volume` + `volumeFadeIn`.
- `CreateAlarmViewController` — новая `Section.volume` между Sound и Vibration с `VolumeCell` (title + "{N}% [· плавно]" + chevron) → push `VolumePickerViewController`.
- `AlarmNotificationPayload` — два новых optional поля; `asUserInfo()` эмитит их только когда заданы (downgrade-safe). Pre-#150 push-ы декодируются с дефолтами.
- `AudioService.startAlarmSound(...)` принимает `volume:` (clamped) и `fadeIn:`. При `fadeIn` стартует с `0` и вызывает `AVAudioPlayer.setVolume(_:fadeDuration: 30)` — ramp работает на audio-thread, переживает screen lock.
- Call sites (`AppDelegate.willPresent`, `AlarmFiringViewController.viewDidLoad`) обновлены.

## Verify
- swiftlint: 0 errors (новые файлы — 0 violations; общее число warnings 67, на 2 меньше baseline 69).
- build_sim: succeeded (`iPhone 17 Pro`, `iOS 26.3.1`).
- build-for-testing: succeeded (тестовые таргеты компилируются).
- test_sim / screenshot: пропущено по запросу.