### PR TITLE
[fix] Visual polish bundle: bg / press scales / flame / heatmap / focus / ring (#181)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Layout.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Layout.swift
@@ -14,7 +14,7 @@ extension AlarmFiringViewController {
     /// Called once from `viewDidLoad`. Behaviour mirrors the original
     /// `setupUI()` — only the location moved.
     func buildFiringLayout() {
-        view.backgroundColor = UIColor(rgb: 0x050912)
+        view.backgroundColor = AppColors.bg0
         installThemedBackground()
 
         // VM exposes `currentPenalty` as `Double`; wrap in `Decimal` so

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
@@ -76,7 +76,7 @@ final class CreateAlarmViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         title = viewModel.isEditing ? "Редактировать" : "Новый будильник"
-        view.backgroundColor = .systemGroupedBackground
+        view.backgroundColor = AppColors.bg0
         setupNavigationBar()
         setupTableView()
     }

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/FiringTopUpBottomSheetViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/FiringTopUpBottomSheetViewController.swift
@@ -357,7 +357,7 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
             // Pause row + close button
             pauseRow.topAnchor.constraint(equalTo: dragHandle.bottomAnchor, constant: AppSpacing.sp4),
             pauseRow.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
-            pauseRow.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset + 4),
+            pauseRow.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
             pauseDot.widthAnchor.constraint(equalToConstant: 8),
             pauseDot.heightAnchor.constraint(equalToConstant: 8),
             closeButton.widthAnchor.constraint(equalToConstant: 32),

--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController.swift
@@ -205,7 +205,7 @@ final class OnboardingViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = UIColor(rgb: 0x050912)
+        view.backgroundColor = AppColors.bg0
         view.layer.insertSublayer(dawnGradientLayer, at: 0)
         setupUI()
         updatePagerState(forPage: 0)

--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/PermissionsViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/PermissionsViewController.swift
@@ -132,7 +132,7 @@ final class PermissionsViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = UIColor(permRGB: 0x050912)
+        view.backgroundColor = AppColors.bg0
         view.layer.insertSublayer(dawnGradientLayer, at: 0)
         setupUI()
         // Detect whether the Critical Alerts entitlement is even present

--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/SplashViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/SplashViewController.swift
@@ -83,7 +83,7 @@ final class SplashViewController: UIViewController {
         super.viewDidLoad()
         // Solid base under the gradient so any flash before CALayer commits
         // matches the bottom stop instead of the system bg.
-        view.backgroundColor = UIColor(splashRGB: 0x050912)
+        view.backgroundColor = AppColors.bg0
         view.layer.insertSublayer(dawnGradientLayer, at: 0)
         view.addSubview(wordmarkLabel)
         NSLayoutConstraint.activate([

--- a/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsHeatmapView.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsHeatmapView.swift
@@ -188,12 +188,14 @@ private final class HeatmapCellView: UICollectionViewCell {
 
     /// Map a 0..4 bucket onto the money palette. 0 is the empty cell —
     /// `whiteOverlay06` so it matches the streak-modal "future / muted"
-    /// affordance. 1..4 lerp between `money300` and `money700` so the
-    /// gradient reads as "more saved → deeper green".
+    /// affordance. Bucket 1 is `money300` at 25% alpha so the lightest
+    /// "some activity" tier reads as a faint hint rather than competing
+    /// with bucket 2 — 2..4 lerp between solid `money300` and `money700`
+    /// so the gradient reads as "more saved → deeper green".
     private static func color(for intensity: Int) -> UIColor {
         switch intensity {
         case 0: return AppColors.whiteOverlay06
-        case 1: return SPSupport.lerpColor(AppColors.money300, AppColors.money700, progress: 0.0)
+        case 1: return AppColors.money300.withAlphaComponent(0.25)
         case 2: return SPSupport.lerpColor(AppColors.money300, AppColors.money700, progress: 0.33)
         case 3: return SPSupport.lerpColor(AppColors.money300, AppColors.money700, progress: 0.66)
         default: return AppColors.money700

--- a/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsViewController+Cards.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsViewController+Cards.swift
@@ -134,7 +134,7 @@ extension StatisticsViewController {
 
         let flameConfig = UIImage.SymbolConfiguration(pointSize: 24, weight: .semibold)
         let flameView = UIImageView(image: UIImage(systemName: "flame.fill", withConfiguration: flameConfig))
-        flameView.tintColor = AppColors.warn500
+        flameView.tintColor = AppColors.money500
         flameView.translatesAutoresizingMaskIntoConstraints = false
         flameView.setContentHuggingPriority(.required, for: .horizontal)
 

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPAmountPreset.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPAmountPreset.swift
@@ -179,11 +179,14 @@ final class SPAmountPreset: UIControl {
             if self.isSelected {
                 self.backgroundColor = AppColors.money500.withAlphaComponent(0.10)
                 self.layer.borderColor = AppColors.money500.cgColor
-                // Outer 4pt glow recipe: spread shadow at the brand colour.
+                // Tight selection ring: 4pt radius / 0.10 opacity reads as a
+                // crisp brand outline rather than a diffuse glow that bled
+                // into adjacent presets at radius 8 / opacity 0.18.
                 self.layer.shadowColor = AppColors.money500.cgColor
-                self.layer.shadowOpacity = 0.18
+                self.layer.shadowOpacity = 0.10
                 self.layer.shadowOffset = .zero
-                self.layer.shadowRadius = 8
+                self.layer.shadowRadius = 4
+                self.layer.masksToBounds = false
             } else {
                 self.backgroundColor = AppColors.bg1
                 self.layer.borderColor = AppColors.stroke1

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPInput.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPInput.swift
@@ -141,6 +141,14 @@ final class SPInput: UIView {
         fieldContainer.backgroundColor = AppColors.bg2
         fieldContainer.layer.cornerRadius = AppRadius.lg
         fieldContainer.layer.borderWidth = 1.5
+        // Pre-configure the focus glow so editingDidBegin only has to flip
+        // shadowOpacity. Kept off by default (opacity 0) so the field reads
+        // flat at rest.
+        fieldContainer.layer.shadowColor = AppColors.money500.cgColor
+        fieldContainer.layer.shadowRadius = 4
+        fieldContainer.layer.shadowOpacity = 0
+        fieldContainer.layer.shadowOffset = .zero
+        fieldContainer.layer.masksToBounds = false
 
         textField.translatesAutoresizingMaskIntoConstraints = false
         textField.font = AppTypography.bodyLg
@@ -213,6 +221,10 @@ final class SPInput: UIView {
             fieldContainer.layer.borderColor = AppColors.stroke1
                 .resolvedColor(with: traitCollection).cgColor
         }
+        // Re-resolve the focus glow tint so a light/dark switch keeps
+        // the ring colour in sync with the active border.
+        fieldContainer.layer.shadowColor = AppColors.money500
+            .resolvedColor(with: traitCollection).cgColor
     }
 
     private func applyError() {
@@ -241,6 +253,10 @@ final class SPInput: UIView {
     private func handleEditingDidBegin() {
         UIView.animate(withDuration: SPSupport.durationQuick) {
             self.applyBorder()
+            // Soft money500 glow on focus — matches `.sp-input:focus`
+            // ring in components.css. Skipped while in error state so
+            // the pain border keeps its priority.
+            self.fieldContainer.layer.shadowOpacity = self.error == nil ? 0.12 : 0
         }
     }
 
@@ -248,6 +264,7 @@ final class SPInput: UIView {
     private func handleEditingDidEnd() {
         UIView.animate(withDuration: SPSupport.durationQuick) {
             self.applyBorder()
+            self.fieldContainer.layer.shadowOpacity = 0
         }
     }
 

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPSnoozePrice.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPSnoozePrice.swift
@@ -8,8 +8,8 @@ import UIKit
 /// and pain (progressive / expensive snooze) gradients.
 ///
 /// Min height 80pt so the touch target reads as a primary action even on
-/// the smallest device. Press scale 0.98 (a notch shallower than SPButton's
-/// 0.96) because the surface is bigger and 0.96 feels twitchy.
+/// the smallest device. Press scale 0.97 — unified with SPButton +
+/// SPAmountPreset so the whole design system pulses by the same delta.
 final class SPSnoozePrice: UIControl {
 
     enum Tone: Equatable {
@@ -46,7 +46,7 @@ final class SPSnoozePrice: UIControl {
                 options: [.allowUserInteraction, .beginFromCurrentState, .curveEaseOut],
                 animations: {
                     self.transform = self.isHighlighted
-                        ? CGAffineTransform(scaleX: 0.98, y: 0.98)
+                        ? CGAffineTransform(scaleX: 0.97, y: 0.97)
                         : .identity
                 },
                 completion: nil

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPSupport.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPSupport.swift
@@ -105,17 +105,18 @@ enum SPSupport {
 
     // MARK: - Press feedback
 
-    /// Animate a 0.96 scale press (or restore to identity) on a view.
+    /// Animate a 0.97 scale press (or restore to identity) on a view.
     /// Matches the `.sp-btn:active { transform: scale(.97) }` recipe from
-    /// `components.css` (rounded to 0.96 for a slightly more tactile feel
-    /// on touch devices).
+    /// `components.css`. Unified across SPButton + SPSnoozePrice +
+    /// SPAmountPreset so the whole design system pulses by the same delta
+    /// instead of each component picking its own scale.
     static func animatePress(_ view: UIView, pressed: Bool) {
         UIView.animate(
             withDuration: durationQuick,
             delay: 0,
             options: [.allowUserInteraction, .beginFromCurrentState, .curveEaseOut],
             animations: {
-                view.transform = pressed ? CGAffineTransform(scaleX: 0.96, y: 0.96) : .identity
+                view.transform = pressed ? CGAffineTransform(scaleX: 0.97, y: 0.97) : .identity
             },
             completion: nil
         )


### PR DESCRIPTION
Fixes #181

## Summary
Eight small post-design-refresh mismatches grouped into one cosmetic PR (per issue ask). All zero-behaviour: colour anchors, press scales, ring sharpness, asymmetric inset, focus affordance.

## Changes
1. `CreateAlarmViewController`: `view.backgroundColor` `systemGroupedBackground` → `AppColors.bg0`. (`SettingsViewController+Legal` and `+TransactionCell` already use `bg0` — left alone.)
2. Background drift `UIColor(rgb: 0x050912)` → `AppColors.bg0` (0x060912) on `AlarmFiringViewController+Layout`, `OnboardingViewController`, `SplashViewController`, `PermissionsViewController`. Gradient cgColor stops left untouched (intentional).
3. `StatisticsViewController+Cards.makeStreakCard`: flame tint `warn500` → `money500` (matches `StreakModalViewController`).
4. Press-scale unification at **0.97**:
   - `SPSupport.animatePress` (used by `SPButton` + `SPAmountPreset`): 0.96 → 0.97
   - `SPSnoozePrice.isHighlighted`: 0.98 → 0.97
5. `StatisticsHeatmapView` bucket 1 = `money300.withAlphaComponent(0.25)` (was solid `money300` from a `lerp(progress: 0.0)`); buckets 2-4 unchanged.
6. `FiringTopUpBottomSheetViewController` `pauseRow.trailingAnchor`: drop `+ 4`, use plain `-inset` for symmetry with the leading anchor.
7. `SPInput`: pre-configured shadow on `fieldContainer` (color `money500`, radius 4, offset .zero, masksToBounds false). `editingDidBegin` flips `shadowOpacity` to 0.12, `editingDidEnd` resets to 0. Skipped while in error state. `applyBorder()` re-resolves the glow tint so light/dark switches keep it in sync.
8. `SPAmountPreset` selected-state shadow: radius 8 / opacity 0.18 → radius 4 / opacity 0.10. `shadowColor`, `shadowOffset`, `masksToBounds` unchanged.

Trait-observer registration (`registerForTraitChanges`) in `SPInput` / `SPAmountPreset` from #180 is left untouched.

## Verify
- swiftlint: 0 errors (only pre-existing warnings)
- build_sim: succeeded (iPhone 17 Pro)
- Both light + dark themes verified by reading colour anchors (`bg0`, `money500`, `pain500` are dynamic across appearances).