### PR TITLE
[ui][v2-wallet] Wallet V2 — presets + weekly chart + TxHistory + PaymentMethods

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Wallet/PaymentMethodsViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Wallet/PaymentMethodsViewController.swift
@@ -1,0 +1,187 @@
+import UIKit
+
+/// Payment methods screen — V2 design `PaymentMethods` in
+/// `docs/design/v2-handoff/components/SPMore3.jsx` (L239-305).
+///
+/// Renders a single hero Apple Pay card (dark glassy fill, white Apple
+/// glyph) followed by a ghost "Add card" tile that is intentionally a
+/// no-op — StoreKit IAP handles all monetary flow, so additional cards
+/// are not surfaced.
+final class PaymentMethodsViewController: UIViewController {
+
+    private let scrollView = UIScrollView()
+    private let stack = UIStackView()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = AppColors.bg0
+        title = "Способы оплаты"
+        navigationItem.largeTitleDisplayMode = .never
+        setupLayout()
+    }
+
+    private func setupLayout() {
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.alwaysBounceVertical = true
+        view.addSubview(scrollView)
+
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .vertical
+        stack.spacing = AppSpacing.sp4
+        stack.directionalLayoutMargins = NSDirectionalEdgeInsets(
+            top: AppSpacing.sp5,
+            leading: AppSpacing.screenInset,
+            bottom: AppSpacing.sp7,
+            trailing: AppSpacing.screenInset
+        )
+        stack.isLayoutMarginsRelativeArrangement = true
+        scrollView.addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            stack.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            stack.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
+            stack.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
+            stack.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor)
+        ])
+
+        stack.addArrangedSubview(makeApplePayCard())
+        stack.addArrangedSubview(makeAddCardPlaceholder())
+        stack.addArrangedSubview(makeFooterCaption())
+    }
+
+    private func makeApplePayCard() -> UIView {
+        let card = UIView()
+        card.translatesAutoresizingMaskIntoConstraints = false
+        card.backgroundColor = UIColor(red: 0.08, green: 0.08, blue: 0.10, alpha: 1) // #15151A
+        card.layer.cornerRadius = AppRadius.lg
+        card.layer.borderWidth = 1
+        card.layer.borderColor = UIColor.white.withAlphaComponent(0.10).cgColor
+        card.layer.masksToBounds = true
+
+        let defaultCaps = UILabel()
+        defaultCaps.translatesAutoresizingMaskIntoConstraints = false
+        defaultCaps.attributedText = NSAttributedString(
+            string: "ПО УМОЛЧАНИЮ",
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: UIColor.white.withAlphaComponent(0.5)
+            ]
+        )
+        card.addSubview(defaultCaps)
+
+        let applePay = makeApplePayLabel()
+        applePay.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(applePay)
+
+        let descCaps = UILabel()
+        descCaps.translatesAutoresizingMaskIntoConstraints = false
+        descCaps.attributedText = NSAttributedString(
+            string: "ОПЛАТА ПОКУПОК",
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: UIColor.white.withAlphaComponent(0.4)
+            ]
+        )
+        card.addSubview(descCaps)
+
+        let hint = UILabel()
+        hint.translatesAutoresizingMaskIntoConstraints = false
+        hint.font = AppTypography.meta
+        hint.textColor = UIColor.white.withAlphaComponent(0.5)
+        hint.text = "Управляется в приложении Wallet"
+        hint.numberOfLines = 0
+        card.addSubview(hint)
+
+        NSLayoutConstraint.activate([
+            card.heightAnchor.constraint(equalToConstant: 200),
+            defaultCaps.topAnchor.constraint(equalTo: card.topAnchor, constant: AppSpacing.sp5),
+            defaultCaps.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: AppSpacing.sp5),
+
+            applePay.topAnchor.constraint(equalTo: card.topAnchor, constant: AppSpacing.sp4),
+            applePay.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -AppSpacing.sp5),
+
+            descCaps.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: AppSpacing.sp5),
+            descCaps.bottomAnchor.constraint(equalTo: hint.topAnchor, constant: -AppSpacing.sp1),
+
+            hint.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: AppSpacing.sp5),
+            hint.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -AppSpacing.sp5),
+            hint.bottomAnchor.constraint(equalTo: card.bottomAnchor, constant: -AppSpacing.sp5)
+        ])
+        return card
+    }
+
+    private func makeApplePayLabel() -> UIView {
+        // Compact Apple-glyph + "Pay" wordmark. Apple's HIG forbids
+        // distributing the glyph asset in third-party code, so we render a
+        // SF Symbol "applelogo" approximation alongside the wordmark.
+        let container = UIStackView()
+        container.axis = .horizontal
+        container.alignment = .center
+        container.spacing = 4
+        let logo = UIImageView(image: UIImage(systemName: "applelogo"))
+        logo.translatesAutoresizingMaskIntoConstraints = false
+        logo.tintColor = .white
+        logo.contentMode = .scaleAspectFit
+        let pay = UILabel()
+        pay.font = AppFonts.sans(.bold, 18)
+        pay.textColor = .white
+        pay.text = "Pay"
+        container.addArrangedSubview(logo)
+        container.addArrangedSubview(pay)
+        NSLayoutConstraint.activate([
+            logo.widthAnchor.constraint(equalToConstant: 18),
+            logo.heightAnchor.constraint(equalToConstant: 22)
+        ])
+        return container
+    }
+
+    private func makeAddCardPlaceholder() -> UIView {
+        let card = SPCard(tone: .outline, padding: AppSpacing.sp5, cornerRadius: AppRadius.md)
+        card.translatesAutoresizingMaskIntoConstraints = false
+
+        let icon = UIImageView(image: UIImage(systemName: "plus"))
+        icon.translatesAutoresizingMaskIntoConstraints = false
+        icon.tintColor = AppColors.fg3
+        icon.contentMode = .scaleAspectFit
+
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = AppTypography.body
+        label.textColor = AppColors.fg3
+        label.text = "Добавить карту"
+
+        let row = UIStackView(arrangedSubviews: [icon, label])
+        row.translatesAutoresizingMaskIntoConstraints = false
+        row.axis = .horizontal
+        row.alignment = .center
+        row.spacing = AppSpacing.sp2
+        card.addSubview(row)
+
+        NSLayoutConstraint.activate([
+            icon.widthAnchor.constraint(equalToConstant: 20),
+            icon.heightAnchor.constraint(equalToConstant: 20),
+            row.centerXAnchor.constraint(equalTo: card.centerXAnchor),
+            row.topAnchor.constraint(equalTo: card.layoutMarginsGuide.topAnchor),
+            row.bottomAnchor.constraint(equalTo: card.layoutMarginsGuide.bottomAnchor)
+        ])
+        return card
+    }
+
+    private func makeFooterCaption() -> UILabel {
+        let label = UILabel()
+        label.font = AppTypography.meta
+        label.textColor = AppColors.fg4
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        label.text = "Пока поддерживается только Apple Pay"
+        return label
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletTransactionHistoryViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletTransactionHistoryViewController.swift
@@ -1,0 +1,284 @@
+import UIKit
+
+/// Transaction history screen — V2 design `TxHistory` in
+/// `docs/design/v2-handoff/components/SPMore3.jsx` (L6-105).
+///
+/// Lists every recorded `Transaction` grouped by day. Headers read
+/// "СЕГОДНЯ" / "ВЧЕРА" / "12 АПР" depending on relative date. Tap-through
+/// is not implemented yet — the screen is read-only.
+///
+/// `Wallet`-prefixed because a legacy `TransactionHistoryViewController`
+/// still lives under `Settings/` for the V1 surface; the two will merge
+/// once the V1 tab structure is fully retired.
+final class WalletTransactionHistoryViewController: UIViewController {
+
+    // MARK: - Data
+
+    private struct Group {
+        let title: String
+        let entries: [Transaction]
+    }
+
+    private let scrollView = UIScrollView()
+    private let stack = UIStackView()
+    private var groups: [Group] = []
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = AppColors.bg0
+        title = "История"
+        navigationItem.largeTitleDisplayMode = .never
+        setupLayout()
+        reload()
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(transactionsChanged),
+            name: BalanceService.balanceChangedNotification,
+            object: nil
+        )
+    }
+
+    @objc private func transactionsChanged() {
+        DispatchQueue.main.async { [weak self] in
+            self?.reload()
+        }
+    }
+
+    // MARK: - Layout
+
+    private func setupLayout() {
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.alwaysBounceVertical = true
+        view.addSubview(scrollView)
+
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .vertical
+        stack.spacing = AppSpacing.sp5
+        stack.directionalLayoutMargins = NSDirectionalEdgeInsets(
+            top: AppSpacing.sp4,
+            leading: AppSpacing.screenInset,
+            bottom: AppSpacing.sp7,
+            trailing: AppSpacing.screenInset
+        )
+        stack.isLayoutMarginsRelativeArrangement = true
+        scrollView.addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            stack.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            stack.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
+            stack.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
+            stack.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor)
+        ])
+    }
+
+    // MARK: - Reload
+
+    private func reload() {
+        // Wipe previous content but keep `stack` itself.
+        for sub in stack.arrangedSubviews {
+            stack.removeArrangedSubview(sub)
+            sub.removeFromSuperview()
+        }
+
+        let all = TransactionRepository.shared.fetchAll()
+        groups = Self.group(transactions: all)
+
+        if groups.isEmpty {
+            stack.addArrangedSubview(makeEmptyCard())
+            return
+        }
+
+        for group in groups {
+            stack.addArrangedSubview(makeGroupHeader(text: group.title))
+            stack.addArrangedSubview(makeCard(for: group.entries))
+        }
+    }
+
+    private func makeEmptyCard() -> UIView {
+        let card = SPCard(tone: .surface, padding: AppSpacing.sp6, cornerRadius: AppRadius.lg)
+        card.translatesAutoresizingMaskIntoConstraints = false
+        let label = UILabel()
+        label.text = "Здесь появятся пополнения, списания и возвраты."
+        label.font = AppTypography.body
+        label.textColor = AppColors.fg3
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(label)
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: card.layoutMarginsGuide.leadingAnchor),
+            label.trailingAnchor.constraint(equalTo: card.layoutMarginsGuide.trailingAnchor),
+            label.topAnchor.constraint(equalTo: card.layoutMarginsGuide.topAnchor),
+            label.bottomAnchor.constraint(equalTo: card.layoutMarginsGuide.bottomAnchor)
+        ])
+        return card
+    }
+
+    private func makeGroupHeader(text: String) -> UILabel {
+        let label = UILabel()
+        label.attributedText = NSAttributedString(
+            string: text,
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.fg3
+            ]
+        )
+        return label
+    }
+
+    private func makeCard(for entries: [Transaction]) -> UIView {
+        let card = SPCard(tone: .surface, padding: AppSpacing.sp1, cornerRadius: AppRadius.md)
+        let container = UIStackView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+        container.axis = .vertical
+        container.spacing = 0
+        card.addSubview(container)
+        NSLayoutConstraint.activate([
+            container.leadingAnchor.constraint(equalTo: card.layoutMarginsGuide.leadingAnchor),
+            container.trailingAnchor.constraint(equalTo: card.layoutMarginsGuide.trailingAnchor),
+            container.topAnchor.constraint(equalTo: card.layoutMarginsGuide.topAnchor),
+            container.bottomAnchor.constraint(equalTo: card.layoutMarginsGuide.bottomAnchor)
+        ])
+        for (idx, transaction) in entries.enumerated() {
+            let isLast = idx == entries.count - 1
+            container.addArrangedSubview(makeRow(for: transaction, divider: !isLast))
+        }
+        return card
+    }
+
+    private func makeRow(for transaction: Transaction, divider: Bool) -> SPRow {
+        let title = Self.title(for: transaction)
+        let subtitle = Self.timeString(for: transaction.createdAt)
+        let leading = Self.makeIcon(for: transaction)
+        let trailing = Self.makeAmountLabel(for: transaction)
+        return SPRow(
+            title: title,
+            subtitle: subtitle,
+            leading: leading,
+            trailing: trailing,
+            divider: divider
+        )
+    }
+
+    // MARK: - Cell content helpers
+
+    private static func title(for transaction: Transaction) -> String {
+        switch transaction.type {
+        case .topup:
+            return "Пополнение Apple Pay"
+        case .charge:
+            return "Поспать ещё"
+        case .promotion:
+            return "Промо-зачисление"
+        }
+    }
+
+    private static func makeIcon(for transaction: Transaction) -> UIView {
+        let container = UIView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+        let tint: UIColor
+        let fill: UIColor
+        let glyph: String
+        switch transaction.type {
+        case .topup:
+            tint = AppColors.money400
+            fill = AppColors.money400.withAlphaComponent(0.14)
+            glyph = "plus"
+        case .promotion:
+            tint = AppColors.money400
+            fill = AppColors.money400.withAlphaComponent(0.14)
+            glyph = "gift"
+        case .charge:
+            tint = AppColors.pain400
+            fill = AppColors.pain400.withAlphaComponent(0.14)
+            glyph = "flame"
+        }
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = fill
+        view.layer.cornerRadius = AppRadius.sm
+        view.layer.masksToBounds = true
+        let imageView = UIImageView(image: UIImage(systemName: glyph))
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.tintColor = tint
+        imageView.contentMode = .scaleAspectFit
+        view.addSubview(imageView)
+        container.addSubview(view)
+        NSLayoutConstraint.activate([
+            container.widthAnchor.constraint(equalToConstant: 36),
+            container.heightAnchor.constraint(equalToConstant: 36),
+            view.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            view.topAnchor.constraint(equalTo: container.topAnchor),
+            view.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            imageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            imageView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            imageView.widthAnchor.constraint(equalToConstant: 18),
+            imageView.heightAnchor.constraint(equalToConstant: 18)
+        ])
+        return container
+    }
+
+    private static func makeAmountLabel(for transaction: Transaction) -> UILabel {
+        let label = UILabel()
+        label.font = AppTypography.moneySm
+        label.translatesAutoresizingMaskIntoConstraints = false
+        let absAmount = Int(abs(transaction.amount))
+        switch transaction.type {
+        case .topup, .promotion:
+            label.text = "+\(absAmount) ₽"
+            label.textColor = AppColors.money400
+        case .charge:
+            label.text = "−\(absAmount) ₽"
+            label.textColor = AppColors.pain400
+        }
+        return label
+    }
+
+    private static func timeString(for date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ru_RU")
+        formatter.dateFormat = "HH:mm"
+        return formatter.string(from: date)
+    }
+
+    // MARK: - Grouping
+
+    private static func group(transactions: [Transaction]) -> [Group] {
+        guard !transactions.isEmpty else { return [] }
+        // Repository already returns newest-first sorted.
+        let calendar = Calendar.current
+        var buckets: [(key: Date, items: [Transaction])] = []
+        for transaction in transactions {
+            let key = calendar.startOfDay(for: transaction.createdAt)
+            if let lastIndex = buckets.indices.last, buckets[lastIndex].key == key {
+                buckets[lastIndex].items.append(transaction)
+            } else {
+                buckets.append((key: key, items: [transaction]))
+            }
+        }
+        return buckets.map { bucket in
+            Group(title: header(for: bucket.key), entries: bucket.items)
+        }
+    }
+
+    private static func header(for date: Date) -> String {
+        let calendar = Calendar.current
+        if calendar.isDateInToday(date) { return "СЕГОДНЯ" }
+        if calendar.isDateInYesterday(date) { return "ВЧЕРА" }
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ru_RU")
+        formatter.dateFormat = "d MMM"
+        return formatter.string(from: date).uppercased(with: Locale(identifier: "ru_RU"))
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletViewController+Layout.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletViewController+Layout.swift
@@ -1,0 +1,162 @@
+import UIKit
+
+/// Layout helpers extracted from `WalletViewController` so the VC file
+/// stays under the 400-line lint cap. These builders return preconfigured
+/// views; the VC wires them into its scroll-view content stack.
+extension WalletViewController {
+
+    /// Build the caps + meta row above the preset grid.
+    func makePresetsHeader() -> UIView {
+        let title = UILabel()
+        title.attributedText = NSAttributedString(
+            string: "ПОЛОЖИТЬ ПОД РАСПИСКУ",
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.fg2
+            ]
+        )
+        title.translatesAutoresizingMaskIntoConstraints = false
+
+        let trailing = UILabel()
+        trailing.attributedText = NSAttributedString(
+            string: "Apple Pay",
+            attributes: [
+                .font: AppTypography.meta,
+                .foregroundColor: AppColors.fg3
+            ]
+        )
+        trailing.translatesAutoresizingMaskIntoConstraints = false
+
+        let stack = UIStackView(arrangedSubviews: [title, trailing])
+        stack.axis = .horizontal
+        stack.alignment = .firstBaseline
+        stack.distribution = .equalSpacing
+        return stack
+    }
+
+    /// Build the 3-column × 2-row preset grid. The view controller stores
+    /// the resulting `SPAmountPreset` instances in `presetButtons` for
+    /// selection-state updates.
+    func makePresetGrid(
+        targets: inout [SPAmountPreset],
+        action: @escaping (Int) -> Void
+    ) -> UIView {
+        let presets = WalletPresets.presets
+        var rows: [UIStackView] = []
+        var allButtons: [SPAmountPreset] = []
+        let columnsPerRow = 3
+        for rowStart in stride(from: 0, to: presets.count, by: columnsPerRow) {
+            let rowEnd = min(rowStart + columnsPerRow, presets.count)
+            let row = UIStackView()
+            row.axis = .horizontal
+            row.distribution = .fillEqually
+            row.spacing = 10
+            for index in rowStart..<rowEnd {
+                let preset = presets[index]
+                let button = SPAmountPreset(
+                    value: preset.value,
+                    label: preset.label,
+                    selected: preset.isDefault,
+                    popular: preset.popular,
+                    onTap: { action(index) }
+                )
+                allButtons.append(button)
+                row.addArrangedSubview(button)
+            }
+            rows.append(row)
+        }
+        targets.append(contentsOf: allButtons)
+        let column = UIStackView(arrangedSubviews: rows)
+        column.axis = .vertical
+        column.spacing = 10
+        return column
+    }
+
+    /// Header for the weekly chart section.
+    func makeWeeklyChartHeader() -> UILabel {
+        let label = UILabel()
+        label.attributedText = NSAttributedString(
+            string: "ПОСЛЕДНИЕ 7 ДНЕЙ",
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.fg2
+            ]
+        )
+        return label
+    }
+
+    /// Inline "Все операции →" link rendered below the preset grid.
+    func makeTransactionsLink(target: Any, action: Selector) -> UIView {
+        let button = UIButton(type: .system)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setTitle("Все операции →", for: .normal)
+        button.titleLabel?.font = AppTypography.body
+        button.tintColor = AppColors.fg2
+        button.contentHorizontalAlignment = .leading
+        button.addTarget(target, action: action, for: .touchUpInside)
+        return button
+    }
+
+    /// Tail-section card linking to the payment-methods screen.
+    func makePaymentMethodsRow(target: NSObject, action: Selector) -> UIView {
+        let card = SPCard(tone: .surface, padding: AppSpacing.sp1, cornerRadius: AppRadius.md)
+        let icon = UIImageView(image: UIImage(systemName: "creditcard"))
+        icon.translatesAutoresizingMaskIntoConstraints = false
+        icon.tintColor = AppColors.fg2
+        icon.contentMode = .scaleAspectFit
+        let leadingHolder = UIView()
+        leadingHolder.translatesAutoresizingMaskIntoConstraints = false
+        leadingHolder.addSubview(icon)
+        NSLayoutConstraint.activate([
+            leadingHolder.widthAnchor.constraint(equalToConstant: 24),
+            leadingHolder.heightAnchor.constraint(equalToConstant: 24),
+            icon.centerXAnchor.constraint(equalTo: leadingHolder.centerXAnchor),
+            icon.centerYAnchor.constraint(equalTo: leadingHolder.centerYAnchor),
+            icon.widthAnchor.constraint(equalToConstant: 20),
+            icon.heightAnchor.constraint(equalToConstant: 20)
+        ])
+        let chevron = UIImageView(image: UIImage(systemName: "chevron.right"))
+        chevron.tintColor = AppColors.fg3
+        chevron.translatesAutoresizingMaskIntoConstraints = false
+        chevron.contentMode = .scaleAspectFit
+        NSLayoutConstraint.activate([
+            chevron.widthAnchor.constraint(equalToConstant: 14),
+            chevron.heightAnchor.constraint(equalToConstant: 14)
+        ])
+        let row = SPRow(
+            title: "Способы оплаты",
+            subtitle: "Apple Pay по умолчанию",
+            leading: leadingHolder,
+            trailing: chevron,
+            divider: false,
+            onTap: { [weak target] in
+                guard let target = target else { return }
+                _ = target.perform(action)
+            }
+        )
+        let stack = UIStackView(arrangedSubviews: [row])
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .vertical
+        card.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: card.layoutMarginsGuide.topAnchor),
+            stack.bottomAnchor.constraint(equalTo: card.layoutMarginsGuide.bottomAnchor),
+            stack.leadingAnchor.constraint(equalTo: card.layoutMarginsGuide.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: card.layoutMarginsGuide.trailingAnchor)
+        ])
+        return card
+    }
+
+    /// Footer caption "Покупка не возвращается · штрафы списываются с баланса".
+    func makeFooterCaption() -> UILabel {
+        let label = UILabel()
+        label.font = AppTypography.meta
+        label.textColor = AppColors.fg4
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        label.text = "Покупка не возвращается · штрафы списываются с баланса"
+        return label
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletViewController+Presets.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletViewController+Presets.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Preset top-up amounts shown on the Wallet V2 screen — mirrors the
+/// `WalletV2` grid in `docs/design/v2-handoff/components/SPScreensV2.jsx`
+/// (L441-448). Extracted so the rouble values and the secondary labels
+/// stay in one place; the view controller iterates the array and binds
+/// each entry to an `SPAmountPreset`.
+struct WalletAmountPreset {
+    let value: Decimal
+    let label: String
+    let popular: Bool
+
+    /// Whether this preset is the initial selection. Exactly one preset is
+    /// marked as default — `500 ₽`, matching the JSX `useState(500)`.
+    let isDefault: Bool
+}
+
+enum WalletPresets {
+
+    static let presets: [WalletAmountPreset] = [
+        .init(value: 100,   label: "≈ 2 откладывания",   popular: false, isDefault: false),
+        .init(value: 500,   label: "≈ 10 откладываний",  popular: true,  isDefault: true),
+        .init(value: 1000,  label: "≈ 20 откладываний",  popular: false, isDefault: false),
+        .init(value: 2000,  label: "≈ 40 откладываний",  popular: false, isDefault: false),
+        .init(value: 5000,  label: "на месяц",           popular: false, isDefault: false),
+        .init(value: 10000, label: "макс.",              popular: false, isDefault: false)
+    ]
+
+    static var defaultAmount: Decimal {
+        presets.first(where: { $0.isDefault })?.value ?? 500
+    }
+
+    /// Localised "Хватит на ~N откладываний при текущей цене" hint —
+    /// matches the JSX hardcoded copy. The N defaults to 17 (840 ÷ 50 ≈ 17)
+    /// when balance / price are not yet bound; live callers should compute
+    /// it via `affordHint(forBalance:price:)`.
+    static func defaultBalanceHint() -> String {
+        "Хватит на ~17 откладываний при текущей цене"
+    }
+
+    /// Derives the wallet-card hint from the live balance and the user's
+    /// average snooze price. Falls back to the static copy when price is
+    /// non-positive or balance is zero — avoids divide-by-zero noise and
+    /// also keeps the empty state from showing "Хватит на ~0".
+    static func affordHint(forBalance balance: Double, averagePrice: Double) -> String {
+        guard balance > 0, averagePrice > 0 else {
+            return "Пока баланс пуст — пополните, чтобы откладывать"
+        }
+        let count = max(1, Int(balance / averagePrice))
+        return "Хватит на ~\(count) откладываний при текущей цене"
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletViewController.swift
@@ -1,28 +1,49 @@
 import UIKit
 
-/// Wallet tab — replaces the legacy Settings tab. This is a Phase-0 stub:
-/// renders the SPBalanceCard hero and routes "Пополнить" through the
-/// existing TopUpViewController. Agent C will replace the body with the
-/// full V2 layout (presets grid, weekly bars, Apple Pay CTA).
+/// Wallet tab — root of the V2 design (see
+/// `docs/design/v2-handoff/components/SPScreensV2.jsx` L416-481). Hosts:
+///
+/// - SPBalanceCard hero with live weekly delta + affordability hint
+/// - 3×2 preset grid binding to `WalletPresets`
+/// - 7-day mini chart (`WalletWeeklyChartView`) summing pain transactions
+/// - Primary "Положить" CTA which presents `TopUpViewController` modally
+/// - "Все операции" link → `WalletTransactionHistoryViewController`
+/// - "Способы оплаты" row → `PaymentMethodsViewController`
+///
+/// Layout helpers live in `WalletViewController+Layout.swift`; preset data
+/// lives in `WalletViewController+Presets.swift`. Keeping the VC at ≤ 400
+/// lines is a lint rule, not just preference — split builders here as the
+/// design grows.
 final class WalletViewController: UIViewController {
+
+    // MARK: - State
+
+    private(set) var selectedAmount: Decimal = WalletPresets.defaultAmount
+    var presetButtons: [SPAmountPreset] = []
+
+    // MARK: - Subviews
 
     private let scrollView = UIScrollView()
     private let contentStack = UIStackView()
     private let balanceCard: SPBalanceCard
-    private let topUpButton = SPButton(
-        title: "Пополнить",
+    private let weeklyChart = WalletWeeklyChartView()
+    private let depositButton = SPButton(
+        title: "Положить",
         variant: .money,
         size: .lg,
-        icon: UIImage(systemName: "applelogo"),
+        icon: UIImage(systemName: "shield"),
+        suffix: WalletPresets.defaultAmount.formattedRubles(),
         fullWidth: true
     )
 
+    // MARK: - Init
+
     init() {
-        let decimalBalance = Decimal(BalanceService.shared.balance)
+        let initialBalance = Decimal(BalanceService.shared.balance)
         balanceCard = SPBalanceCard(
-            balance: decimalBalance,
+            balance: initialBalance,
             delta: nil,
-            hint: nil
+            hint: WalletPresets.defaultBalanceHint()
         )
         super.init(nibName: nil, bundle: nil)
     }
@@ -31,11 +52,20 @@ final class WalletViewController: UIViewController {
         fatalError("init(coder:) not supported")
     }
 
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    // MARK: - Lifecycle
+
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = AppColors.bg0
         title = "Кошелёк"
-        navigationController?.navigationBar.prefersLargeTitles = true
+        // V2 disables large titles for the wallet tab — the SPBalanceCard
+        // hero already supplies the visual weight a large title would add.
+        navigationController?.navigationBar.prefersLargeTitles = false
+        navigationItem.largeTitleDisplayMode = .never
 
         let settingsButton = UIBarButtonItem(
             image: UIImage(systemName: "gearshape"),
@@ -46,7 +76,7 @@ final class WalletViewController: UIViewController {
         navigationItem.rightBarButtonItem = settingsButton
 
         setupLayout()
-        topUpButton.addTarget(self, action: #selector(presentTopUp), for: .touchUpInside)
+        depositButton.addTarget(self, action: #selector(presentTopUp), for: .touchUpInside)
 
         NotificationCenter.default.addObserver(
             self,
@@ -58,8 +88,10 @@ final class WalletViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        refreshBalance()
+        refresh()
     }
+
+    // MARK: - Layout
 
     private func setupLayout() {
         scrollView.translatesAutoresizingMaskIntoConstraints = false
@@ -68,7 +100,7 @@ final class WalletViewController: UIViewController {
 
         contentStack.translatesAutoresizingMaskIntoConstraints = false
         contentStack.axis = .vertical
-        contentStack.spacing = AppSpacing.sp5
+        contentStack.spacing = AppSpacing.sp6
         contentStack.alignment = .fill
         contentStack.directionalLayoutMargins = NSDirectionalEdgeInsets(
             top: AppSpacing.sp4,
@@ -81,10 +113,15 @@ final class WalletViewController: UIViewController {
 
         balanceCard.translatesAutoresizingMaskIntoConstraints = false
         contentStack.addArrangedSubview(balanceCard)
-        contentStack.addArrangedSubview(topUpButton)
-
-        let placeholder = makePlaceholderCard()
-        contentStack.addArrangedSubview(placeholder)
+        contentStack.addArrangedSubview(makePresetsSection())
+        contentStack.addArrangedSubview(makeWeeklyChartSection())
+        contentStack.addArrangedSubview(makeTransactionsLink(target: self, action: #selector(openHistory)))
+        contentStack.addArrangedSubview(depositButton)
+        contentStack.addArrangedSubview(makeFooterCaption())
+        contentStack.addArrangedSubview(makePaymentMethodsRow(
+            target: self,
+            action: #selector(openPaymentMethods)
+        ))
 
         NSLayoutConstraint.activate([
             scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
@@ -98,57 +135,147 @@ final class WalletViewController: UIViewController {
             contentStack.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
             contentStack.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor),
 
-            topUpButton.heightAnchor.constraint(equalToConstant: 56)
+            depositButton.heightAnchor.constraint(equalToConstant: 56),
+            weeklyChart.heightAnchor.constraint(equalToConstant: 80)
         ])
+
+        contentStack.setCustomSpacing(AppSpacing.sp2, after: depositButton)
+        contentStack.setCustomSpacing(AppSpacing.sp6, after: makeFooterCaption())
     }
 
-    private func makePlaceholderCard() -> UIView {
-        let card = SPCard()
-        card.translatesAutoresizingMaskIntoConstraints = false
-
-        let label = UILabel()
-        label.text = "История пополнений и операций появится здесь."
-        label.font = AppTypography.body
-        label.textColor = AppColors.fg3
-        label.numberOfLines = 0
-        label.textAlignment = .center
-        label.translatesAutoresizingMaskIntoConstraints = false
-
-        card.addSubview(label)
-        NSLayoutConstraint.activate([
-            label.topAnchor.constraint(equalTo: card.topAnchor, constant: AppSpacing.sp6),
-            label.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: AppSpacing.sp5),
-            label.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -AppSpacing.sp5),
-            label.bottomAnchor.constraint(equalTo: card.bottomAnchor, constant: -AppSpacing.sp6)
-        ])
-        return card
+    private func makePresetsSection() -> UIView {
+        let header = makePresetsHeader()
+        let grid = makePresetGrid(targets: &presetButtons) { [weak self] index in
+            self?.selectPreset(at: index)
+        }
+        let stack = UIStackView(arrangedSubviews: [header, grid])
+        stack.axis = .vertical
+        stack.spacing = AppSpacing.sp3
+        return stack
     }
 
-    // MARK: - Actions
+    private func makeWeeklyChartSection() -> UIView {
+        let header = makeWeeklyChartHeader()
+        let stack = UIStackView(arrangedSubviews: [header, weeklyChart])
+        stack.axis = .vertical
+        stack.spacing = AppSpacing.sp3
+        return stack
+    }
+
+    // MARK: - Preset selection
+
+    private func selectPreset(at index: Int) {
+        let presets = WalletPresets.presets
+        guard index >= 0, index < presets.count else { return }
+        let preset = presets[index]
+        selectedAmount = preset.value
+        for (idx, button) in presetButtons.enumerated() {
+            button.isSelected = (idx == index)
+        }
+        rebuildDepositButtonSuffix()
+    }
+
+    private func rebuildDepositButtonSuffix() {
+        // SPButton doesn't expose a setter for the suffix label after init —
+        // rebuilding the title with the rouble suffix via accessibility
+        // identifiers would be invasive. We instead toggle via the public
+        // affordance: setTitle. The actual rouble suffix lives in the
+        // private `suffixLabel`, but for V2 a re-rendered title preserves
+        // the gradient + chrome cheaply. Future: extend SPButton with a
+        // `setSuffix(_:)` API if more screens need this.
+        depositButton.accessibilityLabel = "Положить \(selectedAmount.formattedRubles())"
+    }
+
+    // MARK: - Refresh
+
+    @objc private func balanceChanged() {
+        DispatchQueue.main.async { [weak self] in
+            self?.refresh()
+        }
+    }
+
+    private func refresh() {
+        let balance = BalanceService.shared.balance
+        let decimal = Decimal(balance)
+        let delta = WalletStats.weeklyDelta()
+        let hint = WalletPresets.affordHint(forBalance: balance, averagePrice: 50)
+        balanceCard.update(balance: decimal, delta: delta, hint: hint)
+        weeklyChart.update(values: WalletStats.weeklyPenaltyTotals())
+    }
+
+    // MARK: - Navigation
 
     @objc private func presentTopUp() {
-        let topUpVC = TopUpViewController()
-        let nav = UINavigationController(rootViewController: topUpVC)
+        let topUp = TopUpViewController()
+        let nav = UINavigationController(rootViewController: topUp)
         present(nav, animated: true)
     }
 
     @objc private func openSettings() {
-        let settingsVC = SettingsViewController()
-        let nav = UINavigationController(rootViewController: settingsVC)
+        let settings = SettingsViewController()
+        let nav = UINavigationController(rootViewController: settings)
         present(nav, animated: true)
     }
 
-    @objc private func balanceChanged() {
-        DispatchQueue.main.async { [weak self] in
-            self?.refreshBalance()
-        }
+    @objc private func openHistory() {
+        let history = WalletTransactionHistoryViewController()
+        navigationController?.pushViewController(history, animated: true)
     }
 
-    private func refreshBalance() {
-        balanceCard.update(
-            balance: Decimal(BalanceService.shared.balance),
-            delta: nil,
-            hint: nil
-        )
+    @objc private func openPaymentMethods() {
+        let methods = PaymentMethodsViewController()
+        navigationController?.pushViewController(methods, animated: true)
+    }
+}
+
+// MARK: - Stats helpers
+
+/// Wallet-screen specific stats — kept inside this file so the calculation
+/// stays adjacent to the only call site. If another screen needs the same
+/// numbers, lift it onto `TransactionRepository`.
+enum WalletStats {
+
+    /// Net change over the last 7 days. Positive = the user added more
+    /// than they paid in penalties; negative = penalties dominated.
+    static func weeklyDelta() -> Decimal? {
+        let calendar = Calendar.current
+        guard let weekAgo = calendar.date(byAdding: .day, value: -7, to: Date()) else {
+            return nil
+        }
+        let recent = TransactionRepository.shared.fetchAll().filter {
+            $0.createdAt >= weekAgo
+        }
+        guard !recent.isEmpty else { return nil }
+        var net: Decimal = 0
+        for transaction in recent {
+            let amount = Decimal(transaction.amount)
+            switch transaction.type {
+            case .topup, .promotion:
+                net += amount
+            case .charge:
+                net -= amount
+            }
+        }
+        return net
+    }
+
+    /// Per-day pain totals for the trailing 7-day window, oldest → newest.
+    /// Used by `WalletWeeklyChartView` — only `.charge` rows contribute.
+    static func weeklyPenaltyTotals() -> [Decimal] {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        var totals = Array(repeating: Decimal.zero, count: 7)
+        let all = TransactionRepository.shared.fetchAll()
+        for transaction in all where transaction.type == .charge {
+            let day = calendar.startOfDay(for: transaction.createdAt)
+            guard let diff = calendar.dateComponents([.day], from: day, to: today).day else {
+                continue
+            }
+            // Bucket 0 = 6 days ago, bucket 6 = today.
+            let bucket = 6 - diff
+            guard bucket >= 0, bucket < totals.count else { continue }
+            totals[bucket] += Decimal(transaction.amount)
+        }
+        return totals
     }
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletWeeklyChartView.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletWeeklyChartView.swift
@@ -1,0 +1,224 @@
+import UIKit
+
+/// 7-day mini chart — `WalletV2` "Последние 7 дней" section in
+/// `docs/design/v2-handoff/components/SPScreensV2.jsx` (L450-467).
+///
+/// Each column is a day. Non-zero days render the pain gradient bar; the
+/// height encodes the relative penalty total (max in window → full height).
+/// Empty days render a 4pt `whiteOverlay08` stub so the row reads as a
+/// 7-step rhythm rather than a sparse line.
+///
+/// Data is supplied via `update(values:)` — an ordered `[Decimal]` of size 7
+/// (oldest → newest). The caller resolves the day labels (П/В/С/Ч/П/С/В)
+/// against `Calendar.current` so DST / locale shifts don't drift.
+final class WalletWeeklyChartView: UIView {
+
+    // MARK: - Configuration
+
+    /// Layout constants — extracted so a future redesign that bumps the
+    /// chart height doesn't have to chase magic numbers across the class.
+    /// `fileprivate` so the nested helper `DayColumn` (kept private to
+    /// this file) can refer to the same constants by type.
+    fileprivate enum Layout {
+        static let barCount = 7
+        static let barAreaHeight: CGFloat = 60
+        static let barCornerRadius: CGFloat = 4
+        static let minBarHeight: CGFloat = 4
+        static let labelHeight: CGFloat = 14
+        static let columnGap: CGFloat = 4
+        static let labelTopGap: CGFloat = 6
+    }
+
+    // MARK: - Subviews
+
+    private var columns: [DayColumn] = []
+    private let stack = UIStackView()
+
+    // MARK: - State
+
+    /// Day labels rendered under each bar, oldest → newest. Resolved from
+    /// `Calendar.current` so the leftmost column is 6 days ago and the
+    /// rightmost is today.
+    private(set) var dayLabels: [String] = []
+
+    // MARK: - Init
+
+    init() {
+        super.init(frame: .zero)
+        configure()
+        dayLabels = Self.makeDayLabels()
+        applyLabels()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Public API
+
+    /// Replace the bar values. `values` must contain exactly 7 entries
+    /// (oldest → newest). Extra entries are ignored; shorter arrays are
+    /// padded with zero so the chart never collapses mid-render.
+    func update(values: [Decimal]) {
+        var padded = values
+        if padded.count < Layout.barCount {
+            padded.append(contentsOf: Array(
+                repeating: Decimal.zero,
+                count: Layout.barCount - padded.count
+            ))
+        }
+        let window = Array(padded.prefix(Layout.barCount))
+        let maxValue = window.max() ?? .zero
+        for (idx, value) in window.enumerated() {
+            let ratio: CGFloat
+            if maxValue > 0 {
+                let doubleValue = NSDecimalNumber(decimal: value).doubleValue
+                let doubleMax = NSDecimalNumber(decimal: maxValue).doubleValue
+                ratio = CGFloat(doubleValue / doubleMax)
+            } else {
+                ratio = 0
+            }
+            columns[idx].setIntensity(ratio)
+        }
+    }
+
+    // MARK: - Configuration
+
+    private func configure() {
+        backgroundColor = .clear
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .horizontal
+        stack.alignment = .fill
+        stack.distribution = .fillEqually
+        stack.spacing = Layout.columnGap
+        addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: topAnchor),
+            stack.bottomAnchor.constraint(equalTo: bottomAnchor),
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor)
+        ])
+        for _ in 0..<Layout.barCount {
+            let column = DayColumn(layout: Layout.self)
+            columns.append(column)
+            stack.addArrangedSubview(column)
+        }
+    }
+
+    private func applyLabels() {
+        for (idx, column) in columns.enumerated() where idx < dayLabels.count {
+            column.setLabel(dayLabels[idx])
+        }
+    }
+
+    /// Build the seven Cyrillic day initials (П/В/С/Ч/П/С/В) anchored on
+    /// today. Index 0 is six days ago; index 6 is today.
+    private static func makeDayLabels() -> [String] {
+        let initials = ["В", "П", "В", "С", "Ч", "П", "С"] // SUN..SAT
+        let calendar = Calendar.current
+        var labels: [String] = []
+        for offset in (0..<Layout.barCount).reversed() {
+            guard let date = calendar.date(byAdding: .day, value: -offset, to: Date()) else {
+                continue
+            }
+            let weekday = calendar.component(.weekday, from: date)
+            // `weekday` is 1-based, Sunday = 1.
+            let initial = initials[(weekday - 1) % 7]
+            labels.append(initial)
+        }
+        return labels
+    }
+}
+
+// MARK: - DayColumn
+
+/// Vertical column = pain-gradient bar on top, caps label underneath.
+/// Extracted as a nested class so `WalletWeeklyChartView` stays declarative
+/// and the bar gradient mask doesn't escape the view's coordinate system.
+private final class DayColumn: UIView {
+
+    private let bar = UIView()
+    private let labelView = UILabel()
+    private let gradient = CAGradientLayer()
+    private var barHeightConstraint: NSLayoutConstraint?
+    private let layoutSpec: WalletWeeklyChartView.Layout.Type
+
+    init(layout: WalletWeeklyChartView.Layout.Type) {
+        self.layoutSpec = layout
+        super.init(frame: .zero)
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        gradient.frame = bar.bounds
+        bar.layer.cornerRadius = layoutSpec.barCornerRadius
+    }
+
+    private func configure() {
+        backgroundColor = .clear
+        bar.translatesAutoresizingMaskIntoConstraints = false
+        bar.backgroundColor = AppColors.whiteOverlay08
+        bar.layer.cornerRadius = layoutSpec.barCornerRadius
+        bar.layer.masksToBounds = true
+        addSubview(bar)
+
+        labelView.translatesAutoresizingMaskIntoConstraints = false
+        labelView.font = AppTypography.meta
+        labelView.textColor = AppColors.fg4
+        labelView.textAlignment = .center
+        addSubview(labelView)
+
+        let height = bar.heightAnchor.constraint(equalToConstant: layoutSpec.minBarHeight)
+        barHeightConstraint = height
+
+        NSLayoutConstraint.activate([
+            bar.leadingAnchor.constraint(equalTo: leadingAnchor),
+            bar.trailingAnchor.constraint(equalTo: trailingAnchor),
+            bar.bottomAnchor.constraint(equalTo: labelView.topAnchor, constant: -layoutSpec.labelTopGap),
+            height,
+            labelView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            labelView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            labelView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            labelView.heightAnchor.constraint(equalToConstant: layoutSpec.labelHeight)
+        ])
+
+        gradient.colors = SPSupport.painGradientColors
+        gradient.locations = SPSupport.painGradientLocations
+        gradient.startPoint = SPSupport.gradientStart
+        gradient.endPoint = SPSupport.gradientEnd
+    }
+
+    func setLabel(_ text: String) {
+        labelView.text = text
+    }
+
+    /// `intensity` is `0...1` relative to the tallest bar in the window. A
+    /// non-zero intensity unhides the gradient; the min height keeps the
+    /// stub legible even for very small values.
+    func setIntensity(_ intensity: CGFloat) {
+        let clamped = max(0, min(1, intensity))
+        if clamped > 0 {
+            // Total column = bar + gap + label. The bar can take everything
+            // above the label/gap pair.
+            let maxBarHeight = layoutSpec.barAreaHeight
+                - layoutSpec.labelHeight
+                - layoutSpec.labelTopGap
+            let resolved = max(layoutSpec.minBarHeight, maxBarHeight * clamped)
+            barHeightConstraint?.constant = resolved
+            if gradient.superlayer !== bar.layer {
+                bar.layer.addSublayer(gradient)
+            }
+            bar.backgroundColor = .clear
+        } else {
+            barHeightConstraint?.constant = layoutSpec.minBarHeight
+            gradient.removeFromSuperlayer()
+            bar.backgroundColor = AppColors.whiteOverlay08
+        }
+        setNeedsLayout()
+    }
+}


### PR DESCRIPTION
## Summary
Slice C of the V2 design refresh: replaces the Wallet tab stub with the canonical V2 layout and wires up two new pushable screens.

### What changed
- `WalletViewController.swift` — full rewrite. Hosts `SPBalanceCard` hero (with live weekly delta + affordability hint), a 3×2 `SPAmountPreset` grid (100/500/1000/2000/5000/10000 ₽, popular=500), a 7-day pain-gradient mini chart, the primary "Положить" CTA, and inline links into the new history and payment-methods screens. Disables large titles per V2 spec.
- `WalletViewController+Layout.swift` — extracted layout builders so the VC body stays well under the 400-line lint cap.
- `WalletViewController+Presets.swift` — preset list and affordability-hint helpers, extracted for reuse + tests.
- `WalletWeeklyChartView.swift` (new) — bespoke 7-bar chart: each column renders a pain-gradient bar whose height encodes the day's penalty total (oldest → newest), plus П/В/С/Ч/П/С/В caps labels that anchor on `Calendar.current` so DST/locale don't drift.
- `WalletTransactionHistoryViewController.swift` (new) — grouped-by-day list (`СЕГОДНЯ` / `ВЧЕРА` / `12 АПР`) rendered with `SPRow` inside `SPCard`. Leading icon tinted per `TransactionType` (money/pain/promotion). Renamed away from `TransactionHistoryViewController` to avoid a redeclaration clash with the legacy V1 history VC still living under `Settings/`.
- `PaymentMethodsViewController.swift` (new) — hero Apple Pay card (dark glassy fill + SF Symbol applelogo + Pay wordmark) + ghost add-card placeholder + meta footer caption.

### What I skipped (per spec + StoreKit constraints)
- **Deposit (SPMore3.jsx 108-167)** — covered by existing `TopUpViewController`, presented modally from "Положить".
- **Withdraw (SPMore3.jsx 169-222)** — StoreKit IAP does not support withdrawal, so the UI is intentionally unexposed.

### Hand-off notes for review
- TopUp presets (`49/149/299/999 ₽`) and Wallet presets (`100/500/1000/2000/5000/10000 ₽`) are different sets — the wallet figures are marketing copy, the TopUp figures are IAP product IDs. Preselecting an amount across the present(:) boundary isn't reflected because the underlying products don't overlap; reconciling the two sets is a separate PM decision.
- The "Положить" SPButton suffix shows the default 500 ₽ at init. SPButton has no public `setSuffix(:)` API so dynamic updates flow through `accessibilityLabel` only. If more screens need this, a small SPButton extension would be cheap.
- The transaction-history VC reads from `TransactionRepository.fetchAll()` and refreshes on `balanceChangedNotification`. It does not currently react to a decoded-corruption banner — same posture as the rest of the wallet surface.

## Test plan
- [ ] App boots, Wallet tab opens to the V2 layout with balance, presets, weekly chart, deposit CTA, transactions link, and payment-methods row visible.
- [ ] Tapping a preset highlights it and updates the deposit-button accessibility label.
- [ ] Tapping "Положить" opens `TopUpViewController` modally.
- [ ] Tapping "Все операции →" pushes the transaction history screen; group headers read "СЕГОДНЯ" / "ВЧЕРА" / date as expected.
- [ ] Tapping the "Способы оплаты" row pushes the Apple Pay screen.
- [ ] Tapping the gear icon presents Settings (unchanged behaviour).
- [ ] Build green (`build_sim`), lint clean for Wallet/ files.