### PR TITLE
[fix] Reject out-of-range AlarmNotificationPayload values (#208)

### DIFF
--- a/SnoozePay/SnoozePay/Models/AlarmNotificationPayload.swift
+++ b/SnoozePay/SnoozePay/Models/AlarmNotificationPayload.swift
@@ -77,9 +77,16 @@ struct AlarmNotificationPayload: Equatable {
     // MARK: - userInfo bridge
 
     /// Decode from a `UNNotificationContent.userInfo` dictionary. Returns `nil`
-    /// if any required field is missing or has the wrong type — callers MUST
-    /// surface this as a typed error path (log + early return), never proceed
-    /// with synthesised defaults.
+    /// if any required field is missing, has the wrong type, OR is out of
+    /// range — callers MUST surface this as a typed error path (log + early
+    /// return), never proceed with synthesised defaults.
+    ///
+    /// Range validation matters because `userInfo` is a `[AnyHashable: Any]`
+    /// dict that arrives from the notification daemon and could in principle
+    /// carry tampered or schema-drifted values. Without these guards
+    /// `AlarmFiringCoordinator` would compute `pow(2.0, negativeCount)` for
+    /// a progressive penalty, schedule a 0-minute snooze trigger, or attempt
+    /// to charge a `NaN` penalty (issue #208).
     init?(userInfo: [AnyHashable: Any]) {
         guard
             let alarmIDString = userInfo[Key.alarmID] as? String,
@@ -89,6 +96,13 @@ struct AlarmNotificationPayload: Equatable {
             let snoozeCount = userInfo[Key.snoozeCount] as? Int,
             let snoozeMinutes = userInfo[Key.snoozeMinutes] as? Int,
             let soundID = userInfo[Key.soundID] as? String
+        else {
+            return nil
+        }
+        guard
+            penaltyAmount.isFinite, penaltyAmount >= 0,
+            snoozeCount >= 0,
+            snoozeMinutes >= 1, snoozeMinutes <= 60
         else {
             return nil
         }

--- a/SnoozePay/SnoozePayTests/AlarmNotificationPayloadTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmNotificationPayloadTests.swift
@@ -207,6 +207,74 @@ final class AlarmNotificationPayloadTests: XCTestCase {
         XCTAssertNil(AlarmNotificationPayload(userInfo: dict))
     }
 
+    // MARK: - Out-of-range values rejected (issue #208)
+
+    private func validDict() -> [AnyHashable: Any] {
+        [
+            "alarmID": UUID().uuidString,
+            "penaltyAmount": 50.0,
+            "progressiveScale": false,
+            "snoozeCount": 0,
+            "snoozeMinutes": 9,
+            "soundID": "radar"
+        ]
+    }
+
+    func testInit_negativeSnoozeCount_returnsNil() {
+        var dict = validDict()
+        dict["snoozeCount"] = -1
+        XCTAssertNil(AlarmNotificationPayload(userInfo: dict),
+                     "negative snoozeCount would yield pow(2.0, negative) → silently shrunk penalty")
+    }
+
+    func testInit_zeroSnoozeMinutes_returnsNil() {
+        var dict = validDict()
+        dict["snoozeMinutes"] = 0
+        XCTAssertNil(AlarmNotificationPayload(userInfo: dict),
+                     "0 minutes would schedule a trigger at the current instant")
+    }
+
+    func testInit_excessiveSnoozeMinutes_returnsNil() {
+        var dict = validDict()
+        dict["snoozeMinutes"] = 61
+        XCTAssertNil(AlarmNotificationPayload(userInfo: dict),
+                     "spec caps snoozeMinutes at 30; >60 is clearly out-of-range")
+    }
+
+    func testInit_negativePenaltyAmount_returnsNil() {
+        var dict = validDict()
+        dict["penaltyAmount"] = -10.0
+        XCTAssertNil(AlarmNotificationPayload(userInfo: dict))
+    }
+
+    func testInit_nanPenaltyAmount_returnsNil() {
+        var dict = validDict()
+        dict["penaltyAmount"] = Double.nan
+        XCTAssertNil(AlarmNotificationPayload(userInfo: dict),
+                     "NaN penalty would silently disable charge (current >= NaN is false)")
+    }
+
+    func testInit_infinitePenaltyAmount_returnsNil() {
+        var dict = validDict()
+        dict["penaltyAmount"] = Double.infinity
+        XCTAssertNil(AlarmNotificationPayload(userInfo: dict))
+    }
+
+    func testInit_validBoundaryValues_succeeds() {
+        // snoozeMinutes == 1 and snoozeMinutes == 60 must be accepted —
+        // boundary regressions are the typical fallout when ranges tighten.
+        var dict = validDict()
+        dict["snoozeMinutes"] = 1
+        XCTAssertNotNil(AlarmNotificationPayload(userInfo: dict))
+        dict["snoozeMinutes"] = 60
+        XCTAssertNotNil(AlarmNotificationPayload(userInfo: dict))
+        dict["snoozeMinutes"] = 9
+        dict["snoozeCount"] = 0
+        dict["penaltyAmount"] = 0.0
+        XCTAssertNotNil(AlarmNotificationPayload(userInfo: dict),
+                        "Zero penalty / zero count must round-trip (legit fresh-fire state)")
+    }
+
     // MARK: - Compatibility with existing keys
     //
     // The keys here are the exact strings AlarmScheduler / AlarmFiringCoordinator


### PR DESCRIPTION
Fixes #208

## Summary
- init?(userInfo:) only checked types — out-of-range values (negative count, 0/excessive minutes, NaN/Infinity penalty) passed silently and downstream code (pow on negative count, 0-minute trigger, NaN charge gate) misbehaved.
- Added a second guard: penaltyAmount finite + non-negative, snoozeCount non-negative, snoozeMinutes within [1, 60].
- Tests cover each rejection path + boundary acceptance (1 and 60).

## Test plan
- [x] build_sim succeeded
- [x] 7 new tests in AlarmNotificationPayloadTests
- [x] No existing valid traffic affected (existing round-trip tests untouched)