### PR TITLE
[refactor] Split oversized files to satisfy file_length (#182)

### DIFF
--- a/SnoozePay/SnoozePay/Services/AudioService+Tone.swift
+++ b/SnoozePay/SnoozePay/Services/AudioService+Tone.swift
@@ -1,0 +1,106 @@
+import AVFoundation
+import Foundation
+
+// MARK: - Synthetic alarm tone generation
+//
+// Extracted from `AudioService.swift` (#182) so the host file stays under
+// SwiftLint's `file_length` cap. The tone generator is the in-memory
+// fallback played when the bundled alarm file is missing or AVAudioPlayer
+// rejects it. Behaviour is verbatim — only the physical location moved.
+
+extension AudioService {
+
+    /// Generate a 440 Hz sine wave alarm tone as in-memory WAV data.
+    /// Returns an AVAudioPlayer ready to loop, or nil on failure.
+    static func generateAlarmTone() -> AVAudioPlayer? {
+        let sampleRate: Double = 44100
+        let duration: Double = 1.5 // seconds per loop cycle
+        let frequency: Double = 880 // A5 — prominent alarm frequency
+        let totalSamples = Int(sampleRate * duration)
+
+        let samples = renderToneSamples(
+            totalSamples: totalSamples,
+            sampleRate: sampleRate,
+            frequency: frequency
+        )
+
+        let wavData = packWAV(samples: samples, totalSamples: totalSamples)
+        return try? AVAudioPlayer(data: wavData)
+    }
+
+    /// Build interleaved 16-bit PCM samples with the dual-tone amplitude
+    /// envelope (880 Hz + 660 Hz, short fade-in/out, 0.3s-on/0.2s-off pulse).
+    private static func renderToneSamples(
+        totalSamples: Int,
+        sampleRate: Double,
+        frequency: Double
+    ) -> [Int16] {
+        var samples = [Int16]()
+        samples.reserveCapacity(totalSamples)
+
+        for sampleIndex in 0..<totalSamples {
+            let timeSeconds = Double(sampleIndex) / sampleRate
+            // Dual-tone: 880 Hz + 660 Hz for recognizable alarm character
+            let wave = sin(2.0 * .pi * frequency * timeSeconds)
+                + 0.6 * sin(2.0 * .pi * 660.0 * timeSeconds)
+            // Amplitude envelope: short fade-in/out to avoid click
+            let envelope: Double
+            let fadeFrames = Int(sampleRate * 0.02)
+            if sampleIndex < fadeFrames {
+                envelope = Double(sampleIndex) / Double(fadeFrames)
+            } else if sampleIndex > totalSamples - fadeFrames {
+                envelope = Double(totalSamples - sampleIndex) / Double(fadeFrames)
+            } else {
+                // Pulse pattern: 0.3s on, 0.2s off
+                let cyclePos = timeSeconds.truncatingRemainder(dividingBy: 0.5)
+                envelope = cyclePos < 0.3 ? 1.0 : 0.0
+            }
+            let amplitude = wave * envelope * 0.7
+            let sample = Int16(clamping: Int(amplitude * Double(Int16.max)))
+            samples.append(sample)
+        }
+        return samples
+    }
+
+    /// Wrap the rendered PCM samples in a minimal RIFF/WAVE container so
+    /// `AVAudioPlayer(data:)` accepts the in-memory blob.
+    private static func packWAV(samples: [Int16], totalSamples: Int) -> Data {
+        let dataSize = totalSamples * 2 // 16-bit = 2 bytes per sample
+        var wavData = Data()
+        wavData.append(contentsOf: [0x52, 0x49, 0x46, 0x46]) // "RIFF"
+        wavData.append(contentsOf: UInt32(36 + dataSize).littleEndianBytes)
+        wavData.append(contentsOf: [0x57, 0x41, 0x56, 0x45]) // "WAVE"
+        wavData.append(contentsOf: [0x66, 0x6D, 0x74, 0x20]) // "fmt "
+        wavData.append(contentsOf: UInt32(16).littleEndianBytes)           // chunk size
+        wavData.append(contentsOf: UInt16(1).littleEndianBytes)            // PCM format
+        wavData.append(contentsOf: UInt16(1).littleEndianBytes)            // mono
+        wavData.append(contentsOf: UInt32(44100).littleEndianBytes)        // sample rate
+        wavData.append(contentsOf: UInt32(44100 * 2).littleEndianBytes)    // byte rate
+        wavData.append(contentsOf: UInt16(2).littleEndianBytes)            // block align
+        wavData.append(contentsOf: UInt16(16).littleEndianBytes)           // bits per sample
+        wavData.append(contentsOf: [0x64, 0x61, 0x74, 0x61]) // "data"
+        wavData.append(contentsOf: UInt32(dataSize).littleEndianBytes)
+
+        samples.withUnsafeBytes { rawBuffer in
+            wavData.append(contentsOf: rawBuffer)
+        }
+        return wavData
+    }
+}
+
+// MARK: - Binary helpers
+
+private extension UInt32 {
+    var littleEndianBytes: [UInt8] {
+        let value = self.littleEndian
+        return [UInt8(value & 0xFF), UInt8((value >> 8) & 0xFF),
+                UInt8((value >> 16) & 0xFF), UInt8((value >> 24) & 0xFF)]
+    }
+}
+
+private extension UInt16 {
+    var littleEndianBytes: [UInt8] {
+        let value = self.littleEndian
+        return [UInt8(value & 0xFF), UInt8((value >> 8) & 0xFF)]
+    }
+}

--- a/SnoozePay/SnoozePay/Services/AudioService.swift
+++ b/SnoozePay/SnoozePay/Services/AudioService.swift
@@ -128,28 +128,7 @@ final class AudioService {
         // `.vibrationOnly` and `.silentBecauseConfigFailed` so we don't try to
         // restart on top of a partial fallback either.
         guard state == .stopped else {
-            // We're already playing — but the *caller* may be a new alarm taking
-            // over (stacking-replace path #116). Update ownership so the previous
-            // VC's `viewDidDisappear` correctly recognises the session no longer
-            // belongs to it and skips `stopAlarmSound()`.
-            if let alarmID {
-                let previous = currentAlarmID
-                currentAlarmID = alarmID
-                let prevDesc = String(describing: previous)
-                let stateDesc = String(describing: self.state)
-                AppLogger.audio.notice(
-                    "ownership transfer \(prevDesc, privacy: .private) → \(alarmID, privacy: .private), state=\(stateDesc, privacy: .public)"
-                )
-            } else {
-                // No alarmID provided while audio is already playing means the
-                // existing owner is preserved. Log so a regression where a new
-                // call site forgets to pass alarmID is diagnosable in Console.
-                let stateDesc = String(describing: self.state)
-                let ownerDesc = String(describing: self.currentAlarmID)
-                AppLogger.audio.error(
-                    "missing alarmID while state=\(stateDesc, privacy: .public) — ownership NOT transferred, owner=\(ownerDesc, privacy: .private)"
-                )
-            }
+            handleStartWhileNonStopped(alarmID: alarmID)
             return
         }
 
@@ -165,32 +144,7 @@ final class AudioService {
             return
         }
 
-        // Try to find the sound file in the bundle
-        let url: URL? = Bundle.main.url(forResource: soundID, withExtension: "caf")
-            ?? Bundle.main.url(forResource: soundID, withExtension: "m4a")
-            ?? Bundle.main.url(forResource: soundID, withExtension: "wav")
-            ?? Bundle.main.url(forResource: soundID, withExtension: "mp3")
-            ?? Bundle.main.url(forResource: "default_alarm", withExtension: "caf")
-            ?? Bundle.main.url(forResource: "default_alarm", withExtension: "m4a")
-
-        // Try the bundled file first; fall back to synthetic tone if the file
-        // is missing or AVAudioPlayer rejects it (corrupt / format mismatch).
-        var player: AVAudioPlayer?
-        if let soundURL = url {
-            do {
-                player = try AVAudioPlayer(contentsOf: soundURL)
-            } catch {
-                let name = soundURL.lastPathComponent
-                let desc = error.localizedDescription
-                AppLogger.audio.error(
-                    "AVAudioPlayer init failed for \(name, privacy: .public): \(desc, privacy: .public)"
-                )
-                player = nil
-            }
-        }
-        if player == nil {
-            player = Self.generateAlarmTone()
-        }
+        let player = resolveAlarmPlayer(soundID: soundID)
 
         guard let player else {
             // Neither bundled file nor synthetic tone available — refuse to claim
@@ -203,21 +157,7 @@ final class AudioService {
         }
 
         audioPlayer = player
-        player.numberOfLoops = -1
-        // Honour the per-alarm volume (#150). Clamp defensively even though
-        // the call sites + Alarm initializer already do so — a corrupt
-        // payload should still produce a playable alarm rather than crash
-        // here.
-        let clampedVolume = min(max(volume.isFinite ? volume : 1.0, 0), 1)
-        if fadeIn {
-            // Start at 0 and ramp up so the user is woken gently. AVAudio
-            // schedules the ramp on the audio thread and survives screen
-            // lock — no Timer needed.
-            player.volume = 0
-            player.setVolume(clampedVolume, fadeDuration: Self.fadeInDuration)
-        } else {
-            player.volume = clampedVolume
-        }
+        configurePlayerVolume(player, target: volume, fadeIn: fadeIn)
 
         // prepareToPlay returns Bool but does not throw; play() does not throw
         // either, but its return value indicates whether the queue accepted the
@@ -240,6 +180,81 @@ final class AudioService {
         currentAlarmID = alarmID
         state = .playing
         startVibration()
+    }
+
+    /// Handle an `.startAlarmSound` call while the service is already in a
+    /// non-stopped state. Either transfers ownership to the new caller's
+    /// `alarmID` (stacking-replace path #116) or logs a regression when no
+    /// `alarmID` was passed. Pulled out of `startAlarmSound` so its body
+    /// stays under SwiftLint's `function_body_length` cap (#182).
+    private func handleStartWhileNonStopped(alarmID: UUID?) {
+        // We're already playing — but the *caller* may be a new alarm taking
+        // over (stacking-replace path #116). Update ownership so the previous
+        // VC's `viewDidDisappear` correctly recognises the session no longer
+        // belongs to it and skips `stopAlarmSound()`.
+        if let alarmID {
+            let previous = currentAlarmID
+            currentAlarmID = alarmID
+            let prevDesc = String(describing: previous)
+            let stateDesc = String(describing: self.state)
+            AppLogger.audio.notice(
+                "ownership transfer \(prevDesc, privacy: .private) → \(alarmID, privacy: .private), state=\(stateDesc, privacy: .public)"
+            )
+        } else {
+            // No alarmID provided while audio is already playing means the
+            // existing owner is preserved. Log so a regression where a new
+            // call site forgets to pass alarmID is diagnosable in Console.
+            let stateDesc = String(describing: self.state)
+            let ownerDesc = String(describing: self.currentAlarmID)
+            AppLogger.audio.error(
+                "missing alarmID while state=\(stateDesc, privacy: .public) — ownership NOT transferred, owner=\(ownerDesc, privacy: .private)"
+            )
+        }
+    }
+
+    /// Locate the bundled alarm sound (caf/m4a/wav/mp3 — in that order, with a
+    /// `default_alarm` fallback) and try to wrap it in `AVAudioPlayer`. If the
+    /// bundle hit fails or AVAudioPlayer rejects the file we fall back to the
+    /// in-memory synthetic tone so the user still hears *something*.
+    private func resolveAlarmPlayer(soundID: String) -> AVAudioPlayer? {
+        let url: URL? = Bundle.main.url(forResource: soundID, withExtension: "caf")
+            ?? Bundle.main.url(forResource: soundID, withExtension: "m4a")
+            ?? Bundle.main.url(forResource: soundID, withExtension: "wav")
+            ?? Bundle.main.url(forResource: soundID, withExtension: "mp3")
+            ?? Bundle.main.url(forResource: "default_alarm", withExtension: "caf")
+            ?? Bundle.main.url(forResource: "default_alarm", withExtension: "m4a")
+
+        var player: AVAudioPlayer?
+        if let soundURL = url {
+            do {
+                player = try AVAudioPlayer(contentsOf: soundURL)
+            } catch {
+                let name = soundURL.lastPathComponent
+                let desc = error.localizedDescription
+                AppLogger.audio.error(
+                    "AVAudioPlayer init failed for \(name, privacy: .public): \(desc, privacy: .public)"
+                )
+                player = nil
+            }
+        }
+        return player ?? Self.generateAlarmTone()
+    }
+
+    /// Apply per-alarm volume + optional fade-in. Defensive `min/max` clamp
+    /// preserves the historical behaviour even when the caller hands us a
+    /// NaN/Inf value (a corrupt payload still produces a playable alarm).
+    private func configurePlayerVolume(_ player: AVAudioPlayer, target volume: Float, fadeIn: Bool) {
+        player.numberOfLoops = -1
+        let clampedVolume = min(max(volume.isFinite ? volume : 1.0, 0), 1)
+        if fadeIn {
+            // Start at 0 and ramp up so the user is woken gently. AVAudio
+            // schedules the ramp on the audio thread and survives screen
+            // lock — no Timer needed.
+            player.volume = 0
+            player.setVolume(clampedVolume, fadeDuration: Self.fadeInDuration)
+        } else {
+            player.volume = clampedVolume
+        }
     }
 
     /// Stop alarm sound and vibration immediately.
@@ -312,79 +327,10 @@ final class AudioService {
     }
 
     // MARK: - Tone Generation
-
-    /// Generate a 440 Hz sine wave alarm tone as in-memory WAV data.
-    /// Returns an AVAudioPlayer ready to loop, or nil on failure.
-    private static func generateAlarmTone() -> AVAudioPlayer? {
-        let sampleRate: Double = 44100
-        let duration: Double = 1.5 // seconds per loop cycle
-        let frequency: Double = 880 // A5 — prominent alarm frequency
-        let totalSamples = Int(sampleRate * duration)
-
-        // Build interleaved 16-bit PCM samples with amplitude envelope
-        var samples = [Int16]()
-        samples.reserveCapacity(totalSamples)
-
-        for sampleIndex in 0..<totalSamples {
-            let timeSeconds = Double(sampleIndex) / sampleRate
-            // Dual-tone: 880 Hz + 660 Hz for recognizable alarm character
-            let wave = sin(2.0 * .pi * frequency * timeSeconds)
-                + 0.6 * sin(2.0 * .pi * 660.0 * timeSeconds)
-            // Amplitude envelope: short fade-in/out to avoid click
-            let envelope: Double
-            let fadeFrames = Int(sampleRate * 0.02)
-            if sampleIndex < fadeFrames {
-                envelope = Double(sampleIndex) / Double(fadeFrames)
-            } else if sampleIndex > totalSamples - fadeFrames {
-                envelope = Double(totalSamples - sampleIndex) / Double(fadeFrames)
-            } else {
-                // Pulse pattern: 0.3s on, 0.2s off
-                let cyclePos = timeSeconds.truncatingRemainder(dividingBy: 0.5)
-                envelope = cyclePos < 0.3 ? 1.0 : 0.0
-            }
-            let amplitude = wave * envelope * 0.7
-            let sample = Int16(clamping: Int(amplitude * Double(Int16.max)))
-            samples.append(sample)
-        }
-
-        // Build WAV header + data
-        let dataSize = totalSamples * 2 // 16-bit = 2 bytes per sample
-        var wavData = Data()
-        wavData.append(contentsOf: [0x52, 0x49, 0x46, 0x46]) // "RIFF"
-        wavData.append(contentsOf: UInt32(36 + dataSize).littleEndianBytes)
-        wavData.append(contentsOf: [0x57, 0x41, 0x56, 0x45]) // "WAVE"
-        wavData.append(contentsOf: [0x66, 0x6D, 0x74, 0x20]) // "fmt "
-        wavData.append(contentsOf: UInt32(16).littleEndianBytes)           // chunk size
-        wavData.append(contentsOf: UInt16(1).littleEndianBytes)            // PCM format
-        wavData.append(contentsOf: UInt16(1).littleEndianBytes)            // mono
-        wavData.append(contentsOf: UInt32(44100).littleEndianBytes)        // sample rate
-        wavData.append(contentsOf: UInt32(44100 * 2).littleEndianBytes)    // byte rate
-        wavData.append(contentsOf: UInt16(2).littleEndianBytes)            // block align
-        wavData.append(contentsOf: UInt16(16).littleEndianBytes)           // bits per sample
-        wavData.append(contentsOf: [0x64, 0x61, 0x74, 0x61]) // "data"
-        wavData.append(contentsOf: UInt32(dataSize).littleEndianBytes)
-
-        samples.withUnsafeBytes { rawBuffer in
-            wavData.append(contentsOf: rawBuffer)
-        }
-
-        return try? AVAudioPlayer(data: wavData)
-    }
-}
-
-// MARK: - Binary helpers
-
-private extension UInt32 {
-    var littleEndianBytes: [UInt8] {
-        let value = self.littleEndian
-        return [UInt8(value & 0xFF), UInt8((value >> 8) & 0xFF),
-                UInt8((value >> 16) & 0xFF), UInt8((value >> 24) & 0xFF)]
-    }
-}
-
-private extension UInt16 {
-    var littleEndianBytes: [UInt8] {
-        let value = self.littleEndian
-        return [UInt8(value & 0xFF), UInt8((value >> 8) & 0xFF)]
-    }
+    //
+    // The synthetic-tone generator + WAV packer + binary helpers live in
+    // `AudioService+Tone.swift` (#182) so this file stays under SwiftLint's
+    // `file_length` cap. `resolveAlarmPlayer` calls
+    // `Self.generateAlarmTone()` exactly as before — only the physical
+    // location moved.
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Layout.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Layout.swift
@@ -1,0 +1,141 @@
+import UIKit
+
+// MARK: - View-stack + constraint builders
+//
+// Extracted from `AlarmFiringViewController.swift` (#182) so the host file
+// stays under SwiftLint's `file_length` and `type_body_length` caps. The
+// initial `setupUI` constructs the time/name/snooze/dismiss/banner stack and
+// hands it off to the +Progressive / +NoBalance extensions for their
+// respective overlays.
+
+extension AlarmFiringViewController {
+
+    /// Build the firing-screen view stack and pin everything to the screen.
+    /// Called once from `viewDidLoad`. Behaviour mirrors the original
+    /// `setupUI()` — only the location moved.
+    func buildFiringLayout() {
+        view.backgroundColor = UIColor(rgb: 0x050912)
+        installThemedBackground()
+
+        // VM exposes `currentPenalty` as `Double`; wrap in `Decimal` so
+        // `SPSnoozePrice.formattedRubles()` does the locale-aware format.
+        // Pick the initial tone based on the alarm config — progressive
+        // alarms start at intensity 0 (still pure warn) and ramp up as the
+        // user snoozes.
+        let initialTone: SPSnoozePrice.Tone = viewModel.isProgressiveActive
+            ? .progressive(intensity: viewModel.progressiveIntensity)
+            : .warn
+        let snooze = SPSnoozePrice(
+            price: Decimal(viewModel.currentPenalty),
+            minutes: viewModel.alarm.snoozeMinutes,
+            tone: initialTone,
+            hint: nil
+        )
+        snooze.translatesAutoresizingMaskIntoConstraints = false
+        snooze.onTap = { [weak self] in self?.snoozeTapped() }
+        view.addSubview(snooze)
+        snoozeCTA = snooze
+
+        view.addSubview(timeLabel)
+        view.addSubview(nameLabel)
+
+        dismissButton.translatesAutoresizingMaskIntoConstraints = false
+        dismissButton.addTarget(self, action: #selector(dismissTapped), for: .touchUpInside)
+        view.addSubview(dismissButton)
+        view.addSubview(audioWarningBanner)
+
+        let inset: CGFloat = AppSpacing.sp5      // 20pt — Dawn spec
+        let gap: CGFloat = AppSpacing.sp3         // 12pt — Dawn spec
+
+        // Progressive escalation chrome — only mounted for alarms with the
+        // doubling-penalty toggle. The default flow stays exactly as #138.
+        // Anchor the audio-fallback banner to the chrome's top so the banner
+        // never overlaps the indicator when both are on screen.
+        let bannerBottomAnchor: NSLayoutYAxisAnchor
+        if viewModel.isProgressiveActive {
+            let stack = installProgressiveStack(inset: inset)
+            NSLayoutConstraint.activate([
+                stack.bottomAnchor.constraint(equalTo: snooze.topAnchor, constant: -AppSpacing.sp3)
+            ])
+            bannerBottomAnchor = stack.topAnchor
+        } else {
+            bannerBottomAnchor = snooze.topAnchor
+        }
+
+        activateMainConstraints(snooze: snooze, bannerBottomAnchor: bannerBottomAnchor, inset: inset, gap: gap)
+
+        // No-balance stack overlays the same bottom area as the snooze CTA +
+        // dismiss group. Initially hidden — `updateUI()` flips visibility
+        // based on `viewModel.canSnooze`. Building it eagerly keeps the
+        // affordability swap a single property toggle (no constraint churn)
+        // when the user tops up mid-firing and crosses the threshold.
+        installNoBalanceStack(inset: inset, gap: gap)
+
+        updateUI()
+    }
+
+    /// Pin every always-mounted element. Split out of `buildFiringLayout` so
+    /// neither function trips SwiftLint's function_body_length (#182).
+    private func activateMainConstraints(
+        snooze: SPSnoozePrice,
+        bannerBottomAnchor: NSLayoutYAxisAnchor,
+        inset: CGFloat,
+        gap: CGFloat
+    ) {
+        NSLayoutConstraint.activate([
+            timeLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            timeLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: -80),
+            timeLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
+            timeLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
+
+            nameLabel.topAnchor.constraint(equalTo: timeLabel.bottomAnchor, constant: AppSpacing.sp2),
+            nameLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            nameLabel.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: inset),
+            nameLabel.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor, constant: -inset),
+
+            audioWarningBanner.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
+            audioWarningBanner.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
+            audioWarningBanner.bottomAnchor.constraint(equalTo: bannerBottomAnchor, constant: -AppSpacing.sp4),
+
+            snooze.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
+            snooze.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
+            snooze.bottomAnchor.constraint(equalTo: dismissButton.topAnchor, constant: -gap),
+
+            dismissButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
+            dismissButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
+            dismissButton.bottomAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.bottomAnchor,
+                constant: -AppSpacing.sp6
+            )
+        ])
+    }
+
+    /// Update the warm-glow frame on every layout pass so the radial halo
+    /// stays anchored just below the bottom edge regardless of orientation
+    /// changes (the bounds-driven math used to live inline in
+    /// `viewDidLayoutSubviews`).
+    func updateGlowFrame() {
+        let bounds = view.bounds
+        let glowSize = CGSize(width: bounds.width * 1.2, height: bounds.height * 0.6)
+        warmGlowLayer.frame = CGRect(
+            x: -(glowSize.width - bounds.width) / 2,
+            y: bounds.height - glowSize.height * 0.55,
+            width: glowSize.width,
+            height: glowSize.height
+        )
+    }
+}
+
+// MARK: - Hex helper
+
+private extension UIColor {
+    /// `0xRRGGBB` literal initializer mirrored from
+    /// `AlarmFiringViewController.swift`. `private` is file-scope in Swift,
+    /// so each file that needs the helper carries its own copy (#182).
+    convenience init(rgb: UInt32, alpha: CGFloat = 1) {
+        let red = CGFloat((rgb >> 16) & 0xFF) / 255.0
+        let green = CGFloat((rgb >> 8) & 0xFF) / 255.0
+        let blue = CGFloat(rgb & 0xFF) / 255.0
+        self.init(red: red, green: green, blue: blue, alpha: alpha)
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+ViewLifecycle.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+ViewLifecycle.swift
@@ -1,0 +1,98 @@
+import UIKit
+import os
+
+// MARK: - View lifecycle + clock + glow + actions
+//
+// Extracted from `AlarmFiringViewController.swift` (#182) so the host file
+// stays under SwiftLint's `file_length` and `type_body_length` caps. These
+// callbacks used to live as instance members on the main type — only the
+// physical location moved; behaviour is verbatim.
+
+extension AlarmFiringViewController {
+
+    // MARK: Clock
+
+    func startClockTicker() {
+        updateTime()
+        clockTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
+            self?.updateTime()
+        }
+    }
+
+    func updateTime() {
+        timeLabel.text = AlarmFiringTimeFormatter.string(from: Date())
+    }
+
+    // MARK: Glow breathing
+
+    /// 4s ease-in-out autoreverse opacity pulse on the warm glow. Driven via
+    /// CABasicAnimation because the glow is a CAGradientLayer (not a view).
+    func startGlowBreathing() {
+        let animation = CABasicAnimation(keyPath: "opacity")
+        animation.fromValue = 0.55
+        animation.toValue = 1.0
+        animation.duration = 4.0
+        animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+        animation.autoreverses = true
+        animation.repeatCount = .infinity
+        warmGlowLayer.add(animation, forKey: "breathing")
+    }
+
+    // MARK: Actions
+
+    func snoozeTapped() {
+        // scheduleCompletion surfaces a notification-center failure (revoked
+        // permission, 64-pending-limit, malformed trigger) so the user
+        // doesn't pay for a snooze that will never re-fire (#127 finding).
+        let success = viewModel.snooze { [weak self] result in
+            guard let self else { return }
+            if case let .failure(error) = result {
+                self.presentSnoozeScheduleFailureAlert(error: error)
+            }
+        }
+        if success {
+            dismiss(animated: true)
+        }
+    }
+
+    /// Present the firing-time top-up bottom sheet. Public entry point so the
+    /// no-balance UX (#140) can wire it into the snooze affordance once the
+    /// firing VC rewrite (#138) lands. Pause/resume of the alarm audio +
+    /// escalation is owned by the sheet itself via `AlarmFiringCoordinator
+    /// .pauseEscalation()`, so callers don't need to coordinate audio state.
+    func presentTopUpSheet() {
+        let sheet = FiringTopUpBottomSheetViewController()
+        present(sheet, animated: true)
+    }
+
+    func presentSnoozeScheduleFailureAlert(
+        error: AlarmScheduler.SchedulingError
+    ) {
+        let detail = error.errorDescription ?? error.localizedDescription
+        let alert = UIAlertController(
+            title: "Откладывание не запланировано",
+            message: "\(detail) Будильник не зазвенит повторно — установите запасной.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "Ок", style: .default))
+        present(alert, animated: true)
+    }
+}
+
+// MARK: - Time formatter
+
+/// Cached formatter — `updateTime()` runs once per second; rebuilding a
+/// `DateFormatter` each tick is ~1ms wasted. Locale fixed to `en_US_POSIX`
+/// so `HH:mm` is honoured regardless of the user's region.
+enum AlarmFiringTimeFormatter {
+    private static let formatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "HH:mm"
+        return formatter
+    }()
+
+    static func string(from date: Date) -> String {
+        formatter.string(from: date)
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
@@ -28,7 +28,8 @@ class AlarmFiringViewController: UIViewController {
     /// `--sp-grad-dawn` recipe (#138); other built-in themes pull their stops
     /// from `AlarmThemeRendering`. The layer is replaced/recoloured in
     /// `installThemedBackground` based on `viewModel.alarm.theme` (#151).
-    /// `internal` so the +Theme extension in the sibling file can configure it.
+    /// `internal` so the +Theme / +Layout extensions in sibling files can
+    /// configure it.
     let themeGradientLayer: CAGradientLayer = {
         let gradient = CAGradientLayer()
         gradient.startPoint = CGPoint(x: 0.5, y: 0.0)
@@ -80,8 +81,9 @@ class AlarmFiringViewController: UIViewController {
     // MARK: - Content
 
     /// 96pt mono clock — `AppTypography.clockXl` with `.monospacedDigit()`
-    /// so digit columns don't reflow on each tick.
-    private let timeLabel: UILabel = {
+    /// so digit columns don't reflow on each tick. `internal` so the
+    /// `+Layout` / `+ViewLifecycle` extensions can pin + update it (#182).
+    let timeLabel: UILabel = {
         let label = UILabel()
         label.font = AppTypography.clockXl.monospacedDigit()
         label.textColor = AppColors.fg1
@@ -92,7 +94,8 @@ class AlarmFiringViewController: UIViewController {
         return label
     }()
 
-    private let nameLabel: UILabel = {
+    /// `internal` so the `+Layout` extension can pin it next to the clock.
+    let nameLabel: UILabel = {
         let label = UILabel()
         label.font = AppTypography.bodyLg
         label.textColor = AppColors.fg2
@@ -214,7 +217,9 @@ class AlarmFiringViewController: UIViewController {
         return label
     }()
 
-    private var clockTimer: Timer?
+    /// `internal` so the `+ViewLifecycle.startClockTicker` can own the timer
+    /// instance and `viewDidDisappear` can invalidate it.
+    var clockTimer: Timer?
 
     /// Observer token for `AudioService.stateChangedNotification`. Removed
     /// in `deinit` so blocks don't leak across screen presentations.
@@ -254,11 +259,11 @@ class AlarmFiringViewController: UIViewController {
         // screen is intentionally exempt from the brand light theme. Pin
         // `.dark` so the system theme can't bleed through.
         overrideUserInterfaceStyle = .dark
-        setupUI()
+        buildFiringLayout()
         bindViewModel()
         observeAudioState()
         observeBalanceForNoBalanceState()
-        startClock()
+        startClockTicker()
         startGlowBreathing()
 
         // Pass `alarmID` so a stacking-replace race (#116) does not silence
@@ -300,107 +305,18 @@ class AlarmFiringViewController: UIViewController {
     override var prefersHomeIndicatorAutoHidden: Bool { true }
 
     // MARK: - Setup
-
-    private func setupUI() {
-        view.backgroundColor = UIColor(rgb: 0x050912)
-        installThemedBackground()
-
-        // VM exposes `currentPenalty` as `Double`; wrap in `Decimal` so
-        // `SPSnoozePrice.formattedRubles()` does the locale-aware format.
-        // Pick the initial tone based on the alarm config — progressive
-        // alarms start at intensity 0 (still pure warn) and ramp up as the
-        // user snoozes.
-        let initialTone: SPSnoozePrice.Tone = viewModel.isProgressiveActive
-            ? .progressive(intensity: viewModel.progressiveIntensity)
-            : .warn
-        let snooze = SPSnoozePrice(
-            price: Decimal(viewModel.currentPenalty),
-            minutes: viewModel.alarm.snoozeMinutes,
-            tone: initialTone,
-            hint: nil
-        )
-        snooze.translatesAutoresizingMaskIntoConstraints = false
-        snooze.onTap = { [weak self] in self?.snoozeTapped() }
-        view.addSubview(snooze)
-        snoozeCTA = snooze
-
-        view.addSubview(timeLabel)
-        view.addSubview(nameLabel)
-
-        dismissButton.translatesAutoresizingMaskIntoConstraints = false
-        dismissButton.addTarget(self, action: #selector(dismissTapped), for: .touchUpInside)
-        view.addSubview(dismissButton)
-        view.addSubview(audioWarningBanner)
-
-        let inset: CGFloat = AppSpacing.sp5      // 20pt — Dawn spec
-        let gap: CGFloat = AppSpacing.sp3         // 12pt — Dawn spec
-
-        // Progressive escalation chrome — only mounted for alarms with the
-        // doubling-penalty toggle. The default flow stays exactly as #138.
-        // Anchor the audio-fallback banner to the chrome's top so the banner
-        // never overlaps the indicator when both are on screen.
-        let bannerBottomAnchor: NSLayoutYAxisAnchor
-        if viewModel.isProgressiveActive {
-            let stack = installProgressiveStack(inset: inset)
-            NSLayoutConstraint.activate([
-                stack.bottomAnchor.constraint(equalTo: snooze.topAnchor, constant: -AppSpacing.sp3)
-            ])
-            bannerBottomAnchor = stack.topAnchor
-        } else {
-            bannerBottomAnchor = snooze.topAnchor
-        }
-
-        NSLayoutConstraint.activate([
-            timeLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            timeLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: -80),
-            timeLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
-            timeLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
-
-            nameLabel.topAnchor.constraint(equalTo: timeLabel.bottomAnchor, constant: AppSpacing.sp2),
-            nameLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            nameLabel.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: inset),
-            nameLabel.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor, constant: -inset),
-
-            audioWarningBanner.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
-            audioWarningBanner.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
-            audioWarningBanner.bottomAnchor.constraint(equalTo: bannerBottomAnchor, constant: -AppSpacing.sp4),
-
-            snooze.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
-            snooze.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
-            snooze.bottomAnchor.constraint(equalTo: dismissButton.topAnchor, constant: -gap),
-
-            dismissButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
-            dismissButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
-            dismissButton.bottomAnchor.constraint(
-                equalTo: view.safeAreaLayoutGuide.bottomAnchor,
-                constant: -AppSpacing.sp6
-            )
-        ])
-
-        // No-balance stack overlays the same bottom area as the snooze CTA +
-        // dismiss group. Initially hidden — `updateUI()` flips visibility
-        // based on `viewModel.canSnooze`. Building it eagerly keeps the
-        // affordability swap a single property toggle (no constraint churn)
-        // when the user tops up mid-firing and crosses the threshold.
-        installNoBalanceStack(inset: inset, gap: gap)
-
-        updateUI()
-    }
+    //
+    // The view-stack + constraint composition lives in
+    // `AlarmFiringViewController+Layout.swift` so this file stays under
+    // SwiftLint's `file_length` cap (#182). `viewDidLoad` calls
+    // `buildFiringLayout()` which is the verbatim former `setupUI()`.
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         themeGradientLayer.frame = view.bounds
-
         // Glow anchored below the bottom edge — only the upper hemisphere
         // of the radial bleeds into view.
-        let bounds = view.bounds
-        let glowSize = CGSize(width: bounds.width * 1.2, height: bounds.height * 0.6)
-        warmGlowLayer.frame = CGRect(
-            x: -(glowSize.width - bounds.width) / 2,
-            y: bounds.height - glowSize.height * 0.55,
-            width: glowSize.width,
-            height: glowSize.height
-        )
+        updateGlowFrame()
     }
 
     private func bindViewModel() {
@@ -444,44 +360,6 @@ class AlarmFiringViewController: UIViewController {
         refreshNoBalanceVisibility()
     }
 
-    // MARK: - Clock
-
-    private func startClock() {
-        updateTime()
-        clockTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
-            self?.updateTime()
-        }
-    }
-
-    /// Cached formatter — `updateTime()` runs once per second; rebuilding a
-    /// DateFormatter each tick is ~1ms wasted. Locale fixed to `en_US_POSIX`
-    /// so `HH:mm` is honoured regardless of the user's region.
-    private static let timeFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "HH:mm"
-        return formatter
-    }()
-
-    private func updateTime() {
-        timeLabel.text = Self.timeFormatter.string(from: Date())
-    }
-
-    // MARK: - Glow breathing
-
-    /// 4s ease-in-out autoreverse opacity pulse on the warm glow. Driven via
-    /// CABasicAnimation because the glow is a CAGradientLayer (not a view).
-    private func startGlowBreathing() {
-        let animation = CABasicAnimation(keyPath: "opacity")
-        animation.fromValue = 0.55
-        animation.toValue = 1.0
-        animation.duration = 4.0
-        animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-        animation.autoreverses = true
-        animation.repeatCount = .infinity
-        warmGlowLayer.add(animation, forKey: "breathing")
-    }
-
     // MARK: - Actions
 
     /// `internal` so the +NoBalance extension can wire its big ghost
@@ -491,52 +369,20 @@ class AlarmFiringViewController: UIViewController {
         dismiss(animated: true)
     }
 
-    private func snoozeTapped() {
-        // scheduleCompletion surfaces a notification-center failure (revoked
-        // permission, 64-pending-limit, malformed trigger) so the user
-        // doesn't pay for a snooze that will never re-fire (#127 finding).
-        let success = viewModel.snooze { [weak self] result in
-            guard let self else { return }
-            if case let .failure(error) = result {
-                self.presentSnoozeScheduleFailureAlert(error: error)
-            }
-        }
-        if success {
-            dismiss(animated: true)
-        }
-    }
-
-    // MARK: - Top-up sheet (#141)
-
-    /// Present the firing-time top-up bottom sheet. Public entry point so the
-    /// no-balance UX (#140) can wire it into the snooze affordance once the
-    /// firing VC rewrite (#138) lands. Pause/resume of the alarm audio +
-    /// escalation is owned by the sheet itself via `AlarmFiringCoordinator
-    /// .pauseEscalation()`, so callers don't need to coordinate audio state.
-    func presentTopUpSheet() {
-        let sheet = FiringTopUpBottomSheetViewController()
-        present(sheet, animated: true)
-    }
-
-    private func presentSnoozeScheduleFailureAlert(
-        error: AlarmScheduler.SchedulingError
-    ) {
-        let detail = error.errorDescription ?? error.localizedDescription
-        let alert = UIAlertController(
-            title: "Откладывание не запланировано",
-            message: "\(detail) Будильник не зазвенит повторно — установите запасной.",
-            preferredStyle: .alert
-        )
-        alert.addAction(UIAlertAction(title: "Ок", style: .default))
-        present(alert, animated: true)
-    }
+    // Clock ticking, glow breathing, snooze tap handler, top-up sheet, and
+    // the snooze-failure alert live in
+    // `AlarmFiringViewController+ViewLifecycle.swift` (#182).
 }
 
 // MARK: - Hex helper
 
 private extension UIColor {
     /// `0xRRGGBB` literal initializer so the Dawn gradient stops read as in
-    /// `tokens.css`. Local copy mirroring the (private) helper in AppColors.
+    /// `tokens.css`. File-local copy mirroring the (private) helper in
+    /// AppColors — duplicated as `fileprivate` in
+    /// `AlarmFiringViewController+Layout.swift` because `private` means
+    /// file-scope, not type-scope, and the +Layout extension also needs the
+    /// helper for `UIColor(rgb: 0x050912)` in its background fill.
     convenience init(rgb: UInt32, alpha: CGFloat = 1) {
         let red = CGFloat((rgb >> 16) & 0xFF) / 255.0
         let green = CGFloat((rgb >> 8) & 0xFF) / 255.0

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController+Pickers.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController+Pickers.swift
@@ -1,0 +1,95 @@
+import UIKit
+
+// MARK: - Picker push handlers + delete confirmation
+//
+// Extracted from `CreateAlarmViewController.swift` (#182) to keep the host
+// file under SwiftLint's `file_length` cap. Behaviour is unchanged —
+// these used to be `private func`s on the main type.
+
+extension CreateAlarmViewController {
+
+    /// Action-sheet confirmation before destroying the alarm being edited.
+    /// Mirrors the original `confirmDelete()` verbatim — including the iPad
+    /// popover sourceView dance that prevents the crash on regular size class.
+    func confirmDelete() {
+        let alert = UIAlertController(
+            title: "Удалить будильник?",
+            message: "Это действие нельзя отменить.",
+            preferredStyle: .actionSheet
+        )
+        alert.addAction(UIAlertAction(title: "Удалить", style: .destructive) { [weak self] _ in
+            guard let self else { return }
+            // ViewModel.delete forwards to AlarmRepository.delete, which itself
+            // cancels the scheduled UNNotificationRequests via AlarmScheduler.
+            // Returns false when the store is locked due to a corrupt blob
+            // (issue #72) — surface the failure rather than dismiss the
+            // sheet on a no-op delete.
+            let didDelete = self.viewModel.delete()
+            guard didDelete else {
+                self.presentSaveError(
+                    title: "Не удалось сохранить",
+                    error: AlarmRepository.RepositoryError.persistBlocked
+                )
+                return
+            }
+            self.onDelete?()
+            self.dismiss(animated: true)
+        })
+        alert.addAction(UIAlertAction(title: "Отмена", style: .cancel))
+        // Without a sourceView the action sheet crashes on iPad popovers.
+        if let popover = alert.popoverPresentationController {
+            popover.sourceView = view
+            popover.sourceRect = CGRect(x: view.bounds.midX, y: view.bounds.midY, width: 0, height: 0)
+            popover.permittedArrowDirections = []
+        }
+        present(alert, animated: true)
+    }
+
+    func showThemePicker() {
+        let picker = AlarmThemePickerViewController(
+            currentTheme: viewModel.theme,
+            onSelect: { [weak self] theme in
+                guard let self else { return }
+                self.viewModel.theme = theme
+                // Update the trailing-value label inline so the user sees
+                // the new theme name without waiting for `viewWillAppear`'s
+                // section reload (which doesn't fire for the in-place update
+                // that follows the imperative pop).
+                let indexPath = IndexPath(row: 0, section: themeSectionIndex)
+                if let cell = self.tableView.cellForRow(at: indexPath) as? ThemeRowCell {
+                    cell.configure(themeName: self.viewModel.alarmThemeName)
+                }
+            }
+        )
+        navigationController?.pushViewController(picker, animated: true)
+    }
+
+    func showSoundPicker() {
+        let picker = SoundPickerViewController(
+            sounds: viewModel.availableSounds,
+            selectedID: viewModel.soundID,
+            onSelect: { [weak self] soundID in
+                self?.viewModel.soundID = soundID
+            },
+            previewSound: { [weak self] soundID in
+                self?.viewModel.previewSound(soundID)
+            }
+        )
+        navigationController?.pushViewController(picker, animated: true)
+    }
+
+    /// Push the new `VolumePickerViewController` (#150). The picker reports
+    /// every slider / switch change live so dismissing on the back chevron
+    /// is "auto-save" — the parent's `viewWillAppear` then refreshes the
+    /// volume row to render the new value.
+    func showVolumePicker() {
+        let picker = VolumePickerViewController(
+            volume: viewModel.volume,
+            fadeIn: viewModel.volumeFadeIn
+        ) { [weak self] volume, fadeIn in
+            self?.viewModel.volume = volume
+            self?.viewModel.volumeFadeIn = fadeIn
+        }
+        navigationController?.pushViewController(picker, animated: true)
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController+Sections.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController+Sections.swift
@@ -1,0 +1,143 @@
+import UIKit
+
+// MARK: - Section cell builders
+//
+// Extracted from `CreateAlarmViewController.swift` (#182) so the host file
+// stays under SwiftLint's `file_length` cap. Each helper owns its row's
+// dequeue + configure + callback wiring; behaviour is verbatim — only the
+// physical location moved.
+
+extension CreateAlarmViewController {
+
+    /// Register every per-row cell type so `dequeueReusableCell(...)` calls in
+    /// the helpers below always succeed. Called once from `setupTableView`.
+    func registerSectionCells(in tableView: UITableView) {
+        tableView.register(TimePickerCell.self, forCellReuseIdentifier: TimePickerCell.reuseID)
+        tableView.register(DayPickerCell.self, forCellReuseIdentifier: DayPickerCell.reuseID)
+        tableView.register(NameCell.self, forCellReuseIdentifier: NameCell.reuseID)
+        tableView.register(SoundCell.self, forCellReuseIdentifier: SoundCell.reuseID)
+        tableView.register(VolumeCell.self, forCellReuseIdentifier: VolumeCell.reuseID)
+        tableView.register(VibrationCell.self, forCellReuseIdentifier: VibrationCell.reuseID)
+        tableView.register(PenaltyCell.self, forCellReuseIdentifier: PenaltyCell.reuseID)
+        tableView.register(ProgressiveScaleCell.self, forCellReuseIdentifier: ProgressiveScaleCell.reuseID)
+        tableView.register(ProgressivePreviewCell.self, forCellReuseIdentifier: ProgressivePreviewCell.reuseID)
+        tableView.register(SnoozeSliderCell.self, forCellReuseIdentifier: SnoozeSliderCell.reuseID)
+        tableView.register(ThemeRowCell.self, forCellReuseIdentifier: ThemeRowCell.reuseID)
+        tableView.register(DeleteActionCell.self, forCellReuseIdentifier: DeleteActionCell.reuseID)
+    }
+
+    func makeTimePickerCell(_ tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: TimePickerCell.reuseID, for: indexPath)
+        if let cell = cell as? TimePickerCell {
+            cell.configure(time: viewModel.time)
+            cell.onTimeChanged = { [weak self] date in self?.viewModel.time = date }
+        }
+        return cell
+    }
+
+    func makeRepeatDaysCell(_ tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: DayPickerCell.reuseID, for: indexPath)
+        if let cell = cell as? DayPickerCell {
+            cell.configure(selectedDays: viewModel.repeatDays)
+            cell.onDayToggled = { [weak self, weak cell] day in
+                guard let self else { return }
+                self.viewModel.toggleDay(day)
+                cell?.configure(selectedDays: self.viewModel.repeatDays)
+            }
+        }
+        return cell
+    }
+
+    func makeNameCell(_ tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: NameCell.reuseID, for: indexPath)
+        if let cell = cell as? NameCell {
+            cell.configure(name: viewModel.name)
+            cell.onNameChanged = { [weak self] text in self?.viewModel.name = text }
+        }
+        return cell
+    }
+
+    func makeSoundCell(_ tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: SoundCell.reuseID, for: indexPath)
+        if let cell = cell as? SoundCell {
+            let soundName = viewModel.availableSounds
+                .first(where: { $0.id == viewModel.soundID })?.name ?? "По умолчанию"
+            cell.configure(soundName: soundName)
+            cell.onPreviewTapped = { [weak self] in
+                guard let self else { return }
+                self.viewModel.previewSound(self.viewModel.soundID)
+            }
+        }
+        return cell
+    }
+
+    func makeVolumeCell(_ tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: VolumeCell.reuseID, for: indexPath)
+        if let cell = cell as? VolumeCell {
+            cell.configure(volume: viewModel.volume, fadeIn: viewModel.volumeFadeIn)
+        }
+        return cell
+    }
+
+    func makeVibrationCell(_ tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: VibrationCell.reuseID, for: indexPath)
+        if let cell = cell as? VibrationCell {
+            cell.configure(isOn: viewModel.vibrationEnabled)
+            cell.onToggled = { [weak self] isOn in self?.viewModel.vibrationEnabled = isOn }
+        }
+        return cell
+    }
+
+    func makePenaltyCell(_ tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: PenaltyCell.reuseID, for: indexPath)
+        if let cell = cell as? PenaltyCell {
+            cell.configure(amount: viewModel.penaltyAmount)
+            cell.onValueChanged = { [weak self] amount in self?.setPenaltyAmount(amount) }
+        }
+        return cell
+    }
+
+    func makeProgressiveScaleToggleCell(
+        _ tableView: UITableView,
+        at indexPath: IndexPath
+    ) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: ProgressiveScaleCell.reuseID, for: indexPath)
+        if let cell = cell as? ProgressiveScaleCell {
+            cell.configure(isOn: viewModel.progressiveScale)
+            cell.onToggled = { [weak self] isOn in self?.setProgressiveScale(isOn) }
+        }
+        return cell
+    }
+
+    func makeProgressivePreviewCell(
+        _ tableView: UITableView,
+        at indexPath: IndexPath
+    ) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: ProgressivePreviewCell.reuseID, for: indexPath)
+        if let cell = cell as? ProgressivePreviewCell {
+            cell.configure(text: viewModel.progressiveScalePreview)
+        }
+        return cell
+    }
+
+    func makeSnoozeTimeCell(_ tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: SnoozeSliderCell.reuseID, for: indexPath)
+        if let cell = cell as? SnoozeSliderCell {
+            cell.configure(minutes: viewModel.snoozeMinutes)
+            cell.onValueChanged = { [weak self] minutes in self?.viewModel.snoozeMinutes = minutes }
+        }
+        return cell
+    }
+
+    func makeThemeCell(_ tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: ThemeRowCell.reuseID, for: indexPath)
+        if let cell = cell as? ThemeRowCell {
+            cell.configure(themeName: viewModel.alarmThemeName)
+        }
+        return cell
+    }
+
+    func makeDeleteActionCell(_ tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell {
+        tableView.dequeueReusableCell(withIdentifier: DeleteActionCell.reuseID, for: indexPath)
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
@@ -18,11 +18,15 @@ final class CreateAlarmViewController: UIViewController {
 
     // MARK: - Dependencies
 
-    private let viewModel: CreateAlarmViewModel
+    /// `internal` so the cross-file `+Sections` extension can read VM state
+    /// inside the row factory helpers (#182).
+    let viewModel: CreateAlarmViewModel
 
     // MARK: - UI
 
-    private let tableView: UITableView = {
+    /// `internal` so the cross-file `+Pickers` extension can mutate the
+    /// theme row in place after the picker pops (#182).
+    let tableView: UITableView = {
         let view = UITableView(frame: .zero, style: .insetGrouped)
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
@@ -34,7 +38,10 @@ final class CreateAlarmViewController: UIViewController {
     /// create), then time picker, repeat days, snooze slider, penalty,
     /// progressive scale, sound, vibration, theme, and finally the
     /// destructive delete action (edit-mode only).
-    private enum Section: Int, CaseIterable {
+    /// `internal` so the cross-file `+Pickers` extension can resolve
+    /// `Section.theme.rawValue` for the imperative cell refresh after the
+    /// picker pops (#182).
+    enum Section: Int, CaseIterable {
         case name = 0
         case timePicker
         case repeatDays
@@ -48,6 +55,10 @@ final class CreateAlarmViewController: UIViewController {
         /// Destructive "Удалить будильник" row — only visible in edit mode.
         case deleteAction
     }
+
+    /// Convenience accessor used by `+Pickers.showThemePicker` so that file
+    /// does not have to depend on `Section.rawValue` directly.
+    var themeSectionIndex: Int { Section.theme.rawValue }
 
     // MARK: - Init
 
@@ -118,18 +129,7 @@ final class CreateAlarmViewController: UIViewController {
         view.addSubview(tableView)
         tableView.delegate = self
         tableView.dataSource = self
-        tableView.register(TimePickerCell.self, forCellReuseIdentifier: TimePickerCell.reuseID)
-        tableView.register(DayPickerCell.self, forCellReuseIdentifier: DayPickerCell.reuseID)
-        tableView.register(NameCell.self, forCellReuseIdentifier: NameCell.reuseID)
-        tableView.register(SoundCell.self, forCellReuseIdentifier: SoundCell.reuseID)
-        tableView.register(VolumeCell.self, forCellReuseIdentifier: VolumeCell.reuseID)
-        tableView.register(VibrationCell.self, forCellReuseIdentifier: VibrationCell.reuseID)
-        tableView.register(PenaltyCell.self, forCellReuseIdentifier: PenaltyCell.reuseID)
-        tableView.register(ProgressiveScaleCell.self, forCellReuseIdentifier: ProgressiveScaleCell.reuseID)
-        tableView.register(ProgressivePreviewCell.self, forCellReuseIdentifier: ProgressivePreviewCell.reuseID)
-        tableView.register(SnoozeSliderCell.self, forCellReuseIdentifier: SnoozeSliderCell.reuseID)
-        tableView.register(ThemeRowCell.self, forCellReuseIdentifier: ThemeRowCell.reuseID)
-        tableView.register(DeleteActionCell.self, forCellReuseIdentifier: DeleteActionCell.reuseID)
+        registerSectionCells(in: tableView)
 
         // Pin to safe area on top so the first section's "ПОВТОР" header is
         // not clipped under the navigation bar.
@@ -181,8 +181,9 @@ final class CreateAlarmViewController: UIViewController {
 
     /// Inline alert for repository or scheduler failures that block the
     /// save flow. Kept generic so the same call site can present any
-    /// `LocalizedError` (issues #72, #118).
-    private func presentSaveError(title: String, error: LocalizedError) {
+    /// `LocalizedError` (issues #72, #118). `internal` so the `+Pickers`
+    /// extension can surface a delete failure (#182).
+    func presentSaveError(title: String, error: LocalizedError) {
         let alert = UIAlertController(
             title: title,
             message: error.errorDescription ?? "Попробуйте ещё раз.",
@@ -194,7 +195,9 @@ final class CreateAlarmViewController: UIViewController {
 
     // MARK: - View-model bridges
 
-    private func setProgressiveScale(_ isOn: Bool) {
+    /// `internal` so `+Sections.makeProgressiveScaleToggleCell` can wire the
+    /// toggle callback (#182).
+    func setProgressiveScale(_ isOn: Bool) {
         viewModel.progressiveScale = isOn
 
         guard view.window != nil else {
@@ -214,7 +217,9 @@ final class CreateAlarmViewController: UIViewController {
         })
     }
 
-    private func setPenaltyAmount(_ amount: Double) {
+    /// `internal` so `+Sections.makePenaltyCell` can wire the slider callback
+    /// (#182).
+    func setPenaltyAmount(_ amount: Double) {
         viewModel.penaltyAmount = amount
         // Refresh the preview row's text if it's currently visible.
         guard viewModel.progressiveScale else { return }
@@ -279,97 +284,25 @@ extension CreateAlarmViewController: UITableViewDataSource {
         return UITableView.automaticDimension
     }
 
-    // swiftlint:disable:next cyclomatic_complexity function_body_length
+    // swiftlint:disable:next cyclomatic_complexity
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let section = Section(rawValue: indexPath.section) else {
             return UITableViewCell()
         }
         switch section {
-        case .timePicker:
-            let cell = tableView.dequeueReusableCell(withIdentifier: TimePickerCell.reuseID, for: indexPath)
-            if let cell = cell as? TimePickerCell {
-                cell.configure(time: viewModel.time)
-                cell.onTimeChanged = { [weak self] date in self?.viewModel.time = date }
-            }
-            return cell
-        case .repeatDays:
-            let cell = tableView.dequeueReusableCell(withIdentifier: DayPickerCell.reuseID, for: indexPath)
-            if let cell = cell as? DayPickerCell {
-                cell.configure(selectedDays: viewModel.repeatDays)
-                cell.onDayToggled = { [weak self, weak cell] day in
-                    guard let self else { return }
-                    self.viewModel.toggleDay(day)
-                    cell?.configure(selectedDays: self.viewModel.repeatDays)
-                }
-            }
-            return cell
-        case .name:
-            let cell = tableView.dequeueReusableCell(withIdentifier: NameCell.reuseID, for: indexPath)
-            if let cell = cell as? NameCell {
-                cell.configure(name: viewModel.name)
-                cell.onNameChanged = { [weak self] text in self?.viewModel.name = text }
-            }
-            return cell
-        case .sound:
-            let cell = tableView.dequeueReusableCell(withIdentifier: SoundCell.reuseID, for: indexPath)
-            if let cell = cell as? SoundCell {
-                let soundName = viewModel.availableSounds
-                    .first(where: { $0.id == viewModel.soundID })?.name ?? "По умолчанию"
-                cell.configure(soundName: soundName)
-                cell.onPreviewTapped = { [weak self] in
-                    guard let self else { return }
-                    self.viewModel.previewSound(self.viewModel.soundID)
-                }
-            }
-            return cell
-        case .volume:
-            let cell = tableView.dequeueReusableCell(withIdentifier: VolumeCell.reuseID, for: indexPath)
-            if let cell = cell as? VolumeCell {
-                cell.configure(volume: viewModel.volume, fadeIn: viewModel.volumeFadeIn)
-            }
-            return cell
-        case .vibration:
-            let cell = tableView.dequeueReusableCell(withIdentifier: VibrationCell.reuseID, for: indexPath)
-            if let cell = cell as? VibrationCell {
-                cell.configure(isOn: viewModel.vibrationEnabled)
-                cell.onToggled = { [weak self] isOn in self?.viewModel.vibrationEnabled = isOn }
-            }
-            return cell
-        case .penalty:
-            let cell = tableView.dequeueReusableCell(withIdentifier: PenaltyCell.reuseID, for: indexPath)
-            if let cell = cell as? PenaltyCell {
-                cell.configure(amount: viewModel.penaltyAmount)
-                cell.onValueChanged = { [weak self] amount in self?.setPenaltyAmount(amount) }
-            }
-            return cell
+        case .timePicker:        return makeTimePickerCell(tableView, at: indexPath)
+        case .repeatDays:        return makeRepeatDaysCell(tableView, at: indexPath)
+        case .name:              return makeNameCell(tableView, at: indexPath)
+        case .sound:             return makeSoundCell(tableView, at: indexPath)
+        case .volume:            return makeVolumeCell(tableView, at: indexPath)
+        case .vibration:         return makeVibrationCell(tableView, at: indexPath)
+        case .penalty:           return makePenaltyCell(tableView, at: indexPath)
         case .progressiveScale where indexPath.row == 0:
-            let cell = tableView.dequeueReusableCell(withIdentifier: ProgressiveScaleCell.reuseID, for: indexPath)
-            if let cell = cell as? ProgressiveScaleCell {
-                cell.configure(isOn: viewModel.progressiveScale)
-                cell.onToggled = { [weak self] isOn in self?.setProgressiveScale(isOn) }
-            }
-            return cell
-        case .progressiveScale:
-            let cell = tableView.dequeueReusableCell(withIdentifier: ProgressivePreviewCell.reuseID, for: indexPath)
-            if let cell = cell as? ProgressivePreviewCell {
-                cell.configure(text: viewModel.progressiveScalePreview)
-            }
-            return cell
-        case .snoozeTime:
-            let cell = tableView.dequeueReusableCell(withIdentifier: SnoozeSliderCell.reuseID, for: indexPath)
-            if let cell = cell as? SnoozeSliderCell {
-                cell.configure(minutes: viewModel.snoozeMinutes)
-                cell.onValueChanged = { [weak self] minutes in self?.viewModel.snoozeMinutes = minutes }
-            }
-            return cell
-        case .theme:
-            let cell = tableView.dequeueReusableCell(withIdentifier: ThemeRowCell.reuseID, for: indexPath)
-            if let cell = cell as? ThemeRowCell {
-                cell.configure(themeName: viewModel.alarmThemeName)
-            }
-            return cell
-        case .deleteAction:
-            return tableView.dequeueReusableCell(withIdentifier: DeleteActionCell.reuseID, for: indexPath)
+            return makeProgressiveScaleToggleCell(tableView, at: indexPath)
+        case .progressiveScale:  return makeProgressivePreviewCell(tableView, at: indexPath)
+        case .snoozeTime:        return makeSnoozeTimeCell(tableView, at: indexPath)
+        case .theme:             return makeThemeCell(tableView, at: indexPath)
+        case .deleteAction:      return makeDeleteActionCell(tableView, at: indexPath)
         }
     }
 }
@@ -415,121 +348,8 @@ extension CreateAlarmViewController: UITableViewDelegate {
         }
     }
 
-    private func confirmDelete() {
-        let alert = UIAlertController(
-            title: "Удалить будильник?",
-            message: "Это действие нельзя отменить.",
-            preferredStyle: .actionSheet
-        )
-        alert.addAction(UIAlertAction(title: "Удалить", style: .destructive) { [weak self] _ in
-            guard let self else { return }
-            // ViewModel.delete forwards to AlarmRepository.delete, which itself
-            // cancels the scheduled UNNotificationRequests via AlarmScheduler.
-            // Returns false when the store is locked due to a corrupt blob
-            // (issue #72) — surface the failure rather than dismiss the
-            // sheet on a no-op delete.
-            let didDelete = self.viewModel.delete()
-            guard didDelete else {
-                self.presentSaveError(
-                    title: "Не удалось сохранить",
-                    error: AlarmRepository.RepositoryError.persistBlocked
-                )
-                return
-            }
-            self.onDelete?()
-            self.dismiss(animated: true)
-        })
-        alert.addAction(UIAlertAction(title: "Отмена", style: .cancel))
-        // Without a sourceView the action sheet crashes on iPad popovers.
-        if let popover = alert.popoverPresentationController {
-            popover.sourceView = view
-            popover.sourceRect = CGRect(x: view.bounds.midX, y: view.bounds.midY, width: 0, height: 0)
-            popover.permittedArrowDirections = []
-        }
-        present(alert, animated: true)
-    }
-
-    private func showThemePicker() {
-        let picker = AlarmThemePickerViewController(
-            currentTheme: viewModel.theme,
-            onSelect: { [weak self] theme in
-                guard let self else { return }
-                self.viewModel.theme = theme
-                // Update the trailing-value label inline so the user sees
-                // the new theme name without waiting for `viewWillAppear`'s
-                // section reload (which doesn't fire for the in-place update
-                // that follows the imperative pop).
-                let indexPath = IndexPath(row: 0, section: Section.theme.rawValue)
-                if let cell = self.tableView.cellForRow(at: indexPath) as? ThemeRowCell {
-                    cell.configure(themeName: self.viewModel.alarmThemeName)
-                }
-            }
-        )
-        navigationController?.pushViewController(picker, animated: true)
-    }
-
-    private func showSoundPicker() {
-        let picker = SoundPickerViewController(
-            sounds: viewModel.availableSounds,
-            selectedID: viewModel.soundID,
-            onSelect: { [weak self] soundID in
-                self?.viewModel.soundID = soundID
-            },
-            previewSound: { [weak self] soundID in
-                self?.viewModel.previewSound(soundID)
-            }
-        )
-        navigationController?.pushViewController(picker, animated: true)
-    }
-
-    /// Push the new `VolumePickerViewController` (#150). The picker reports
-    /// every slider / switch change live so dismissing on the back chevron
-    /// is "auto-save" — the parent's `viewWillAppear` then refreshes the
-    /// volume row to render the new value.
-    private func showVolumePicker() {
-        let picker = VolumePickerViewController(
-            volume: viewModel.volume,
-            fadeIn: viewModel.volumeFadeIn
-        ) { [weak self] volume, fadeIn in
-            self?.viewModel.volume = volume
-            self?.viewModel.volumeFadeIn = fadeIn
-        }
-        navigationController?.pushViewController(picker, animated: true)
-    }
 }
 
-// MARK: - Section header
-
-/// Custom section-header view rendered above each `.insetGrouped` group on
-/// the create/edit form. Replaces the default footnote-cased header with the
-/// design-system `caps` role + tracking so headers read at the same weight
-/// as the rest of the brand-refreshed surfaces (#143, builds on #135).
-private final class SectionHeaderView: UIView {
-
-    init(text: String) {
-        super.init(frame: .zero)
-        backgroundColor = .clear
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.attributedText = NSAttributedString(
-            string: text.uppercased(),
-            attributes: [
-                .font: AppTypography.caps,
-                .kern: AppTypography.capsKerning,
-                .foregroundColor: AppColors.fg3
-            ]
-        )
-        addSubview(label)
-        NSLayoutConstraint.activate([
-            label.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
-            label.trailingAnchor.constraint(lessThanOrEqualTo: layoutMarginsGuide.trailingAnchor),
-            label.topAnchor.constraint(equalTo: topAnchor, constant: AppSpacing.lg),
-            label.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -AppSpacing.sm)
-        ])
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-}
+// `SectionHeaderView` lives in `Views/DesignSystem/SectionHeaderView.swift` so
+// the same caps-styled header can be reused by Settings + Transaction history
+// without copy-paste (#182).

--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController+Pages.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController+Pages.swift
@@ -1,0 +1,205 @@
+import UIKit
+
+// MARK: - Page content builders
+//
+// Extracted from `OnboardingViewController.swift` (#182) so the host file
+// stays under SwiftLint's `file_length` and `type_body_length` caps. The
+// helpers below previously lived as `private` instance methods on the main
+// type — only the physical location moved; behaviour is verbatim.
+
+extension OnboardingViewController {
+
+    /// Steps 1 & 2 — `h1` heading + `bodyLg` body, vertically centred and
+    /// inset by 32pt so the text wraps naturally without hugging the edges.
+    func makeTextPageView(title: String, body: String) -> UIView {
+        let container = UIView()
+        let stack = makeCopyStack(title: title, body: body)
+        container.addSubview(stack)
+        NSLayoutConstraint.activate([
+            // Slightly above centre so the action button + page dots don't
+            // optically crowd the body copy.
+            stack.centerYAnchor.constraint(equalTo: container.centerYAnchor, constant: -AppSpacing.sp9),
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: AppSpacing.sp7),
+            stack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -AppSpacing.sp7)
+        ])
+        return container
+    }
+
+    /// Step 3 — heading, body, three preset tiles, Apple Pay CTA, ghost
+    /// "Позже". The CTAs live inside the page (rather than the shared
+    /// `actionButton`) so the page-3 controls feel cohesive with the preset
+    /// tiles instead of appearing detached at the screen bottom.
+    func makeDepositPageView(title: String, body: String) -> UIView {
+        let container = UIView()
+        let copyStack = makeCopyStack(title: title, body: body)
+        let presetsStack = makePresetsStack()
+        container.addSubview(copyStack)
+        container.addSubview(presetsStack)
+        container.addSubview(ctaStack)
+        let inset = AppSpacing.screenInset
+        let outerInset = AppSpacing.sp7
+        NSLayoutConstraint.activate([
+            copyStack.topAnchor.constraint(
+                equalTo: container.safeAreaLayoutGuide.topAnchor,
+                constant: AppSpacing.sp10
+            ),
+            copyStack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: outerInset),
+            copyStack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -outerInset),
+
+            presetsStack.topAnchor.constraint(equalTo: copyStack.bottomAnchor, constant: outerInset),
+            presetsStack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: inset),
+            presetsStack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -inset),
+
+            ctaStack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: inset),
+            ctaStack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -inset),
+            ctaStack.bottomAnchor.constraint(
+                equalTo: container.safeAreaLayoutGuide.bottomAnchor,
+                constant: -AppSpacing.sp6
+            )
+        ])
+        return container
+    }
+
+    func makeCopyStack(title: String, body: String) -> UIStackView {
+        let titleLabel = UILabel()
+        titleLabel.text = title
+        titleLabel.font = AppTypography.h1
+        titleLabel.textColor = AppColors.fg1
+        titleLabel.textAlignment = .center
+        titleLabel.numberOfLines = 0
+
+        let bodyLabel = UILabel()
+        bodyLabel.text = body
+        bodyLabel.font = AppTypography.bodyLg
+        bodyLabel.textColor = AppColors.fg2
+        bodyLabel.textAlignment = .center
+        bodyLabel.numberOfLines = 0
+
+        let stack = UIStackView(arrangedSubviews: [titleLabel, bodyLabel])
+        stack.axis = .vertical
+        stack.spacing = AppSpacing.sp4
+        stack.alignment = .fill
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }
+
+    /// Replace the Apple Pay button instance with a fresh one whose title
+    /// reflects the currently-selected preset amount. SPButton has no public
+    /// title setter (its label is private), so the cheapest faithful path is
+    /// a full re-create — same trade-off `FiringTopUpBottomSheet` accepts
+    /// (one extra alloc per preset tap; max 3 swaps).
+    func updateApplePayTitle() {
+        guard let oldButton = ctaStack.arrangedSubviews.first as? SPButton else { return }
+        let amount = presetAmounts[selectedPresetIndex]
+        let newButton = SPButton(
+            title: "Начать с \(amount.formattedRubles())",
+            variant: .money,
+            size: .lg,
+            fullWidth: true
+        )
+        newButton.addTarget(self, action: #selector(applePayTapped), for: .touchUpInside)
+        ctaStack.removeArrangedSubview(oldButton)
+        oldButton.removeFromSuperview()
+        ctaStack.insertArrangedSubview(newButton, at: 0)
+        applePayButton = newButton
+    }
+
+    // MARK: - Actions
+
+    @objc
+    func applePayTapped() {
+        // Apple Pay path — mark onboarding completed and let the parent
+        // SceneDelegate swap the root. The actual IAP is handled from the
+        // main app's TopUp flow; the onboarding stays a pure UI layer so the
+        // SceneDelegate transition isn't blocked on a StoreKit round-trip.
+        // (PR #145 ships the visual + flag wiring; the StoreKit hook-up is a
+        // follow-up issue.)
+        UserDefaults.standard.set(true, forKey: Self.completedKey)
+        UserDefaults.standard.set(false, forKey: Self.firstTopUpDoneKey)
+        onFinished?()
+    }
+
+    @objc
+    func actionTapped() {
+        // `actionTapped` only fires while the shared CTA is visible (steps
+        // 1-2). Step 3 uses `applePayButton` / `laterButton` instead.
+        let currentPage = pageControl.currentPage
+        guard currentPage < pages.count - 1 else { return }
+        let nextPage = currentPage + 1
+        let offsetX = scrollView.bounds.width * CGFloat(nextPage)
+        scrollView.setContentOffset(CGPoint(x: offsetX, y: 0), animated: true)
+        pageControl.currentPage = nextPage
+        updatePagerState(forPage: nextPage)
+    }
+
+    @objc
+    func laterTapped() {
+        // "Позже" path — finish without IAP. Same persistence as the Apple
+        // Pay path so SceneDelegate doesn't re-mount onboarding next launch.
+        UserDefaults.standard.set(true, forKey: Self.completedKey)
+        UserDefaults.standard.set(false, forKey: Self.firstTopUpDoneKey)
+        onFinished?()
+    }
+
+    @objc
+    func skipTapped() {
+        // Top-right "Пропустить" — completes onboarding from any page; balance
+        // stays at 0 (the existing default in `BalanceService`).
+        UserDefaults.standard.set(true, forKey: Self.completedKey)
+        onFinished?()
+    }
+
+    // MARK: - State
+
+    /// Wired to each `SPAmountPreset.onTap` from `makePresetsStack`. Picks
+    /// the new index, recolours the tile row, and rebuilds the Apple Pay
+    /// CTA so its title shows the freshly-selected amount.
+    func handlePresetTap(index: Int) {
+        guard index < presetTiles.count else { return }
+        selectedPresetIndex = index
+        for (tileIndex, tile) in presetTiles.enumerated() {
+            tile.isSelected = tileIndex == index
+        }
+        updateApplePayTitle()
+    }
+
+    /// Drive the shared CTA (steps 1-2) and page-control state on every
+    /// scroll settle. Step 3 hides the shared CTA + page dots so the
+    /// page-3 layout owns the bottom edge.
+    func updatePagerState(forPage page: Int) {
+        let isLastPage = page == pages.count - 1
+
+        // Hide the shared action button on step 3 — that page mounts its own
+        // Apple Pay + "Позже" CTAs inside its content view. Likewise hide the
+        // page dots so they don't visually compete with the preset tiles.
+        actionButton.isHidden = isLastPage
+        pageControl.isHidden = isLastPage
+
+        // Step 3 controls focus on the deposit decision; "Пропустить" stays
+        // visible everywhere (including step 3) per spec — it's the global
+        // escape hatch, distinct from "Позже" which still records the
+        // first-top-up flag.
+        skipButton.isHidden = false
+
+        // The shared action button title is always "Далее" on steps 1-2 (no
+        // per-page copy) so there's nothing to update beyond visibility.
+    }
+
+    // MARK: - Page builders
+
+    func makePresetsStack() -> UIStackView {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.alignment = .fill
+        stack.distribution = .fillEqually
+        stack.spacing = AppSpacing.sp3
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        for (index, amount) in presetAmounts.enumerated() {
+            let tile = SPAmountPreset(value: amount, selected: index == defaultPresetIndex)
+            tile.onTap = { [weak self] in self?.handlePresetTap(index: index) }
+            presetTiles.append(tile)
+            stack.addArrangedSubview(tile)
+        }
+        return stack
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController.swift
@@ -18,12 +18,14 @@ final class OnboardingViewController: UIViewController {
 
     // MARK: - Persistence keys
 
-    private static let completedKey = "onboarding_completed"
+    /// `internal` so the cross-file `+Pages` extension can write the
+    /// onboarding-completion flag from its tap handlers (#182).
+    static let completedKey = "onboarding_completed"
     /// Set to `false` when the user finishes step 3 via "Позже" so future
     /// analytics / re-engagement can distinguish "user opted out of the
     /// first deposit" from "user paid". Stays absent until the user actually
     /// reaches step 3.
-    private static let firstTopUpDoneKey = "first_top_up_done"
+    static let firstTopUpDoneKey = "first_top_up_done"
 
     /// `true` once the user has finished onboarding (either Apple Pay path
     /// or "Позже" path). Read by `SceneDelegate` to decide whether to mount
@@ -34,12 +36,18 @@ final class OnboardingViewController: UIViewController {
 
     // MARK: - Page Data
 
-    private struct Page {
+    /// `internal` so the `+Pages` extension's page-builder helpers (which
+    /// receive `title` + `body` as plain strings) keep their parent type
+    /// visible from the cross-file extension (#182).
+    struct Page {
         let title: String
         let body: String
     }
 
-    private let pages: [Page] = [
+    /// `internal` so the cross-file `+Pages` extension can iterate this list
+    /// when computing pager state and the page count for the deposit page
+    /// (#182).
+    let pages: [Page] = [
         Page(
             title: "Что такое SnoozePay",
             body: """
@@ -67,8 +75,10 @@ final class OnboardingViewController: UIViewController {
     ]
 
     /// Preset amounts on step 3. Default selection is the middle tile (500 ₽).
-    private let presetAmounts: [Decimal] = [200, 500, 1000]
-    private let defaultPresetIndex: Int = 1
+    /// `internal` so the cross-file `+Pages` extension can build the preset
+    /// stack from this list (#182).
+    let presetAmounts: [Decimal] = [200, 500, 1000]
+    let defaultPresetIndex: Int = 1
 
     // MARK: - Callback
 
@@ -97,7 +107,9 @@ final class OnboardingViewController: UIViewController {
 
     // MARK: - UI Elements
 
-    private let scrollView: UIScrollView = {
+    /// `internal` so the `+Pages` extension can drive page-snap from the
+    /// "Далее" CTA tap handler (#182).
+    let scrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.isPagingEnabled = true
         scrollView.showsHorizontalScrollIndicator = false
@@ -110,8 +122,9 @@ final class OnboardingViewController: UIViewController {
     /// Page dots — kept as `UIPageControl` so the existing test
     /// (`OnboardingTests.testOnboardingPages_count`) keeps reaching for the
     /// same view kind. Tinted with brand tokens: `money500` for the active
-    /// dot (matches the deposit hero), `fg3` for the rest.
-    private let pageControl: UIPageControl = {
+    /// dot (matches the deposit hero), `fg3` for the rest. `internal` so
+    /// the `+Pages` extension can flip its visibility / index (#182).
+    let pageControl: UIPageControl = {
         let pageControl = UIPageControl()
         pageControl.currentPageIndicatorTintColor = AppColors.money500
         pageControl.pageIndicatorTintColor = AppColors.fg3
@@ -121,7 +134,8 @@ final class OnboardingViewController: UIViewController {
     }()
 
     /// Top-right "Пропустить" — restyled as `SPButton(.quiet, .sm)`.
-    private let skipButton = SPButton(
+    /// `internal` so `+Pages.updatePagerState` can flip its hidden flag.
+    let skipButton = SPButton(
         title: "Пропустить",
         variant: .quiet,
         size: .sm
@@ -130,8 +144,9 @@ final class OnboardingViewController: UIViewController {
     /// Primary CTA. On steps 1-2 this reads "Далее" and advances the pager;
     /// on step 3 the VC swaps it for an Apple Pay-flavoured money button
     /// (`actionButton` is the step-1/2 instance only; step-3 uses
-    /// `applePayButton` mounted inside the page).
-    private let actionButton = SPButton(
+    /// `applePayButton` mounted inside the page). `internal` so
+    /// `+Pages.updatePagerState` can flip its hidden flag (#182).
+    let actionButton = SPButton(
         title: "Далее",
         variant: .money,
         size: .lg,
@@ -141,8 +156,10 @@ final class OnboardingViewController: UIViewController {
     /// Step-3 Apple Pay primary CTA — mounted inside the third page so it
     /// scrolls in/out with the page. SPButton has no public title setter, so
     /// the title-change-on-preset-change path replaces the whole button via
-    /// `rebuildApplePayButton()` (same pattern as FiringTopUpBottomSheet).
-    private var applePayButton: SPButton = SPButton(
+    /// `updateApplePayTitle()` (same pattern as FiringTopUpBottomSheet).
+    /// `internal` so the cross-file `+Pages.updateApplePayTitle` can swap
+    /// the instance (#182).
+    var applePayButton: SPButton = SPButton(
         title: "Начать с 500 ₽",
         variant: .money,
         size: .lg,
@@ -162,8 +179,9 @@ final class OnboardingViewController: UIViewController {
 
     /// CTA stack on step 3 — owns the (re-creatable) Apple Pay button as its
     /// first arranged subview so `rebuildApplePayButton()` can swap the
-    /// instance without re-pinning constraints.
-    private let ctaStack: UIStackView = {
+    /// instance without re-pinning constraints. `internal` so the `+Pages`
+    /// extension can mount it inside the deposit page (#182).
+    let ctaStack: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
         stackView.spacing = AppSpacing.sp3
@@ -173,12 +191,15 @@ final class OnboardingViewController: UIViewController {
     }()
 
     private var pageViews: [UIView] = []
-    private var presetTiles: [SPAmountPreset] = []
+    /// `internal` so the `+Pages` extension can append to the same array
+    /// during the page-build pass (#182).
+    var presetTiles: [SPAmountPreset] = []
 
     /// Currently-selected preset index on step 3. Initialised to
     /// `defaultPresetIndex` (500 ₽). Drives both the Apple Pay CTA title and
-    /// which tile renders selected.
-    private lazy var selectedPresetIndex: Int = defaultPresetIndex
+    /// which tile renders selected. `internal` so the cross-file `+Pages`
+    /// extension can read the current selection inside `updateApplePayTitle`.
+    lazy var selectedPresetIndex: Int = defaultPresetIndex
 
     // MARK: - Lifecycle
 
@@ -232,6 +253,15 @@ final class OnboardingViewController: UIViewController {
         pageControl.numberOfPages = pages.count
         pageControl.currentPage = 0
 
+        activateChromeConstraints()
+        wireActionTargets()
+        buildPageStack()
+    }
+
+    /// Pin skip button, scroll view, action button, and page control to the
+    /// view edges. Split off `setupUI` so the function body stays under
+    /// SwiftLint's `function_body_length` cap (#182).
+    private func activateChromeConstraints() {
         NSLayoutConstraint.activate([
             // Skip button — top right.
             skipButton.topAnchor.constraint(
@@ -270,7 +300,11 @@ final class OnboardingViewController: UIViewController {
                 constant: -AppSpacing.sp4
             )
         ])
+    }
 
+    /// Wire scrollView delegate + every CTA's target/action. Pulled out of
+    /// `setupUI` so its body fits SwiftLint's function-length cap (#182).
+    private func wireActionTargets() {
         scrollView.delegate = self
         skipButton.addTarget(self, action: #selector(skipTapped), for: .touchUpInside)
         actionButton.addTarget(self, action: #selector(actionTapped), for: .touchUpInside)
@@ -279,209 +313,26 @@ final class OnboardingViewController: UIViewController {
 
         ctaStack.addArrangedSubview(applePayButton)
         ctaStack.addArrangedSubview(laterButton)
+    }
 
-        // Build page content — first two pages share one layout, step 3 is a
-        // bespoke "deposit" page with preset tiles + dual CTAs.
+    /// Build page content — first two pages share one layout, step 3 is a
+    /// bespoke "deposit" page with preset tiles + dual CTAs. Page builders
+    /// live in `OnboardingViewController+Pages.swift` (#182).
+    private func buildPageStack() {
         for (index, page) in pages.enumerated() {
             let pageView: UIView
             if index == pages.count - 1 {
-                pageView = makeDepositPageView(page: page)
+                pageView = makeDepositPageView(title: page.title, body: page.body)
             } else {
-                pageView = makeTextPageView(page: page)
+                pageView = makeTextPageView(title: page.title, body: page.body)
             }
             scrollView.addSubview(pageView)
             pageViews.append(pageView)
         }
     }
 
-    /// Steps 1 & 2 — `h1` heading + `bodyLg` body, vertically centred and
-    /// inset by 32pt so the text wraps naturally without hugging the edges.
-    private func makeTextPageView(page: Page) -> UIView {
-        let container = UIView()
-        let stack = makeCopyStack(title: page.title, body: page.body)
-        container.addSubview(stack)
-        NSLayoutConstraint.activate([
-            // Slightly above centre so the action button + page dots don't
-            // optically crowd the body copy.
-            stack.centerYAnchor.constraint(equalTo: container.centerYAnchor, constant: -AppSpacing.sp9),
-            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: AppSpacing.sp7),
-            stack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -AppSpacing.sp7)
-        ])
-        return container
-    }
-
-    /// Step 3 — heading, body, three preset tiles, Apple Pay CTA, ghost
-    /// "Позже". The CTAs live inside the page (rather than the shared
-    /// `actionButton`) so the page-3 controls feel cohesive with the preset
-    /// tiles instead of appearing detached at the screen bottom.
-    private func makeDepositPageView(page: Page) -> UIView {
-        let container = UIView()
-        let copyStack = makeCopyStack(title: page.title, body: page.body)
-        let presetsStack = makePresetsStack()
-        container.addSubview(copyStack)
-        container.addSubview(presetsStack)
-        container.addSubview(ctaStack)
-        let inset = AppSpacing.screenInset
-        let outerInset = AppSpacing.sp7
-        NSLayoutConstraint.activate([
-            copyStack.topAnchor.constraint(
-                equalTo: container.safeAreaLayoutGuide.topAnchor,
-                constant: AppSpacing.sp10
-            ),
-            copyStack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: outerInset),
-            copyStack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -outerInset),
-
-            presetsStack.topAnchor.constraint(equalTo: copyStack.bottomAnchor, constant: outerInset),
-            presetsStack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: inset),
-            presetsStack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -inset),
-
-            ctaStack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: inset),
-            ctaStack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -inset),
-            ctaStack.bottomAnchor.constraint(
-                equalTo: container.safeAreaLayoutGuide.bottomAnchor,
-                constant: -AppSpacing.sp6
-            )
-        ])
-        return container
-    }
-
-    private func makeCopyStack(title: String, body: String) -> UIStackView {
-        let titleLabel = UILabel()
-        titleLabel.text = title
-        titleLabel.font = AppTypography.h1
-        titleLabel.textColor = AppColors.fg1
-        titleLabel.textAlignment = .center
-        titleLabel.numberOfLines = 0
-
-        let bodyLabel = UILabel()
-        bodyLabel.text = body
-        bodyLabel.font = AppTypography.bodyLg
-        bodyLabel.textColor = AppColors.fg2
-        bodyLabel.textAlignment = .center
-        bodyLabel.numberOfLines = 0
-
-        let stack = UIStackView(arrangedSubviews: [titleLabel, bodyLabel])
-        stack.axis = .vertical
-        stack.spacing = AppSpacing.sp4
-        stack.alignment = .fill
-        stack.translatesAutoresizingMaskIntoConstraints = false
-        return stack
-    }
-
-    private func makePresetsStack() -> UIStackView {
-        let stack = UIStackView()
-        stack.axis = .horizontal
-        stack.alignment = .fill
-        stack.distribution = .fillEqually
-        stack.spacing = AppSpacing.sp3
-        stack.translatesAutoresizingMaskIntoConstraints = false
-        for (index, amount) in presetAmounts.enumerated() {
-            let tile = SPAmountPreset(value: amount, selected: index == defaultPresetIndex)
-            tile.onTap = { [weak self] in self?.handlePresetTap(index: index) }
-            presetTiles.append(tile)
-            stack.addArrangedSubview(tile)
-        }
-        return stack
-    }
-
-    // MARK: - Actions
-
-    @objc
-    private func actionTapped() {
-        // `actionTapped` only fires while the shared CTA is visible (steps
-        // 1-2). Step 3 uses `applePayButton` / `laterButton` instead.
-        let currentPage = pageControl.currentPage
-        guard currentPage < pages.count - 1 else { return }
-        let nextPage = currentPage + 1
-        let offsetX = scrollView.bounds.width * CGFloat(nextPage)
-        scrollView.setContentOffset(CGPoint(x: offsetX, y: 0), animated: true)
-        pageControl.currentPage = nextPage
-        updatePagerState(forPage: nextPage)
-    }
-
-    @objc
-    private func applePayTapped() {
-        // Apple Pay path — mark onboarding completed and let the parent
-        // SceneDelegate swap the root. The actual IAP is handled from the
-        // main app's TopUp flow; the onboarding stays a pure UI layer so the
-        // SceneDelegate transition isn't blocked on a StoreKit round-trip.
-        // (PR #145 ships the visual + flag wiring; the StoreKit hook-up is a
-        // follow-up issue.)
-        UserDefaults.standard.set(true, forKey: Self.completedKey)
-        UserDefaults.standard.set(false, forKey: Self.firstTopUpDoneKey)
-        onFinished?()
-    }
-
-    @objc
-    private func laterTapped() {
-        // "Позже" path — finish without IAP. Same persistence as the Apple
-        // Pay path so SceneDelegate doesn't re-mount onboarding next launch.
-        UserDefaults.standard.set(true, forKey: Self.completedKey)
-        UserDefaults.standard.set(false, forKey: Self.firstTopUpDoneKey)
-        onFinished?()
-    }
-
-    @objc
-    private func skipTapped() {
-        // Top-right "Пропустить" — completes onboarding from any page; balance
-        // stays at 0 (the existing default in `BalanceService`).
-        UserDefaults.standard.set(true, forKey: Self.completedKey)
-        onFinished?()
-    }
-
-    // MARK: - State
-
-    private func handlePresetTap(index: Int) {
-        guard index < presetTiles.count else { return }
-        selectedPresetIndex = index
-        for (tileIndex, tile) in presetTiles.enumerated() {
-            tile.isSelected = tileIndex == index
-        }
-        updateApplePayTitle()
-    }
-
-    /// Replace the Apple Pay button instance with a fresh one whose title
-    /// reflects the currently-selected preset amount. SPButton has no public
-    /// title setter (its label is private), so the cheapest faithful path is
-    /// a full re-create — same trade-off `FiringTopUpBottomSheet` accepts
-    /// (one extra alloc per preset tap; max 3 swaps).
-    private func updateApplePayTitle() {
-        guard let oldButton = ctaStack.arrangedSubviews.first as? SPButton else { return }
-        let amount = presetAmounts[selectedPresetIndex]
-        let newButton = SPButton(
-            title: "Начать с \(amount.formattedRubles())",
-            variant: .money,
-            size: .lg,
-            fullWidth: true
-        )
-        newButton.addTarget(self, action: #selector(applePayTapped), for: .touchUpInside)
-        ctaStack.removeArrangedSubview(oldButton)
-        oldButton.removeFromSuperview()
-        ctaStack.insertArrangedSubview(newButton, at: 0)
-        applePayButton = newButton
-    }
-
-    /// Drive the shared CTA (steps 1-2) and page-control state on every
-    /// scroll settle. Step 3 hides the shared CTA + page dots so the
-    /// page-3 layout owns the bottom edge.
-    private func updatePagerState(forPage page: Int) {
-        let isLastPage = page == pages.count - 1
-
-        // Hide the shared action button on step 3 — that page mounts its own
-        // Apple Pay + "Позже" CTAs inside its content view. Likewise hide the
-        // page dots so they don't visually compete with the preset tiles.
-        actionButton.isHidden = isLastPage
-        pageControl.isHidden = isLastPage
-
-        // Step 3 controls focus on the deposit decision; "Пропустить" stays
-        // visible everywhere (including step 3) per spec — it's the global
-        // escape hatch, distinct from "Позже" which still records the
-        // first-top-up flag.
-        skipButton.isHidden = false
-
-        // The shared action button title is always "Далее" on steps 1-2 (no
-        // per-page copy) so there's nothing to update beyond visibility.
-    }
+    // Actions, preset-tap handler, and pager state live in
+    // `OnboardingViewController+Pages.swift` (#182).
 }
 
 // MARK: - UIScrollViewDelegate

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController+Legal.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController+Legal.swift
@@ -1,0 +1,45 @@
+import UIKit
+
+// MARK: - Legal VC
+//
+// Pushed by `SettingsViewController` for the "Privacy" / "Terms" rows in the
+// `.info` section. Extracted from the host file (#182) to keep it under the
+// SwiftLint `file_length` cap; behaviour is unchanged.
+
+/// Simple text placeholder view controller — the actual legal documents
+/// will land before App Store submission.
+final class LegalViewController: UIViewController {
+
+    private let legalTitle: String
+
+    init(title: String) {
+        self.legalTitle = title
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = legalTitle
+        view.backgroundColor = AppColors.bg0
+
+        let textView = UITextView()
+        textView.text = "\(legalTitle)\n\nДокумент будет добавлен перед публикацией в App Store."
+        textView.font = AppTypography.body
+        textView.textColor = AppColors.fg1
+        textView.backgroundColor = .clear
+        textView.isEditable = false
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(textView)
+
+        NSLayoutConstraint.activate([
+            textView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 16),
+            textView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
+            textView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+            textView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController+Sections.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController+Sections.swift
@@ -1,0 +1,217 @@
+import UIKit
+
+// MARK: - Section + cell builders
+//
+// Extracted from `SettingsViewController.swift` (#182) so the host file stays
+// under SwiftLint's `file_length` cap. Each helper owns its row's UIKit
+// composition; behaviour is verbatim — only the physical location moved.
+
+extension SettingsViewController {
+
+    // MARK: Account section
+
+    func makeTransactionHistoryRow() -> UITableViewCell {
+        makeIconRow(
+            systemName: "list.bullet.rectangle",
+            iconColor: AppColors.info500,
+            title: "История транзакций",
+            accessory: .disclosureIndicator
+        )
+    }
+
+    func makeBalanceRow() -> UITableViewCell {
+        let cell = makeIconRow(
+            systemName: "dollarsign.circle",
+            iconColor: AppColors.money500,
+            title: "Баланс",
+            accessory: .none
+        )
+
+        let balanceAmount = UILabel()
+        balanceAmount.text = "₽\(Int(BalanceService.shared.balance))"
+        balanceAmount.font = AppTypography.moneyMd
+        balanceAmount.textColor = AppColors.money500
+        balanceAmount.translatesAutoresizingMaskIntoConstraints = false
+        balanceAmount.setContentHuggingPriority(.required, for: .horizontal)
+        cell.contentView.addSubview(balanceAmount)
+
+        NSLayoutConstraint.activate([
+            balanceAmount.trailingAnchor.constraint(
+                equalTo: cell.contentView.trailingAnchor,
+                constant: -AppSpacing.lg
+            ),
+            balanceAmount.centerYAnchor.constraint(equalTo: cell.contentView.centerYAnchor)
+        ])
+
+        // Track the latest label instance so the balance observer can
+        // refresh it. When the cell is recycled the weak ref nils out
+        // automatically, so the observer becomes a no-op until the row
+        // is rebuilt — at which point this assignment captures the new label.
+        self.balanceAmountLabel = balanceAmount
+
+        cell.selectionStyle = .none
+        return cell
+    }
+
+    // MARK: Info section
+
+    func makeInfoRow(at indexPath: IndexPath) -> UITableViewCell {
+        let title = indexPath.row == 0 ? "Политика конфиденциальности" : "Пользовательское соглашение"
+        return makeIconRow(
+            systemName: "doc.text",
+            iconColor: UIColor.systemGray,
+            title: title,
+            accessory: .disclosureIndicator
+        )
+    }
+
+    // MARK: Contact section
+
+    func makeContactRow() -> UITableViewCell {
+        let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
+        cell.backgroundColor = .secondarySystemBackground
+
+        let icon = makeSettingsIcon(systemName: "envelope", backgroundColor: AppColors.warn500)
+        let titleLabel = UILabel()
+        titleLabel.text = "Связаться с нами"
+        titleLabel.font = AppTypography.bodyLg
+        titleLabel.textColor = AppColors.fg1
+
+        let detailLabel = UILabel()
+        detailLabel.text = "support@alarmcash.app"
+        detailLabel.font = AppTypography.meta
+        detailLabel.textColor = AppColors.fg3
+
+        let textStack = UIStackView(arrangedSubviews: [titleLabel, detailLabel])
+        textStack.axis = .vertical
+        textStack.spacing = 2
+
+        let stack = UIStackView(arrangedSubviews: [icon, textStack])
+        stack.axis = .horizontal
+        stack.spacing = AppSpacing.md
+        stack.alignment = .center
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        cell.contentView.addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(
+                equalTo: cell.contentView.leadingAnchor,
+                constant: AppSpacing.lg
+            ),
+            stack.centerYAnchor.constraint(equalTo: cell.contentView.centerYAnchor),
+            stack.trailingAnchor.constraint(
+                lessThanOrEqualTo: cell.contentView.trailingAnchor,
+                constant: -AppSpacing.lg
+            )
+        ])
+
+        cell.accessoryType = .disclosureIndicator
+        return cell
+    }
+
+    // MARK: - Cell factory helpers
+
+    func makeIconRow(
+        systemName: String,
+        iconColor: UIColor,
+        title: String,
+        accessory: UITableViewCell.AccessoryType
+    ) -> UITableViewCell {
+        let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
+        cell.backgroundColor = .secondarySystemBackground
+
+        let icon = makeSettingsIcon(systemName: systemName, backgroundColor: iconColor)
+        let label = UILabel()
+        label.text = title
+        label.font = AppTypography.bodyLg
+        label.textColor = AppColors.fg1
+
+        let stack = UIStackView(arrangedSubviews: [icon, label])
+        stack.axis = .horizontal
+        stack.spacing = AppSpacing.md
+        stack.alignment = .center
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        cell.contentView.addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor, constant: AppSpacing.lg),
+            stack.centerYAnchor.constraint(equalTo: cell.contentView.centerYAnchor)
+        ])
+
+        cell.accessoryType = accessory
+        return cell
+    }
+
+    /// Creates a rounded-rect icon with an SF Symbol, similar to iOS Settings style.
+    func makeSettingsIcon(systemName: String, backgroundColor: UIColor) -> UIView {
+        let size: CGFloat = 30
+        let container = UIView()
+        container.backgroundColor = backgroundColor
+        container.layer.cornerRadius = 7
+        container.layer.masksToBounds = true
+        container.translatesAutoresizingMaskIntoConstraints = false
+
+        let imageView = UIImageView()
+        imageView.image = UIImage(systemName: systemName)?.withConfiguration(
+            UIImage.SymbolConfiguration(pointSize: 15, weight: .medium)
+        )
+        imageView.tintColor = .white
+        imageView.contentMode = .scaleAspectFit
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(imageView)
+
+        NSLayoutConstraint.activate([
+            container.widthAnchor.constraint(equalToConstant: size),
+            container.heightAnchor.constraint(equalToConstant: size),
+            imageView.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+            imageView.centerYAnchor.constraint(equalTo: container.centerYAnchor)
+        ])
+
+        return container
+    }
+
+    // MARK: - Section header builder
+
+    /// Returns the caps-styled header view for the given section title. Kept
+    /// as a tiny helper so `viewForHeaderInSection` (in the host file) is a
+    /// one-liner and the typography lives next to the rest of the row UI.
+    func makeSettingsSectionHeader(text: String) -> UIView {
+        SettingsSectionHeaderView(text: text)
+    }
+}
+
+// MARK: - Section header view
+
+/// Caps-styled section header used by both `SettingsViewController` and the
+/// nested `TransactionHistoryViewController`. Mirrors `CreateAlarmViewController`'s
+/// shared `SectionHeaderView` (#177); kept as a private file-scoped duplicate
+/// inside the Settings stack per #182's "don't touch the private header" note.
+final class SettingsSectionHeaderView: UIView {
+
+    init(text: String) {
+        super.init(frame: .zero)
+        backgroundColor = .clear
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.attributedText = NSAttributedString(
+            string: text.uppercased(),
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.fg3
+            ]
+        )
+        addSubview(label)
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
+            label.trailingAnchor.constraint(lessThanOrEqualTo: layoutMarginsGuide.trailingAnchor),
+            label.topAnchor.constraint(equalTo: topAnchor, constant: AppSpacing.lg),
+            label.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -AppSpacing.sm)
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController+TransactionCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController+TransactionCell.swift
@@ -1,0 +1,298 @@
+import UIKit
+import os
+
+// MARK: - Transaction History VC + cell
+//
+// Extracted from `SettingsViewController.swift` (#182) so the host file
+// stays under SwiftLint's `file_length` cap. These two siblings used to
+// live at file scope below the main VC — only the physical location moved;
+// behaviour is verbatim.
+
+/// Pushed by `SettingsViewController` when the user taps "История транзакций"
+/// in the .account section. Renders the latest ledger entries as inset-grouped
+/// rows with the `TransactionCell` below.
+final class TransactionHistoryViewController: UIViewController {
+
+    private let tableView: UITableView = {
+        let table = UITableView(frame: .zero, style: .insetGrouped)
+        table.translatesAutoresizingMaskIntoConstraints = false
+        return table
+    }()
+
+    private var transactions: [Transaction] = []
+    private let alarmRepository = AlarmRepository.shared
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "История транзакций"
+        view.backgroundColor = AppColors.bg0
+        setupTableView()
+        loadTransactions()
+    }
+
+    private func setupTableView() {
+        view.addSubview(tableView)
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.register(TransactionCell.self, forCellReuseIdentifier: TransactionCell.reuseID)
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+
+    private func loadTransactions() {
+        // Use the checked variant so a corrupt ledger surfaces an alert
+        // instead of rendering the misleading "Нет транзакций" empty state
+        // — that would let the user assume the app reset itself (issue #117).
+        do {
+            transactions = try TransactionRepository.shared.fetchAllChecked()
+        } catch let error as TransactionRepository.RepositoryError {
+            transactions = []
+            presentLoadError(error)
+        } catch {
+            transactions = []
+        }
+        tableView.reloadData()
+    }
+
+    private func presentLoadError(_ error: LocalizedError) {
+        let alert = UIAlertController(
+            title: "Ошибка",
+            message: error.errorDescription,
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
+    }
+}
+
+extension TransactionHistoryViewController: UITableViewDataSource, UITableViewDelegate {
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        transactions.isEmpty ? 1 : transactions.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        if transactions.isEmpty {
+            let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
+            cell.textLabel?.text = "Нет транзакций"
+            cell.textLabel?.textColor = .secondaryLabel
+            cell.textLabel?.textAlignment = .center
+            cell.backgroundColor = .secondarySystemBackground
+            cell.selectionStyle = .none
+            return cell
+        }
+
+        guard let cell = tableView.dequeueReusableCell(
+            withIdentifier: TransactionCell.reuseID, for: indexPath
+        ) as? TransactionCell else {
+            assertionFailure("dequeueReusableCell returned wrong type for \(TransactionCell.reuseID)")
+            return UITableViewCell()
+        }
+
+        let transaction = transactions[indexPath.row]
+
+        // Look up alarm name if available — best-effort enrichment. If the
+        // alarm store is corrupt we log and fall back to nil so the row
+        // still renders (transaction amount/date is still meaningful).
+        // Without this, a single corrupt alarms blob would silently strip
+        // alarm names from every history row (issue #117).
+        var alarmName: String?
+        if let alarmIDString = transaction.alarmID, let alarmUUID = UUID(uuidString: alarmIDString) {
+            do {
+                alarmName = try alarmRepository.fetchChecked(id: alarmUUID)?.name
+            } catch {
+                let errorDesc = String(describing: error)
+                AppLogger.ui.error(
+                    "TxHistory: name lookup failed for \(alarmUUID, privacy: .private): \(errorDesc, privacy: .public)"
+                )
+            }
+        }
+
+        cell.configure(with: transaction, alarmName: alarmName)
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        transactions.isEmpty ? 52 : 64
+    }
+
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        "ИСТОРИЯ"
+    }
+
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard let title = self.tableView(tableView, titleForHeaderInSection: section) else {
+            return nil
+        }
+        return SectionHeaderView(text: title)
+    }
+
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        UITableView.automaticDimension
+    }
+
+    /// Mirror SettingsViewController so the transaction list reads as a card
+    /// in light mode rather than blending into the page.
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        let totalRows = self.tableView(tableView, numberOfRowsInSection: indexPath.section)
+        let position = CardRowPosition.resolve(row: indexPath.row, totalRows: totalRows)
+        cell.styleAsCardRow(position: position)
+    }
+}
+
+// MARK: - Transaction Cell
+
+final class TransactionCell: UITableViewCell {
+
+    static let reuseID = "TransactionCell"
+
+    // MARK: - UI
+
+    private let iconContainer: UIView = {
+        let view = UIView()
+        view.layer.cornerRadius = 20
+        view.layer.masksToBounds = true
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let iconImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.tintColor = .white
+        imageView.contentMode = .scaleAspectFit
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = AppTypography.bodyLg
+        label.textColor = AppColors.fg1
+        return label
+    }()
+
+    private let subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.font = AppTypography.meta
+        label.textColor = AppColors.fg3
+        return label
+    }()
+
+    private let amountLabel: UILabel = {
+        let label = UILabel()
+        label.font = AppTypography.moneyMd
+        label.textAlignment = .right
+        label.setContentHuggingPriority(.required, for: .horizontal)
+        label.setContentCompressionResistancePriority(.required, for: .horizontal)
+        return label
+    }()
+
+    // MARK: - Init
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Setup
+
+    private func setupUI() {
+        backgroundColor = .secondarySystemBackground
+        selectionStyle = .none
+
+        iconContainer.addSubview(iconImageView)
+
+        let textStack = UIStackView(arrangedSubviews: [titleLabel, subtitleLabel])
+        textStack.axis = .vertical
+        textStack.spacing = 2
+
+        let mainStack = UIStackView(arrangedSubviews: [iconContainer, textStack, amountLabel])
+        mainStack.axis = .horizontal
+        mainStack.spacing = AppSpacing.md
+        mainStack.alignment = .center
+        mainStack.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(mainStack)
+
+        NSLayoutConstraint.activate([
+            iconContainer.widthAnchor.constraint(equalToConstant: 40),
+            iconContainer.heightAnchor.constraint(equalToConstant: 40),
+            iconImageView.centerXAnchor.constraint(equalTo: iconContainer.centerXAnchor),
+            iconImageView.centerYAnchor.constraint(equalTo: iconContainer.centerYAnchor),
+            iconImageView.widthAnchor.constraint(equalToConstant: 18),
+            iconImageView.heightAnchor.constraint(equalToConstant: 18),
+
+            mainStack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.lg),
+            mainStack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.lg),
+            mainStack.topAnchor.constraint(equalTo: contentView.topAnchor, constant: AppSpacing.sm),
+            mainStack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -AppSpacing.sm)
+        ])
+    }
+
+    // MARK: - Configure
+
+    func configure(with transaction: Transaction, alarmName: String?) {
+        let isCredit = transaction.type != .charge
+
+        // Icon — credits (topup, promotion) read green/up; charges red/down.
+        // Promotion gets a distinct gift glyph so the user can tell a
+        // referral bonus apart from an IAP top-up at a glance (issue #144).
+        iconContainer.backgroundColor = isCredit ? AppColors.money500 : AppColors.pain500
+        let iconName: String
+        switch transaction.type {
+        case .topup:     iconName = "arrow.up"
+        case .charge:    iconName = "arrow.down"
+        case .promotion: iconName = "gift.fill"
+        }
+        iconImageView.image = UIImage(systemName: iconName)?.withConfiguration(
+            UIImage.SymbolConfiguration(pointSize: 14, weight: .bold)
+        )
+
+        // Title — promotion reads "Бонус" so the row doesn't claim the user
+        // paid for the credit (which would mislead anyone scanning their
+        // history for IAP receipts).
+        switch transaction.type {
+        case .topup:     titleLabel.text = "Пополнение"
+        case .charge:    titleLabel.text = "Откладывание"
+        case .promotion: titleLabel.text = "Бонус"
+        }
+
+        // Subtitle: alarm name + date for charges; just the date otherwise.
+        let dateString = Self.formatDate(transaction.createdAt)
+        if let name = alarmName, transaction.type == .charge {
+            subtitleLabel.text = "\(name) \u{00B7} \(dateString)"
+        } else {
+            subtitleLabel.text = dateString
+        }
+
+        // Amount
+        let amount = Int(transaction.amount)
+        if isCredit {
+            amountLabel.text = "+₽\(amount)"
+            amountLabel.textColor = AppColors.money500
+        } else {
+            amountLabel.text = "₽\(amount)"
+            amountLabel.textColor = AppColors.pain500
+        }
+    }
+
+    // MARK: - Date formatting
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ru_RU")
+        formatter.dateFormat = "d MMMM 'в' HH:mm"
+        return formatter
+    }()
+
+    private static func formatDate(_ date: Date) -> String {
+        dateFormatter.string(from: date)
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController.swift
@@ -19,8 +19,10 @@ class SettingsViewController: UIViewController {
     }()
 
     /// Held weakly so the cell may be recycled (and the label deallocated)
-    /// without leaving the observer with a dangling reference.
-    private weak var balanceAmountLabel: UILabel?
+    /// without leaving the observer with a dangling reference. `internal`
+    /// so the cross-file `+Sections.makeBalanceRow` can capture a fresh
+    /// reference each time the row is dequeued (#182).
+    weak var balanceAmountLabel: UILabel?
 
     // MARK: - Init
 
@@ -180,7 +182,7 @@ extension SettingsViewController: UITableViewDataSource {
         guard let title = self.tableView(tableView, titleForHeaderInSection: section) else {
             return nil
         }
-        return SettingsSectionHeaderView(text: title)
+        return makeSettingsSectionHeader(text: title)
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
@@ -196,178 +198,42 @@ extension SettingsViewController: UITableViewDataSource {
         guard let section = Section(rawValue: indexPath.section) else { return UITableViewCell() }
 
         switch section {
-        case .account:
-            if indexPath.row == 0 {
-                return makeIconRow(
-                    systemName: "list.bullet.rectangle",
-                    iconColor: AppColors.info500,
-                    title: "История транзакций",
-                    accessory: .disclosureIndicator
-                )
-            } else {
-                let cell = makeIconRow(
-                    systemName: "dollarsign.circle",
-                    iconColor: AppColors.money500,
-                    title: "Баланс",
-                    accessory: .none
-                )
-
-                let balanceAmount = UILabel()
-                balanceAmount.text = "₽\(Int(BalanceService.shared.balance))"
-                balanceAmount.font = AppTypography.moneyMd
-                balanceAmount.textColor = AppColors.money500
-                balanceAmount.translatesAutoresizingMaskIntoConstraints = false
-                balanceAmount.setContentHuggingPriority(.required, for: .horizontal)
-                cell.contentView.addSubview(balanceAmount)
-
-                NSLayoutConstraint.activate([
-                    balanceAmount.trailingAnchor.constraint(
-                        equalTo: cell.contentView.trailingAnchor,
-                        constant: -AppSpacing.lg
-                    ),
-                    balanceAmount.centerYAnchor.constraint(equalTo: cell.contentView.centerYAnchor)
-                ])
-
-                // Track the latest label instance so the balance observer can
-                // refresh it. When the cell is recycled the weak ref nils out
-                // automatically, so the observer becomes a no-op until the row
-                // is rebuilt — at which point this assignment captures the new label.
-                self.balanceAmountLabel = balanceAmount
-
-                cell.selectionStyle = .none
-                return cell
-            }
-
-        case .referral:
-            return makeReferralCell(at: indexPath)
-
-        case .appearance:
-            // Dedicated cell type owns the segment control — avoids the previous
-            // removeFromSuperview/re-add dance that left the control bound to
-            // whichever cell rendered last.
-            guard let cell = tableView.dequeueReusableCell(
-                withIdentifier: ThemeSegmentCell.reuseID,
-                for: indexPath
-            ) as? ThemeSegmentCell else {
-                assertionFailure("dequeueReusableCell returned wrong type for \(ThemeSegmentCell.reuseID)")
-                return UITableViewCell()
-            }
-            cell.configure(selectedIndex: themeSegmentIndex) { [weak self] index in
-                self?.handleThemeSegmentChange(index)
-            }
-            return cell
-
-        case .info:
-            let title = indexPath.row == 0 ? "Политика конфиденциальности" : "Пользовательское соглашение"
-            return makeIconRow(
-                systemName: "doc.text",
-                iconColor: UIColor.systemGray,
-                title: title,
-                accessory: .disclosureIndicator
-            )
-
-        case .contact:
-            let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
-            cell.backgroundColor = .secondarySystemBackground
-
-            let icon = makeSettingsIcon(systemName: "envelope", backgroundColor: AppColors.warn500)
-            let titleLabel = UILabel()
-            titleLabel.text = "Связаться с нами"
-            titleLabel.font = AppTypography.bodyLg
-            titleLabel.textColor = AppColors.fg1
-
-            let detailLabel = UILabel()
-            detailLabel.text = "support@alarmcash.app"
-            detailLabel.font = AppTypography.meta
-            detailLabel.textColor = AppColors.fg3
-
-            let textStack = UIStackView(arrangedSubviews: [titleLabel, detailLabel])
-            textStack.axis = .vertical
-            textStack.spacing = 2
-
-            let stack = UIStackView(arrangedSubviews: [icon, textStack])
-            stack.axis = .horizontal
-            stack.spacing = AppSpacing.md
-            stack.alignment = .center
-            stack.translatesAutoresizingMaskIntoConstraints = false
-            cell.contentView.addSubview(stack)
-
-            NSLayoutConstraint.activate([
-                stack.leadingAnchor.constraint(
-                    equalTo: cell.contentView.leadingAnchor,
-                    constant: AppSpacing.lg
-                ),
-                stack.centerYAnchor.constraint(equalTo: cell.contentView.centerYAnchor),
-                stack.trailingAnchor.constraint(
-                    lessThanOrEqualTo: cell.contentView.trailingAnchor,
-                    constant: -AppSpacing.lg
-                )
-            ])
-
-            cell.accessoryType = .disclosureIndicator
-            return cell
+        case .account:    return makeAccountCell(at: indexPath)
+        case .referral:   return makeReferralCell(at: indexPath)
+        case .appearance: return makeAppearanceCell(tableView, at: indexPath)
+        case .info:       return makeInfoRow(at: indexPath)
+        case .contact:    return makeContactRow()
         }
     }
 
-    // MARK: - Cell factory helpers
-
-    private func makeIconRow(
-        systemName: String,
-        iconColor: UIColor,
-        title: String,
-        accessory: UITableViewCell.AccessoryType
-    ) -> UITableViewCell {
-        let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
-        cell.backgroundColor = .secondarySystemBackground
-
-        let icon = makeSettingsIcon(systemName: systemName, backgroundColor: iconColor)
-        let label = UILabel()
-        label.text = title
-        label.font = AppTypography.bodyLg
-        label.textColor = AppColors.fg1
-
-        let stack = UIStackView(arrangedSubviews: [icon, label])
-        stack.axis = .horizontal
-        stack.spacing = AppSpacing.md
-        stack.alignment = .center
-        stack.translatesAutoresizingMaskIntoConstraints = false
-        cell.contentView.addSubview(stack)
-
-        NSLayoutConstraint.activate([
-            stack.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor, constant: AppSpacing.lg),
-            stack.centerYAnchor.constraint(equalTo: cell.contentView.centerYAnchor)
-        ])
-
-        cell.accessoryType = accessory
-        return cell
+    /// Account section dispatches between the History row (`row == 0`) and
+    /// the Balance row (`row == 1`). Split off `cellForRowAt` so the main
+    /// switch stays a one-screen overview (#182).
+    private func makeAccountCell(at indexPath: IndexPath) -> UITableViewCell {
+        indexPath.row == 0 ? makeTransactionHistoryRow() : makeBalanceRow()
     }
 
-    /// Creates a rounded-rect icon with an SF Symbol, similar to iOS Settings style
-    private func makeSettingsIcon(systemName: String, backgroundColor: UIColor) -> UIView {
-        let size: CGFloat = 30
-        let container = UIView()
-        container.backgroundColor = backgroundColor
-        container.layer.cornerRadius = 7
-        container.layer.masksToBounds = true
-        container.translatesAutoresizingMaskIntoConstraints = false
-
-        let imageView = UIImageView()
-        imageView.image = UIImage(systemName: systemName)?.withConfiguration(
-            UIImage.SymbolConfiguration(pointSize: 15, weight: .medium)
-        )
-        imageView.tintColor = .white
-        imageView.contentMode = .scaleAspectFit
-        imageView.translatesAutoresizingMaskIntoConstraints = false
-        container.addSubview(imageView)
-
-        NSLayoutConstraint.activate([
-            container.widthAnchor.constraint(equalToConstant: size),
-            container.heightAnchor.constraint(equalToConstant: size),
-            imageView.centerXAnchor.constraint(equalTo: container.centerXAnchor),
-            imageView.centerYAnchor.constraint(equalTo: container.centerYAnchor)
-        ])
-
-        return container
+    /// Dequeue + configure for the segmented Theme cell. Pulled out of
+    /// `cellForRowAt` so the main switch stays under SwiftLint's
+    /// `function_body_length` cap (#182).
+    private func makeAppearanceCell(
+        _ tableView: UITableView,
+        at indexPath: IndexPath
+    ) -> UITableViewCell {
+        // Dedicated cell type owns the segment control — avoids the previous
+        // removeFromSuperview/re-add dance that left the control bound to
+        // whichever cell rendered last.
+        guard let cell = tableView.dequeueReusableCell(
+            withIdentifier: ThemeSegmentCell.reuseID,
+            for: indexPath
+        ) as? ThemeSegmentCell else {
+            assertionFailure("dequeueReusableCell returned wrong type for \(ThemeSegmentCell.reuseID)")
+            return UITableViewCell()
+        }
+        cell.configure(selectedIndex: themeSegmentIndex) { [weak self] index in
+            self?.handleThemeSegmentChange(index)
+        }
+        return cell
     }
 }
 
@@ -453,364 +319,8 @@ extension SettingsViewController: UITableViewDelegate {
     }
 }
 
-// MARK: - Transaction History VC
-
-final class TransactionHistoryViewController: UIViewController {
-
-    private let tableView: UITableView = {
-        let table = UITableView(frame: .zero, style: .insetGrouped)
-        table.translatesAutoresizingMaskIntoConstraints = false
-        return table
-    }()
-
-    private var transactions: [Transaction] = []
-    private let alarmRepository = AlarmRepository.shared
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        title = "История транзакций"
-        view.backgroundColor = AppColors.bg0
-        setupTableView()
-        loadTransactions()
-    }
-
-    private func setupTableView() {
-        view.addSubview(tableView)
-        tableView.dataSource = self
-        tableView.delegate = self
-        tableView.register(TransactionCell.self, forCellReuseIdentifier: TransactionCell.reuseID)
-        NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-        ])
-    }
-
-    private func loadTransactions() {
-        // Use the checked variant so a corrupt ledger surfaces an alert
-        // instead of rendering the misleading "Нет транзакций" empty state
-        // — that would let the user assume the app reset itself (issue #117).
-        do {
-            transactions = try TransactionRepository.shared.fetchAllChecked()
-        } catch let error as TransactionRepository.RepositoryError {
-            transactions = []
-            presentLoadError(error)
-        } catch {
-            transactions = []
-        }
-        tableView.reloadData()
-    }
-
-    private func presentLoadError(_ error: LocalizedError) {
-        let alert = UIAlertController(
-            title: "Ошибка",
-            message: error.errorDescription,
-            preferredStyle: .alert
-        )
-        alert.addAction(UIAlertAction(title: "OK", style: .default))
-        present(alert, animated: true)
-    }
-}
-
-extension TransactionHistoryViewController: UITableViewDataSource, UITableViewDelegate {
-
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        transactions.isEmpty ? 1 : transactions.count
-    }
-
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        if transactions.isEmpty {
-            let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
-            cell.textLabel?.text = "Нет транзакций"
-            cell.textLabel?.textColor = .secondaryLabel
-            cell.textLabel?.textAlignment = .center
-            cell.backgroundColor = .secondarySystemBackground
-            cell.selectionStyle = .none
-            return cell
-        }
-
-        guard let cell = tableView.dequeueReusableCell(
-            withIdentifier: TransactionCell.reuseID, for: indexPath
-        ) as? TransactionCell else {
-            assertionFailure("dequeueReusableCell returned wrong type for \(TransactionCell.reuseID)")
-            return UITableViewCell()
-        }
-
-        let transaction = transactions[indexPath.row]
-
-        // Look up alarm name if available — best-effort enrichment. If the
-        // alarm store is corrupt we log and fall back to nil so the row
-        // still renders (transaction amount/date is still meaningful).
-        // Without this, a single corrupt alarms blob would silently strip
-        // alarm names from every history row (issue #117).
-        var alarmName: String?
-        if let alarmIDString = transaction.alarmID, let alarmUUID = UUID(uuidString: alarmIDString) {
-            do {
-                alarmName = try alarmRepository.fetchChecked(id: alarmUUID)?.name
-            } catch {
-                let errorDesc = String(describing: error)
-                AppLogger.ui.error(
-                    "TxHistory: name lookup failed for \(alarmUUID, privacy: .private): \(errorDesc, privacy: .public)"
-                )
-            }
-        }
-
-        cell.configure(with: transaction, alarmName: alarmName)
-        return cell
-    }
-
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        transactions.isEmpty ? 52 : 64
-    }
-
-    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        "ИСТОРИЯ"
-    }
-
-    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        guard let title = self.tableView(tableView, titleForHeaderInSection: section) else {
-            return nil
-        }
-        return SettingsSectionHeaderView(text: title)
-    }
-
-    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        UITableView.automaticDimension
-    }
-
-    /// Mirror SettingsViewController so the transaction list reads as a card
-    /// in light mode rather than blending into the page.
-    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        let totalRows = self.tableView(tableView, numberOfRowsInSection: indexPath.section)
-        let position = CardRowPosition.resolve(row: indexPath.row, totalRows: totalRows)
-        cell.styleAsCardRow(position: position)
-    }
-}
-
-// MARK: - Transaction Cell
-
-final class TransactionCell: UITableViewCell {
-
-    static let reuseID = "TransactionCell"
-
-    // MARK: - UI
-
-    private let iconContainer: UIView = {
-        let view = UIView()
-        view.layer.cornerRadius = 20
-        view.layer.masksToBounds = true
-        view.translatesAutoresizingMaskIntoConstraints = false
-        return view
-    }()
-
-    private let iconImageView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.tintColor = .white
-        imageView.contentMode = .scaleAspectFit
-        imageView.translatesAutoresizingMaskIntoConstraints = false
-        return imageView
-    }()
-
-    private let titleLabel: UILabel = {
-        let label = UILabel()
-        label.font = AppTypography.bodyLg
-        label.textColor = AppColors.fg1
-        return label
-    }()
-
-    private let subtitleLabel: UILabel = {
-        let label = UILabel()
-        label.font = AppTypography.meta
-        label.textColor = AppColors.fg3
-        return label
-    }()
-
-    private let amountLabel: UILabel = {
-        let label = UILabel()
-        label.font = AppTypography.moneyMd
-        label.textAlignment = .right
-        label.setContentHuggingPriority(.required, for: .horizontal)
-        label.setContentCompressionResistancePriority(.required, for: .horizontal)
-        return label
-    }()
-
-    // MARK: - Init
-
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
-        setupUI()
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    // MARK: - Setup
-
-    private func setupUI() {
-        backgroundColor = .secondarySystemBackground
-        selectionStyle = .none
-
-        iconContainer.addSubview(iconImageView)
-
-        let textStack = UIStackView(arrangedSubviews: [titleLabel, subtitleLabel])
-        textStack.axis = .vertical
-        textStack.spacing = 2
-
-        let mainStack = UIStackView(arrangedSubviews: [iconContainer, textStack, amountLabel])
-        mainStack.axis = .horizontal
-        mainStack.spacing = AppSpacing.md
-        mainStack.alignment = .center
-        mainStack.translatesAutoresizingMaskIntoConstraints = false
-        contentView.addSubview(mainStack)
-
-        NSLayoutConstraint.activate([
-            iconContainer.widthAnchor.constraint(equalToConstant: 40),
-            iconContainer.heightAnchor.constraint(equalToConstant: 40),
-            iconImageView.centerXAnchor.constraint(equalTo: iconContainer.centerXAnchor),
-            iconImageView.centerYAnchor.constraint(equalTo: iconContainer.centerYAnchor),
-            iconImageView.widthAnchor.constraint(equalToConstant: 18),
-            iconImageView.heightAnchor.constraint(equalToConstant: 18),
-
-            mainStack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.lg),
-            mainStack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.lg),
-            mainStack.topAnchor.constraint(equalTo: contentView.topAnchor, constant: AppSpacing.sm),
-            mainStack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -AppSpacing.sm)
-        ])
-    }
-
-    // MARK: - Configure
-
-    func configure(with transaction: Transaction, alarmName: String?) {
-        let isCredit = transaction.type != .charge
-
-        // Icon — credits (topup, promotion) read green/up; charges red/down.
-        // Promotion gets a distinct gift glyph so the user can tell a
-        // referral bonus apart from an IAP top-up at a glance (issue #144).
-        iconContainer.backgroundColor = isCredit ? AppColors.money500 : AppColors.pain500
-        let iconName: String
-        switch transaction.type {
-        case .topup:     iconName = "arrow.up"
-        case .charge:    iconName = "arrow.down"
-        case .promotion: iconName = "gift.fill"
-        }
-        iconImageView.image = UIImage(systemName: iconName)?.withConfiguration(
-            UIImage.SymbolConfiguration(pointSize: 14, weight: .bold)
-        )
-
-        // Title — promotion reads "Бонус" so the row doesn't claim the user
-        // paid for the credit (which would mislead anyone scanning their
-        // history for IAP receipts).
-        switch transaction.type {
-        case .topup:     titleLabel.text = "Пополнение"
-        case .charge:    titleLabel.text = "Откладывание"
-        case .promotion: titleLabel.text = "Бонус"
-        }
-
-        // Subtitle: alarm name + date for charges; just the date otherwise.
-        let dateString = Self.formatDate(transaction.createdAt)
-        if let name = alarmName, transaction.type == .charge {
-            subtitleLabel.text = "\(name) \u{00B7} \(dateString)"
-        } else {
-            subtitleLabel.text = dateString
-        }
-
-        // Amount
-        let amount = Int(transaction.amount)
-        if isCredit {
-            amountLabel.text = "+₽\(amount)"
-            amountLabel.textColor = AppColors.money500
-        } else {
-            amountLabel.text = "₽\(amount)"
-            amountLabel.textColor = AppColors.pain500
-        }
-    }
-
-    // MARK: - Date formatting
-
-    private static let dateFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "ru_RU")
-        formatter.dateFormat = "d MMMM 'в' HH:mm"
-        return formatter
-    }()
-
-    private static func formatDate(_ date: Date) -> String {
-        dateFormatter.string(from: date)
-    }
-}
-
-// MARK: - Section header
-
-/// Caps-styled section header used by both `SettingsViewController` and the
-/// nested `TransactionHistoryViewController`. Mirrors `CreateAlarmViewController`'s
-/// private `SectionHeaderView` so the brand `caps` role + 0.12em tracking lands
-/// consistently across the Settings stack (#177).
-private final class SettingsSectionHeaderView: UIView {
-
-    init(text: String) {
-        super.init(frame: .zero)
-        backgroundColor = .clear
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.attributedText = NSAttributedString(
-            string: text.uppercased(),
-            attributes: [
-                .font: AppTypography.caps,
-                .kern: AppTypography.capsKerning,
-                .foregroundColor: AppColors.fg3
-            ]
-        )
-        addSubview(label)
-        NSLayoutConstraint.activate([
-            label.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
-            label.trailingAnchor.constraint(lessThanOrEqualTo: layoutMarginsGuide.trailingAnchor),
-            label.topAnchor.constraint(equalTo: topAnchor, constant: AppSpacing.lg),
-            label.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -AppSpacing.sm)
-        ])
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-}
-
-// MARK: - Legal VC (simple text placeholder)
-
-final class LegalViewController: UIViewController {
-
-    private let legalTitle: String
-
-    init(title: String) {
-        self.legalTitle = title
-        super.init(nibName: nil, bundle: nil)
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        title = legalTitle
-        view.backgroundColor = AppColors.bg0
-
-        let textView = UITextView()
-        textView.text = "\(legalTitle)\n\nДокумент будет добавлен перед публикацией в App Store."
-        textView.font = AppTypography.body
-        textView.textColor = AppColors.fg1
-        textView.backgroundColor = .clear
-        textView.isEditable = false
-        textView.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(textView)
-
-        NSLayoutConstraint.activate([
-            textView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 16),
-            textView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
-            textView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
-            textView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-        ])
-    }
-}
+// `TransactionHistoryViewController`, `TransactionCell`,
+// `SettingsSectionHeaderView`, and `LegalViewController` were extracted to
+// sibling extension files (`+TransactionCell.swift`, `+Sections.swift`,
+// `+Legal.swift`) in #182 to satisfy SwiftLint's `file_length` cap. Behaviour
+// is unchanged — only the physical location moved.

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SectionHeaderView.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SectionHeaderView.swift
@@ -1,0 +1,36 @@
+import UIKit
+
+/// Shared caps-styled section header used by inset-grouped tables across the
+/// design-refresh surfaces (CreateAlarm, Settings, Transaction history). Mirrors
+/// the original private `SectionHeaderView` introduced in #143 — extracted to
+/// `Views/DesignSystem` so the brand `caps` role + 0.12em tracking lands
+/// consistently without duplicate per-screen copies (#182).
+final class SectionHeaderView: UIView {
+
+    init(text: String) {
+        super.init(frame: .zero)
+        backgroundColor = .clear
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.attributedText = NSAttributedString(
+            string: text.uppercased(),
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.fg3
+            ]
+        )
+        addSubview(label)
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
+            label.trailingAnchor.constraint(lessThanOrEqualTo: layoutMarginsGuide.trailingAnchor),
+            label.topAnchor.constraint(equalTo: topAnchor, constant: AppSpacing.lg),
+            label.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -AppSpacing.sm)
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}


### PR DESCRIPTION
Fixes #182

## Summary
Splits the four design-refresh VCs (Settings, AlarmFiring, CreateAlarm, Onboarding) and AudioService into sibling extension files so SwiftLint's `file_length` / `type_body_length` / `function_body_length` warnings stay clear on these files.

Pure refactor — no behaviour changes. Observers, animation timing, side effects, and threading are all preserved verbatim.

## What changed

### SettingsViewController.swift (816 → 326 LOC)
- `+TransactionCell.swift` — `TransactionHistoryViewController` + `TransactionCell` (~298 LOC).
- `+Legal.swift` — `LegalViewController` (~45 LOC).
- `+Sections.swift` — row factory helpers (`makeBalanceRow`, `makeContactRow`, `makeIconRow`, `makeSettingsIcon`) + `SettingsSectionHeaderView` (~217 LOC).
- `cellForRowAt` reduced from a 115-line dispatch to a 7-case overview that calls focused helpers (`makeAccountCell`, `makeAppearanceCell`, etc.).

### AlarmFiringViewController.swift (546 → 392 LOC)
- `+Layout.swift` — `buildFiringLayout` + `activateMainConstraints` + `updateGlowFrame` (~141 LOC).
- `+ViewLifecycle.swift` — clock ticker, glow breathing, snooze handler, top-up sheet, snooze-failure alert + cached time formatter (~98 LOC).
- The `viewDidLoad` callsite now calls `buildFiringLayout()` / `startClockTicker()` instead of the inline implementations.

### CreateAlarmViewController.swift (535 → 355 LOC)
- `+Sections.swift` — per-row factories (`makeTimePickerCell`, `makeRepeatDaysCell`, …) + `registerSectionCells` (~143 LOC).
- `+Pickers.swift` — push handlers (`showSoundPicker`, `showVolumePicker`, `showThemePicker`, `confirmDelete`) (~95 LOC).
- Private `SectionHeaderView` removed — it now uses the new shared `Views/DesignSystem/SectionHeaderView.swift`.
- `cellForRowAt` collapsed from a long inline switch to a one-liner per case calling helpers.

### OnboardingViewController.swift (509 → 360 LOC)
- `+Pages.swift` — `makeTextPageView`, `makeDepositPageView`, `makeCopyStack`, `makePresetsStack`, `updateApplePayTitle`, action handlers (`actionTapped`, `applePayTapped`, `laterTapped`, `skipTapped`), `handlePresetTap`, `updatePagerState` (~205 LOC).
- `setupUI` split into `activateChromeConstraints` / `wireActionTargets` / `buildPageStack` to clear the function-body-length warning.

### AudioService.swift (390 → 336 LOC)
- `+Tone.swift` — `generateAlarmTone` + extracted `renderToneSamples` / `packWAV` + `UInt32`/`UInt16` `littleEndianBytes` helpers (~106 LOC).
- `startAlarmSound` (was 79 lines) split into `handleStartWhileNonStopped`, `resolveAlarmPlayer`, `configurePlayerVolume` helpers — main body now ~38 lines.

### New shared `Views/DesignSystem/SectionHeaderView.swift`
Caps-styled section header pulled out of `CreateAlarmViewController.swift`. SettingsVC retains its own private `SettingsSectionHeaderView` per #182's *"do NOT touch SettingsVC's private one in this PR"* note.

## Verify
- swiftlint: 0 `file_length` / 0 `type_body_length` / 0 `function_body_length` / 0 `cyclomatic_complexity` warnings on touched files (the remaining warnings live in untouched files like `FiringTopUpBottomSheetViewController`, `AppDelegate`, `AlarmScheduler`, `StatisticsViewController` — out of scope per #182's PRIMARY GOAL list).
- `build_sim` (iPhone 17 Pro): succeeded.
- `project.pbxproj` not modified — the project uses `PBXFileSystemSynchronizedRootGroup` so new `.swift` files in `SnoozePay/SnoozePay/...` are picked up automatically.

## Test plan
- [ ] Open Settings → tap Балансе & История транзакций — both rows render with correct icons, history list pushes.
- [ ] Tap Privacy / Terms in Settings → `LegalViewController` placeholder loads.
- [ ] Create / edit an alarm → time, repeat, sound, volume, theme rows still wire up; "Удалить" still pops the confirmation action sheet.
- [ ] Fire an alarm → clock ticks, glow breathes, snooze CTA enabled at non-zero balance, no-balance Apple Pay path still flips correctly.
- [ ] Onboarding → swipe through three pages, "Далее" advances, preset tile tap updates Apple Pay button title, "Позже" / "Пропустить" finish the flow.
- [ ] AudioService synthetic tone: rename a bundled alarm to force the tone fallback → tone still plays at correct loop rate.