### PR TITLE
[fix] Link refunded snooze charges so stats and streak ignore them (#133)

### DIFF
--- a/SnoozePay/SnoozePay/Models/Transaction.swift
+++ b/SnoozePay/SnoozePay/Models/Transaction.swift
@@ -13,19 +13,27 @@ struct Transaction: Identifiable, Codable {
     let amount: Double
     let alarmID: String?
     let createdAt: Date
+    /// When this transaction is a `topup` posted to offset a failed snooze
+    /// schedule, points back at the original `charge` so stats consumers can
+    /// exclude both rows from snooze counts / streak resets (issue #133).
+    /// `nil` for organic top-ups and for legacy ledger entries written before
+    /// the field existed — those continue to count as real charges/top-ups.
+    let refundsTransactionID: UUID?
 
     init(
         id: UUID = UUID(),
         type: TransactionType,
         amount: Double,
         alarmID: String? = nil,
-        createdAt: Date = Date()
+        createdAt: Date = Date(),
+        refundsTransactionID: UUID? = nil
     ) {
         self.id = id
         self.type = type
         self.amount = amount
         self.alarmID = alarmID
         self.createdAt = createdAt
+        self.refundsTransactionID = refundsTransactionID
     }
 
     var formattedAmount: String {

--- a/SnoozePay/SnoozePay/Services/AlarmFiringCoordinator.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmFiringCoordinator.swift
@@ -130,8 +130,13 @@ final class AlarmFiringCoordinator {
         let newCount = payload.snoozeCount + 1
         let penalty = alarm.penalty(forSnoozeCount: newCount)
 
-        let charged = balanceService.charge(amount: penalty, alarmID: payload.alarmID)
-        guard charged else {
+        // `chargeWithReceipt` returns the persisted Transaction so a later
+        // refund can link back to it (issue #133) — without that link stats
+        // can't tell a refunded charge apart from a real snooze.
+        guard let chargeTransaction = balanceService.chargeWithReceipt(
+            amount: penalty,
+            alarmID: payload.alarmID
+        ) else {
             let alarmID = payload.alarmID
             AppLogger.coordinator.notice(
                 "snooze: insufficient funds alarm=\(alarmID, privacy: .private) penalty=\(penalty, privacy: .public)"
@@ -146,6 +151,7 @@ final class AlarmFiringCoordinator {
                 alarmID: payload.alarmID,
                 newCount: newCount,
                 penalty: penalty,
+                chargeTransactionID: chargeTransaction.id,
                 completion: completion
             )
         }
@@ -161,6 +167,7 @@ final class AlarmFiringCoordinator {
         alarmID: UUID,
         newCount: Int,
         penalty: Double,
+        chargeTransactionID: UUID,
         completion: ((SnoozeOutcome) -> Void)?
     ) {
         switch result {
@@ -174,7 +181,13 @@ final class AlarmFiringCoordinator {
             // will never re-fire. `topUp` records an offsetting ledger entry
             // (rather than mutating storage directly) so transaction history
             // shows both the charge and the refund — stats stay auditable.
-            let refunded = balanceService.topUp(amount: penalty)
+            // Link the refund to the original charge ID so stats consumers
+            // can pair the two rows (issue #133); without the link a refund
+            // still inflates snoozeCount/totalSpent and resets streak.
+            let refunded = balanceService.topUp(
+                amount: penalty,
+                refundsTransactionID: chargeTransactionID
+            )
             let desc = error.errorDescription ?? error.localizedDescription
             if refunded {
                 AppLogger.coordinator.error(

--- a/SnoozePay/SnoozePay/Services/BalanceService.swift
+++ b/SnoozePay/SnoozePay/Services/BalanceService.swift
@@ -108,16 +108,24 @@ final class BalanceService {
     /// (mirrors locked-ledger pattern from #72).
     @discardableResult
     func charge(amount: Double, alarmID: UUID?) -> Bool {
+        chargeWithReceipt(amount: amount, alarmID: alarmID) != nil
+    }
+
+    /// Charge variant that returns the persisted `Transaction` so the caller
+    /// can later post a refund linked to this exact ledger entry (issue #133).
+    /// Returns `nil` on the same failure modes as `charge` — insufficient
+    /// funds, corrupted balance, or repository write rejection.
+    func chargeWithReceipt(amount: Double, alarmID: UUID?) -> Transaction? {
+        let transaction = Transaction(
+            type: .charge,
+            amount: amount,
+            alarmID: alarmID?.uuidString
+        )
         let result: (charged: Bool, newBalance: Double) = queue.sync {
             let current = readRawBalance()
             guard !_balanceCorrupted else { return (false, current) }
             guard current >= amount else { return (false, current) }
 
-            let transaction = Transaction(
-                type: .charge,
-                amount: amount,
-                alarmID: alarmID?.uuidString
-            )
             // Record the ledger entry FIRST. If the transaction repository is
             // locked (corrupt blob waiting on user ack) or encoding fails, we
             // refuse to mutate the balance — otherwise money would silently
@@ -134,8 +142,9 @@ final class BalanceService {
 
         if result.charged {
             notifyBalanceChanged(result.newBalance)
+            return transaction
         }
-        return result.charged
+        return nil
     }
 
     // MARK: - Top up (IAP)
@@ -146,15 +155,21 @@ final class BalanceService {
     /// caller should surface this to the user instead of pretending
     /// the IAP credited (silent ledger desync was the regression behind the #72
     /// PR #101 hunter feedback).
+    ///
+    /// `refundsTransactionID` links the top-up to the original `charge` it
+    /// reverses. `AlarmFiringCoordinator` sets it after a snooze schedule
+    /// fails so stats can pair the two rows and avoid counting the snooze
+    /// (issue #133). Organic top-ups (IAP, dev tools) leave it `nil`.
     @discardableResult
-    func topUp(amount: Double) -> Bool {
+    func topUp(amount: Double, refundsTransactionID: UUID? = nil) -> Bool {
         let result: (recorded: Bool, newBalance: Double) = queue.sync {
             let current = readRawBalance()
             guard !_balanceCorrupted else { return (false, current) }
 
             let transaction = Transaction(
                 type: .topup,
-                amount: amount
+                amount: amount,
+                refundsTransactionID: refundsTransactionID
             )
             guard transactionRepository.record(transaction) else {
                 return (false, current)

--- a/SnoozePay/SnoozePay/Services/TransactionRepository.swift
+++ b/SnoozePay/SnoozePay/Services/TransactionRepository.swift
@@ -136,14 +136,18 @@ final class TransactionRepository {
     /// and `currentStreak(from:)` cannot drift apart. Lives as `static` so
     /// it can't accidentally read instance state and reintroduce the silent
     /// decode the caller-supplied variant exists to avoid.
+    ///
+    /// Refunded charges (those whose ID appears in another row's
+    /// `refundsTransactionID`) are excluded — a snooze that failed to
+    /// schedule and was rolled back must not break the streak (issue #133).
     private static func computeStreak(from transactions: [Transaction]) -> Int {
         guard !transactions.isEmpty else { return 0 }
 
         let calendar = Calendar.current
         var streak = 0
         var checkDate = calendar.startOfDay(for: Date())
-        let allCharges = transactions.filter { $0.type == .charge }
-        let chargeDates = Set(allCharges.map { calendar.startOfDay(for: $0.createdAt) })
+        let realCharges = realCharges(from: transactions)
+        let chargeDates = Set(realCharges.map { calendar.startOfDay(for: $0.createdAt) })
 
         let firstTransactionDate = calendar.startOfDay(
             for: transactions.map { $0.createdAt }.min() ?? Date()
@@ -156,6 +160,14 @@ final class TransactionRepository {
         }
 
         return streak
+    }
+
+    /// Returns the subset of `transactions` that represent real (non-refunded)
+    /// charges. Used by streak computation and by `StatisticsViewModel` so the
+    /// two sites can never drift on what counts as "the user actually snoozed".
+    static func realCharges(from transactions: [Transaction]) -> [Transaction] {
+        let refundedIDs = Set(transactions.compactMap { $0.refundsTransactionID })
+        return transactions.filter { $0.type == .charge && !refundedIDs.contains($0.id) }
     }
 
     // MARK: - Recovery

--- a/SnoozePay/SnoozePay/ViewModels/StatisticsViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/StatisticsViewModel.swift
@@ -77,11 +77,15 @@ final class StatisticsViewModel {
         // banner and the streak number consistent.
         do {
             let allTransactions = try transactionRepository.fetchAllChecked()
+            // Exclude charges that were refunded by an offsetting top-up so a
+            // snooze that failed to schedule (#130) doesn't count as a real
+            // snooze in either total spend or count (issue #133). Same source
+            // of truth as `computeStreak` — `realCharges` is the shared filter.
+            let realCharges = TransactionRepository.realCharges(from: allTransactions)
             if period == .allTime {
-                charges = allTransactions.filter { $0.type == .charge }
+                charges = realCharges
             } else {
-                charges = allTransactions
-                    .filter { $0.type == .charge && $0.createdAt >= since }
+                charges = realCharges.filter { $0.createdAt >= since }
             }
             streak = transactionRepository.currentStreak(from: allTransactions)
         } catch let error as TransactionRepository.RepositoryError {

--- a/SnoozePay/SnoozePayTests/BalanceServiceTests.swift
+++ b/SnoozePay/SnoozePayTests/BalanceServiceTests.swift
@@ -189,6 +189,73 @@ final class BalanceServiceTests: XCTestCase {
         XCTAssertEqual(service.balance, 149)
     }
 
+    // MARK: - Refund linkage (issue #133)
+
+    /// `chargeWithReceipt` returns the persisted Transaction so a subsequent
+    /// refund can target it by ID. Without the receipt the coordinator would
+    /// have to look up the most recent charge by alarmID/timestamp — a
+    /// race-prone heuristic that breaks under concurrent snoozes.
+    func testChargeWithReceipt_returnsPersistedTransaction() {
+        let alarmID = UUID()
+        let (service, ledger) = makeServiceWithLedger(
+            balance: 200, notificationCenter: NotificationCenter()
+        )
+
+        let receipt = service.chargeWithReceipt(amount: 75, alarmID: alarmID)
+
+        XCTAssertNotNil(receipt)
+        XCTAssertEqual(receipt?.type, .charge)
+        XCTAssertEqual(receipt?.amount, 75)
+        XCTAssertEqual(receipt?.alarmID, alarmID.uuidString)
+
+        let stored = ledger.fetchAll().first { $0.id == receipt?.id }
+        XCTAssertNotNil(stored,
+            "Receipt's id must match the persisted Transaction so the caller can later refund by ID")
+    }
+
+    /// Insufficient-funds returns `nil` from `chargeWithReceipt` and does not
+    /// touch the ledger — same contract as `charge(...) -> Bool`.
+    func testChargeWithReceipt_insufficientFunds_returnsNil() {
+        let (service, ledger) = makeServiceWithLedger(
+            balance: 10, notificationCenter: NotificationCenter()
+        )
+
+        XCTAssertNil(service.chargeWithReceipt(amount: 50, alarmID: UUID()))
+        XCTAssertTrue(ledger.fetchAll().isEmpty)
+        XCTAssertEqual(service.balance, 10)
+    }
+
+    /// `topUp(amount:refundsTransactionID:)` records the link in the ledger
+    /// row so stats can pair the refund with its original charge.
+    func testTopUp_withRefundsTransactionID_persistsLink() {
+        let originalChargeID = UUID()
+        let (service, ledger) = makeServiceWithLedger(
+            balance: 0, notificationCenter: NotificationCenter()
+        )
+
+        XCTAssertTrue(service.topUp(amount: 50, refundsTransactionID: originalChargeID))
+
+        let txs = ledger.fetchAll()
+        XCTAssertEqual(txs.count, 1)
+        XCTAssertEqual(txs[0].type, .topup)
+        XCTAssertEqual(txs[0].refundsTransactionID, originalChargeID,
+            "Refund link must round-trip through persistence so stats consumers can pair charge + refund")
+    }
+
+    /// Backward compatibility: `topUp(amount:)` (legacy signature) writes a
+    /// Transaction with `refundsTransactionID == nil`. Organic IAP top-ups
+    /// must not be misclassified as refunds.
+    func testTopUp_organic_hasNilRefundLink() {
+        let (service, ledger) = makeServiceWithLedger(
+            balance: 0, notificationCenter: NotificationCenter()
+        )
+
+        service.topUp(amount: 100)
+
+        XCTAssertNil(ledger.fetchAll().first?.refundsTransactionID,
+            "Organic top-ups must not look like refunds")
+    }
+
     /// Boundary: balance == amount must satisfy `canAfford` (>=, not >).
     /// A subtle off-by-one here would silently disable the user's last snooze.
     func testCanAfford_boundaryAtExactEquality() {

--- a/SnoozePay/SnoozePayTests/StatisticsViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/StatisticsViewModelTests.swift
@@ -40,6 +40,25 @@ final class StatisticsViewModelDataTests: XCTestCase {
         txRepo.record(tx)
     }
 
+    /// Records a charge + matching refund pair so tests can assert that the
+    /// resulting state mirrors what `AlarmFiringCoordinator` writes after a
+    /// scheduler failure (issue #133).
+    @discardableResult
+    private func addRefundedCharge(amount: Double, daysAgo: Int = 0) -> Transaction {
+        let calendar = Calendar.current
+        let date = calendar.date(byAdding: .day, value: -daysAgo, to: Date())!
+        let charge = Transaction(type: .charge, amount: amount, createdAt: date)
+        let refund = Transaction(
+            type: .topup,
+            amount: amount,
+            createdAt: date,
+            refundsTransactionID: charge.id
+        )
+        txRepo.record(charge)
+        txRepo.record(refund)
+        return charge
+    }
+
     // MARK: - loadData period filtering
 
     func testLoadData_weekPeriod_filtersCorrectly() {
@@ -117,6 +136,38 @@ final class StatisticsViewModelDataTests: XCTestCase {
 
         XCTAssertEqual(vm.snoozeCount, 3)
         XCTAssertEqual(vm.snoozeCountFormatted, "3 раз")
+    }
+
+    // MARK: - Refunded snooze charges (issue #133)
+
+    /// A snooze that was charged but refunded after a scheduler failure
+    /// (revoked notification permission, pending-limit, etc.) must not appear
+    /// in `snoozeCount` or `totalSpent` — the alarm never re-fired so the
+    /// stats headline would lie about user behaviour.
+    func testLoadData_refundedCharge_excludedFromStats() {
+        addRefundedCharge(amount: 50, daysAgo: 1)
+
+        let vm = makeVM()
+        vm.loadData(period: .week)
+
+        XCTAssertEqual(vm.snoozeCount, 0,
+            "Refunded charge represents a snooze that didn't actually fire")
+        XCTAssertEqual(vm.totalSpent, 0,
+            "Refunded charge has a matching topup — net spend is zero")
+    }
+
+    /// A real charge alongside a refunded one should be counted normally.
+    /// Guards against the filter being too aggressive — only charges with a
+    /// matching refund row are excluded.
+    func testLoadData_realChargeAlongsideRefunded_countsRealOnly() {
+        addCharge(amount: 50, daysAgo: 0)
+        addRefundedCharge(amount: 50, daysAgo: 1)
+
+        let vm = makeVM()
+        vm.loadData(period: .week)
+
+        XCTAssertEqual(vm.snoozeCount, 1)
+        XCTAssertEqual(vm.totalSpent, 50)
     }
 
     // MARK: - Motivational messages

--- a/SnoozePay/SnoozePayTests/TransactionRepositoryTests.swift
+++ b/SnoozePay/SnoozePayTests/TransactionRepositoryTests.swift
@@ -137,6 +137,51 @@ final class TransactionRepositoryTests: XCTestCase {
         XCTAssertEqual(streak, 6, "All days from first tx to today should be clean")
     }
 
+    // MARK: - Refunded charges (issue #133)
+
+    /// A snooze that fails to schedule is rolled back via a `topup` carrying
+    /// `refundsTransactionID` pointing at the original charge. The streak must
+    /// treat the day as clean — the user did not actually snooze, so penalising
+    /// their streak would punish a permission/system failure they can't avoid.
+    func testCurrentStreak_chargeRefundedSameDay_doesNotResetStreak() {
+        // 5 days ago a charge was attempted and refunded; nothing else.
+        let originalCharge = charge(amount: 50, daysAgo: 5)
+        let refund = Transaction(
+            type: .topup,
+            amount: 50,
+            createdAt: originalCharge.createdAt,
+            refundsTransactionID: originalCharge.id
+        )
+        repo.record(originalCharge)
+        repo.record(refund)
+
+        // Streak should walk back to the day BEFORE the refunded charge
+        // without halting on the refunded entry.
+        let streak = repo.currentStreak()
+        XCTAssertGreaterThanOrEqual(streak, 5,
+            "Refunded charge must not interrupt the streak — the snooze never actually fired")
+    }
+
+    /// A real (non-refunded) charge alongside a refunded one still ends the
+    /// streak on the real charge's day. Guards against the filter being too
+    /// aggressive — only charges with a matching refund row are excluded.
+    func testCurrentStreak_realChargePresent_stillResetsStreak() {
+        let realCharge = charge(amount: 50, daysAgo: 0)
+        let refundedCharge = charge(amount: 50, daysAgo: 1)
+        let refund = Transaction(
+            type: .topup,
+            amount: 50,
+            createdAt: refundedCharge.createdAt,
+            refundsTransactionID: refundedCharge.id
+        )
+        repo.record(realCharge)
+        repo.record(refundedCharge)
+        repo.record(refund)
+
+        XCTAssertEqual(repo.currentStreak(), 0,
+            "Real charge today must end the streak even when an older charge was refunded")
+    }
+
     func testCurrentStreak_intermittentCharges() {
         // Day 0: clean (topup), Day 1: clean, Day 2: charge -> streak = 2
         repo.record(charge(amount: 50, daysAgo: 2))


### PR DESCRIPTION
Fixes #133

## Summary
- Когда снузу не удалось запланироваться (revoked permission, 64-pending limit), `AlarmFiringCoordinator` делает offsetting `topUp` — но `Transaction` ничем не связывал refund с оригинальным charge. Stats считали refunded charge как реальный → inflated `snoozeCount`/`totalSpent` и обнулённый streak за поведение, которого не было.
- Добавил `Transaction.refundsTransactionID: UUID?` — линк refund-row на исходный charge-row.
- `BalanceService.chargeWithReceipt(amount:alarmID:)` возвращает persisted Transaction, чтобы coordinator смог рефанднуть по id; `topUp(amount:refundsTransactionID:)` пишет линк в ledger.
- `TransactionRepository.realCharges(from:)` — single source of truth для "что считается реальным снузом". Используется и в `computeStreak`, и в `StatisticsViewModel.loadData` — две площадки больше не могут разойтись.
- Legacy ledger entries без поля decode-ятся как `nil` (synthesized Codable handles optional missing keys) → backward compatible.

## Test plan
- [x] Build_sim succeeded
- [x] Lint: 0 new warnings
- [x] Added unit tests (`TransactionRepositoryTests` для refunded streak, `StatisticsViewModelTests` для snoozeCount/totalSpent, `BalanceServiceTests` для `chargeWithReceipt` + `topUp(refundsTransactionID:)`)
- [ ] test_sim flaky на main (см. memory `test_gate_disabled`) — pre-existing crashes не от этого PR. Build target компилируется.

## Acceptance из issue
- [x] Refunded charges не накручивают snoozeCount/totalSpent
- [x] Streak preserved через refunded snooze attempts
- [x] Existing happy-path stats unchanged (existing happy-path tests структурно covered, см. comment про realCharges)
- [x] Migration: existing wallets без `refundsTransactionID` decoded gracefully (Codable optional handling)