### PR TITLE
[fix] Brand-tint SnoozeSliderCell + audio-warning banner (#179)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
@@ -200,11 +200,11 @@ class AlarmFiringViewController: UIViewController {
     /// `internal` so the AudioState extension in the sibling file can update it.
     let audioWarningBanner: UILabel = {
         let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 13, weight: .medium)
+        label.font = AppTypography.meta
         label.textColor = .white
         label.textAlignment = .center
         label.numberOfLines = 0
-        label.backgroundColor = UIColor(red: 0.86, green: 0.27, blue: 0.27, alpha: 0.85)
+        label.backgroundColor = AppColors.pain500.withAlphaComponent(0.85)
         label.layer.cornerRadius = 10
         label.layer.masksToBounds = true
         label.translatesAutoresizingMaskIntoConstraints = false

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/SnoozeSliderCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/SnoozeSliderCell.swift
@@ -21,6 +21,11 @@ final class SnoozeSliderCell: UITableViewCell {
         let view = UISlider()
         view.minimumValue = Float(SnoozeSliderCell.minMinutes)
         view.maximumValue = Float(SnoozeSliderCell.maxMinutes)
+        // Brand-tint the track to match the volume slider on the same screen
+        // (#179) — the system blue clashes with the SP money palette.
+        view.minimumTrackTintColor = AppColors.money500
+        view.setThumbImage(SnoozeSliderCell.makeThumb(diameter: 28), for: .normal)
+        view.setThumbImage(SnoozeSliderCell.makeThumb(diameter: 30), for: .highlighted)
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
@@ -102,5 +107,33 @@ final class SnoozeSliderCell: UITableViewCell {
         slider.value = Float(clamped)
         valueLabel.text = "\(clamped) мин"
         onValueChanged?(clamped)
+    }
+
+    // MARK: - Thumb image
+
+    /// Render a money-tinted circle into a UIImage for use as the slider
+    /// thumb. Sizing the thumb via `setThumbImage` is the only supported
+    /// path on `UISlider` — there's no `thumbDiameter` knob. Mirrors the
+    /// recipe in `VolumePickerViewController` so the two sliders that sit
+    /// on the CreateAlarm screen render with visual parity (#179).
+    private static func makeThumb(diameter: CGFloat) -> UIImage {
+        let size = CGSize(width: diameter, height: diameter)
+        let renderer = UIGraphicsImageRenderer(size: size)
+        return renderer.image { context in
+            let rect = CGRect(origin: .zero, size: size).insetBy(dx: 1, dy: 1)
+            // Soft ring shadow so the thumb lifts off the track in light mode.
+            context.cgContext.setShadow(
+                offset: CGSize(width: 0, height: 1),
+                blur: 2,
+                color: UIColor.black.withAlphaComponent(0.25).cgColor
+            )
+            AppColors.money500.setFill()
+            UIBezierPath(ovalIn: rect).fill()
+            // White inner dot so the thumb reads on dark + light alike.
+            context.cgContext.setShadow(offset: .zero, blur: 0, color: nil)
+            UIColor.white.withAlphaComponent(0.35).setFill()
+            let inner = rect.insetBy(dx: rect.width * 0.32, dy: rect.height * 0.32)
+            UIBezierPath(ovalIn: inner).fill()
+        }
     }
 }


### PR DESCRIPTION
Fixes #179

## What changed
- **SnoozeSliderCell**: minimum-track tint switched to `AppColors.money500` and the thumb is rendered via a private static `makeThumb(diameter:)` (28pt normal / 30pt highlighted). Mirrors the recipe in `VolumePickerViewController` so the two sliders on the CreateAlarm screen render with visual parity instead of one defaulting to system blue.
- **AlarmFiringViewController.audioWarningBanner**: replaced the hardcoded `UIColor(red: 0.86, green: 0.27, blue: 0.27, alpha: 0.85)` (#DC4545) with `AppColors.pain500.withAlphaComponent(0.85)` (tokens.css `--sp-pain-500: #F4523F`), and swapped the raw 13pt system font for `AppTypography.meta`.

Helper duplicated rather than extracted because there is no existing shared utility and only two call sites — keeping the helper local avoids churning a third file.

## Verify
- swiftlint: 0 errors on the two touched files (3 pre-existing warnings about file/type/function length on `AlarmFiringViewController.swift`, untouched by this PR)
- build_sim: succeeded (simulator: iPhone 17 Pro)
- Touched files only: `SnoozeSliderCell.swift`, `AlarmFiringViewController.swift`. No DEBUG-button reintroduction. `+NoBalance` / `+Audio` extensions untouched (banner literally lives in the main VC; grep for `0.86, green: 0.27` returned exactly one hit there).