### PR TITLE
[fix] Two-stop light shadow + raised SPCard hairline (#176)

### DIFF
--- a/SnoozePay/SnoozePay/Utilities/AppShadow.swift
+++ b/SnoozePay/SnoozePay/Utilities/AppShadow.swift
@@ -3,19 +3,35 @@ import UIKit
 /// Shadow recipes from `tokens.css` (`--sp-shadow-1` / `--sp-shadow-2`). The
 /// dark variant is a single drop shadow; the light variant is a two-stop
 /// drop shadow (`0 1px 3px / 0 4px 14px rgba(8,14,30,.06)`) that fakes the
-/// ambient + key light a flat single shadow can't reproduce. CALayer renders
-/// one stop natively, so we use the wider stop for visibility on light
-/// surfaces. Apply via `apply(to: layer)` from `traitCollectionDidChange`
-/// so the shadow re-resolves on theme switch.
+/// ambient + key light a flat single shadow can't reproduce.
+///
+/// CALayer can render only one shadow natively, so the wider key stop is
+/// installed on the host layer via `apply(to:)` and the narrower ambient stop
+/// is rendered through a dedicated sibling sublayer inserted at index 0 by
+/// ``installAmbientShadow1Layer(on:cornerRadius:trait:)``. The sublayer is a
+/// `CAShapeLayer` clipped to a clear path so only its shadow is visible.
+///
+/// Apply via `apply(to: layer)` from `traitCollectionDidChange` so the shadow
+/// re-resolves on theme switch, and call
+/// ``installAmbientShadow1Layer(on:cornerRadius:trait:)`` from both
+/// `traitCollectionDidChange` (to install/remove on theme flip) and
+/// `layoutSubviews` (so the ambient layer's frame stays in sync with the host).
 struct AppShadow {
     let color: UIColor
     let opacity: Float
     let offset: CGSize
     let radius: CGFloat
 
-    /// Default card shadow. Dark `0 2px 8px rgba(0,0,0,.35)`. Light is the
-    /// dominant stop of `0 1px 3px / 0 4px 14px rgba(8,14,30,.06)` — we use
-    /// the wider 14pt radius for legibility on near-white surfaces.
+    /// Sublayer name used to identify the ambient (narrow) shadow stop layer.
+    /// Stored as a constant so callers can never spell it differently.
+    static let ambientShadow1LayerName = "AppShadow.ambientShadow1"
+
+    /// Default card shadow — the wider/key stop only. Dark
+    /// `0 2px 8px rgba(0,0,0,.35)`. Light is the dominant stop of
+    /// `0 1px 3px / 0 4px 14px rgba(8,14,30,.06)` — we use the wider 14pt
+    /// radius for legibility on near-white surfaces. Pair with
+    /// ``installAmbientShadow1Layer(on:cornerRadius:trait:)`` to render the
+    /// narrower ambient stop on light-mode surfaces.
     static func shadow1(for trait: UITraitCollection) -> AppShadow {
         if trait.userInterfaceStyle == .light {
             return AppShadow(
@@ -60,5 +76,69 @@ struct AppShadow {
         layer.shadowOpacity = opacity
         layer.shadowOffset = offset
         layer.shadowRadius = radius
+    }
+
+    /// Install / refresh / remove the narrow ambient stop of `shadow1` on a
+    /// host layer.
+    ///
+    /// The two-stop spec is `0 1px 3px / 0 4px 14px rgba(8,14,30,.06)`. The
+    /// wider stop is rendered by `shadow1(for:).apply(to: layer)` directly on
+    /// the host layer; this method maintains a sibling `CAShapeLayer` named
+    /// ``ambientShadow1LayerName`` inserted at sublayer index 0 to render the
+    /// narrower `0 1px 3px` ambient stop. The ambient layer fills with
+    /// `clear` and uses its own shadow chain so the visible card surface
+    /// (drawn by the host's `backgroundColor` / `borderColor` on the host
+    /// layer itself) is unaffected.
+    ///
+    /// Dark mode collapses back to a single stop, so this method removes the
+    /// ambient layer if `trait.userInterfaceStyle == .dark`.
+    ///
+    /// Call from both `layoutSubviews` (so `frame` and `shadowPath` track
+    /// host bounds) and `traitCollectionDidChange` (so the layer is added or
+    /// removed when the user flips theme).
+    static func installAmbientShadow1Layer(
+        on hostLayer: CALayer,
+        cornerRadius: CGFloat,
+        trait: UITraitCollection
+    ) {
+        let isLight = trait.userInterfaceStyle != .dark
+        let existing = hostLayer.sublayers?.first { $0.name == ambientShadow1LayerName } as? CAShapeLayer
+
+        guard isLight else {
+            // Dark mode uses the single deep stop only — drop the ambient
+            // sublayer so we don't carry stale state across a theme flip.
+            existing?.removeFromSuperlayer()
+            return
+        }
+
+        let ambient: CAShapeLayer
+        if let layer = existing {
+            ambient = layer
+        } else {
+            let layer = CAShapeLayer()
+            layer.name = ambientShadow1LayerName
+            // Insert at index 0 so it sits behind any gradient/content
+            // sublayers a card might own. The ambient layer renders only
+            // its shadow (fill is clear), so z-order doesn't bleed visible
+            // pixels onto the card surface.
+            hostLayer.insertSublayer(layer, at: 0)
+            ambient = layer
+        }
+
+        ambient.frame = hostLayer.bounds
+        let path = UIBezierPath(roundedRect: hostLayer.bounds, cornerRadius: cornerRadius).cgPath
+        ambient.path = path
+        ambient.fillColor = UIColor.clear.cgColor
+        // Narrow ambient stop: `0 1px 3px rgba(8,14,30,.06)`.
+        ambient.shadowColor = UIColor(
+            red: 8.0 / 255.0, green: 14.0 / 255.0, blue: 30.0 / 255.0, alpha: 1.0
+        ).cgColor
+        ambient.shadowOpacity = 0.06
+        ambient.shadowOffset = CGSize(width: 0, height: 1)
+        ambient.shadowRadius = 3
+        // Pre-rasterise the ambient shadow against the rounded path for the
+        // same offscreen-pass reasons as the wider stop.
+        ambient.shadowPath = path
+        ambient.masksToBounds = false
     }
 }

--- a/SnoozePay/SnoozePay/Utilities/UIView+CardStyle.swift
+++ b/SnoozePay/SnoozePay/Utilities/UIView+CardStyle.swift
@@ -23,11 +23,17 @@ extension UIView {
         layer.cornerRadius = cornerRadius
         layer.masksToBounds = false
         // Brand `shadow1` is theme-aware: dark mode gets a single deep stop
-        // (`rgba(0,0,0,.35)`); light mode gets a wider, softer stop pulled
-        // from the two-stop `0 1px 3px / 0 4px 14px` recipe in `tokens.css`
-        // so cards lift cleanly off the near-white surface instead of
-        // reading as a flat slab.
+        // (`rgba(0,0,0,.35)`); light mode gets a two-stop recipe — the wider
+        // `0 4px 14px` stop renders here on `view.layer`, and the narrower
+        // `0 1px 3px` ambient stop is added as a sibling sublayer by
+        // `updateCardShadowPath` so cards lift cleanly off the near-white
+        // surface instead of reading as a flat slab.
         AppShadow.shadow1(for: traitCollection).apply(to: layer)
+        AppShadow.installAmbientShadow1Layer(
+            on: layer,
+            cornerRadius: cornerRadius,
+            trait: traitCollection
+        )
         // Hairline border reinforces the edge — `stroke1` is theme-aware
         // (8% white on dark, 8% near-black ink on light), so the border has
         // visible weight in light mode where the system's grey separator
@@ -50,6 +56,15 @@ extension UIView {
         // colours, opacities, offsets and radii (single-stop deep shadow vs
         // wider soft shadow), so it isn't enough to just refresh `cgColor`.
         AppShadow.shadow1(for: traitCollection).apply(to: layer)
+        // Light mode adds a second narrow ambient stop via a sibling
+        // sublayer; dark mode removes it. Pass through the host's current
+        // corner radius so the ambient shadow path matches the visible
+        // rounded shape.
+        AppShadow.installAmbientShadow1Layer(
+            on: layer,
+            cornerRadius: layer.cornerRadius,
+            trait: traitCollection
+        )
     }
 
     /// Pre-rasterise the shadow against the rounded card frame so scrolling
@@ -60,6 +75,16 @@ extension UIView {
             roundedRect: bounds,
             cornerRadius: cornerRadius
         ).cgPath
+        // The two-stop `shadow1` recipe in light mode owns a sibling
+        // ambient layer that needs its frame + path resized whenever the
+        // host's bounds change. `installAmbientShadow1Layer` is idempotent
+        // and short-circuits on dark mode, so we can safely fan it out
+        // from every layoutSubviews-driven update path.
+        AppShadow.installAmbientShadow1Layer(
+            on: layer,
+            cornerRadius: cornerRadius,
+            trait: traitCollection
+        )
     }
 }
 

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPCard.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPCard.swift
@@ -84,6 +84,16 @@ final class SPCard: UIView {
                 cornerRadius: cardCornerRadius
             ).cgPath
         }
+        // Surface tone uses the two-stop `shadow1` recipe in light mode; the
+        // narrow ambient stop lives on a sibling sublayer that needs its
+        // frame + path resized whenever the host's bounds change.
+        if tone == .surface {
+            AppShadow.installAmbientShadow1Layer(
+                on: layer,
+                cornerRadius: cardCornerRadius,
+                trait: traitCollection
+            )
+        }
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -127,8 +137,14 @@ final class SPCard: UIView {
             applyShadow1()
         case .raised:
             backgroundColor = AppColors.bg2
-            // No hairline on `.raised` — bg2 has enough contrast against bg0
-            // that a stroke would read as a double-edge in dark mode.
+            // Light mode: bg2 (#ECEEF6) vs bg0 (#F4F6FB) is only ~5%
+            // luminance — the card visually merges with the page without a
+            // stroke. Memory `feedback_design_system_consistency.md`
+            // requires "shadow + border" on light cards, so add a hairline
+            // there. Dark mode keeps the stroke off — bg2 already has
+            // enough contrast against bg0 and a border would read as a
+            // double-edge.
+            applyRaisedHairlineIfLight()
             applyShadow2()
         case .outline:
             backgroundColor = .clear
@@ -170,7 +186,28 @@ final class SPCard: UIView {
     }
 
     private func applyShadow1() {
+        // Wider/key stop on the host layer; the narrow ambient stop is
+        // installed as a sibling sublayer in `layoutSubviews` (ambient layer
+        // also needs its frame to track host bounds, so layout is the
+        // canonical owner). `installAmbientShadow1Layer` is also called here
+        // so a theme flip immediately removes/re-adds the ambient sublayer
+        // without waiting for the next layout pass.
         AppShadow.shadow1(for: traitCollection).apply(to: layer)
+        AppShadow.installAmbientShadow1Layer(
+            on: layer,
+            cornerRadius: cardCornerRadius,
+            trait: traitCollection
+        )
+    }
+
+    private func applyRaisedHairlineIfLight() {
+        guard traitCollection.userInterfaceStyle != .dark else {
+            layer.borderWidth = 0
+            return
+        }
+        let scale = traitCollection.displayScale > 0 ? traitCollection.displayScale : 1
+        layer.borderWidth = 1.0 / scale
+        layer.borderColor = AppColors.stroke1.resolvedColor(with: traitCollection).cgColor
     }
 
     private func applyShadow2() {
@@ -214,6 +251,7 @@ final class SPCard: UIView {
             applyHairlineStroke()
             applyShadow1()
         case .raised:
+            applyRaisedHairlineIfLight()
             applyShadow2()
         case .outline:
             applyOutlineStroke()


### PR DESCRIPTION
Fixes #176

## Что сделано

### Fix 1 — Two-stop `shadow1` in light mode
`tokens.css --sp-shadow-1` спекает paired ambient (`0 1px 3px`) + key (`0 4px 14px rgba(8,14,30,.06)`), но `CALayer` рендерит только один stop, поэтому раньше использовался только wide stop. Светлые карточки получались «плоскими».

- `AppShadow.installAmbientShadow1Layer(on:cornerRadius:trait:)` — новый helper, вставляет `CAShapeLayer` в sublayer-index 0 c clear-fill + узким ambient shadow. Dark mode безопасно убирает sublayer.
- `SPCard` (`.surface` tone), `CardView`, `UIView.applyCardStyle()` (`updateCardShadowPath` / `refreshCardBorderForTraitChange`) — все вызывают helper в `layoutSubviews` (frame/path следуют за bounds) и при трейт-смене (мгновенный install/remove на light↔dark).
- Wide/key stop по-прежнему рендерится через `shadow1(for:).apply(to: layer)` на хост-слое.

### Fix 2 — `.raised` SPCard light hairline
`bg2 #ECEEF6` vs `bg0 #F4F6FB` = ~5% luminance в light → без stroke карточка сливается с фоном. Memory `feedback_design_system_consistency` требует `shadow + border` для light карточек.

- `SPCard.applyRaisedHairlineIfLight()` — ставит `1.0 / displayScale` border со `stroke1` только когда `userInterfaceStyle != .dark`. Dark — `borderWidth = 0`.
- Вызывается в `applyTone()` и в `refreshDynamicColors()`, чтобы трейт-смена корректно сбрасывала/добавляла hairline.

## Constraints
Тронуто только: `AppShadow.swift`, `SPCard.swift`, `UIView+CardStyle.swift`. Никаких изменений в Info.plist / project.pbxproj / зависимостях. Out-of-scope: `AlarmCell` имеет свой `layoutSubviews`/`shadowPath` (custom 8pt radius / 2pt offset) — не покрыт #176; ambient layer в `styleAsCardRow` не добавлен (там нет layout-hook на backgroundView).

## Verify
- swiftlint: 0 errors (все warnings — pre-existing в тестах / `traitCollectionDidChange` deprecated по #180)
- build_sim (iPhone 17 Pro, scheme SnoozePay): succeeded

## Acceptance
- Light SPCard.surface: видны узкий + широкий shadow stops
- Light SPCard.raised: hairline 1pt stroke1 + shadow2
- Dark SPCard: без регрессии (ambient sublayer удаляется, raised без border)