### PR TITLE
[design-refresh] Alarm theme picker (#151)

### DIFF
--- a/SnoozePay/SnoozePay/Models/Alarm.swift
+++ b/SnoozePay/SnoozePay/Models/Alarm.swift
@@ -19,6 +19,11 @@ struct Alarm: Identifiable, Equatable, Codable {
     /// firing time so the user is woken gently. Default `false` preserves the
     /// pre-#150 instant-on behaviour.
     var volumeFadeIn: Bool
+    /// Visual theme used for the alarm-card background strip and the firing
+    /// screen background (#151). Defaults to `.dawn` for both new alarms and
+    /// legacy alarms persisted before the theme picker landed — see the
+    /// custom `init(from:)` below for the migration path.
+    var theme: AlarmTheme
 
     init(
         id: UUID = UUID(),
@@ -32,7 +37,8 @@ struct Alarm: Identifiable, Equatable, Codable {
         progressiveScale: Bool = false,
         enabled: Bool = true,
         volume: Float = 1.0,
-        volumeFadeIn: Bool = false
+        volumeFadeIn: Bool = false,
+        theme: AlarmTheme = .dawn
     ) {
         self.id = id
         self.time = time
@@ -46,19 +52,24 @@ struct Alarm: Identifiable, Equatable, Codable {
         self.enabled = enabled
         self.volume = min(max(volume, 0), 1)
         self.volumeFadeIn = volumeFadeIn
+        self.theme = theme
     }
 
     // MARK: - Codable (backwards-compatible decode)
     //
-    // `volume` + `volumeFadeIn` were added in #150. Pre-#150 stored alarms do
-    // not carry these keys — `decodeIfPresent` plus the documented defaults
-    // keeps existing JSON readable without forcing a migration step. The
-    // default encode path is fine because new keys are simply additive.
+    // `volume` + `volumeFadeIn` were added in #150 and `theme` in #151.
+    // Pre-#150 / pre-#151 stored alarms do not carry these keys —
+    // `decodeIfPresent` plus the documented defaults keeps existing JSON
+    // readable without forcing a migration step. Synthesized Codable would
+    // throw `keyNotFound`, which `AlarmRepository.readAll()` propagates as
+    // a fatal `decodeFailure` (issue #117 / #72 lock the entire store).
+    // Adding a field MUST be backward-compatible — this initializer is the
+    // contract that ships safely on top of #143.
 
     private enum CodingKeys: String, CodingKey {
         case id, time, repeatDays, name, soundID, vibrationEnabled
         case snoozeMinutes, penaltyAmount, progressiveScale, enabled
-        case volume, volumeFadeIn
+        case volume, volumeFadeIn, theme
     }
 
     init(from decoder: Decoder) throws {
@@ -78,6 +89,8 @@ struct Alarm: Identifiable, Equatable, Codable {
         let rawVolume = try container.decodeIfPresent(Float.self, forKey: .volume) ?? 1.0
         self.volume = min(max(rawVolume.isFinite ? rawVolume : 1.0, 0), 1)
         self.volumeFadeIn = try container.decodeIfPresent(Bool.self, forKey: .volumeFadeIn) ?? false
+        // Migration: pre-#151 alarms have no `theme` field — default to .dawn.
+        self.theme = try container.decodeIfPresent(AlarmTheme.self, forKey: .theme) ?? .dawn
     }
 
     /// Human-readable repeat days string (e.g. "Пн, Вт, Пт")

--- a/SnoozePay/SnoozePay/Models/AlarmTheme.swift
+++ b/SnoozePay/SnoozePay/Models/AlarmTheme.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// Visual theme applied to an alarm's card preview and firing screen (#151).
+///
+/// The five built-in cases are gradient-only so they ship without bundled
+/// imagery; `.custom` carries an absolute file URL for a user-picked photo
+/// stored in the app's Caches directory by `AlarmThemeImageStore`.
+///
+/// Codable is hand-rolled because Swift's synthesized representation for
+/// enums-with-associated-values pulls in Apple's `_$s…` type wrappers that
+/// surface as tagged JSON keys. Keeping the encoded form flat (`{"id": "dawn"}`
+/// or `{"id": "custom", "imagePath": "/var/.../IMG.jpg"}`) lets us migrate the
+/// model on disk in #151 without re-encoding every existing alarm.
+enum AlarmTheme: Equatable {
+    case dawn
+    case mountains
+    case ocean
+    case abstract
+    case custom(imagePath: URL)
+
+    // MARK: - Identity
+
+    /// Stable string identifier used in JSON storage and as an
+    /// `Equatable`-friendly key for collection views.
+    var id: String {
+        switch self {
+        case .dawn: return "dawn"
+        case .mountains: return "mountains"
+        case .ocean: return "ocean"
+        case .abstract: return "abstract"
+        case .custom: return "custom"
+        }
+    }
+
+    // MARK: - Display
+
+    /// Russian display name surfaced in the picker tile and the create-form
+    /// trailing label.
+    var displayName: String {
+        switch self {
+        case .dawn: return "Рассвет"
+        case .mountains: return "Горы"
+        case .ocean: return "Океан"
+        case .abstract: return "Абстракция"
+        case .custom: return "Своё фото"
+        }
+    }
+
+    /// Built-in (non-custom) themes in their canonical picker order. The
+    /// `.custom` tile is appended separately by the picker view-controller so
+    /// the "+" affordance always reads as the trailing slot.
+    static let builtInOrder: [AlarmTheme] = [.dawn, .mountains, .ocean, .abstract]
+}
+
+// MARK: - Codable
+
+extension AlarmTheme: Codable {
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case imagePath
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let id = try container.decode(String.self, forKey: .id)
+        switch id {
+        case "dawn": self = .dawn
+        case "mountains": self = .mountains
+        case "ocean": self = .ocean
+        case "abstract": self = .abstract
+        case "custom":
+            // Path stored as a string so the JSON stays portable across
+            // app reinstalls (URLs round-trip cleanly via init(string:)).
+            // If the path is missing we degrade to `.dawn` rather than
+            // throwing — a corrupt theme should not block the alarm decode.
+            if let raw = try container.decodeIfPresent(String.self, forKey: .imagePath),
+               let url = URL(string: raw) {
+                self = .custom(imagePath: url)
+            } else {
+                self = .dawn
+            }
+        default:
+            // Forward-compat: an unknown theme id (added by a newer build)
+            // degrades silently to the default rather than throwing — the
+            // old build would otherwise refuse to decode the alarm at all.
+            self = .dawn
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        if case .custom(let url) = self {
+            try container.encode(url.absoluteString, forKey: .imagePath)
+        }
+    }
+}

--- a/SnoozePay/SnoozePay/Services/AlarmThemeImageStore.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmThemeImageStore.swift
@@ -1,0 +1,64 @@
+import UIKit
+import os
+
+/// Persists user-picked photos for `AlarmTheme.custom` (#151).
+///
+/// Images land in `Caches/AlarmThemes/` rather than `Documents/` because they
+/// are derived assets — the source of truth lives in Photos and the user can
+/// always re-pick. Caches survives normal launches but the OS may purge under
+/// disk pressure; if that happens the firing screen falls back to the Dawn
+/// gradient via `themedBackgroundFactory`.
+enum AlarmThemeImageStore {
+
+    private static let log = OSLog(subsystem: "Ivan-Emelyanov.SnoozePay", category: "AlarmThemeImageStore")
+    private static let directoryName = "AlarmThemes"
+    private static let jpegQuality: CGFloat = 0.85
+
+    /// Resolve (and create on first use) the on-disk directory holding all
+    /// custom theme images. Returned URL has a trailing slash via
+    /// `appendingPathComponent(_:isDirectory:)`.
+    static func directoryURL() throws -> URL {
+        let caches = try FileManager.default.url(
+            for: .cachesDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        let folder = caches.appendingPathComponent(directoryName, isDirectory: true)
+        if !FileManager.default.fileExists(atPath: folder.path) {
+            try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        }
+        return folder
+    }
+
+    /// Encode `image` as JPEG and write it under a fresh UUID filename so the
+    /// caller can safely keep the previous image around (e.g. for an undo
+    /// flow) without us overwriting it. Returns the absolute file URL on
+    /// success or nil if encoding / disk write fails — the picker degrades
+    /// the failure into "stay on the previous theme" rather than crashing.
+    static func saveImage(_ image: UIImage) -> URL? {
+        guard let data = image.jpegData(compressionQuality: jpegQuality) else {
+            os_log("Failed to encode picked image as JPEG", log: log, type: .error)
+            return nil
+        }
+        do {
+            let folder = try directoryURL()
+            let filename = "alarm-theme-\(UUID().uuidString).jpg"
+            let fileURL = folder.appendingPathComponent(filename)
+            try data.write(to: fileURL, options: .atomic)
+            return fileURL
+        } catch {
+            os_log("Failed to write picked image: %{public}@", log: log, type: .error, String(describing: error))
+            return nil
+        }
+    }
+
+    /// Load a previously persisted image. Returns nil when the file is gone
+    /// (Caches purge) or cannot be decoded — the caller is responsible for
+    /// falling back to a default theme.
+    static func loadImage(at url: URL) -> UIImage? {
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return UIImage(data: data)
+    }
+}

--- a/SnoozePay/SnoozePay/Utilities/AlarmThemeRendering.swift
+++ b/SnoozePay/SnoozePay/Utilities/AlarmThemeRendering.swift
@@ -1,0 +1,95 @@
+import UIKit
+
+/// Visual recipes shared between the theme picker tile, the leading strip on
+/// `AlarmCell`, and the `AlarmFiringViewController` background (#151).
+///
+/// Every consumer reaches for the same gradient stops so the tile preview the
+/// user picks really matches the firing screen they see. Custom photos load
+/// out of `AlarmThemeImageStore`; if the file is missing the helpers return
+/// the Dawn gradient so the firing screen is never blank.
+enum AlarmThemeRendering {
+
+    // MARK: - Gradient stops
+
+    /// Vertical (top → bottom) gradient stops for a built-in theme. The Dawn
+    /// recipe matches the literal layer in `AlarmFiringViewController` so
+    /// switching `.dawn` keeps the historical look untouched.
+    /// Returns nil for `.custom` — that case renders an image, not a gradient.
+    static func gradientColors(for theme: AlarmTheme) -> [CGColor]? {
+        switch theme {
+        case .dawn:
+            return [
+                UIColor(themeRGB: 0x14122A).cgColor,
+                UIColor(themeRGB: 0x0F1A2E).cgColor,
+                UIColor(themeRGB: 0x0A1320).cgColor,
+                UIColor(themeRGB: 0x050912).cgColor
+            ]
+        case .mountains:
+            // Placeholder gradient until design ships an alpine image asset
+            // (tracked as a #151 follow-up). The deep mountain blue →
+            // near-black stops still read as "alpine night" until then.
+            return [
+                UIColor(themeRGB: 0x3D5A80).cgColor,
+                UIColor(themeRGB: 0x293241).cgColor
+            ]
+        case .ocean:
+            return [
+                UIColor(themeRGB: 0x1A659E).cgColor,
+                UIColor(themeRGB: 0x003554).cgColor
+            ]
+        case .abstract:
+            // Money-tinted radial vibe — dark green core fading into the
+            // brand near-black ink. Rendered as a vertical gradient here
+            // because both consumers (firing screen, picker tile) use a
+            // CAGradientLayer; the "radial" character is sold by the stop
+            // distribution rather than `.radial` type.
+            return [
+                UIColor(themeRGB: 0x10B981).cgColor,
+                UIColor(themeRGB: 0x064E3B).cgColor,
+                UIColor(themeRGB: 0x050912).cgColor
+            ]
+        case .custom:
+            return nil
+        }
+    }
+
+    /// Stop locations that pair with `gradientColors(for:)`. Optional so
+    /// CAGradientLayer auto-distributes when the theme exposes only two
+    /// colours.
+    static func gradientLocations(for theme: AlarmTheme) -> [NSNumber]? {
+        switch theme {
+        case .dawn:
+            return [0.0, 0.4, 0.7, 1.0]
+        case .abstract:
+            return [0.0, 0.55, 1.0]
+        case .mountains, .ocean:
+            return [0.0, 1.0]
+        case .custom:
+            return nil
+        }
+    }
+
+    // MARK: - Custom-image loader
+
+    /// Resolve the user-picked photo for `.custom`. Returns nil for built-in
+    /// themes and for `.custom` whose file is no longer on disk (Caches
+    /// purge or first launch after restore).
+    static func customImage(for theme: AlarmTheme) -> UIImage? {
+        guard case .custom(let url) = theme else { return nil }
+        return AlarmThemeImageStore.loadImage(at: url)
+    }
+}
+
+// MARK: - Hex helper (file-scoped)
+
+private extension UIColor {
+    /// `0xRRGGBB` literal initializer used by the gradient stop tables above.
+    /// File-scoped so it doesn't clash with the identical helper inside
+    /// `AlarmFiringViewController`.
+    convenience init(themeRGB rgb: UInt32, alpha: CGFloat = 1) {
+        let red = CGFloat((rgb >> 16) & 0xFF) / 255.0
+        let green = CGFloat((rgb >> 8) & 0xFF) / 255.0
+        let blue = CGFloat(rgb & 0xFF) / 255.0
+        self.init(red: red, green: green, blue: blue, alpha: alpha)
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmCell.swift
@@ -17,9 +17,33 @@ final class AlarmCell: UITableViewCell {
         view.applyCardStyle()
         view.layer.shadowRadius = 8
         view.layer.shadowOffset = CGSize(width: 0, height: 2)
+        view.clipsToBounds = false
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
+
+    /// Leading 6pt vertical strip painted with the alarm's theme gradient
+    /// (or thumbnail for `.custom`) so the user can spot which theme each
+    /// row uses without opening the editor (#151). Lives inside the card
+    /// view so it inherits the card's clip + corner radius.
+    private let themeStripContainer: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.clipsToBounds = true
+        return view
+    }()
+
+    private let themeStripImageView: UIImageView = {
+        let view = UIImageView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.contentMode = .scaleAspectFill
+        view.clipsToBounds = true
+        view.layer.cornerRadius = 3
+        view.isHidden = true
+        return view
+    }()
+
+    private var themeStripGradient: CAGradientLayer?
 
     private let timeLabel: UILabel = {
         let label = UILabel()
@@ -89,10 +113,20 @@ final class AlarmCell: UITableViewCell {
         selectionStyle = .none
 
         contentView.addSubview(cardView)
+        cardView.addSubview(themeStripContainer)
+        themeStripContainer.addSubview(themeStripImageView)
         cardView.addSubview(timeLabel)
         cardView.addSubview(detailLabel)
         cardView.addSubview(penaltyLabel)
         cardView.addSubview(toggleSwitch)
+
+        // 6pt theme strip pinned to the leading edge, shifted in 6pt from the
+        // card edge so it doesn't sit flush against the rounded corner. The
+        // strip's height fills the card minus 8pt top/bottom insets so it
+        // reads as a deliberate accent rather than a clipped fill.
+        let stripLeading = AppSpacing.sm
+        let stripWidth: CGFloat = 6
+        let timeLeading = stripLeading + stripWidth + AppSpacing.md // 8 + 6 + 12 = 26
 
         NSLayoutConstraint.activate([
             // Card with horizontal and vertical insets
@@ -101,23 +135,34 @@ final class AlarmCell: UITableViewCell {
             cardView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.lg),
             cardView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -AppSpacing.sm / 2),
 
+            // Theme strip — leading edge of the card, full height minus padding.
+            themeStripContainer.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: stripLeading),
+            themeStripContainer.topAnchor.constraint(equalTo: cardView.topAnchor, constant: AppSpacing.sm),
+            themeStripContainer.bottomAnchor.constraint(equalTo: cardView.bottomAnchor, constant: -AppSpacing.sm),
+            themeStripContainer.widthAnchor.constraint(equalToConstant: stripWidth),
+
+            themeStripImageView.topAnchor.constraint(equalTo: themeStripContainer.topAnchor),
+            themeStripImageView.leadingAnchor.constraint(equalTo: themeStripContainer.leadingAnchor),
+            themeStripImageView.trailingAnchor.constraint(equalTo: themeStripContainer.trailingAnchor),
+            themeStripImageView.bottomAnchor.constraint(equalTo: themeStripContainer.bottomAnchor),
+
             // Toggle in top-right corner of card
             toggleSwitch.topAnchor.constraint(equalTo: cardView.topAnchor, constant: AppSpacing.lg),
             toggleSwitch.trailingAnchor.constraint(equalTo: cardView.trailingAnchor, constant: -AppSpacing.lg),
 
-            // Time label (large, top-left)
+            // Time label (large, top-left) — left-padded to leave room for the strip.
             timeLabel.topAnchor.constraint(equalTo: cardView.topAnchor, constant: AppSpacing.md),
-            timeLabel.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: AppSpacing.lg),
+            timeLabel.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: timeLeading),
             timeLabel.trailingAnchor.constraint(lessThanOrEqualTo: toggleSwitch.leadingAnchor, constant: -AppSpacing.sm),
 
             // Detail line: "Name - Days"
             detailLabel.topAnchor.constraint(equalTo: timeLabel.bottomAnchor, constant: AppSpacing.xs),
-            detailLabel.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: AppSpacing.lg),
+            detailLabel.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: timeLeading),
             detailLabel.trailingAnchor.constraint(lessThanOrEqualTo: cardView.trailingAnchor, constant: -AppSpacing.lg),
 
             // Penalty line at the bottom
             penaltyLabel.topAnchor.constraint(equalTo: detailLabel.bottomAnchor, constant: AppSpacing.sm),
-            penaltyLabel.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: AppSpacing.lg),
+            penaltyLabel.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: timeLeading),
             penaltyLabel.trailingAnchor.constraint(lessThanOrEqualTo: cardView.trailingAnchor, constant: -AppSpacing.lg),
             penaltyLabel.bottomAnchor.constraint(equalTo: cardView.bottomAnchor, constant: -AppSpacing.md),
         ])
@@ -128,6 +173,12 @@ final class AlarmCell: UITableViewCell {
         // The closure captures the previous row's identity — drop it so the
         // recycled cell never fires the wrong alarm before the next configure.
         onToggle = nil
+        // Reset the theme strip so the next row's gradient doesn't briefly
+        // show the previous row's colours before configure() reapplies.
+        themeStripGradient?.removeFromSuperlayer()
+        themeStripGradient = nil
+        themeStripImageView.image = nil
+        themeStripImageView.isHidden = true
     }
 
     override func layoutSubviews() {
@@ -143,16 +194,54 @@ final class AlarmCell: UITableViewCell {
         cardView.layer.borderColor = UIColor.separator.resolvedColor(
             with: traitCollection
         ).cgColor
+
+        // Round the strip and its gradient sublayer to a soft pill so it
+        // reads as an accent rather than a hard rectangle.
+        themeStripContainer.layer.cornerRadius = 3
+        themeStripGradient?.frame = themeStripContainer.bounds
     }
 
     // MARK: - Configure
 
-    func configure(time: String, detail: String, penalty: String, enabled: Bool) {
+    func configure(time: String, detail: String, penalty: String, enabled: Bool, theme: AlarmTheme) {
         timeLabel.text = time
         detailLabel.text = detail
         penaltyLabel.text = penalty
         toggleSwitch.isOn = enabled
         setEnabledAppearance(enabled)
+        applyTheme(theme)
+    }
+
+    /// Paint the leading 6pt strip with the alarm's theme. Built-in themes
+    /// install a vertical gradient layer; `.custom` swaps to the picked
+    /// thumbnail image, falling back to the Dawn gradient when the file is
+    /// gone (Caches purge).
+    private func applyTheme(_ theme: AlarmTheme) {
+        themeStripGradient?.removeFromSuperlayer()
+        themeStripGradient = nil
+        themeStripImageView.image = nil
+        themeStripImageView.isHidden = true
+
+        if case .custom(let url) = theme, let image = AlarmThemeImageStore.loadImage(at: url) {
+            themeStripImageView.image = image
+            themeStripImageView.isHidden = false
+            return
+        }
+
+        let resolvedTheme: AlarmTheme = {
+            if case .custom = theme { return .dawn }
+            return theme
+        }()
+        guard let colors = AlarmThemeRendering.gradientColors(for: resolvedTheme) else { return }
+        let gradient = CAGradientLayer()
+        gradient.colors = colors
+        gradient.locations = AlarmThemeRendering.gradientLocations(for: resolvedTheme)
+        gradient.startPoint = CGPoint(x: 0.5, y: 0.0)
+        gradient.endPoint = CGPoint(x: 0.5, y: 1.0)
+        gradient.frame = themeStripContainer.bounds
+        gradient.cornerRadius = 3
+        themeStripContainer.layer.insertSublayer(gradient, at: 0)
+        themeStripGradient = gradient
     }
 
     /// Updates the dim/full opacity of text labels to match enabled state.

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Theme.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Theme.swift
@@ -1,0 +1,65 @@
+import UIKit
+
+/// Background recipes for the alarm-firing screen, split out by theme (#151).
+///
+/// The default Dawn flow stays exactly as #138 — vertical 4-stop gradient with
+/// the warm radial glow breathing below it. Built-in themes (Mountains,
+/// Ocean, Abstract) swap the gradient stops while keeping the rest of the
+/// screen identical. `.custom(imagePath:)` replaces the gradient + glow with
+/// a full-bleed user photo plus a 45% black dim so the 96pt clock + warn
+/// snooze CTA stay legible.
+extension AlarmFiringViewController {
+
+    /// Install the background appropriate to the alarm's theme. Called once
+    /// from `setupUI`. Falls back to Dawn if `.custom`'s on-disk file is
+    /// gone (Caches purge) so the firing screen is never blank.
+    func installThemedBackground() {
+        let theme = viewModel.alarm.theme
+
+        // Always insert the gradient + glow at the bottom of the layer tree
+        // so they sit beneath any subsequently added content. The image view
+        // and its dim are added as subviews so they stack above the gradient
+        // automatically.
+        view.layer.insertSublayer(themeGradientLayer, at: 0)
+        view.layer.insertSublayer(warmGlowLayer, at: 1)
+        view.insertSubview(themeImageView, at: 0)
+        view.insertSubview(themeImageDimView, aboveSubview: themeImageView)
+
+        NSLayoutConstraint.activate([
+            themeImageView.topAnchor.constraint(equalTo: view.topAnchor),
+            themeImageView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            themeImageView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            themeImageView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            themeImageDimView.topAnchor.constraint(equalTo: view.topAnchor),
+            themeImageDimView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            themeImageDimView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            themeImageDimView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+
+        if case .custom(let url) = theme, let image = AlarmThemeImageStore.loadImage(at: url) {
+            themeImageView.image = image
+            themeImageView.isHidden = false
+            themeImageDimView.isHidden = false
+            // Hide the gradient + warm glow — the photo is the background of
+            // record and we don't want the amber halo bleeding through.
+            themeGradientLayer.isHidden = true
+            warmGlowLayer.isHidden = true
+        } else {
+            // Built-in (or .custom with missing file) → vertical gradient.
+            // Default to Dawn when the gradient lookup misses (defensive —
+            // every built-in case currently returns colours).
+            let resolved: AlarmTheme = {
+                if case .custom = theme { return .dawn }
+                return theme
+            }()
+            themeGradientLayer.colors = AlarmThemeRendering.gradientColors(for: resolved)
+                ?? AlarmThemeRendering.gradientColors(for: .dawn)
+            themeGradientLayer.locations = AlarmThemeRendering.gradientLocations(for: resolved)
+                ?? AlarmThemeRendering.gradientLocations(for: .dawn)
+            themeGradientLayer.isHidden = false
+            themeImageView.isHidden = true
+            themeImageDimView.isHidden = true
+        }
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
@@ -24,25 +24,46 @@ class AlarmFiringViewController: UIViewController {
 
     // MARK: - Background layers
 
-    /// Dawn 180° gradient sourced from `--sp-grad-dawn` in `tokens.css`:
-    /// #14122A → #0F1A2E (40%) → #0A1320 (70%) → #050912.
-    private let dawnGradientLayer: CAGradientLayer = {
+    /// Theme-driven gradient layer. For `.dawn` this matches the original
+    /// `--sp-grad-dawn` recipe (#138); other built-in themes pull their stops
+    /// from `AlarmThemeRendering`. The layer is replaced/recoloured in
+    /// `installThemedBackground` based on `viewModel.alarm.theme` (#151).
+    /// `internal` so the +Theme extension in the sibling file can configure it.
+    let themeGradientLayer: CAGradientLayer = {
         let gradient = CAGradientLayer()
-        gradient.colors = [
-            UIColor(rgb: 0x14122A).cgColor,
-            UIColor(rgb: 0x0F1A2E).cgColor,
-            UIColor(rgb: 0x0A1320).cgColor,
-            UIColor(rgb: 0x050912).cgColor
-        ]
-        gradient.locations = [0.0, 0.4, 0.7, 1.0]
         gradient.startPoint = CGPoint(x: 0.5, y: 0.0)
         gradient.endPoint = CGPoint(x: 0.5, y: 1.0)
         return gradient
     }()
 
+    /// Image view used when `viewModel.alarm.theme == .custom(_)`. Lives on
+    /// the layer tree even when not in use (hidden) so the theme swap is a
+    /// single visibility flip rather than a rebuild. `internal` so the
+    /// +Theme extension can configure it.
+    let themeImageView: UIImageView = {
+        let view = UIImageView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.contentMode = .scaleAspectFill
+        view.clipsToBounds = true
+        view.isHidden = true
+        return view
+    }()
+
+    /// Translucent dim layer drawn over `.custom` photo backgrounds so the
+    /// 96pt mono clock + warn snooze CTA keep enough contrast to remain
+    /// legible against arbitrary user-picked imagery.
+    let themeImageDimView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = UIColor.black.withAlphaComponent(0.45)
+        view.isHidden = true
+        return view
+    }()
+
     /// Warm radial glow anchored below the bottom edge — a warn500-flavoured
-    /// halo that "breathes" via a 4s opacity animation.
-    private let warmGlowLayer: CAGradientLayer = {
+    /// halo that "breathes" via a 4s opacity animation. `internal` so the
+    /// +Theme extension can hide it for `.custom` photo backgrounds.
+    let warmGlowLayer: CAGradientLayer = {
         let gradient = CAGradientLayer()
         gradient.type = .radial
         gradient.colors = [
@@ -286,8 +307,7 @@ class AlarmFiringViewController: UIViewController {
 
     private func setupUI() {
         view.backgroundColor = UIColor(rgb: 0x050912)
-        view.layer.insertSublayer(dawnGradientLayer, at: 0)
-        view.layer.insertSublayer(warmGlowLayer, at: 1)
+        installThemedBackground()
 
         // VM exposes `currentPenalty` as `Double`; wrap in `Decimal` so
         // `SPSnoozePrice.formattedRubles()` does the locale-aware format.
@@ -373,7 +393,7 @@ class AlarmFiringViewController: UIViewController {
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        dawnGradientLayer.frame = view.bounds
+        themeGradientLayer.frame = view.bounds
 
         // Glow anchored below the bottom edge — only the upper hemisphere
         // of the radial bleeds into view.

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmThemePickerViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmThemePickerViewController.swift
@@ -1,0 +1,243 @@
+import UIKit
+import PhotosUI
+
+/// Push-navigation grid picker for `AlarmTheme` (#151).
+///
+/// Layout: 2-column compositional grid, screen inset 16pt, item spacing 12pt,
+/// each tile is a 16:9 SPCard surface previewing the theme's gradient/photo
+/// with a uppercased name + checkmark when selected. The trailing tile is a
+/// `+ Своё фото` affordance that presents `PHPickerViewController`; the
+/// returned image is persisted via `AlarmThemeImageStore` and surfaced to the
+/// caller via `onSelect`.
+///
+/// The VC owns no business state — the caller passes in the current selection
+/// and provides an `onSelect` callback. Going back via the navigation chevron
+/// without picking is treated as cancel.
+final class AlarmThemePickerViewController: UIViewController {
+
+    // MARK: - Inputs
+
+    private var currentTheme: AlarmTheme
+    private let onSelect: (AlarmTheme) -> Void
+
+    /// Items rendered in the grid. Built-in themes first, custom slot last.
+    /// Resolved on init so reordering the static `AlarmTheme.builtInOrder`
+    /// list automatically reflects in the picker without further wiring.
+    private let items: [Item]
+
+    private enum Item {
+        case theme(AlarmTheme)
+        /// Trailing "+ Своё фото" tile. Distinct case so the cell can render
+        /// the placeholder iconography even when no custom image is picked.
+        case customSlot
+    }
+
+    // MARK: - UI
+
+    private var collectionView: UICollectionView!
+
+    // MARK: - Init
+
+    /// - Parameters:
+    ///   - currentTheme: Theme to surface as selected when the grid first
+    ///     appears. The caller usually pulls this from the view-model.
+    ///   - onSelect: Invoked with the chosen theme. For `.custom` this fires
+    ///     after the user has both confirmed in PHPicker AND we've persisted
+    ///     the image to disk — never on cancel.
+    init(currentTheme: AlarmTheme, onSelect: @escaping (AlarmTheme) -> Void) {
+        self.currentTheme = currentTheme
+        self.onSelect = onSelect
+        var built: [Item] = AlarmTheme.builtInOrder.map { .theme($0) }
+        built.append(.customSlot)
+        self.items = built
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Тема"
+        view.backgroundColor = AppColors.bg0
+        setupCollectionView()
+    }
+
+    // MARK: - Setup
+
+    private func setupCollectionView() {
+        let layout = makeLayout()
+        let view = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = .clear
+        view.alwaysBounceVertical = true
+        view.dataSource = self
+        view.delegate = self
+        view.register(AlarmThemeTileCell.self, forCellWithReuseIdentifier: AlarmThemeTileCell.reuseID)
+        self.view.addSubview(view)
+        NSLayoutConstraint.activate([
+            view.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
+            view.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+            view.bottomAnchor.constraint(equalTo: self.view.bottomAnchor)
+        ])
+        self.collectionView = view
+    }
+
+    /// Two-column compositional grid. Item ratio is 16:9 — width is whatever
+    /// the column resolves to, height tracks via `.fractionalWidth(9.0/16.0)`
+    /// on the group, dropped to ~`0.625` to leave room for the in-tile name
+    /// label without forcing a separate sectional header layout.
+    private func makeLayout() -> UICollectionViewLayout {
+        let item = NSCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(0.5),
+            heightDimension: .fractionalHeight(1.0)
+        ))
+        item.contentInsets = NSDirectionalEdgeInsets(
+            top: 0, leading: 0, bottom: 0, trailing: AppSpacing.sp3
+        )
+
+        // Group height = (9/16) * group-width. Group width ≈ available width
+        // after content insets; each row contains 2 items.
+        let group = NSCollectionLayoutGroup.horizontal(
+            layoutSize: NSCollectionLayoutSize(
+                widthDimension: .fractionalWidth(1.0),
+                heightDimension: .fractionalWidth(0.5 * (9.0 / 16.0) + 0.06)
+            ),
+            subitems: [item]
+        )
+        group.interItemSpacing = .fixed(0)
+
+        let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = NSDirectionalEdgeInsets(
+            top: AppSpacing.sp4,
+            leading: AppSpacing.sp4,
+            bottom: AppSpacing.sp4,
+            trailing: AppSpacing.sp4 - AppSpacing.sp3 // trailing inset already on items
+        )
+        section.interGroupSpacing = AppSpacing.sp3
+
+        return UICollectionViewCompositionalLayout(section: section)
+    }
+
+    // MARK: - Selection
+
+    /// Apply the selection and pop back. Built-in themes commit immediately;
+    /// `.custom` routes through the photo picker first.
+    private func selectItem(at indexPath: IndexPath) {
+        switch items[indexPath.item] {
+        case .theme(let theme):
+            currentTheme = theme
+            onSelect(theme)
+            navigationController?.popViewController(animated: true)
+        case .customSlot:
+            presentPhotoPicker()
+        }
+    }
+
+    private func presentPhotoPicker() {
+        var configuration = PHPickerConfiguration(photoLibrary: .shared())
+        configuration.filter = .images
+        configuration.selectionLimit = 1
+        let picker = PHPickerViewController(configuration: configuration)
+        picker.delegate = self
+        present(picker, animated: true)
+    }
+
+    // MARK: - Helpers
+
+    private func isSelected(_ item: Item) -> Bool {
+        switch (item, currentTheme) {
+        case (.theme(let lhs), let rhs):
+            return lhs.id == rhs.id && lhs.id != "custom"
+        case (.customSlot, .custom):
+            return true
+        case (.customSlot, _):
+            return false
+        }
+    }
+}
+
+// MARK: - UICollectionViewDataSource / Delegate
+
+extension AlarmThemePickerViewController: UICollectionViewDataSource, UICollectionViewDelegate {
+
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        items.count
+    }
+
+    func collectionView(
+        _ collectionView: UICollectionView,
+        cellForItemAt indexPath: IndexPath
+    ) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(
+            withReuseIdentifier: AlarmThemeTileCell.reuseID,
+            for: indexPath
+        ) as? AlarmThemeTileCell else {
+            assertionFailure("dequeue returned wrong type for AlarmThemeTileCell")
+            return UICollectionViewCell()
+        }
+        let item = items[indexPath.item]
+        switch item {
+        case .theme(let theme):
+            cell.configure(theme: theme, isCustomSlot: false, isSelected: isSelected(item), customImage: nil)
+        case .customSlot:
+            // The slot tile previews the latest custom image (if the user
+            // already picked one) so they can tell which photo is currently
+            // applied without re-entering PHPicker.
+            let image = AlarmThemeRendering.customImage(for: currentTheme)
+            cell.configure(theme: .dawn, isCustomSlot: true, isSelected: isSelected(item), customImage: image)
+        }
+        return cell
+    }
+
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        collectionView.deselectItem(at: indexPath, animated: true)
+        selectItem(at: indexPath)
+    }
+}
+
+// MARK: - PHPickerViewControllerDelegate
+
+extension AlarmThemePickerViewController: PHPickerViewControllerDelegate {
+
+    func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+        picker.dismiss(animated: true)
+        guard let result = results.first else { return }
+        let provider = result.itemProvider
+        guard provider.canLoadObject(ofClass: UIImage.self) else { return }
+        provider.loadObject(ofClass: UIImage.self) { [weak self] object, _ in
+            guard let self, let image = object as? UIImage else { return }
+            DispatchQueue.main.async {
+                guard let url = AlarmThemeImageStore.saveImage(image) else {
+                    // Keep the picker on screen — selection didn't happen.
+                    self.presentSaveFailureAlert()
+                    return
+                }
+                let theme = AlarmTheme.custom(imagePath: url)
+                self.currentTheme = theme
+                self.onSelect(theme)
+                self.navigationController?.popViewController(animated: true)
+            }
+        }
+    }
+
+    private func presentSaveFailureAlert() {
+        let alert = UIAlertController(
+            title: "Не удалось сохранить фото",
+            message: "Попробуйте выбрать другое изображение.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
+    }
+}
+
+// MARK: - Tile cell
+// `AlarmThemeTileCell` lives in its own file under
+// `ViewControllers/Alarms/Cells/` so this file stays under the SwiftLint
+// `file_length` cap. The picker is the only consumer.

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
@@ -294,7 +294,8 @@ extension AlarmsListViewController: UITableViewDataSource {
             time: viewModel.alarmTimeString(at: indexPath.row),
             detail: viewModel.alarmDetail(at: indexPath.row),
             penalty: viewModel.alarmPenaltyString(at: indexPath.row),
-            enabled: alarm.enabled
+            enabled: alarm.enabled,
+            theme: alarm.theme
         )
 
         // Capture the alarm's stable UUID rather than the row index — the

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/AlarmThemeTileCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/AlarmThemeTileCell.swift
@@ -1,0 +1,217 @@
+import UIKit
+
+/// Single grid tile rendered by `AlarmThemePickerViewController` (#151).
+///
+/// Top of the tile previews the theme (gradient layer for built-ins, photo
+/// or "+ icon" for `.custom`); the footer band carries the uppercased name
+/// and a checkmark when selected. The tile uses `SPCard(tone: .surface,
+/// padding: 0, cornerRadius: AppRadius.lg)` so it shares the design system's
+/// shadow + stroke recipe with the rest of the create-form surfaces.
+final class AlarmThemeTileCell: UICollectionViewCell {
+
+    static let reuseID = "AlarmThemeTileCell"
+
+    // MARK: - UI
+
+    private let card: SPCard = {
+        let card = SPCard(tone: .surface, padding: 0, cornerRadius: AppRadius.lg)
+        card.translatesAutoresizingMaskIntoConstraints = false
+        card.clipsToBounds = true
+        return card
+    }()
+
+    private let gradientView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.layer.masksToBounds = true
+        return view
+    }()
+
+    private let imageView: UIImageView = {
+        let view = UIImageView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.contentMode = .scaleAspectFill
+        view.clipsToBounds = true
+        view.isHidden = true
+        return view
+    }()
+
+    /// Centered "+" symbol for the empty `.custom` slot. Hidden the moment a
+    /// custom image is picked so the user gets a thumbnail preview.
+    private let plusIcon: UIImageView = {
+        let icon = UIImageView(image: UIImage(systemName: "plus")?
+            .withConfiguration(UIImage.SymbolConfiguration(pointSize: 28, weight: .semibold)))
+        icon.translatesAutoresizingMaskIntoConstraints = false
+        icon.tintColor = AppColors.fg2
+        icon.contentMode = .center
+        icon.isHidden = true
+        return icon
+    }()
+
+    private let nameLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textAlignment = .center
+        label.attributedText = nil
+        label.textColor = AppColors.fg1
+        return label
+    }()
+
+    /// `bg2` chrome at the bottom of the tile holds the name + checkmark so
+    /// the type stays legible against any underlying gradient or photo.
+    private let footerView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = AppColors.bg2.withAlphaComponent(0.92)
+        return view
+    }()
+
+    private let checkmark: UIImageView = {
+        let view = UIImageView(image: UIImage(systemName: "checkmark.circle.fill")?
+            .withConfiguration(UIImage.SymbolConfiguration(pointSize: 22, weight: .bold)))
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.tintColor = AppColors.money500
+        view.isHidden = true
+        return view
+    }()
+
+    private var gradientLayer: CAGradientLayer?
+
+    // MARK: - Init
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setup() {
+        contentView.addSubview(card)
+        card.addSubview(gradientView)
+        card.addSubview(imageView)
+        card.addSubview(plusIcon)
+        card.addSubview(footerView)
+        footerView.addSubview(nameLabel)
+        footerView.addSubview(checkmark)
+
+        NSLayoutConstraint.activate([
+            card.topAnchor.constraint(equalTo: contentView.topAnchor),
+            card.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            card.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            card.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+
+            gradientView.topAnchor.constraint(equalTo: card.topAnchor),
+            gradientView.leadingAnchor.constraint(equalTo: card.leadingAnchor),
+            gradientView.trailingAnchor.constraint(equalTo: card.trailingAnchor),
+            gradientView.bottomAnchor.constraint(equalTo: card.bottomAnchor),
+
+            imageView.topAnchor.constraint(equalTo: card.topAnchor),
+            imageView.leadingAnchor.constraint(equalTo: card.leadingAnchor),
+            imageView.trailingAnchor.constraint(equalTo: card.trailingAnchor),
+            imageView.bottomAnchor.constraint(equalTo: card.bottomAnchor),
+
+            plusIcon.centerXAnchor.constraint(equalTo: card.centerXAnchor),
+            plusIcon.centerYAnchor.constraint(equalTo: card.centerYAnchor, constant: -10),
+
+            footerView.leadingAnchor.constraint(equalTo: card.leadingAnchor),
+            footerView.trailingAnchor.constraint(equalTo: card.trailingAnchor),
+            footerView.bottomAnchor.constraint(equalTo: card.bottomAnchor),
+            footerView.heightAnchor.constraint(equalToConstant: 28),
+
+            nameLabel.centerYAnchor.constraint(equalTo: footerView.centerYAnchor),
+            nameLabel.leadingAnchor.constraint(equalTo: footerView.leadingAnchor, constant: AppSpacing.sp3),
+            nameLabel.trailingAnchor.constraint(lessThanOrEqualTo: checkmark.leadingAnchor, constant: -AppSpacing.sp2),
+
+            checkmark.centerYAnchor.constraint(equalTo: footerView.centerYAnchor),
+            checkmark.trailingAnchor.constraint(equalTo: footerView.trailingAnchor, constant: -AppSpacing.sp2),
+            checkmark.widthAnchor.constraint(equalToConstant: 24),
+            checkmark.heightAnchor.constraint(equalToConstant: 24)
+        ])
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        gradientLayer?.frame = gradientView.bounds
+    }
+
+    // MARK: - Configure
+
+    /// - Parameters:
+    ///   - theme: built-in theme to render the gradient/name from. Ignored
+    ///     for the custom slot (pass `.dawn` as a placeholder).
+    ///   - isCustomSlot: when true, render the `+` affordance plus a dimmed
+    ///     placeholder gradient. When the user has already picked a photo,
+    ///     pass `customImage` to surface the thumbnail instead.
+    ///   - isSelected: highlights the tile (money-tinted border + checkmark).
+    ///   - customImage: thumbnail for the `.custom` slot when a photo has
+    ///     been picked previously. nil → "+ Своё фото" placeholder.
+    func configure(theme: AlarmTheme, isCustomSlot: Bool, isSelected: Bool, customImage: UIImage?) {
+        // Reset prior state so recycled cells don't keep the previous tile's
+        // gradient / image.
+        gradientLayer?.removeFromSuperlayer()
+        gradientLayer = nil
+        imageView.image = nil
+        imageView.isHidden = true
+        plusIcon.isHidden = true
+
+        let displayName: String
+        if isCustomSlot {
+            displayName = AlarmTheme.custom(imagePath: URL(fileURLWithPath: "/")).displayName
+            if let image = customImage {
+                imageView.image = image
+                imageView.isHidden = false
+            } else {
+                installGradient(for: .dawn)
+                gradientView.alpha = 0.4 // dim the placeholder so "+" pops
+                plusIcon.isHidden = false
+            }
+        } else if case .custom(let url) = theme {
+            displayName = theme.displayName
+            if let image = AlarmThemeImageStore.loadImage(at: url) {
+                imageView.image = image
+                imageView.isHidden = false
+            } else {
+                installGradient(for: .dawn)
+            }
+        } else {
+            displayName = theme.displayName
+            installGradient(for: theme)
+            gradientView.alpha = 1.0
+        }
+
+        nameLabel.attributedText = NSAttributedString(
+            string: displayName.uppercased(),
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.fg1
+            ]
+        )
+
+        checkmark.isHidden = !isSelected
+        // Outline the selected tile with a money-tinted border for an extra
+        // affordance beyond the checkmark.
+        if isSelected {
+            card.layer.borderColor = AppColors.money500.cgColor
+            card.layer.borderWidth = 2
+        } else {
+            card.layer.borderWidth = 0
+        }
+    }
+
+    private func installGradient(for theme: AlarmTheme) {
+        guard let colors = AlarmThemeRendering.gradientColors(for: theme) else { return }
+        let layer = CAGradientLayer()
+        layer.colors = colors
+        layer.locations = AlarmThemeRendering.gradientLocations(for: theme)
+        layer.startPoint = CGPoint(x: 0.5, y: 0.0)
+        layer.endPoint = CGPoint(x: 0.5, y: 1.0)
+        layer.frame = gradientView.bounds
+        gradientView.layer.insertSublayer(layer, at: 0)
+        gradientLayer = layer
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
@@ -407,11 +407,7 @@ extension CreateAlarmViewController: UITableViewDelegate {
         case .volume:
             showVolumePicker()
         case .theme:
-            // The full theme picker (`AlarmThemePickerViewController`) is
-            // tracked by #151. Until it lands the row is a no-op so the form
-            // doesn't push an empty placeholder VC. The chevron + value
-            // chrome still surfaces the row's intent.
-            break
+            showThemePicker()
         case .deleteAction:
             confirmDelete()
         default:
@@ -451,6 +447,25 @@ extension CreateAlarmViewController: UITableViewDelegate {
             popover.permittedArrowDirections = []
         }
         present(alert, animated: true)
+    }
+
+    private func showThemePicker() {
+        let picker = AlarmThemePickerViewController(
+            currentTheme: viewModel.theme,
+            onSelect: { [weak self] theme in
+                guard let self else { return }
+                self.viewModel.theme = theme
+                // Update the trailing-value label inline so the user sees
+                // the new theme name without waiting for `viewWillAppear`'s
+                // section reload (which doesn't fire for the in-place update
+                // that follows the imperative pop).
+                let indexPath = IndexPath(row: 0, section: Section.theme.rawValue)
+                if let cell = self.tableView.cellForRow(at: indexPath) as? ThemeRowCell {
+                    cell.configure(themeName: self.viewModel.alarmThemeName)
+                }
+            }
+        )
+        navigationController?.pushViewController(picker, animated: true)
     }
 
     private func showSoundPicker() {

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/TopUpViewController+Restore.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/TopUpViewController+Restore.swift
@@ -1,5 +1,6 @@
 import UIKit
 import StoreKit
+import os
 
 /// Restore-purchases support split out from the main `TopUpViewController`
 /// so the host file stays under the project's file/type-body length

--- a/SnoozePay/SnoozePay/ViewModels/CreateAlarmViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/CreateAlarmViewModel.swift
@@ -23,6 +23,7 @@ final class CreateAlarmViewModel {
     var volume: Float
     /// Per-alarm "ramp from 0 → volume over 30 seconds" toggle (#150).
     var volumeFadeIn: Bool
+    var theme: AlarmTheme
 
     private let existingID: UUID?
 
@@ -54,6 +55,7 @@ final class CreateAlarmViewModel {
         self.enabled = alarm?.enabled ?? true
         self.volume = alarm?.volume ?? 1.0
         self.volumeFadeIn = alarm?.volumeFadeIn ?? false
+        self.theme = alarm?.theme ?? .dawn
     }
 
     // MARK: - Save
@@ -116,7 +118,8 @@ final class CreateAlarmViewModel {
             progressiveScale: progressiveScale,
             enabled: enabled,
             volume: volume,
-            volumeFadeIn: volumeFadeIn
+            volumeFadeIn: volumeFadeIn,
+            theme: theme
         )
     }
 
@@ -190,11 +193,10 @@ final class CreateAlarmViewModel {
         AudioServicesPlaySystemSound(systemID)
     }
 
-    // MARK: - Alarm theme (placeholder for #151)
+    // MARK: - Alarm theme (#151)
 
-    /// Display name of the alarm-firing-screen theme. The picker that lets
-    /// the user change it lands in #151 — until then we surface the default
-    /// "Рассвет" label so the row in the create/edit form renders the same
-    /// row chrome as Sound / Vibration.
-    var alarmThemeName: String { "Рассвет" }
+    /// Display name of the currently selected theme. Surfaced in the
+    /// `ThemeRowCell` trailing label and refreshed by the controller after
+    /// the picker pops back.
+    var alarmThemeName: String { theme.displayName }
 }

--- a/SnoozePay/SnoozePayTests/AlarmThemeTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmThemeTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+@testable import SnoozePay
+
+/// Coverage for `AlarmTheme` Codable + the `Alarm` migration path that lets
+/// pre-#151 alarms decode cleanly without a `theme` field. The migration is
+/// the contract that ships #151 safely on top of #143 — without it,
+/// `AlarmRepository.readAll()` would throw `decodeFailure` on every existing
+/// install and lock the entire alarm store via `_lastLoadFailed`.
+final class AlarmThemeTests: XCTestCase {
+
+    // MARK: - AlarmTheme round-trip
+
+    func testBuiltInThemesRoundTripThroughJSON() throws {
+        for theme in AlarmTheme.builtInOrder {
+            let data = try JSONEncoder().encode(theme)
+            let decoded = try JSONDecoder().decode(AlarmTheme.self, from: data)
+            XCTAssertEqual(decoded, theme, "Round-trip failed for \(theme.id)")
+        }
+    }
+
+    func testCustomThemeRoundTripPreservesPath() throws {
+        let url = URL(fileURLWithPath: "/var/mobile/Caches/AlarmThemes/IMG.jpg")
+        let theme = AlarmTheme.custom(imagePath: url)
+        let data = try JSONEncoder().encode(theme)
+        let decoded = try JSONDecoder().decode(AlarmTheme.self, from: data)
+        if case .custom(let decodedURL) = decoded {
+            XCTAssertEqual(decodedURL.absoluteString, url.absoluteString)
+        } else {
+            XCTFail("Expected .custom, got \(decoded)")
+        }
+    }
+
+    func testUnknownThemeIDDecodesAsDawn() throws {
+        let json = #"{"id":"made-up-future-theme"}"#.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(AlarmTheme.self, from: json)
+        XCTAssertEqual(decoded, .dawn)
+    }
+
+    func testCustomWithoutPathDecodesAsDawn() throws {
+        // `.custom` requires `imagePath`. A corrupt entry without the path
+        // should degrade to `.dawn` rather than throw — a missing theme
+        // must not block the entire alarm decode.
+        let json = #"{"id":"custom"}"#.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(AlarmTheme.self, from: json)
+        XCTAssertEqual(decoded, .dawn)
+    }
+
+    // MARK: - Alarm migration
+
+    func testLegacyAlarmJSONWithoutThemeDecodesWithDawnDefault() throws {
+        // Hand-rolled JSON identical to a pre-#151 stored alarm — the
+        // `theme` key is intentionally absent. Must decode to `.dawn` so
+        // `AlarmRepository.readAll()` doesn't throw `decodeFailure` on
+        // every existing install (issues #72 / #117).
+        let json = """
+        {
+            "id":"\(UUID().uuidString)",
+            "time":\(Date().timeIntervalSinceReferenceDate),
+            "repeatDays":[0,1,2],
+            "name":"Утренний",
+            "soundID":"radar",
+            "vibrationEnabled":true,
+            "snoozeMinutes":9,
+            "penaltyAmount":50.0,
+            "progressiveScale":false,
+            "enabled":true
+        }
+        """.data(using: .utf8)!
+        let alarm = try JSONDecoder().decode(Alarm.self, from: json)
+        XCTAssertEqual(alarm.theme, .dawn)
+        XCTAssertEqual(alarm.name, "Утренний")
+    }
+
+    func testNewAlarmEncodesAndDecodesWithExplicitTheme() throws {
+        let alarm = Alarm(
+            penaltyAmount: 100,
+            theme: .ocean
+        )
+        let data = try JSONEncoder().encode(alarm)
+        let decoded = try JSONDecoder().decode(Alarm.self, from: data)
+        XCTAssertEqual(decoded.theme, .ocean)
+    }
+
+    func testAlarmListDecodesMixedLegacyAndNewEntries() throws {
+        // Real-world AlarmRepository state right after the user upgrades:
+        // some alarms were saved before #151 (no `theme`), some after.
+        let legacyID = UUID()
+        let modernID = UUID()
+        let json = """
+        [
+            {
+                "id":"\(legacyID.uuidString)",
+                "time":770000000,
+                "repeatDays":[],
+                "name":"Старый",
+                "soundID":"dawn",
+                "vibrationEnabled":false,
+                "snoozeMinutes":5,
+                "penaltyAmount":25.0,
+                "progressiveScale":false,
+                "enabled":true
+            },
+            {
+                "id":"\(modernID.uuidString)",
+                "time":770003600,
+                "repeatDays":[1,2,3],
+                "name":"Новый",
+                "soundID":"radar",
+                "vibrationEnabled":true,
+                "snoozeMinutes":9,
+                "penaltyAmount":50.0,
+                "progressiveScale":true,
+                "enabled":true,
+                "theme":{"id":"abstract"}
+            }
+        ]
+        """.data(using: .utf8)!
+        let alarms = try JSONDecoder().decode([Alarm].self, from: json)
+        XCTAssertEqual(alarms.count, 2)
+        let legacy = alarms.first { $0.id == legacyID }
+        let modern = alarms.first { $0.id == modernID }
+        XCTAssertEqual(legacy?.theme, .dawn)
+        XCTAssertEqual(modern?.theme, .abstract)
+    }
+
+    // MARK: - Display
+
+    func testDisplayNamesAreLocalised() {
+        XCTAssertEqual(AlarmTheme.dawn.displayName, "Рассвет")
+        XCTAssertEqual(AlarmTheme.mountains.displayName, "Горы")
+        XCTAssertEqual(AlarmTheme.ocean.displayName, "Океан")
+        XCTAssertEqual(AlarmTheme.abstract.displayName, "Абстракция")
+        let custom = AlarmTheme.custom(imagePath: URL(fileURLWithPath: "/x.jpg"))
+        XCTAssertEqual(custom.displayName, "Своё фото")
+    }
+}


### PR DESCRIPTION
Fixes #151

## Summary

Adds the alarm theme picker promised by the #143 stub row. Users can now pick from 4 built-in themes (Dawn / Mountains / Ocean / Abstract) plus a "Своё фото" custom slot backed by `PHPickerViewController`. The selected theme drives both the alarm-card leading accent strip and the firing screen's full-bleed background — picking Ocean in the form means the firing screen fades to deep blue, picking a custom photo means the picked image fills the screen with a 45% black dim for legibility.

## What changed

- **`AlarmTheme` enum** with stable `id` strings + Russian display names. Hand-rolled `Codable` so it round-trips to flat JSON (`{"id":"ocean"}` / `{"id":"custom","imagePath":"…"}`).
- **`Alarm.theme`** field with a custom `init(from:)` that uses `decodeIfPresent` for the new key — pre-#151 stored alarms keep decoding cleanly with `.dawn` default. This is the migration that lets us ship without tripping `AlarmRepository`'s `decodeFailure` lock (issue #72 / #117).
- **`AlarmThemeImageStore`** persists user-picked photos under `Caches/AlarmThemes/<UUID>.jpg` so they survive normal launches and degrade to `.dawn` on Caches purge instead of crashing.
- **`AlarmThemePickerViewController`** — push-navigation 2-column compositional grid, 16:9 SPCard tiles with gradient/photo previews + uppercased name footer + selection checkmark. Trailing tile is the `+ Своё фото` affordance that presents `PHPickerViewController`.
- **`AlarmFiringViewController+Theme.swift`** — split-out background installer keeps the parent VC under SwiftLint's `type_body_length` cap. Dawn behaviour preserved verbatim; built-in themes swap gradient stops; `.custom` swaps the gradient + warm glow for a full-bleed photo + dim.
- **`AlarmCell`** — 6pt leading accent strip painted with the alarm's theme so the user can spot which theme each row uses without opening the editor. `.custom` shows a thumbnail.
- **`CreateAlarmViewController`** — wires the existing "Тема" stub row to push the new picker; trailing-value label refreshes inline on return.
- **`AlarmThemeTests`** covers Codable round-trip for built-in + custom themes, unknown-id fallback, the legacy-JSON migration path (no `theme` key → `.dawn`), and a mixed list of legacy + new entries.

## PM follow-ups (not in this PR)

- **`NSPhotoLibraryUsageDescription`** in `Info.plist` — `PHPickerViewController` runs out-of-process and works without the legacy permission key, but if iOS ever tightens the policy or the picker falls through to a private code path the user would see a silent crash. PM should add the key in a separate ticket. The picker degrades gracefully if PHPicker fails (no crash, just stays on the previous theme).
- **Mountains image asset** — current placeholder is a deep-blue gradient. `AlarmThemeRendering` carries a comment for the swap once design ships the real asset.

## Verify

- ✅ swiftlint: 0 errors (67 warnings, 2 fewer than base — no new categories introduced)
- ✅ build_sim: succeeded (iPhone 17 Pro)
- ⏭️ test_sim: skipped per spec (memory:test gate disabled)
- ⏭️ screenshot: skipped per spec (memory:screenshot gate disabled)

## Test plan

- [ ] Open Create Alarm → tap "Тема" → grid pushes with current theme selected
- [ ] Pick Ocean → row label updates to "Океан" → save → firing screen tints deep blue
- [ ] Pick "+ Своё фото" → PHPicker → confirm a photo → picker pops back, alarm cell shows thumbnail strip, firing screen fills with the photo
- [ ] Cancel out of PHPicker → previous theme is preserved
- [ ] Restore from a build without #151 (legacy alarms in UserDefaults) → all alarms decode, list renders Dawn strip on each, no `decodeFailure` alert