### PR TITLE
[fix] Remove DEBUG top-up button from AlarmFiringViewController (#173)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
@@ -274,10 +274,6 @@ class AlarmFiringViewController: UIViewController {
         // Initial transition may have happened synchronously inside
         // `startAlarmSound` before our observer is wired — sync now.
         applyAudioState(AudioService.shared.state)
-
-        #if DEBUG
-        installDebugTopUpButton()
-        #endif
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -521,43 +517,6 @@ class AlarmFiringViewController: UIViewController {
         let sheet = FiringTopUpBottomSheetViewController()
         present(sheet, animated: true)
     }
-
-    #if DEBUG
-    /// Debug-only floating button for manually triggering the top-up sheet
-    /// during development. Wired in `viewDidLoad` behind `#if DEBUG`. Removed
-    /// once #140 hooks the trigger to the real "balance < snooze price" UX.
-    private lazy var debugTopUpButton: UIButton = {
-        var config = UIButton.Configuration.filled()
-        config.title = "DEBUG: Top-up"
-        config.baseBackgroundColor = UIColor.systemPurple.withAlphaComponent(0.6)
-        config.baseForegroundColor = .white
-        config.cornerStyle = .capsule
-        let button = UIButton(configuration: config)
-        button.translatesAutoresizingMaskIntoConstraints = false
-        button.addTarget(self, action: #selector(debugTopUpTapped), for: .touchUpInside)
-        return button
-    }()
-
-    @objc private func debugTopUpTapped() {
-        presentTopUpSheet()
-    }
-
-    /// Installs the debug top-up button. Called from `viewDidLoad` only in
-    /// DEBUG builds so the production binary never carries the affordance.
-    private func installDebugTopUpButton() {
-        view.addSubview(debugTopUpButton)
-        NSLayoutConstraint.activate([
-            debugTopUpButton.topAnchor.constraint(
-                equalTo: view.safeAreaLayoutGuide.topAnchor,
-                constant: 8
-            ),
-            debugTopUpButton.trailingAnchor.constraint(
-                equalTo: view.trailingAnchor,
-                constant: -16
-            )
-        ])
-    }
-    #endif
 
     private func presentSnoozeScheduleFailureAlert(
         error: AlarmScheduler.SchedulingError


### PR DESCRIPTION
Fixes #173

## What
Removed the leaked DEBUG floating top-up button from `AlarmFiringViewController.swift`:
- `debugTopUpButton` lazy var
- `debugTopUpTapped()` selector
- `installDebugTopUpButton()` method
- Its `#if DEBUG` call site in `viewDidLoad`

## Why
The button was scaffolding for #140 (balance < snooze price UX). #140 shipped its real Apple Pay 500 ₽ CTA via `AlarmFiringViewController+NoBalance`, but the DEBUG affordance was never removed. It rendered in every DEBUG build (including QA/TestFlight DEBUG) on top of the Dawn gradient and clashed visually with the PM-approved CTA.

## Scope guard
- Touched ONLY `AlarmFiringViewController.swift`
- `+NoBalance` extension untouched (real CTA still works)
- Audio banner hex (line 207) untouched (#179 territory)
- `presentTopUpSheet()` kept — it is still called from `+NoBalance`

## Verify
- swiftlint: 0 serious (3 pre-existing length warnings, file got shorter not longer)
- build_sim (iPhone 17 Pro, scheme SnoozePay): succeeded
- grep `debugTopUp` / `installDebugTopUp` across repo: 0 hits