### PR TITLE
[fix] Surface 3 low-severity silent failures via os_log (#210 partial)

### DIFF
--- a/SnoozePay/SnoozePay/SceneDelegate.swift
+++ b/SnoozePay/SnoozePay/SceneDelegate.swift
@@ -4,6 +4,7 @@
 //
 
 import UIKit
+import os
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
@@ -40,7 +41,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     // MARK: - Onboarding transition
 
     private func transitionToMainApp() {
-        guard let window = window else { return }
+        guard let window = window else {
+            AppLogger.appDelegate.error(
+                "transitionToMainApp: window is nil — onboarding ack was set but the user is stuck on the old root"
+            )
+            return
+        }
         let tabBar = makeRootViewController()
         UIView.transition(with: window, duration: 0.4, options: .transitionCrossDissolve) {
             window.rootViewController = tabBar

--- a/SnoozePay/SnoozePay/Services/AudioService.swift
+++ b/SnoozePay/SnoozePay/Services/AudioService.swift
@@ -300,7 +300,14 @@ final class AudioService {
             wavData.append(contentsOf: rawBuffer)
         }
 
-        return try? AVAudioPlayer(data: wavData)
+        do {
+            return try AVAudioPlayer(data: wavData)
+        } catch {
+            AppLogger.audio.error(
+                "generateAlarmTone: AVAudioPlayer init failed — \(String(describing: error), privacy: .public)"
+            )
+            return nil
+        }
     }
 }
 

--- a/SnoozePay/SnoozePay/ViewModels/CreateAlarmViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/CreateAlarmViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AudioToolbox
+import os
 
 /// ViewModel for create/edit alarm screen.
 final class CreateAlarmViewModel {
@@ -170,7 +171,13 @@ final class CreateAlarmViewModel {
 
     /// Play a preview of the given sound using system sounds
     func previewSound(_ soundID: String) {
-        guard let systemID = Self.systemSoundMap[soundID] else { return }
+        guard let systemID = Self.systemSoundMap[soundID] else {
+            // Silent no-op was the original behaviour, but if `availableSounds`
+            // ever drifts from `systemSoundMap` every preview tap is a dead
+            // button with no signal. Log so the regression surfaces.
+            AppLogger.audio.error("previewSound: unknown soundID \(soundID, privacy: .public)")
+            return
+        }
         AudioServicesPlaySystemSound(systemID)
     }
 }


### PR DESCRIPTION
Partial fix of #210 — 3 of 4 items addressed; 4th left for separate PR.

## Summary
- SceneDelegate.transitionToMainApp: log when window is nil
- CreateAlarmViewModel.previewSound: log unknown soundID
- AudioService.generateAlarmTone: replace try? with do/catch + log

The 4th item (deprecate unchecked repository fetch variants) needs a migration strategy — many tests rely on the unchecked API. Filing a follow-up.

## Test plan
- [x] build_sim succeeded
- [x] All additions are diagnostic (logging only); no behaviour change for the happy path
- [x] os import added to SceneDelegate and CreateAlarmViewModel