### PR TITLE
[fix] Balance hero moneyXl + weekly delta on alarms list header (#175)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
@@ -230,10 +230,16 @@ class AlarmsListViewController: UIViewController {
     /// Push the latest balance / hint / warning state into the sticky
     /// header. Called both from `onBalanceUpdated` (BalanceService
     /// notification) and `onAlarmsUpdated` (alarm-set change shifts the
-    /// average penalty).
+    /// average penalty). Also pipes the rolling weekly delta from the
+    /// transaction ledger (#175) so the sticky header echoes the
+    /// `.sp-balance__delta` row from the design spec.
     private func refreshHeader() {
         let balance = Decimal(viewModel.balance)
-        header.setBalance(balance, hint: viewModel.affordabilityHint)
+        header.setBalance(
+            balance,
+            hint: viewModel.affordabilityHint,
+            delta: viewModel.weeklyDelta
+        )
         header.setWarning(visible: viewModel.isLowBalance, balance: balance)
     }
 

--- a/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
@@ -9,6 +9,7 @@ final class AlarmsListViewModel {
 
     private let alarmRepository: AlarmRepository
     private let balanceService: BalanceService
+    private let transactionRepository: TransactionRepository
 
     // MARK: - State
 
@@ -36,10 +37,12 @@ final class AlarmsListViewModel {
 
     init(
         alarmRepository: AlarmRepository = .shared,
-        balanceService: BalanceService = .shared
+        balanceService: BalanceService = .shared,
+        transactionRepository: TransactionRepository = .shared
     ) {
         self.alarmRepository = alarmRepository
         self.balanceService = balanceService
+        self.transactionRepository = transactionRepository
 
         balanceObserver = NotificationCenter.default.addObserver(
             forName: BalanceService.balanceChangedNotification,
@@ -261,6 +264,28 @@ final class AlarmsListViewModel {
     var affordabilityHint: String {
         let count = affordableSnoozeCount
         return "Хватит на ~\(count) \(Self.snoozeWord(for: count))"
+    }
+
+    /// Weekly net delta surfaced in the sticky header beneath the balance
+    /// (#175). Charge transactions are penalty deductions stored as
+    /// positive `Double`s with `type == .charge`, so the user-facing net
+    /// change versus a week ago is `-sum(charges)`. Returns `nil` when
+    /// there are no charges in the last 7 days so the header hides the
+    /// row entirely (matches `components.css` L163-165 — `.is-up` /
+    /// `.is-down` are opt-in via `setBalance`).
+    var weeklyDelta: Decimal? {
+        // Anchor against `now - 7 days` rather than the start of an ISO
+        // week — the user reads "за неделю" as a rolling 7-day window,
+        // and an ISO-week boundary would make Monday morning's header
+        // briefly show "0 ₽" until the first charge of the new week.
+        guard let weekAgo = Calendar.current.date(byAdding: .day, value: -7, to: Date()) else {
+            return nil
+        }
+        let charges = transactionRepository.fetchCharges(since: weekAgo)
+        guard !charges.isEmpty else { return nil }
+        let totalCharged = charges.reduce(0.0) { $0 + $1.amount }
+        guard totalCharged > 0 else { return nil }
+        return -Decimal(totalCharged)
     }
 
     /// `true` when the balance is at or below the low-balance

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPAlarmsListHeader.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPAlarmsListHeader.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import UIKit
 
 /// Sticky header for the alarms list — composes a balance card and an
@@ -8,11 +9,12 @@ import UIKit
 /// Visual recipe:
 /// - **Balance card**: same SPBalanceCard chrome (`bg2` raised surface,
 ///   28pt vertical / 24pt horizontal padding, 28pt corner radius). Caps
-///   header "БАЛАНС", `moneyLg` value, a centered "Хватит на ~N
-///   откладываний" hint **below** the value, and a trailing
-///   `SPButton(.money, .sm)` "Пополнить" placed to the right of the
-///   value row. The centered hint placement is a direct fix for PM
-///   feedback (chat1.md line 971) — the previous layout put the hint
+///   header "БАЛАНС", `moneyXl` value (56pt mono — see #175), an
+///   optional weekly delta line (`↑/↓ amount за неделю`), a centered
+///   "Хватит на ~N откладываний" hint **below** the value, and a
+///   trailing `SPButton(.money, .sm)` "Пополнить" placed to the right
+///   of the value row. The centered hint placement is a direct fix for
+///   PM feedback (chat1.md line 971) — the previous layout put the hint
 ///   inline with the value and PM called it out as misaligned.
 /// - **Warning banner**: `SPCard(.warn)` shown when balance ≤ 100. Caps
 ///   "БАЛАНС ПОЧТИ ПУСТ", current balance meta, and a small
@@ -36,14 +38,24 @@ final class SPAlarmsListHeader: UIView {
     var onWarnTopUpTap: (() -> Void)?
 
     /// Update the balance card. `hint` is rendered as a centered line
-    /// below the balance number — pass `nil` to hide.
-    func setBalance(_ balance: Decimal, hint: String?) {
+    /// below the balance number — pass `nil` to hide. `delta` is the
+    /// optional weekly net change rendered between the value and hint;
+    /// positive values get the up arrow + money tint, negative the down
+    /// arrow + pain tint, `nil` or zero hides the row (per `components.css`
+    /// L163-165 — `.sp-balance__delta { is-up | is-down }`).
+    func setBalance(_ balance: Decimal, hint: String?, delta: Decimal? = nil) {
         balanceValueLabel.text = balance.formattedRubles()
         if let hint = hint, !hint.isEmpty {
             balanceHintLabel.text = hint
             balanceHintLabel.isHidden = false
         } else {
             balanceHintLabel.isHidden = true
+        }
+        if let delta = delta, delta != 0 {
+            balanceDeltaLabel.attributedText = Self.renderDelta(delta)
+            balanceDeltaLabel.isHidden = false
+        } else {
+            balanceDeltaLabel.isHidden = true
         }
         // Remask the gradient on the value once layout reflows so the
         // mask tracks the new digit width (#137 SPBalanceCard pattern).
@@ -66,6 +78,7 @@ final class SPAlarmsListHeader: UIView {
     private let balanceCapsLabel = UILabel()
     private let balanceValueLabel = UILabel()
     private let balanceValueGradient = CAGradientLayer()
+    private let balanceDeltaLabel = UILabel()
     private let balanceHintLabel = UILabel()
     private let balanceTopUpButton = SPButton(
         title: "Пополнить",
@@ -164,9 +177,16 @@ final class SPAlarmsListHeader: UIView {
         )
 
         balanceValueLabel.translatesAutoresizingMaskIntoConstraints = false
-        balanceValueLabel.font = AppTypography.moneyLg
+        // Hero balance: `moneyXl` (56pt mono bold) per `tokens.css` L168.
+        // 56pt glyphs can overflow on narrow devices when the balance grows
+        // past "999 999 ₽" alongside the trailing top-up pill, so we let
+        // UIKit shrink to 75% before clipping (matches SPBalanceCard).
+        balanceValueLabel.font = AppTypography.moneyXl
         balanceValueLabel.textColor = AppColors.fg1
         balanceValueLabel.adjustsFontForContentSizeCategory = false
+        balanceValueLabel.numberOfLines = 1
+        balanceValueLabel.adjustsFontSizeToFitWidth = true
+        balanceValueLabel.minimumScaleFactor = 0.75
         balanceValueLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
 
         balanceTopUpButton.translatesAutoresizingMaskIntoConstraints = false
@@ -189,18 +209,28 @@ final class SPAlarmsListHeader: UIView {
         balanceHintLabel.numberOfLines = 1
         balanceHintLabel.isHidden = true
 
-        // Caps + value row + centered hint — vertical stack inside the
-        // card. Custom spacing keeps the hint visually separate from the
-        // value (matches the JSX `gap-y-2` after value).
+        // Weekly delta: `moneySm` mono with arrow + tint per
+        // `components.css` L163-165. Hidden by default — `setBalance(_:hint:delta:)`
+        // flips the visibility once the controller pipes the computed
+        // delta from `AlarmsListViewModel`.
+        balanceDeltaLabel.translatesAutoresizingMaskIntoConstraints = false
+        balanceDeltaLabel.font = AppTypography.moneySm
+        balanceDeltaLabel.numberOfLines = 1
+        balanceDeltaLabel.isHidden = true
+
+        // Caps + value row + delta + centered hint — vertical stack inside
+        // the card. Custom spacing keeps the hint visually separate from
+        // the value (matches the JSX `gap-y-2` after value).
         let innerStack = UIStackView(arrangedSubviews: [
-            balanceCapsLabel, valueRow, balanceHintLabel
+            balanceCapsLabel, valueRow, balanceDeltaLabel, balanceHintLabel
         ])
         innerStack.translatesAutoresizingMaskIntoConstraints = false
         innerStack.axis = .vertical
         innerStack.alignment = .fill
         innerStack.spacing = 8
         innerStack.setCustomSpacing(8, after: balanceCapsLabel)
-        innerStack.setCustomSpacing(10, after: valueRow)
+        innerStack.setCustomSpacing(6, after: valueRow)
+        innerStack.setCustomSpacing(10, after: balanceDeltaLabel)
         balanceCard.addSubview(innerStack)
 
         NSLayoutConstraint.activate([
@@ -321,6 +351,27 @@ final class SPAlarmsListHeader: UIView {
 
     @objc private func warnTopUpTapped() {
         onWarnTopUpTap?()
+    }
+
+    // MARK: - Delta rendering
+
+    /// Build the weekly delta line. Mirrors `SPBalanceCard.renderDelta`
+    /// (#137) — kept local to the sticky header so the two surfaces stay
+    /// visually identical without a shared helper coupling these
+    /// component files together. Format: `↑ 240 ₽ за неделю` /
+    /// `↓ 130 ₽ за неделю` with U+2191 / U+2193 arrows.
+    private static func renderDelta(_ delta: Decimal) -> NSAttributedString {
+        let arrow = delta < 0 ? "\u{2193}" : "\u{2191}"
+        let absValue = NSDecimalNumber(decimal: delta < 0 ? -delta : delta).decimalValue
+        let str = "\(arrow) \(absValue.formattedRubles()) за неделю"
+        let color = delta < 0 ? AppColors.pain400 : AppColors.money400
+        return NSAttributedString(
+            string: str,
+            attributes: [
+                .font: AppTypography.moneySm,
+                .foregroundColor: color
+            ]
+        )
     }
 }
 

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPBalanceCard.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPBalanceCard.swift
@@ -115,11 +115,18 @@ final class SPBalanceCard: UIView {
         )
 
         valueLabel.translatesAutoresizingMaskIntoConstraints = false
-        valueLabel.font = AppTypography.moneyLg
+        // Hero balance uses `moneyXl` (56pt mono bold) per `tokens.css` L168
+        // — `--sp-t-money-xl: 700 56px/60px var(--sp-font-mono)`. The bigger
+        // glyphs can overflow on narrow devices for large balances
+        // ("1 234 567 ₽"), so we let UIKit shrink to 75% before clipping.
+        valueLabel.font = AppTypography.moneyXl
         // Set a neutral text colour as a safety net — `applyValueGradient`
         // promotes this to a gradient mask once layout resolves.
         valueLabel.textColor = AppColors.fg1
         valueLabel.adjustsFontForContentSizeCategory = false
+        valueLabel.numberOfLines = 1
+        valueLabel.adjustsFontSizeToFitWidth = true
+        valueLabel.minimumScaleFactor = 0.75
 
         deltaLabel.translatesAutoresizingMaskIntoConstraints = false
         deltaLabel.font = AppTypography.moneySm


### PR DESCRIPTION
Fixes #175

## Что сделано

### Fix 1 — Balance hero `moneyLg` → `moneyXl`
- `SPBalanceCard.valueLabel` and `SPAlarmsListHeader.balanceValueLabel` now use `AppTypography.moneyXl` (56pt mono bold) per `tokens.css` L168 — `--sp-t-money-xl: 700 56px/60px var(--sp-font-mono)`.
- Added `numberOfLines = 1`, `adjustsFontSizeToFitWidth = true`, `minimumScaleFactor = 0.75` on both labels so large balances ("1 234 567 ₽") shrink rather than clip on 393pt screens.

### Fix 2 — Weekly delta on the sticky `SPAlarmsListHeader`
- New `balanceDeltaLabel` between the value row and the centered hint, rendered via `setBalance(_:hint:delta:)` (delta is an optional new parameter — defaults to `nil` so existing call sites stay compatible).
- Format: `↑ 240 ₽ за неделю` / `↓ 130 ₽ за неделю` (U+2191 / U+2193 arrows), `AppColors.money400` when ≥ 0 and `AppColors.pain400` when < 0 — matches `.sp-balance__delta { is-up | is-down }` in `components.css` L163-165.
- Hidden when delta is `nil` OR exactly zero.
- `AlarmsListViewModel.weeklyDelta` reads `TransactionRepository.fetchCharges(since: now-7d)`, sums them, and returns `-totalCharged` so the user reads the line as a net change versus a week ago. Returns `nil` when the user has no charges in the last 7 days.
- `AlarmsListViewController.refreshHeader` pipes `viewModel.weeklyDelta` into the new `setBalance` parameter.

## Verify
- swiftlint: 0 errors, 0 violations on the four touched files.
- build_sim (iPhone 16 Pro, iOS 18): succeeded.
- screenshot: skipped — UI gate disabled per project memory; PM verifies visually.