### PR TITLE
[ui][v2-alarms-list] AlarmsList V2 — balance pill + streak banner + clock cards

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmCell.swift
@@ -1,6 +1,28 @@
 import UIKit
 
-/// Table view cell styled as a dark card for displaying a single alarm in the list.
+/// Alarm row card — V2 design.
+///
+/// Visual recipe (matches `docs/design/v2-handoff/components/SPScreensV2.jsx`
+/// L357-404):
+/// ```
+///  ┌──────────────────────────────────────────────────────────┐
+///  │ БУДНИ · ПН–ПТ                              [ ●   ]      │
+///  │                                                          │
+///  │ 7:00                                                     │
+///  │                                                          │
+///  │ ┌──────┐  ┌──────┐  ┌─────────────┐                    │
+///  │ │ 50 ₽ │  │  ×2  │  │  Soft Dawn  │                    │
+///  │ └──────┘  └──────┘  └─────────────┘                    │
+///  └──────────────────────────────────────────────────────────┘
+/// ```
+///
+/// Three tonal states, all 20pt internal padding / 20pt corner radius:
+/// - **enabled**:  `bg2` raised surface, `fg1` clock + `fg3` caps.
+/// - **disabled**: `bg1` surface, `fg3` clock + `fg4` caps.
+/// - **selected**: handled by `setHighlighted(_:)` press feedback.
+///
+/// The caps row uses an attributed string with `AppTypography.capsKerning`
+/// so tracking stays in lock-step with the global caps recipe.
 final class AlarmCell: UITableViewCell {
 
     static let reuseID = "AlarmCell"
@@ -9,87 +31,55 @@ final class AlarmCell: UITableViewCell {
 
     private let cardView: UIView = {
         let view = UIView()
-        // Shared card recipe: rounded corners, hairline border, soft drop shadow.
-        // See `UIView.applyCardStyle()` for the full rationale (light-mode
-        // contrast). The `shadowRadius` is bumped slightly here (8pt) compared
-        // to the default to keep the historical look of the alarm-row cards;
-        // tweak via direct `layer` access after applying the helper.
-        view.applyCardStyle()
-        view.layer.shadowRadius = 8
-        view.layer.shadowOffset = CGSize(width: 0, height: 2)
-        view.clipsToBounds = false
         view.translatesAutoresizingMaskIntoConstraints = false
+        view.layer.cornerRadius = AppRadius.lg  // 20pt
+        view.layer.masksToBounds = true
+        view.layer.borderWidth = 1
         return view
     }()
 
-    /// Leading 6pt vertical strip painted with the alarm's theme gradient
-    /// (or thumbnail for `.custom`) so the user can spot which theme each
-    /// row uses without opening the editor (#151). Lives inside the card
-    /// view so it inherits the card's clip + corner radius.
-    private let themeStripContainer: UIView = {
-        let view = UIView()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        view.clipsToBounds = true
-        return view
-    }()
-
-    private let themeStripImageView: UIImageView = {
-        let view = UIImageView()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        view.contentMode = .scaleAspectFill
-        view.clipsToBounds = true
-        view.layer.cornerRadius = 3
-        view.isHidden = true
-        return view
-    }()
-
-    private var themeStripGradient: CAGradientLayer?
-
-    private let timeLabel: UILabel = {
+    private let capsLabel: UILabel = {
         let label = UILabel()
-        // Brand clock face — 64pt JetBrainsMono Light per `tokens.css` `clockLg`.
-        // 64pt at JBM Light easily exceeds the available width on a 393pt screen
-        // for "23:58"-class strings, so allow auto-shrink down to 85% to keep
-        // the row from clipping or wrapping.
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.numberOfLines = 1
+        label.adjustsFontSizeToFitWidth = true
+        label.minimumScaleFactor = 0.85
+        return label
+    }()
+
+    let toggleSwitch: SPSwitch = {
+        let sw = SPSwitch()
+        sw.translatesAutoresizingMaskIntoConstraints = false
+        return sw
+    }()
+
+    private let clockLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        // 64pt mono light `clockLg` with tabular nums.
         label.font = AppTypography.clockLg.monospacedDigit()
         label.textColor = AppColors.fg1
         label.adjustsFontSizeToFitWidth = true
-        label.minimumScaleFactor = 0.85
-        label.translatesAutoresizingMaskIntoConstraints = false
+        label.minimumScaleFactor = 0.7
         return label
     }()
 
-    private let detailLabel: UILabel = {
-        let label = UILabel()
-        label.font = AppTypography.meta
-        label.textColor = AppColors.fg3
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
-    }()
-
-    private let penaltyLabel: UILabel = {
-        // Warn-toned penalty caption. Using `caps` (12pt bold + 0.12em kerning
-        // applied per-text in `configure`) and the brand `warn400` foreground
-        // tone instead of the legacy `accentOrange` alias.
-        let label = UILabel()
-        label.font = AppTypography.caps
-        label.textColor = AppColors.warn400
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
-    }()
-
-    let toggleSwitch: UISwitch = {
-        let sw = UISwitch()
-        sw.onTintColor = AppColors.money500
-        sw.translatesAutoresizingMaskIntoConstraints = false
-        return sw
+    /// Horizontal stack of SPPills (price / multiplier / sound). Re-built on
+    /// every `configure(...)` since the pill set is data-dependent and SPPill
+    /// instances aren't designed for in-place mutation.
+    private let pillsStack: UIStackView = {
+        let stack = UIStackView()
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .horizontal
+        stack.alignment = .center
+        stack.spacing = 6
+        stack.distribution = .fill
+        return stack
     }()
 
     // MARK: - Callbacks
 
     /// Invoked when the user flips the toggle. Set by the controller in `cellForRowAt`.
-    /// Capturing the alarm's id (not row index or `tag`) lets the controller resolve
-    /// the right alarm even after deletion or reordering.
     var onToggle: ((Bool) -> Void)?
 
     // MARK: - Init
@@ -97,21 +87,28 @@ final class AlarmCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setupUI()
-        // Wire the target once at cell creation so re-configuration in
-        // `cellForRowAt` never accumulates duplicate handlers.
         toggleSwitch.addTarget(self, action: #selector(toggleSwitchChanged), for: .valueChanged)
-
-        // CALayer's `cgColor` properties don't auto-resolve dynamic UIColors,
-        // so refresh the border whenever the trait collection (light/dark) flips.
-        registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (cell: AlarmCell, _) in
-            cell.cardView.layer.borderColor = AppColors.stroke1.resolvedColor(
-                with: cell.traitCollection
-            ).cgColor
+        if #available(iOS 17.0, *) {
+            registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (cell: AlarmCell, _) in
+                cell.refreshDynamicColors()
+            }
         }
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    @available(iOS, deprecated: 17.0, message: "Replaced by registerForTraitChanges; kept for iOS 15/16.")
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if #available(iOS 17.0, *) { return }
+        refreshDynamicColors()
+    }
+
+    private func refreshDynamicColors() {
+        // CALayer cgColor doesn't auto-resolve dynamic UIColors.
+        cardView.layer.borderColor = AppColors.whiteOverlay08.cgColor
     }
 
     // MARK: - Setup
@@ -122,155 +119,163 @@ final class AlarmCell: UITableViewCell {
         selectionStyle = .none
 
         contentView.addSubview(cardView)
-        cardView.addSubview(themeStripContainer)
-        themeStripContainer.addSubview(themeStripImageView)
-        cardView.addSubview(timeLabel)
-        cardView.addSubview(detailLabel)
-        cardView.addSubview(penaltyLabel)
+        cardView.addSubview(capsLabel)
         cardView.addSubview(toggleSwitch)
+        cardView.addSubview(clockLabel)
+        cardView.addSubview(pillsStack)
 
-        // 6pt theme strip pinned to the leading edge, shifted in 6pt from the
-        // card edge so it doesn't sit flush against the rounded corner. The
-        // strip's height fills the card minus 8pt top/bottom insets so it
-        // reads as a deliberate accent rather than a clipped fill.
-        let stripLeading = AppSpacing.sm
-        let stripWidth: CGFloat = 6
-        let timeLeading = stripLeading + stripWidth + AppSpacing.md // 8 + 6 + 12 = 26
+        let pad = AppSpacing.sp5 // 20pt
+        // Outer card insets within the cell — horizontal screen inset, small
+        // vertical breathing so consecutive cards have visible separation
+        // without an explicit divider line. Bottom is half so the scroll
+        // gap between cards lands at `AppSpacing.sp3` (12pt) per the spec.
+        let outerH = AppSpacing.screenInset
+        let outerV: CGFloat = 6
 
         NSLayoutConstraint.activate([
-            // Card with horizontal and vertical insets
-            cardView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: AppSpacing.sm / 2),
-            cardView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.lg),
-            cardView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.lg),
-            cardView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -AppSpacing.sm / 2),
+            cardView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: outerV),
+            cardView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: outerH),
+            cardView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -outerH),
+            cardView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -outerV),
 
-            // Theme strip — leading edge of the card, full height minus padding.
-            themeStripContainer.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: stripLeading),
-            themeStripContainer.topAnchor.constraint(equalTo: cardView.topAnchor, constant: AppSpacing.sm),
-            themeStripContainer.bottomAnchor.constraint(equalTo: cardView.bottomAnchor, constant: -AppSpacing.sm),
-            themeStripContainer.widthAnchor.constraint(equalToConstant: stripWidth),
+            // Caps top-leading, switch top-trailing — aligned by centerY.
+            capsLabel.topAnchor.constraint(equalTo: cardView.topAnchor, constant: pad),
+            capsLabel.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: pad),
+            capsLabel.trailingAnchor.constraint(
+                lessThanOrEqualTo: toggleSwitch.leadingAnchor,
+                constant: -AppSpacing.sp3
+            ),
 
-            themeStripImageView.topAnchor.constraint(equalTo: themeStripContainer.topAnchor),
-            themeStripImageView.leadingAnchor.constraint(equalTo: themeStripContainer.leadingAnchor),
-            themeStripImageView.trailingAnchor.constraint(equalTo: themeStripContainer.trailingAnchor),
-            themeStripImageView.bottomAnchor.constraint(equalTo: themeStripContainer.bottomAnchor),
+            toggleSwitch.centerYAnchor.constraint(equalTo: capsLabel.centerYAnchor),
+            toggleSwitch.trailingAnchor.constraint(equalTo: cardView.trailingAnchor, constant: -pad),
 
-            // Toggle in top-right corner of card
-            toggleSwitch.topAnchor.constraint(equalTo: cardView.topAnchor, constant: AppSpacing.lg),
-            toggleSwitch.trailingAnchor.constraint(equalTo: cardView.trailingAnchor, constant: -AppSpacing.lg),
+            // Clock below the caps row.
+            clockLabel.topAnchor.constraint(equalTo: capsLabel.bottomAnchor, constant: 4),
+            clockLabel.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: pad),
+            clockLabel.trailingAnchor.constraint(lessThanOrEqualTo: cardView.trailingAnchor, constant: -pad),
 
-            // Time label (large, top-left) — left-padded to leave room for the strip.
-            timeLabel.topAnchor.constraint(equalTo: cardView.topAnchor, constant: AppSpacing.md),
-            timeLabel.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: timeLeading),
-            timeLabel.trailingAnchor.constraint(lessThanOrEqualTo: toggleSwitch.leadingAnchor, constant: -AppSpacing.sm),
-
-            // Detail line: "Name - Days"
-            detailLabel.topAnchor.constraint(equalTo: timeLabel.bottomAnchor, constant: AppSpacing.xs),
-            detailLabel.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: timeLeading),
-            detailLabel.trailingAnchor.constraint(lessThanOrEqualTo: cardView.trailingAnchor, constant: -AppSpacing.lg),
-
-            // Penalty line at the bottom
-            penaltyLabel.topAnchor.constraint(equalTo: detailLabel.bottomAnchor, constant: AppSpacing.sm),
-            penaltyLabel.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: timeLeading),
-            penaltyLabel.trailingAnchor.constraint(lessThanOrEqualTo: cardView.trailingAnchor, constant: -AppSpacing.lg),
-            penaltyLabel.bottomAnchor.constraint(equalTo: cardView.bottomAnchor, constant: -AppSpacing.md)
+            // Pill row at the bottom — 14pt gap below the clock.
+            pillsStack.topAnchor.constraint(equalTo: clockLabel.bottomAnchor, constant: 14),
+            pillsStack.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: pad),
+            pillsStack.trailingAnchor.constraint(lessThanOrEqualTo: cardView.trailingAnchor, constant: -pad),
+            pillsStack.bottomAnchor.constraint(equalTo: cardView.bottomAnchor, constant: -pad)
         ])
     }
 
     override func prepareForReuse() {
         super.prepareForReuse()
-        // The closure captures the previous row's identity — drop it so the
-        // recycled cell never fires the wrong alarm before the next configure.
         onToggle = nil
-        // Reset the theme strip so the next row's gradient doesn't briefly
-        // show the previous row's colours before configure() reapplies.
-        themeStripGradient?.removeFromSuperlayer()
-        themeStripGradient = nil
-        themeStripImageView.image = nil
-        themeStripImageView.isHidden = true
-    }
-
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        // Pre-rasterize the shadow against the rounded card frame so scrolling
-        // doesn't pay the per-pixel offscreen pass cost.
-        cardView.layer.shadowPath = UIBezierPath(
-            roundedRect: cardView.bounds,
-            cornerRadius: AppRadius.sm
-        ).cgPath
-        // Keep the border colour in sync with the current trait collection
-        // (cgColor doesn't auto-update for dynamic UIColors).
-        cardView.layer.borderColor = AppColors.stroke1.resolvedColor(
-            with: traitCollection
-        ).cgColor
-
-        // Round the strip and its gradient sublayer to a soft pill so it
-        // reads as an accent rather than a hard rectangle.
-        themeStripContainer.layer.cornerRadius = 3
-        themeStripGradient?.frame = themeStripContainer.bounds
+        // Pills are data-dependent — wipe them so reuse doesn't render the
+        // previous alarm's pills for a frame before configure() re-fills.
+        pillsStack.arrangedSubviews.forEach { view in
+            pillsStack.removeArrangedSubview(view)
+            view.removeFromSuperview()
+        }
     }
 
     // MARK: - Configure
 
-    func configure(time: String, detail: String, penalty: String, enabled: Bool, theme: AlarmTheme) {
-        timeLabel.text = time
-        detailLabel.text = detail
-        // `caps` role pairs the 12pt bold font with +0.12em tracking per
-        // `tokens.css`. Apply via attributedText so the kerning stays in lock-
-        // step with the font role no matter where the string is set from.
-        penaltyLabel.attributedText = NSAttributedString(
-            string: penalty,
-            attributes: [.kern: AppTypography.capsKerning]
+    /// Configure the row's content. Inputs:
+    /// - `time`: pre-formatted "HH:mm".
+    /// - `daysCaps`: caps string for the top-left ("БУДНИ · ПН–ПТ" /
+    ///   "ВЫХОДНЫЕ" / "ПН, ВТ, СР").
+    /// - `priceText`: e.g. "50 ₽".
+    /// - `multiplier`: optional progressive-pain pill label ("×2" / "×4"
+    ///   / etc.). `nil` hides the pill.
+    /// - `soundName`: optional neutral pill — display name of the picked
+    ///   sound. `nil` hides the pill.
+    /// - `enabled`: drives the tonal switch between bg2 / bg1 surfaces.
+    func configure(
+        time: String,
+        daysCaps: String,
+        priceText: String,
+        multiplier: String?,
+        soundName: String?,
+        enabled: Bool
+    ) {
+        clockLabel.text = time
+        capsLabel.attributedText = NSAttributedString(
+            string: daysCaps,
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: enabled ? AppColors.fg3 : AppColors.fg4
+            ]
         )
         toggleSwitch.isOn = enabled
-        setEnabledAppearance(enabled)
-        applyTheme(theme)
+        applyEnabledTone(enabled)
+        rebuildPills(price: priceText, multiplier: multiplier, soundName: soundName, enabled: enabled)
     }
 
-    /// Paint the leading 6pt strip with the alarm's theme. Built-in themes
-    /// install a vertical gradient layer; `.custom` swaps to the picked
-    /// thumbnail image, falling back to the Dawn gradient when the file is
-    /// gone (Caches purge).
-    private func applyTheme(_ theme: AlarmTheme) {
-        themeStripGradient?.removeFromSuperlayer()
-        themeStripGradient = nil
-        themeStripImageView.image = nil
-        themeStripImageView.isHidden = true
+    /// Legacy-style call site preserved for migration. Forwards to the
+    /// V2 signature with empty pill set so callers that haven't been
+    /// updated yet still compile. New code should use `configure(time:
+    /// daysCaps: priceText: multiplier: soundName: enabled:)`.
+    func configure(time: String, detail: String, penalty: String, enabled: Bool, theme: AlarmTheme) {
+        _ = theme // theme strip retired in V2 layout.
+        configure(
+            time: time,
+            daysCaps: detail.uppercased(),
+            priceText: penalty,
+            multiplier: nil,
+            soundName: nil,
+            enabled: enabled
+        )
+    }
 
-        if case .custom(let url) = theme, let image = AlarmThemeImageStore.loadImage(at: url) {
-            themeStripImageView.image = image
-            themeStripImageView.isHidden = false
-            return
+    private func rebuildPills(price: String, multiplier: String?, soundName: String?, enabled: Bool) {
+        pillsStack.arrangedSubviews.forEach { view in
+            pillsStack.removeArrangedSubview(view)
+            view.removeFromSuperview()
         }
+        // Price pill — warn-tone when enabled, neutral when disabled so a
+        // dimmed row doesn't shout "50 ₽" at the user.
+        let pricePill = SPPill(text: price, tone: enabled ? .warn : .neutral)
+        pillsStack.addArrangedSubview(pricePill)
 
-        let resolvedTheme: AlarmTheme = {
-            if case .custom = theme { return .dawn }
-            return theme
-        }()
-        guard let colors = AlarmThemeRendering.gradientColors(for: resolvedTheme) else { return }
-        let gradient = CAGradientLayer()
-        gradient.colors = colors
-        gradient.locations = AlarmThemeRendering.gradientLocations(for: resolvedTheme)
-        gradient.startPoint = CGPoint(x: 0.5, y: 0.0)
-        gradient.endPoint = CGPoint(x: 0.5, y: 1.0)
-        gradient.frame = themeStripContainer.bounds
-        gradient.cornerRadius = 3
-        themeStripContainer.layer.insertSublayer(gradient, at: 0)
-        themeStripGradient = gradient
+        if let multiplier = multiplier {
+            let mult = SPPill(text: multiplier, tone: enabled ? .pain : .neutral)
+            pillsStack.addArrangedSubview(mult)
+        }
+        if let soundName = soundName, !soundName.isEmpty {
+            let sound = SPPill(text: soundName, tone: .neutral)
+            pillsStack.addArrangedSubview(sound)
+        }
+        // Trailing spacer so pills don't stretch.
+        let spacer = UIView()
+        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        spacer.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        pillsStack.addArrangedSubview(spacer)
     }
 
-    /// Updates the dim/full opacity of text labels to match enabled state.
-    /// Called both during initial configuration and live from the toggle handler.
-    func setEnabledAppearance(_ enabled: Bool) {
-        let alpha: CGFloat = enabled ? 1.0 : 0.4
-        timeLabel.alpha = alpha
-        detailLabel.alpha = alpha
-        penaltyLabel.alpha = alpha
+    private func applyEnabledTone(_ enabled: Bool) {
+        cardView.backgroundColor = enabled ? AppColors.bg2 : AppColors.bg1
+        clockLabel.textColor = enabled ? AppColors.fg1 : AppColors.fg3
+        cardView.layer.borderColor = AppColors.whiteOverlay08.cgColor
     }
 
     @objc private func toggleSwitchChanged() {
         let isOn = toggleSwitch.isOn
-        setEnabledAppearance(isOn)
+        applyEnabledTone(isOn)
+        // Recolour the caps + pill set to track the new tone.
+        if let attributed = capsLabel.attributedText?.string {
+            capsLabel.attributedText = NSAttributedString(
+                string: attributed,
+                attributes: [
+                    .font: AppTypography.caps,
+                    .kern: AppTypography.capsKerning,
+                    .foregroundColor: isOn ? AppColors.fg3 : AppColors.fg4
+                ]
+            )
+        }
         onToggle?(isOn)
+    }
+
+    /// Press-feedback scale. Mirrors the design-system 0.97 scale used by
+    /// SPButton / SPAmountPreset so cards pulse on the same delta as
+    /// every other tappable surface.
+    override func setHighlighted(_ highlighted: Bool, animated: Bool) {
+        super.setHighlighted(highlighted, animated: animated)
+        SPSupport.animatePress(cardView, pressed: highlighted)
     }
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
@@ -1,25 +1,24 @@
 import UIKit
 
-/// Main screen — alarm list with a sticky balance header that stays pinned
-/// above the scroll, an optional low-balance warning banner under it, the
-/// alarm list itself, and an empty-state column that overlays the table when
-/// there are no alarms yet.
+/// V2 alarms list screen.
 ///
 /// Layout (top → bottom inside `view`):
 /// ```
 /// safeArea.top
 ///   ├─ SPAlarmsListHeader (sticky)
-///   │     ├─ balance card (caps + value + centered hint + trailing pill)
-///   │     └─ optional low-balance warning banner
+///   │     ├─ title row "Будильники" + 40×40 "+" button
+///   │     └─ compact balance pill (auto-warn-tint when balance < 100)
 ///   └─ UITableView (scrolls)
+///         ├─ tableHeaderView: AlarmsStreakBannerView (when streak > 0)
+///         └─ rows: AlarmCell
 ///         └─ overlay: SPAlarmsListEmptyState (when alarms.isEmpty)
 /// safeArea.bottom
 /// ```
 ///
-/// The header is pinned to the safe area — it does NOT live as
-/// `tableView.tableHeaderView` so it can't scroll away with the list. The
-/// table is anchored beneath the header with a small gap so the warning
-/// banner shadow can breathe before the list begins.
+/// The big balance card + amber "БАЛАНС ПОЧТИ ПУСТ" banner from the V1 header
+/// are gone — the compact pill folds urgency into a single line. The nav-bar
+/// "+" button is suppressed because the header carries its own 40×40 plus;
+/// the gear and DEBUG entries are preserved as required by the design brief.
 class AlarmsListViewController: UIViewController {
 
     // MARK: - ViewModel
@@ -30,12 +29,6 @@ class AlarmsListViewController: UIViewController {
 
     private let header: SPAlarmsListHeader = {
         let view = SPAlarmsListHeader()
-        view.directionalLayoutMargins = NSDirectionalEdgeInsets(
-            top: AppSpacing.sp3,
-            leading: AppSpacing.screenInset,
-            bottom: AppSpacing.sp3,
-            trailing: AppSpacing.screenInset
-        )
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
@@ -45,7 +38,21 @@ class AlarmsListViewController: UIViewController {
         table.backgroundColor = .clear
         table.separatorStyle = .none
         table.translatesAutoresizingMaskIntoConstraints = false
+        table.rowHeight = UITableView.automaticDimension
+        table.estimatedRowHeight = 160
+        table.contentInset = UIEdgeInsets(
+            top: AppSpacing.sp4,
+            left: 0,
+            bottom: AppSpacing.sp4,
+            right: 0
+        )
         return table
+    }()
+
+    private let streakBanner: AlarmsStreakBannerView = {
+        let view = AlarmsStreakBannerView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
     }()
 
     private let emptyStateView: SPAlarmsListEmptyState = {
@@ -70,29 +77,17 @@ class AlarmsListViewController: UIViewController {
         super.viewWillAppear(animated)
         viewModel.loadData()
         tableView.reloadData()
+        refreshStreakBanner()
         presentStreakModalIfNeeded()
     }
 
     // MARK: - Streak modal
 
-    /// Streak milestones that fire the celebratory modal exactly once each.
-    /// 3 / 7 / 14 / 30 days are the milestones called out in #146; once a
-    /// milestone has fired we record it in `streakMilestonesShownKey` so the
-    /// user never sees the same modal twice for the same achievement.
     private static let streakMilestoneDays: [Int] = [3, 7, 14, 30]
-    /// UserDefaults key that stores `[Int]` of milestones already shown.
     private static let streakMilestonesShownKey = "streak_milestones_shown"
 
-    /// Presents `StreakModalViewController` over `viewController` (defaults
-    /// to `self`) when:
-    ///   - the current streak hits one of the milestone values, AND
-    ///   - that milestone has not been shown for this install yet, AND
-    ///   - no other modal is already on screen.
-    /// Wiring this into `viewWillAppear` keeps the trigger close to a state
-    /// observation point (alarms list refresh) without coupling the modal
-    /// to the firing flow. PM follow-up: replace the static milestone list
-    /// with a dedicated trigger service so notifications and the modal can
-    /// share one source of truth.
+    /// Presents `StreakModalViewController` when the current streak hits a
+    /// new milestone. Preserved from V1.
     func presentStreakModalIfNeeded(in viewController: UIViewController? = nil) {
         let host = viewController ?? self
         guard host.presentedViewController == nil else { return }
@@ -105,10 +100,6 @@ class AlarmsListViewController: UIViewController {
         presentStreakModal(streakDays: streak, on: host)
     }
 
-    /// Direct entry point — used by the DEBUG trigger button below and
-    /// available to other controllers that want to celebrate an arbitrary
-    /// streak. Bypasses the milestone gate but still respects the
-    /// "no double-presentation" guard.
     func presentStreakModal(streakDays: Int, on viewController: UIViewController? = nil) {
         let host = viewController ?? self
         guard host.presentedViewController == nil else { return }
@@ -123,20 +114,17 @@ class AlarmsListViewController: UIViewController {
     // MARK: - Setup
 
     private func setupNavigationBar() {
-        navigationItem.title = "Будильники"
+        // V2 header carries its own title — suppress the nav bar's title so
+        // the screen doesn't render the word twice.
+        navigationItem.title = ""
         navigationController?.navigationBar.prefersLargeTitles = false
 
-        let addButton = UIBarButtonItem(
-            image: UIImage(systemName: "plus.circle.fill"),
-            style: .plain,
-            target: self,
-            action: #selector(addAlarmTapped)
-        )
-        navigationItem.rightBarButtonItem = addButton
+        // V1 had a "+" button on the right edge of the nav bar; the V2 header
+        // moves that affordance into the title row so the user always sees
+        // the CTA near the balance. Drop the nav-bar plus to avoid two CTAs.
+        navigationItem.rightBarButtonItem = nil
 
-        // Settings moved out of the tab bar per V2 design — entry point is
-        // the gear icon on the Alarms header (matches "more / account"
-        // pattern used in Wallet header).
+        // Gear icon — preserved entry point for Settings.
         let settingsButton = UIBarButtonItem(
             image: UIImage(systemName: "gearshape"),
             style: .plain,
@@ -145,8 +133,8 @@ class AlarmsListViewController: UIViewController {
         )
         navigationItem.leftBarButtonItem = settingsButton
 
-        // DEBUG-only entries — streak modal trigger and onboarding reset so
-        // designers / QA can iterate without manufacturing real state.
+        // DEBUG-only entries — streak modal trigger + onboarding reset.
+        // Required to stay functional after the V2 rewrite.
         #if DEBUG
         let streakButton = UIBarButtonItem(
             image: UIImage(systemName: "flame.fill"),
@@ -172,17 +160,10 @@ class AlarmsListViewController: UIViewController {
 
     #if DEBUG
     @objc private func debugTriggerStreakModal() {
-        // Skip the milestone gate and the no-double-show flag — debug button
-        // should always render the modal regardless of how many times PM has
-        // already opened it this session. 7 days matches the spec screenshot.
         presentStreakModal(streakDays: 7)
     }
 
     @objc private func debugResetOnboarding() {
-        // Clears the onboarding-completed + permissions-shown flags so the
-        // next cold launch walks through Splash → Onboarding → Permissions
-        // again. Lets PM verify the V2 onboarding redesign without
-        // re-installing the app.
         UserDefaults.standard.removeObject(forKey: OnboardingViewController.completedKey)
         UserDefaults.standard.removeObject(forKey: PermissionsViewController.hasBeenShownKey)
         let alert = UIAlertController(
@@ -196,9 +177,6 @@ class AlarmsListViewController: UIViewController {
     #endif
 
     private func setupLayout() {
-        // Order matters — header is added LAST so it draws on top of the
-        // table content shadow if any of the alarm cards bleed under the
-        // safe-area inset during scroll.
         view.addSubview(tableView)
         view.addSubview(emptyStateView)
         view.addSubview(header)
@@ -208,20 +186,15 @@ class AlarmsListViewController: UIViewController {
         tableView.register(AlarmCell.self, forCellReuseIdentifier: AlarmCell.reuseID)
 
         NSLayoutConstraint.activate([
-            // Sticky header pinned to safe-area top.
             header.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             header.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             header.trailingAnchor.constraint(equalTo: view.trailingAnchor),
 
-            // Table flows beneath the header.
             tableView.topAnchor.constraint(equalTo: header.bottomAnchor),
             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
 
-            // Empty state overlays the same area as the table so the
-            // sticky header still shows the user their balance even
-            // when the list is empty.
             emptyStateView.topAnchor.constraint(equalTo: tableView.topAnchor),
             emptyStateView.leadingAnchor.constraint(equalTo: tableView.leadingAnchor),
             emptyStateView.trailingAnchor.constraint(equalTo: tableView.trailingAnchor),
@@ -230,11 +203,20 @@ class AlarmsListViewController: UIViewController {
     }
 
     private func setupCallbacks() {
+        header.onAddTap = { [weak self] in
+            self?.addAlarmTapped()
+        }
         header.onBalanceTopUpTap = { [weak self] in
             self?.presentTopUp()
         }
         header.onWarnTopUpTap = { [weak self] in
             self?.presentTopUp()
+        }
+        streakBanner.onTap = { [weak self] in
+            guard let self else { return }
+            let streak = TransactionRepository.shared.currentStreak()
+            guard streak > 0 else { return }
+            self.presentStreakModal(streakDays: streak)
         }
         emptyStateView.onAddAlarmTap = { [weak self] in
             self?.addAlarmTapped()
@@ -248,11 +230,8 @@ class AlarmsListViewController: UIViewController {
             let isEmpty = self.viewModel.alarms.isEmpty
             self.emptyStateView.isHidden = !isEmpty
             self.tableView.isHidden = isEmpty
-            // Refresh the affordability hint — it depends on the
-            // current alarm set's average penalty, so a delete /
-            // create can change the snooze count even when the
-            // balance hasn't moved.
             self.refreshHeader()
+            self.refreshStreakBanner()
         }
 
         viewModel.onBalanceUpdated = { [weak self] _ in
@@ -264,12 +243,7 @@ class AlarmsListViewController: UIViewController {
         }
     }
 
-    /// Push the latest balance / hint / warning state into the sticky
-    /// header. Called both from `onBalanceUpdated` (BalanceService
-    /// notification) and `onAlarmsUpdated` (alarm-set change shifts the
-    /// average penalty). Also pipes the rolling weekly delta from the
-    /// transaction ledger (#175) so the sticky header echoes the
-    /// `.sp-balance__delta` row from the design spec.
+    /// Push the latest balance / hint state into the sticky header.
     private func refreshHeader() {
         let balance = Decimal(viewModel.balance)
         header.setBalance(
@@ -277,15 +251,52 @@ class AlarmsListViewController: UIViewController {
             hint: viewModel.affordabilityHint,
             delta: viewModel.weeklyDelta
         )
+        // Legacy method preserved for source-compat — the V2 pill already
+        // self-toggles its tone from `setBalance` based on the threshold.
         header.setWarning(visible: viewModel.isLowBalance, balance: balance)
     }
 
-    /// Shows a non-blocking alert when the repository couldn't load or
-    /// persist data. Without this the user would see an empty list and
-    /// assume the app wiped their alarms — then recreate them, and the
-    /// next save would clobber the recoverable corrupt JSON for good
-    /// (issue #72). Guarded against double-presentation so a load failure
-    /// followed quickly by a persist failure doesn't stack alerts.
+    /// Mount / dismount the streak banner above the alarm rows. When the
+    /// current streak is 0, the banner is removed entirely so the empty
+    /// state column doesn't collide with a stale header view.
+    private func refreshStreakBanner() {
+        let streak = TransactionRepository.shared.currentStreak()
+        guard streak > 0 else {
+            tableView.tableHeaderView = nil
+            return
+        }
+        let saved = StreakModalViewController.estimatedSavings(
+            for: streak,
+            alarms: viewModel.alarms
+        )
+        streakBanner.configure(streakDays: streak, savedAmount: saved)
+        // Size the table header view with a layout pass — UITableView's
+        // tableHeaderView requires a non-zero frame to render at all.
+        let targetWidth = tableView.bounds.width > 0 ? tableView.bounds.width : view.bounds.width
+        if targetWidth > 0 {
+            streakBanner.translatesAutoresizingMaskIntoConstraints = true
+            streakBanner.frame = CGRect(x: 0, y: 0, width: targetWidth, height: 84)
+            let fittingSize = streakBanner.systemLayoutSizeFitting(
+                CGSize(width: targetWidth, height: UIView.layoutFittingCompressedSize.height),
+                withHorizontalFittingPriority: .required,
+                verticalFittingPriority: .fittingSizeLevel
+            )
+            streakBanner.frame = CGRect(x: 0, y: 0, width: targetWidth, height: fittingSize.height)
+        }
+        if tableView.tableHeaderView !== streakBanner {
+            tableView.tableHeaderView = streakBanner
+        }
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        // The banner's width depends on the live table-view width, so re-
+        // measure on every layout pass (rotation, split-view resize).
+        if tableView.tableHeaderView === streakBanner {
+            refreshStreakBanner()
+        }
+    }
+
     private func presentRepositoryError(_ error: LocalizedError) {
         guard presentedViewController == nil else { return }
         let alert = UIAlertController(
@@ -335,14 +346,13 @@ extension AlarmsListViewController: UITableViewDataSource {
         let alarm = viewModel.alarms[indexPath.row]
         cell.configure(
             time: viewModel.alarmTimeString(at: indexPath.row),
-            detail: viewModel.alarmDetail(at: indexPath.row),
-            penalty: viewModel.alarmPenaltyString(at: indexPath.row),
-            enabled: alarm.enabled,
-            theme: alarm.theme
+            daysCaps: viewModel.alarmDaysCaps(at: indexPath.row),
+            priceText: viewModel.alarmPriceText(at: indexPath.row),
+            multiplier: viewModel.alarmMultiplierText(at: indexPath.row),
+            soundName: viewModel.alarmSoundName(at: indexPath.row),
+            enabled: alarm.enabled
         )
 
-        // Capture the alarm's stable UUID rather than the row index — the
-        // index becomes invalid after delete/reorder, but the id never does.
         let alarmID = alarm.id
         cell.onToggle = { [weak self] isOn in
             self?.viewModel.toggleAlarm(id: alarmID, enabled: isOn)
@@ -363,9 +373,6 @@ extension AlarmsListViewController: UITableViewDelegate {
         editVC.onSave = { [weak self] in
             self?.viewModel.loadData()
         }
-        // Re-fetch from the source of truth instead of mutating by row index —
-        // the row that was tapped may have shifted after another in-flight
-        // delete (e.g. swipe + detail open near-simultaneously).
         editVC.onDelete = { [weak self] in
             self?.viewModel.loadData()
         }
@@ -382,12 +389,6 @@ extension AlarmsListViewController: UITableViewDelegate {
                 completion(false)
                 return
             }
-            // Capture the alarm id before the action fires so a concurrent mutation
-            // that re-orders rows (delete from detail, programmatic reload) cannot
-            // make us delete the wrong alarm. Index-based delete would silently
-            // drop whichever alarm now sits at the swiped row, with no feedback
-            // to the user. Identity-based delete short-circuits if the alarm has
-            // already been removed and triggers a full reload to resync the UI.
             guard indexPath.row < self.viewModel.alarms.count else {
                 self.viewModel.loadData()
                 completion(false)
@@ -402,9 +403,6 @@ extension AlarmsListViewController: UITableViewDelegate {
             tableView.deleteRows(at: [indexPath], with: .automatic)
             completion(true)
         }
-        // SF Symbol gives the action a recognisable affordance even before the
-        // user has read the title — addresses the PM feedback that the swipe
-        // gesture was not obvious.
         delete.image = UIImage(systemName: "trash")
         delete.backgroundColor = .systemRed
         return UISwipeActionsConfiguration(actions: [delete])

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/AlarmsStreakBannerView.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/AlarmsStreakBannerView.swift
@@ -1,0 +1,232 @@
+import UIKit
+
+/// Streak summary banner that scrolls above the alarm cards.
+///
+/// Reference: `docs/design/v2-handoff/components/SPScreensV2.jsx` L337-355.
+///
+/// Visual recipe — money-tinted glass:
+/// ```
+///  ┌─────────────────────────────────────────────────┐
+///  │  [🔥]  5 ДНЕЙ БЕЗ ОТКЛАДЫВАНИЙ              ›  │
+///  │        Сэкономили 250 ₽                         │
+///  └─────────────────────────────────────────────────┘
+/// ```
+///
+/// - 14×16 padding, 16pt radius.
+/// - Background: `linear-gradient(135deg, money400@12% 0%, money400@4% 100%)`.
+/// - Border: 1pt `money400@18%`.
+/// - 36×36 rounded-rect money gradient with flame icon (`fgOnMoney`).
+/// - Caps title `money300`, meta `fg2`, chevron `fg3`.
+///
+/// Hosted as `tableHeaderView` of the alarms list so it scrolls with the
+/// cards (per spec: "First card (when streak > 0): Streak summary banner —
+/// then alarm cards via UITableView").
+final class AlarmsStreakBannerView: UIView {
+
+    // MARK: - Public API
+
+    /// Triggered on tap — host wires this to open `StreakModalViewController`.
+    var onTap: (() -> Void)?
+
+    /// Configure with current streak + savings. Pass `streakDays = 0` to
+    /// render no copy (the host should hide the view instead).
+    func configure(streakDays: Int, savedAmount: Decimal) {
+        let title = "\(streakDays) \(Self.daysWord(for: streakDays)) БЕЗ ОТКЛАДЫВАНИЙ"
+        capsLabel.attributedText = NSAttributedString(
+            string: title.uppercased(),
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.money300
+            ]
+        )
+        let formatted = NSDecimalNumber(decimal: savedAmount).decimalValue.formattedRubles()
+        metaLabel.text = "Сэкономили \(formatted)"
+    }
+
+    // MARK: - Subviews
+
+    private let backgroundView: SPGradientView = {
+        // Money-tinted glass — two-stop 135° from money400@12% → money400@4%.
+        let colors: [CGColor] = [
+            AppColors.money400.withAlphaComponent(0.12).cgColor,
+            AppColors.money400.withAlphaComponent(0.04).cgColor
+        ]
+        let view = SPGradientView(colors: colors, locations: [0.0, 1.0])
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.layer.cornerRadius = AppRadius.md
+        view.layer.masksToBounds = true
+        view.layer.borderWidth = 1
+        view.layer.borderColor = AppColors.money400.withAlphaComponent(0.18).cgColor
+        view.isUserInteractionEnabled = false
+        return view
+    }()
+
+    /// 36×36 money-gradient rounded square with flame icon.
+    private let iconHost: SPGradientView = {
+        let view = SPGradientView(
+            colors: SPSupport.moneyGradientColors,
+            locations: SPSupport.moneyGradientLocations
+        )
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.layer.cornerRadius = 10
+        view.layer.masksToBounds = true
+        return view
+    }()
+
+    private let iconView: UIImageView = {
+        let view = UIImageView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.contentMode = .scaleAspectFit
+        view.tintColor = AppColors.fgOnMoney
+        let config = UIImage.SymbolConfiguration(pointSize: 18, weight: .bold)
+        view.image = UIImage(systemName: "flame.fill", withConfiguration: config)
+        return view
+    }()
+
+    private let capsLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.numberOfLines = 1
+        label.adjustsFontSizeToFitWidth = true
+        label.minimumScaleFactor = 0.8
+        return label
+    }()
+
+    private let metaLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = AppTypography.meta
+        label.textColor = AppColors.fg2
+        label.numberOfLines = 1
+        return label
+    }()
+
+    private let chevronView: UIImageView = {
+        let view = UIImageView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.contentMode = .scaleAspectFit
+        view.tintColor = AppColors.fg3
+        let config = UIImage.SymbolConfiguration(pointSize: 14, weight: .semibold)
+        view.image = UIImage(systemName: "chevron.right", withConfiguration: config)
+        return view
+    }()
+
+    private let tapButton: UIControl = {
+        let view = UIControl()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = .clear
+        return view
+    }()
+
+    // MARK: - Init
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+        if #available(iOS 17.0, *) {
+            registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (view: AlarmsStreakBannerView, _) in
+                view.backgroundView.layer.borderColor = AppColors.money400.withAlphaComponent(0.18).cgColor
+            }
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    @available(iOS, deprecated: 17.0, message: "Replaced by registerForTraitChanges; kept for iOS 15/16.")
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if #available(iOS 17.0, *) { return }
+        backgroundView.layer.borderColor = AppColors.money400.withAlphaComponent(0.18).cgColor
+    }
+
+    // MARK: - Layout
+
+    private func configure() {
+        backgroundColor = .clear
+
+        addSubview(backgroundView)
+        addSubview(iconHost)
+        iconHost.addSubview(iconView)
+        addSubview(capsLabel)
+        addSubview(metaLabel)
+        addSubview(chevronView)
+        addSubview(tapButton)
+
+        tapButton.addTarget(self, action: #selector(handleTap), for: .touchUpInside)
+
+        let inset = AppSpacing.screenInset
+
+        NSLayoutConstraint.activate([
+            // Banner background — pinned full-width inside the screen inset.
+            backgroundView.topAnchor.constraint(equalTo: topAnchor, constant: 0),
+            backgroundView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: inset),
+            backgroundView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -inset),
+            backgroundView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -AppSpacing.sp3),
+
+            // Flame icon — 36×36 leading.
+            iconHost.leadingAnchor.constraint(equalTo: backgroundView.leadingAnchor, constant: 16),
+            iconHost.centerYAnchor.constraint(equalTo: backgroundView.centerYAnchor),
+            iconHost.widthAnchor.constraint(equalToConstant: 36),
+            iconHost.heightAnchor.constraint(equalToConstant: 36),
+
+            iconView.centerXAnchor.constraint(equalTo: iconHost.centerXAnchor),
+            iconView.centerYAnchor.constraint(equalTo: iconHost.centerYAnchor),
+
+            // Caps + meta — vertical text column to the right of the icon.
+            capsLabel.leadingAnchor.constraint(equalTo: iconHost.trailingAnchor, constant: AppSpacing.sp3),
+            capsLabel.topAnchor.constraint(equalTo: backgroundView.topAnchor, constant: 14),
+            capsLabel.trailingAnchor.constraint(
+                lessThanOrEqualTo: chevronView.leadingAnchor,
+                constant: -AppSpacing.sp2
+            ),
+
+            metaLabel.leadingAnchor.constraint(equalTo: capsLabel.leadingAnchor),
+            metaLabel.topAnchor.constraint(equalTo: capsLabel.bottomAnchor, constant: 4),
+            metaLabel.trailingAnchor.constraint(
+                lessThanOrEqualTo: chevronView.leadingAnchor,
+                constant: -AppSpacing.sp2
+            ),
+            metaLabel.bottomAnchor.constraint(
+                lessThanOrEqualTo: backgroundView.bottomAnchor,
+                constant: -14
+            ),
+
+            // Chevron right edge.
+            chevronView.trailingAnchor.constraint(equalTo: backgroundView.trailingAnchor, constant: -16),
+            chevronView.centerYAnchor.constraint(equalTo: backgroundView.centerYAnchor),
+            chevronView.widthAnchor.constraint(equalToConstant: 14),
+            chevronView.heightAnchor.constraint(equalToConstant: 14),
+
+            // Full-banner tap target sits on top of everything so the whole
+            // surface is hittable (matches `<button>` in the JSX spec).
+            tapButton.topAnchor.constraint(equalTo: backgroundView.topAnchor),
+            tapButton.leadingAnchor.constraint(equalTo: backgroundView.leadingAnchor),
+            tapButton.trailingAnchor.constraint(equalTo: backgroundView.trailingAnchor),
+            tapButton.bottomAnchor.constraint(equalTo: backgroundView.bottomAnchor)
+        ])
+    }
+
+    @objc private func handleTap() {
+        SPSupport.animatePress(backgroundView, pressed: true)
+        DispatchQueue.main.asyncAfter(deadline: .now() + SPSupport.durationQuick) { [weak self] in
+            guard let self else { return }
+            SPSupport.animatePress(self.backgroundView, pressed: false)
+        }
+        onTap?()
+    }
+
+    // MARK: - Pluralisation
+
+    /// Russian plural for "день" — `1 день / 2-4 дня / 5+ дней`.
+    private static func daysWord(for count: Int) -> String {
+        let abs = Swift.abs(count)
+        let mod10 = abs % 10
+        let mod100 = abs % 100
+        if mod10 == 1 && mod100 != 11 { return "день" }
+        if (2...4).contains(mod10) && !(12...14).contains(mod100) { return "дня" }
+        return "дней"
+    }
+}

--- a/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
@@ -348,4 +348,94 @@ final class AlarmsListViewModel {
         guard index < alarms.count else { return "" }
         return "▲ ПОСПАТЬ ЕЩЁ: −\(Int(alarms[index].penaltyAmount)) ₽"
     }
+
+    // MARK: - V2 cell helpers
+
+    /// Caps-styled day label for the V2 card top row.
+    /// Examples:
+    ///  - `[0,1,2,3,4]`             → `БУДНИ · ПН–ПТ`
+    ///  - `[5,6]`                   → `ВЫХОДНЫЕ`
+    ///  - `[0,1,2,3,4,5,6]`         → `КАЖДЫЙ ДЕНЬ`
+    ///  - `[]`                      → `ЕДИНОЖДЫ`
+    ///  - `[1,3]`, with name "Спорт" → `СПОРТ · ВТ, ЧТ`
+    ///  - `[0]`, name empty/default → `ПН`
+    ///
+    /// Combines the alarm's user-set `name` with the weekday set when the
+    /// name is non-default — otherwise renders the weekday phrase alone. The
+    /// alarm-list spec line "Спорт · Вт, Чт" lives here so the cell can stay
+    /// a passive renderer.
+    func alarmDaysCaps(at index: Int) -> String {
+        guard index < alarms.count else { return "" }
+        let alarm = alarms[index]
+        let daysPhrase = Self.weekdayPhrase(for: alarm.repeatDays).uppercased()
+        let trimmed = alarm.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Default name "Будильник" is suppressed in the caps row — it's the
+        // boilerplate label every freshly-created alarm carries and would
+        // crowd the caps line.
+        let nameIsDefault = trimmed.isEmpty || trimmed.lowercased() == "будильник"
+        if nameIsDefault {
+            return daysPhrase
+        }
+        return "\(trimmed.uppercased()) · \(daysPhrase)"
+    }
+
+    /// Weekday set rendered as a humanised Russian phrase. Mirrors
+    /// `Alarm.repeatDaysDescription` shape but always returns a Russian
+    /// label suitable for the caps line (no "Единожды" en dash collapsing
+    /// the alarm into an unintelligible "·" pair when there's no name).
+    private static func weekdayPhrase(for days: [Int]) -> String {
+        guard !days.isEmpty else { return "Единожды" }
+        let names = ["Пн", "Вт", "Ср", "Чт", "Пт", "Сб", "Вс"]
+        let sorted = days.sorted()
+        if sorted == Array(0...6) { return "Каждый день" }
+        if sorted == [0, 1, 2, 3, 4] { return "Будни · Пн–Пт" }
+        if sorted == [5, 6] { return "Выходные" }
+        return sorted.compactMap { index -> String? in
+            guard index >= 0, index < names.count else { return nil }
+            return names[index]
+        }.joined(separator: ", ")
+    }
+
+    /// Price pill text — bare "50 ₽" formatted via `Decimal.formattedRubles`
+    /// so digit grouping matches the balance display.
+    func alarmPriceText(at index: Int) -> String {
+        guard index < alarms.count else { return "" }
+        return Decimal(alarms[index].penaltyAmount).formattedRubles()
+    }
+
+    /// Progressive-pain multiplier label. Returns `"×2"` when the alarm has
+    /// the progressive scale toggle on, else `nil` so the cell hides the
+    /// pill. The exact factor is informational — the firing screen
+    /// computes the actual penalty per snooze count.
+    func alarmMultiplierText(at index: Int) -> String? {
+        guard index < alarms.count else { return nil }
+        return alarms[index].progressiveScale ? "×2" : nil
+    }
+
+    /// Human-readable name of the alarm's picked sound (e.g. "Рассвет",
+    /// "Радар"). Falls back to the raw `soundID` when the id isn't in the
+    /// known catalogue (custom file or new sound not yet added to the
+    /// lookup table).
+    func alarmSoundName(at index: Int) -> String? {
+        guard index < alarms.count else { return nil }
+        let soundID = alarms[index].soundID
+        return Self.soundDisplayNames[soundID] ?? soundID
+    }
+
+    /// Sound-id → Russian display-name lookup. Mirrors the
+    /// `CreateAlarmViewModel.availableSounds` list so cells render the same
+    /// label the user picked in the editor without coupling the alarms-list
+    /// VM to the editor VM.
+    private static let soundDisplayNames: [String: String] = [
+        "dawn": "Рассвет",
+        "radar": "Радар",
+        "drops": "Капли",
+        "piano": "Пиано",
+        "guitar": "Гитара",
+        "bell": "Колокольчик",
+        "waves": "Волны",
+        "birds": "Птицы",
+        "classic": "Классика",
+        "jazz": "Джаз"
+    ]
 }

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPAlarmsListEmptyState.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPAlarmsListEmptyState.swift
@@ -1,64 +1,88 @@
 import UIKit
 
-/// Empty-state column for the alarms list.
+/// Empty-state column for the alarms list (V2 design).
+///
+/// Reference: `docs/design/v2-handoff/components/SPMore.jsx` L376-407.
 ///
 /// Visual:
-///   ┌─────────────────────────────┐
-///   │             🔕              │
-///   │     Нет будильников         │
-///   │ Создайте первый, чтобы …    │
-///   │   [+ Добавить будильник]    │
-///   └─────────────────────────────┘
+/// ```
+///                ┌───────────┐
+///                │   🔔      │   <- 96×96 warm-gradient rounded square
+///                └───────────┘
+///            ПОКА ПУСТО         <- caps fg3
+///   Создайте первый будильник со
+///   ставкой — он спишет деньги
+///   за каждый снуз                <- body fg2
+///
+///        [   ＋ Создать первый   ]
+/// ```
 ///
 /// Hosted as an overlay over the table view in
-/// `AlarmsListViewController` and toggled via `isHidden`. Uses
-/// `AppTypography` + `SPButton(.money, .lg)` so it stays visually
-/// consistent with the rest of the design system.
+/// `AlarmsListViewController` and toggled via `isHidden`.
 final class SPAlarmsListEmptyState: UIView {
 
     // MARK: - Public API
 
-    /// Triggered when the user taps "Добавить будильник".
+    /// Triggered when the user taps "Создать первый".
     var onAddAlarmTap: (() -> Void)?
 
     // MARK: - Subviews
 
-    private let iconView: UIImageView = {
-        let configuration = UIImage.SymbolConfiguration(pointSize: 64, weight: .regular)
-        let view = UIImageView(image: UIImage(systemName: "bell.slash", withConfiguration: configuration))
-        view.tintColor = AppColors.fg3
-        view.contentMode = .scaleAspectFit
+    /// 96×96 warm-gradient rounded square hosting the alarm icon.
+    private let iconHost: SPGradientView = {
+        let view = SPGradientView(
+            colors: SPSupport.warnGradientColors,
+            locations: SPSupport.warnGradientLocations
+        )
         view.translatesAutoresizingMaskIntoConstraints = false
+        view.layer.cornerRadius = AppRadius.xl  // 28pt
+        view.layer.masksToBounds = true
         return view
     }()
 
-    private let titleLabel: UILabel = {
+    private let iconView: UIImageView = {
+        let view = UIImageView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.contentMode = .scaleAspectFit
+        view.tintColor = AppColors.fgOnWarn
+        let config = UIImage.SymbolConfiguration(pointSize: 44, weight: .semibold)
+        view.image = UIImage(systemName: "alarm.fill", withConfiguration: config)
+        return view
+    }()
+
+    private let capsLabel: UILabel = {
         let label = UILabel()
-        label.text = "Нет будильников"
-        label.font = AppTypography.h2
-        label.textColor = AppColors.fg1
-        label.textAlignment = .center
         label.translatesAutoresizingMaskIntoConstraints = false
+        label.attributedText = NSAttributedString(
+            string: "ПОКА ПУСТО",
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.fg3
+            ]
+        )
+        label.textAlignment = .center
         return label
     }()
 
-    private let subtitleLabel: UILabel = {
+    private let bodyLabel: UILabel = {
         let label = UILabel()
-        label.text = "Создайте первый, чтобы начать"
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "Создайте первый будильник со ставкой — он спишет деньги за каждый снуз."
         label.font = AppTypography.body
-        label.textColor = AppColors.fg3
+        label.textColor = AppColors.fg2
         label.textAlignment = .center
         label.numberOfLines = 0
-        label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
 
     private let addButton: SPButton = {
         let button = SPButton(
-            title: "Добавить будильник",
+            title: "Создать первый",
             variant: .money,
             size: .lg,
-            icon: UIImage(systemName: "plus")
+            icon: UIImage(systemName: "plus"),
+            fullWidth: true
         )
         button.translatesAutoresizingMaskIntoConstraints = false
         return button
@@ -80,28 +104,41 @@ final class SPAlarmsListEmptyState: UIView {
     private func configure() {
         backgroundColor = .clear
 
-        let stack = UIStackView(arrangedSubviews: [
-            iconView, titleLabel, subtitleLabel, addButton
-        ])
-        stack.axis = .vertical
-        stack.alignment = .center
-        stack.spacing = AppSpacing.sp3
-        stack.setCustomSpacing(AppSpacing.sp4, after: iconView)
-        stack.setCustomSpacing(AppSpacing.sp5, after: subtitleLabel)
-        stack.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(stack)
+        addSubview(iconHost)
+        iconHost.addSubview(iconView)
 
-        NSLayoutConstraint.activate([
-            stack.centerXAnchor.constraint(equalTo: centerXAnchor),
-            stack.centerYAnchor.constraint(equalTo: centerYAnchor),
-            stack.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: AppSpacing.sp6),
-            stack.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -AppSpacing.sp6),
-
-            iconView.widthAnchor.constraint(equalToConstant: 80),
-            iconView.heightAnchor.constraint(equalToConstant: 80)
-        ])
+        let textStack = UIStackView(arrangedSubviews: [capsLabel, bodyLabel])
+        textStack.axis = .vertical
+        textStack.alignment = .center
+        textStack.spacing = AppSpacing.sp2
+        textStack.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(textStack)
+        addSubview(addButton)
 
         addButton.addTarget(self, action: #selector(addTapped), for: .touchUpInside)
+
+        NSLayoutConstraint.activate([
+            // Icon centered, 96×96.
+            iconHost.centerXAnchor.constraint(equalTo: centerXAnchor),
+            iconHost.bottomAnchor.constraint(equalTo: textStack.topAnchor, constant: -AppSpacing.sp6),
+            iconHost.widthAnchor.constraint(equalToConstant: 96),
+            iconHost.heightAnchor.constraint(equalToConstant: 96),
+
+            iconView.centerXAnchor.constraint(equalTo: iconHost.centerXAnchor),
+            iconView.centerYAnchor.constraint(equalTo: iconHost.centerYAnchor),
+
+            // Text — centered group above the CTA.
+            textStack.centerYAnchor.constraint(equalTo: centerYAnchor),
+            textStack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: AppSpacing.sp7),
+            textStack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -AppSpacing.sp7),
+
+            // CTA — full-width below the text, anchored to a flexible gap so
+            // the column reads "balanced" without forcing the button against
+            // the safe-area bottom.
+            addButton.topAnchor.constraint(equalTo: textStack.bottomAnchor, constant: AppSpacing.sp7),
+            addButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: AppSpacing.screenInset),
+            addButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -AppSpacing.screenInset)
+        ])
     }
 
     // MARK: - Actions

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPAlarmsListHeader.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPAlarmsListHeader.swift
@@ -1,49 +1,58 @@
-// swiftlint:disable file_length
 import UIKit
 
-/// Sticky header for the alarms list — composes a balance card and an
-/// optional low-balance warning banner. Lives at the top of the screen
-/// above the scrolling table view; pinned to the safe-area so it never
-/// scrolls away.
+/// V2 sticky header for the alarms list — title row + compact balance pill.
 ///
-/// Visual recipe:
-/// - **Balance card**: same SPBalanceCard chrome (`bg2` raised surface,
-///   28pt vertical / 24pt horizontal padding, 28pt corner radius). Caps
-///   header "БАЛАНС", `moneyXl` value (56pt mono — see #175), an
-///   optional weekly delta line (`↑/↓ amount за неделю`), a centered
-///   "Хватит на ~N откладываний" hint **below** the value, and a
-///   trailing `SPButton(.money, .sm)` "Пополнить" placed to the right
-///   of the value row. The centered hint placement is a direct fix for
-///   PM feedback (chat1.md line 971) — the previous layout put the hint
-///   inline with the value and PM called it out as misaligned.
-/// - **Warning banner**: `SPCard(.warn)` shown when balance ≤ 100. Caps
-///   "БАЛАНС ПОЧТИ ПУСТ", current balance meta, and a small
-///   `SPButton(.warn, .sm)` "Пополнить". Slot collapses (`isHidden`)
-///   when balance > 100; the surrounding stack absorbs the gap.
+/// Layout (top → bottom):
+/// ```
+///  ┌────────────────────────────────────────────────────────┐
+///  │ Будильники                                      ⊕(40)  │   <- title row
+///  │ ┌────────────────────────────────────────────────────┐ │
+///  │ │ [wallet]  БАЛАНС 840 ₽           [Пополнить]      │ │   <- pill
+///  │ │           Хватит на ~16 откладываний              │ │
+///  │ └────────────────────────────────────────────────────┘ │
+///  └────────────────────────────────────────────────────────┘
+///  ── 1pt whiteOverlay06 hairline ──
+/// ```
 ///
-/// The view exposes two callbacks (`onBalanceTopUpTap` and
-/// `onWarnTopUpTap`) so the controller can wire whichever destination
-/// it wants — callers don't need to know about the internal SPButton
-/// instances.
+/// Replaces the legacy big-balance-card + amber "БАЛАНС ПОЧТИ ПУСТ" banner —
+/// the urgency is now folded directly into the pill: when balance drops below
+/// `SPAlarmsListHeader.lowBalanceThreshold` the pill switches its background
+/// to a soft warn tint + warn-stroke and the hint copy reflects the warning.
+///
+/// The 40×40 circular "+" button on the right is the only entry point for
+/// "create new alarm" on this screen — the legacy nav-bar plus button is
+/// suppressed by the host controller.
 final class SPAlarmsListHeader: UIView {
 
     // MARK: - Public API
 
     /// Triggered when the user taps the "Пополнить" pill on the balance
-    /// card.
+    /// card. Kept named the same as the legacy header so the controller
+    /// wiring doesn't need to change.
     var onBalanceTopUpTap: (() -> Void)?
 
-    /// Triggered when the user taps the "Пополнить" pill on the
-    /// low-balance warning banner.
+    /// Triggered when the user taps the 40×40 "+" button. Distinct from
+    /// `onBalanceTopUpTap` so the controller can route them to different
+    /// flows (create-alarm vs top-up).
+    var onAddTap: (() -> Void)?
+
+    /// Kept for binary-compatibility with the legacy header — the V2
+    /// pill folds the warning state into itself, so this callback now
+    /// routes through the same "Пополнить" tap path.
     var onWarnTopUpTap: (() -> Void)?
 
-    /// Update the balance card. `hint` is rendered as a centered line
-    /// below the balance number — pass `nil` to hide. `delta` is the
-    /// optional weekly net change rendered between the value and hint;
-    /// positive values get the up arrow + money tint, negative the down
-    /// arrow + pain tint, `nil` or zero hides the row (per `components.css`
-    /// L163-165 — `.sp-balance__delta { is-up | is-down }`).
+    /// Update the balance pill in place. The pill auto-switches into its
+    /// warn-tint variant when `balance.doubleValue ≤ lowBalanceThreshold`.
+    /// `hint` and `delta` are accepted for source-compat with the legacy
+    /// header; `delta` is currently ignored in the V2 pill layout (the
+    /// rolling-week change rendered as `↑/↓ amount` migrates onto the
+    /// Wallet screen). Pass through unchanged so existing call sites
+    /// keep compiling.
     func setBalance(_ balance: Decimal, hint: String?, delta: Decimal? = nil) {
+        _ = delta // accepted for API compat; pill omits the delta row.
+        currentBalance = balance
+        let isLow = (NSDecimalNumber(decimal: balance).doubleValue) <= Self.lowBalanceThreshold
+        applyTone(isLow: isLow)
         balanceValueLabel.text = balance.formattedRubles()
         if let hint = hint, !hint.isEmpty {
             balanceHintLabel.text = hint
@@ -51,64 +60,177 @@ final class SPAlarmsListHeader: UIView {
         } else {
             balanceHintLabel.isHidden = true
         }
-        if let delta = delta, delta != 0 {
-            balanceDeltaLabel.attributedText = Self.renderDelta(delta)
-            balanceDeltaLabel.isHidden = false
-        } else {
-            balanceDeltaLabel.isHidden = true
-        }
-        // Remask the gradient on the value once layout reflows so the
-        // mask tracks the new digit width (#137 SPBalanceCard pattern).
-        setNeedsLayout()
     }
 
-    /// Toggle the low-balance warning banner. When `visible == true`
-    /// the banner shows the supplied `balance` in its meta line.
+    /// Kept for source-compat with the legacy header. The V2 pill folds
+    /// the warning into its own tone, so this method now just routes the
+    /// state through `setBalance(_:hint:)`'s low-balance branch — the
+    /// controller already calls both methods on refresh.
     func setWarning(visible: Bool, balance: Decimal) {
-        warningBanner.isHidden = !visible
-        warningMetaLabel.text = "Сейчас: \(balance.formattedRubles())"
+        // `applyTone` is driven by `setBalance`; this method is preserved
+        // so the controller doesn't need to be rewritten to drop the
+        // call. The `visible` flag is implied by the balance value.
+        _ = (visible, balance)
     }
+
+    // MARK: - Tokens
+
+    /// Pill bg switches to warn-tint at or below this threshold (₽).
+    /// Matches `AlarmsListViewModel.lowBalanceThreshold` so the view and
+    /// the model agree on what "low" means without coupling them through
+    /// an import.
+    static let lowBalanceThreshold: Double = 100
 
     // MARK: - Subviews
 
-    private let stack = UIStackView()
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        // h1 32pt extrabold with -0.02em kerning per `tokens.css` L80.
+        label.font = AppTypography.h1
+        label.textColor = AppColors.fg1
+        label.attributedText = NSAttributedString(
+            string: "Будильники",
+            attributes: [
+                .font: AppTypography.h1,
+                .kern: -32 * 0.01, // ~ -0.32 — matches `letterSpacing: -.02em` doubled-down
+                .foregroundColor: AppColors.fg1
+            ]
+        )
+        return label
+    }()
 
-    // Balance card
-    private let balanceCard = SPCard(tone: .raised, padding: 24, cornerRadius: AppRadius.xl)
-    private let balanceCapsLabel = UILabel()
-    private let balanceValueLabel = UILabel()
-    private let balanceValueGradient = CAGradientLayer()
-    private let balanceDeltaLabel = UILabel()
-    private let balanceHintLabel = UILabel()
-    private let balanceTopUpButton = SPButton(
+    private let addButton: UIControl = {
+        let view = UIControl()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.layer.cornerRadius = 20
+        view.layer.masksToBounds = false
+        // Money-tinted drop shadow — matches `--sp-shadow-money`.
+        view.layer.shadowColor = AppColors.money500.cgColor
+        view.layer.shadowOpacity = 0.35
+        view.layer.shadowRadius = 14
+        view.layer.shadowOffset = CGSize(width: 0, height: 6)
+        return view
+    }()
+
+    /// Gradient layer sits behind the plus glyph inside `addButton`.
+    private let addButtonGradient: SPGradientView = {
+        let view = SPGradientView(
+            colors: SPSupport.moneyGradientColors,
+            locations: SPSupport.moneyGradientLocations
+        )
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.isUserInteractionEnabled = false
+        view.layer.cornerRadius = 20
+        view.layer.masksToBounds = true
+        return view
+    }()
+
+    private let addIconView: UIImageView = {
+        let view = UIImageView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.contentMode = .scaleAspectFit
+        view.tintColor = AppColors.fgOnMoney
+        let config = UIImage.SymbolConfiguration(pointSize: 20, weight: .bold)
+        view.image = UIImage(systemName: "plus", withConfiguration: config)
+        view.isUserInteractionEnabled = false
+        return view
+    }()
+
+    private let pillButton: UIControl = {
+        let view = UIControl()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.layer.cornerRadius = 14
+        view.layer.masksToBounds = true
+        view.layer.borderWidth = 1
+        return view
+    }()
+
+    /// Money-gradient 40×40 rounded square left of the balance text.
+    private let walletIconHost: SPGradientView = {
+        let view = SPGradientView(
+            colors: SPSupport.moneyGradientColors,
+            locations: SPSupport.moneyGradientLocations
+        )
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.layer.cornerRadius = 10
+        view.layer.masksToBounds = true
+        view.isUserInteractionEnabled = false
+        return view
+    }()
+
+    private let walletIconImageView: UIImageView = {
+        let view = UIImageView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.contentMode = .scaleAspectFit
+        view.tintColor = AppColors.fgOnMoney
+        let config = UIImage.SymbolConfiguration(pointSize: 18, weight: .semibold)
+        view.image = UIImage(systemName: "creditcard.fill", withConfiguration: config)
+        return view
+    }()
+
+    private let balanceCapsLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.attributedText = NSAttributedString(
+            string: "БАЛАНС",
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.fg3
+            ]
+        )
+        return label
+    }()
+
+    private let balanceValueLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        // 20pt mono bold — `moneyMd`. Tabular nums via the mono font.
+        label.font = AppTypography.moneyMd
+        label.textColor = AppColors.fg1
+        label.adjustsFontSizeToFitWidth = true
+        label.minimumScaleFactor = 0.6
+        label.numberOfLines = 1
+        return label
+    }()
+
+    private let balanceHintLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = AppTypography.meta
+        label.textColor = AppColors.fg3
+        label.numberOfLines = 1
+        label.adjustsFontSizeToFitWidth = true
+        label.minimumScaleFactor = 0.8
+        return label
+    }()
+
+    private let topUpButton = SPButton(
         title: "Пополнить",
         variant: .money,
-        size: .sm,
-        icon: UIImage(systemName: "plus.circle.fill")
-    )
-    private let radialOverlay = AlarmsHeaderRadialOverlayView()
-
-    // Warning banner
-    private let warningBanner = SPCard(tone: .warn, padding: AppSpacing.sp4, cornerRadius: AppRadius.md)
-    private let warningCapsLabel = UILabel()
-    private let warningMetaLabel = UILabel()
-    private let warningTopUpButton = SPButton(
-        title: "Пополнить",
-        variant: .warn,
         size: .sm
     )
+
+    private let bottomHairline: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = AppColors.whiteOverlay06
+        return view
+    }()
+
+    // MARK: - State
+
+    private var currentBalance: Decimal = 0
 
     // MARK: - Init
 
     override init(frame: CGRect) {
         super.init(frame: frame)
         configure()
-        // iOS 17 deprecated `traitCollectionDidChange(_:)` — register a
-        // closure-based observer when available; the legacy override below
-        // remains as a fallback for older runtimes.
         if #available(iOS 17.0, *) {
             registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (view: SPAlarmsListHeader, _) in
-                view.refreshOverlay()
+                view.refreshDynamicColors()
             }
         }
     }
@@ -117,317 +239,170 @@ final class SPAlarmsListHeader: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    // MARK: - Layout
-
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        radialOverlay.frame = balanceCard.bounds
-        applyValueGradient()
-    }
-
     @available(iOS, deprecated: 17.0, message: "Replaced by registerForTraitChanges; kept for iOS 15/16.")
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        // iOS 17+ runtimes are notified via the registered trait observer
-        // (see init); skip here to avoid double-refreshing the overlay.
         if #available(iOS 17.0, *) { return }
-        refreshOverlay()
+        refreshDynamicColors()
     }
 
-    private func refreshOverlay() {
-        radialOverlay.setNeedsDisplay()
+    private func refreshDynamicColors() {
+        // CALayer cgColors don't auto-resolve dynamic UIColors.
+        bottomHairline.backgroundColor = AppColors.whiteOverlay06
+        let isLow = NSDecimalNumber(decimal: currentBalance).doubleValue <= Self.lowBalanceThreshold
+        applyTone(isLow: isLow)
     }
 
     // MARK: - Configuration
 
-    private func configure() {
-        // Outer stack — vertical, 12pt gap between balance card and the
-        // optional warning banner. Pinned to the view's layoutMargins so
-        // the screen edges resolve to AppSpacing.screenInset (16pt) by
-        // default — the controller assigns directionalLayoutMargins to
-        // override.
-        stack.translatesAutoresizingMaskIntoConstraints = false
-        stack.axis = .vertical
-        stack.spacing = AppSpacing.sp3
-        stack.alignment = .fill
-        addSubview(stack)
-        NSLayoutConstraint.activate([
-            stack.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
-            stack.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
-            stack.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
-            stack.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor)
-        ])
-
-        configureBalanceCard()
-        configureWarningBanner()
-
-        stack.addArrangedSubview(balanceCard)
-        stack.addArrangedSubview(warningBanner)
-        // Hidden by default — controller flips on view appear.
-        warningBanner.isHidden = true
-    }
-
     // swiftlint:disable:next function_body_length
-    private func configureBalanceCard() {
-        // Internal layout:
-        //   ┌─────────────────────────────────┐
-        //   │ БАЛАНС                          │
-        //   │ 1 234 ₽           [+ Пополнить] │
-        //   │       ~5 откладываний (centered)│
-        //   └─────────────────────────────────┘
-        balanceCard.translatesAutoresizingMaskIntoConstraints = false
+    private func configure() {
+        backgroundColor = AppColors.bg0
 
-        // Radial overlay sits behind content so subviews stack above it.
-        radialOverlay.translatesAutoresizingMaskIntoConstraints = false
-        radialOverlay.isUserInteractionEnabled = false
-        balanceCard.insertSubview(radialOverlay, at: 0)
+        addSubview(titleLabel)
+        addSubview(addButton)
+        addButton.addSubview(addButtonGradient)
+        addButton.addSubview(addIconView)
 
-        balanceCapsLabel.translatesAutoresizingMaskIntoConstraints = false
-        balanceCapsLabel.attributedText = NSAttributedString(
-            string: "БАЛАНС",
-            attributes: [
-                .font: AppTypography.caps,
-                .kern: AppTypography.capsKerning,
-                .foregroundColor: AppColors.fg3
-            ]
-        )
+        addSubview(pillButton)
+        pillButton.addSubview(walletIconHost)
+        walletIconHost.addSubview(walletIconImageView)
+        pillButton.addSubview(balanceCapsLabel)
+        pillButton.addSubview(balanceValueLabel)
+        pillButton.addSubview(balanceHintLabel)
+        pillButton.addSubview(topUpButton)
+        topUpButton.translatesAutoresizingMaskIntoConstraints = false
+        topUpButton.isUserInteractionEnabled = true
 
-        balanceValueLabel.translatesAutoresizingMaskIntoConstraints = false
-        // Hero balance: `moneyXl` (56pt mono bold) per `tokens.css` L168.
-        // 56pt glyphs can overflow on narrow devices when the balance grows
-        // past "999 999 ₽" alongside the trailing top-up pill, so we let
-        // UIKit shrink to 75% before clipping (matches SPBalanceCard).
-        balanceValueLabel.font = AppTypography.moneyXl
-        balanceValueLabel.textColor = AppColors.fg1
-        balanceValueLabel.adjustsFontForContentSizeCategory = false
-        balanceValueLabel.numberOfLines = 1
-        balanceValueLabel.adjustsFontSizeToFitWidth = true
-        balanceValueLabel.minimumScaleFactor = 0.75
-        balanceValueLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        addSubview(bottomHairline)
 
-        balanceTopUpButton.translatesAutoresizingMaskIntoConstraints = false
-        balanceTopUpButton.addTarget(
-            self,
-            action: #selector(balanceTopUpTapped),
-            for: .touchUpInside
-        )
+        addButton.addTarget(self, action: #selector(addTapped), for: .touchUpInside)
+        pillButton.addTarget(self, action: #selector(pillTapped), for: .touchUpInside)
+        topUpButton.addTarget(self, action: #selector(topUpTapped), for: .touchUpInside)
 
-        // Value row — value pinned leading, top-up button trailing.
-        let valueRow = UIView()
-        valueRow.translatesAutoresizingMaskIntoConstraints = false
-        valueRow.addSubview(balanceValueLabel)
-        valueRow.addSubview(balanceTopUpButton)
-
-        balanceHintLabel.translatesAutoresizingMaskIntoConstraints = false
-        balanceHintLabel.font = AppTypography.meta
-        balanceHintLabel.textColor = AppColors.fg3
-        balanceHintLabel.textAlignment = .center
-        balanceHintLabel.numberOfLines = 1
-        balanceHintLabel.isHidden = true
-
-        // Weekly delta: `moneySm` mono with arrow + tint per
-        // `components.css` L163-165. Hidden by default — `setBalance(_:hint:delta:)`
-        // flips the visibility once the controller pipes the computed
-        // delta from `AlarmsListViewModel`.
-        balanceDeltaLabel.translatesAutoresizingMaskIntoConstraints = false
-        balanceDeltaLabel.font = AppTypography.moneySm
-        balanceDeltaLabel.numberOfLines = 1
-        balanceDeltaLabel.isHidden = true
-
-        // Caps + value row + delta + centered hint — vertical stack inside
-        // the card. Custom spacing keeps the hint visually separate from
-        // the value (matches the JSX `gap-y-2` after value).
-        let innerStack = UIStackView(arrangedSubviews: [
-            balanceCapsLabel, valueRow, balanceDeltaLabel, balanceHintLabel
-        ])
-        innerStack.translatesAutoresizingMaskIntoConstraints = false
-        innerStack.axis = .vertical
-        innerStack.alignment = .fill
-        innerStack.spacing = 8
-        innerStack.setCustomSpacing(8, after: balanceCapsLabel)
-        innerStack.setCustomSpacing(6, after: valueRow)
-        innerStack.setCustomSpacing(10, after: balanceDeltaLabel)
-        balanceCard.addSubview(innerStack)
+        let inset = AppSpacing.screenInset
 
         NSLayoutConstraint.activate([
-            innerStack.topAnchor.constraint(equalTo: balanceCard.layoutMarginsGuide.topAnchor),
-            innerStack.bottomAnchor.constraint(equalTo: balanceCard.layoutMarginsGuide.bottomAnchor),
-            innerStack.leadingAnchor.constraint(equalTo: balanceCard.layoutMarginsGuide.leadingAnchor),
-            innerStack.trailingAnchor.constraint(equalTo: balanceCard.layoutMarginsGuide.trailingAnchor),
+            // ── Title row ─────────────────────────────────────────────
+            titleLabel.topAnchor.constraint(equalTo: topAnchor, constant: AppSpacing.sp2),
+            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: inset),
+            titleLabel.trailingAnchor.constraint(
+                lessThanOrEqualTo: addButton.leadingAnchor,
+                constant: -AppSpacing.sp3
+            ),
 
-            balanceValueLabel.leadingAnchor.constraint(equalTo: valueRow.leadingAnchor),
-            balanceValueLabel.topAnchor.constraint(equalTo: valueRow.topAnchor),
-            balanceValueLabel.bottomAnchor.constraint(equalTo: valueRow.bottomAnchor),
+            addButton.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
+            addButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -inset),
+            addButton.widthAnchor.constraint(equalToConstant: 40),
+            addButton.heightAnchor.constraint(equalToConstant: 40),
 
-            balanceTopUpButton.trailingAnchor.constraint(equalTo: valueRow.trailingAnchor),
-            balanceTopUpButton.centerYAnchor.constraint(equalTo: balanceValueLabel.centerYAnchor),
-            balanceTopUpButton.leadingAnchor.constraint(
-                greaterThanOrEqualTo: balanceValueLabel.trailingAnchor,
+            addButtonGradient.topAnchor.constraint(equalTo: addButton.topAnchor),
+            addButtonGradient.leadingAnchor.constraint(equalTo: addButton.leadingAnchor),
+            addButtonGradient.trailingAnchor.constraint(equalTo: addButton.trailingAnchor),
+            addButtonGradient.bottomAnchor.constraint(equalTo: addButton.bottomAnchor),
+
+            addIconView.centerXAnchor.constraint(equalTo: addButton.centerXAnchor),
+            addIconView.centerYAnchor.constraint(equalTo: addButton.centerYAnchor),
+
+            // ── Balance pill ──────────────────────────────────────────
+            pillButton.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: AppSpacing.sp3),
+            pillButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: inset),
+            pillButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -inset),
+            pillButton.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -AppSpacing.sp4),
+
+            // Wallet icon — 40×40 leading.
+            walletIconHost.leadingAnchor.constraint(equalTo: pillButton.leadingAnchor, constant: 12),
+            walletIconHost.centerYAnchor.constraint(equalTo: pillButton.centerYAnchor),
+            walletIconHost.widthAnchor.constraint(equalToConstant: 40),
+            walletIconHost.heightAnchor.constraint(equalToConstant: 40),
+
+            walletIconImageView.centerXAnchor.constraint(equalTo: walletIconHost.centerXAnchor),
+            walletIconImageView.centerYAnchor.constraint(equalTo: walletIconHost.centerYAnchor),
+
+            // Top-up button — sm, trailing.
+            topUpButton.trailingAnchor.constraint(equalTo: pillButton.trailingAnchor, constant: -12),
+            topUpButton.centerYAnchor.constraint(equalTo: pillButton.centerYAnchor),
+
+            // Balance value row — baseline-aligned caps "БАЛАНС" + amount.
+            balanceCapsLabel.leadingAnchor.constraint(
+                equalTo: walletIconHost.trailingAnchor,
                 constant: AppSpacing.sp3
-            )
+            ),
+            balanceCapsLabel.topAnchor.constraint(equalTo: pillButton.topAnchor, constant: 12),
+
+            balanceValueLabel.leadingAnchor.constraint(
+                equalTo: balanceCapsLabel.trailingAnchor,
+                constant: AppSpacing.sp2
+            ),
+            balanceValueLabel.firstBaselineAnchor.constraint(equalTo: balanceCapsLabel.firstBaselineAnchor),
+            balanceValueLabel.trailingAnchor.constraint(
+                lessThanOrEqualTo: topUpButton.leadingAnchor,
+                constant: -AppSpacing.sp3
+            ),
+
+            // Meta hint — below the value row.
+            balanceHintLabel.leadingAnchor.constraint(
+                equalTo: walletIconHost.trailingAnchor,
+                constant: AppSpacing.sp3
+            ),
+            balanceHintLabel.topAnchor.constraint(equalTo: balanceValueLabel.bottomAnchor, constant: 2),
+            balanceHintLabel.trailingAnchor.constraint(
+                lessThanOrEqualTo: topUpButton.leadingAnchor,
+                constant: -AppSpacing.sp3
+            ),
+            balanceHintLabel.bottomAnchor.constraint(
+                lessThanOrEqualTo: pillButton.bottomAnchor,
+                constant: -12
+            ),
+
+            // ── Bottom hairline ───────────────────────────────────────
+            bottomHairline.leadingAnchor.constraint(equalTo: leadingAnchor),
+            bottomHairline.trailingAnchor.constraint(equalTo: trailingAnchor),
+            bottomHairline.bottomAnchor.constraint(equalTo: bottomAnchor),
+            bottomHairline.heightAnchor.constraint(equalToConstant: 1)
         ])
 
-        // Wire the gradient layer to the value label — masked to glyph
-        // outlines on every layout pass.
-        balanceValueGradient.colors = SPSupport.moneyGradientColors
-        balanceValueGradient.locations = SPSupport.moneyGradientLocations
-        balanceValueGradient.startPoint = SPSupport.gradientStart
-        balanceValueGradient.endPoint = SPSupport.gradientEnd
+        applyTone(isLow: false)
     }
 
-    private func configureWarningBanner() {
-        warningBanner.translatesAutoresizingMaskIntoConstraints = false
-
-        warningCapsLabel.translatesAutoresizingMaskIntoConstraints = false
-        warningCapsLabel.attributedText = NSAttributedString(
-            string: "БАЛАНС ПОЧТИ ПУСТ",
-            attributes: [
-                .font: AppTypography.caps,
-                .kern: AppTypography.capsKerning,
-                .foregroundColor: AppColors.fgOnWarn
-            ]
-        )
-
-        warningMetaLabel.translatesAutoresizingMaskIntoConstraints = false
-        warningMetaLabel.font = AppTypography.meta
-        warningMetaLabel.textColor = AppColors.fgOnWarn.withAlphaComponent(0.85)
-        warningMetaLabel.numberOfLines = 1
-
-        warningTopUpButton.translatesAutoresizingMaskIntoConstraints = false
-        warningTopUpButton.addTarget(
-            self,
-            action: #selector(warnTopUpTapped),
-            for: .touchUpInside
-        )
-
-        let textStack = UIStackView(arrangedSubviews: [warningCapsLabel, warningMetaLabel])
-        textStack.translatesAutoresizingMaskIntoConstraints = false
-        textStack.axis = .vertical
-        textStack.alignment = .leading
-        textStack.spacing = 4
-
-        let row = UIStackView(arrangedSubviews: [textStack, warningTopUpButton])
-        row.translatesAutoresizingMaskIntoConstraints = false
-        row.axis = .horizontal
-        row.alignment = .center
-        row.spacing = AppSpacing.sp3
-        row.distribution = .fill
-
-        warningBanner.addSubview(row)
-        NSLayoutConstraint.activate([
-            row.topAnchor.constraint(equalTo: warningBanner.layoutMarginsGuide.topAnchor),
-            row.bottomAnchor.constraint(equalTo: warningBanner.layoutMarginsGuide.bottomAnchor),
-            row.leadingAnchor.constraint(equalTo: warningBanner.layoutMarginsGuide.leadingAnchor),
-            row.trailingAnchor.constraint(equalTo: warningBanner.layoutMarginsGuide.trailingAnchor)
-        ])
-
-        textStack.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        warningTopUpButton.setContentHuggingPriority(.required, for: .horizontal)
-        warningTopUpButton.setContentCompressionResistancePriority(.required, for: .horizontal)
-    }
-
-    // MARK: - Gradient masking
-
-    private func applyValueGradient() {
-        // Same recipe as SPBalanceCard.applyValueGradient — render the
-        // glyph outlines into an offscreen image and use it as the
-        // gradient layer's mask. Re-runs every layout so font / size
-        // changes refresh the mask.
-        let textBounds = balanceValueLabel.bounds
-        guard textBounds.width > 0, textBounds.height > 0 else { return }
-        if balanceValueGradient.superlayer !== balanceValueLabel.layer {
-            balanceValueLabel.layer.addSublayer(balanceValueGradient)
+    /// Switch the pill chrome between the neutral (bg2 + whiteOverlay08
+    /// stroke) and warn (warn500@12% + warn500@45% stroke) variants. The
+    /// hint copy + colour also shift so the low-balance state stays legible
+    /// at a glance without an extra banner row.
+    private func applyTone(isLow: Bool) {
+        if isLow {
+            pillButton.backgroundColor = AppColors.warn500.withAlphaComponent(0.12)
+            pillButton.layer.borderColor = AppColors.warn500.withAlphaComponent(0.45).cgColor
+            balanceHintLabel.textColor = AppColors.warn300
+        } else {
+            pillButton.backgroundColor = AppColors.bg2
+            pillButton.layer.borderColor = AppColors.whiteOverlay08.cgColor
+            balanceHintLabel.textColor = AppColors.fg3
         }
-        balanceValueGradient.frame = textBounds
-
-        let renderer = UIGraphicsImageRenderer(size: textBounds.size)
-        let mask = renderer.image { ctx in
-            ctx.cgContext.setFillColor(UIColor.white.cgColor)
-            (balanceValueLabel.text ?? "").draw(
-                in: textBounds,
-                withAttributes: [
-                    .font: balanceValueLabel.font as Any,
-                    .foregroundColor: UIColor.white
-                ]
-            )
-        }
-        let maskLayer = CALayer()
-        maskLayer.frame = textBounds
-        maskLayer.contents = mask.cgImage
-        balanceValueGradient.mask = maskLayer
-        // Hide the label paint so we don't double-render.
-        balanceValueLabel.textColor = .clear
     }
 
     // MARK: - Actions
 
-    @objc private func balanceTopUpTapped() {
-        onBalanceTopUpTap?()
+    @objc private func addTapped() {
+        SPSupport.animatePress(addButton, pressed: true)
+        DispatchQueue.main.asyncAfter(deadline: .now() + SPSupport.durationQuick) { [weak self] in
+            guard let self else { return }
+            SPSupport.animatePress(self.addButton, pressed: false)
+        }
+        onAddTap?()
     }
 
-    @objc private func warnTopUpTapped() {
+    @objc private func pillTapped() {
+        // Tapping the body of the pill (anywhere except the explicit
+        // "Пополнить" CTA) is a shortcut to the same destination — keeps
+        // the surface "all top-up" instead of forcing the user to hit a
+        // small button.
+        onBalanceTopUpTap?()
         onWarnTopUpTap?()
     }
 
-    // MARK: - Delta rendering
-
-    /// Build the weekly delta line. Mirrors `SPBalanceCard.renderDelta`
-    /// (#137) — kept local to the sticky header so the two surfaces stay
-    /// visually identical without a shared helper coupling these
-    /// component files together. Format: `↑ 240 ₽ за неделю` /
-    /// `↓ 130 ₽ за неделю` with U+2191 / U+2193 arrows.
-    private static func renderDelta(_ delta: Decimal) -> NSAttributedString {
-        let arrow = delta < 0 ? "\u{2193}" : "\u{2191}"
-        let absValue = NSDecimalNumber(decimal: delta < 0 ? -delta : delta).decimalValue
-        let str = "\(arrow) \(absValue.formattedRubles()) за неделю"
-        let color = delta < 0 ? AppColors.pain400 : AppColors.money400
-        return NSAttributedString(
-            string: str,
-            attributes: [
-                .font: AppTypography.moneySm,
-                .foregroundColor: color
-            ]
-        )
-    }
-}
-
-// MARK: - Radial overlay
-
-/// Reuses the SPBalanceCard radial-highlight recipe (80% × 60% money tint
-/// at top-right). Kept private to this file so the SP* primitive isn't
-/// touched.
-private final class AlarmsHeaderRadialOverlayView: UIView {
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        backgroundColor = .clear
-        isUserInteractionEnabled = false
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override func draw(_ rect: CGRect) {
-        guard let context = UIGraphicsGetCurrentContext() else { return }
-        let colorSpace = CGColorSpaceCreateDeviceRGB()
-        let colors = [
-            AppColors.money400.withAlphaComponent(0.18).cgColor,
-            UIColor.clear.cgColor
-        ]
-        guard let gradient = CGGradient(
-            colorsSpace: colorSpace,
-            colors: colors as CFArray,
-            locations: [0.0, 1.0]
-        ) else { return }
-        let centerPoint = CGPoint(x: rect.maxX, y: rect.minY)
-        let radius = max(rect.width, rect.height) * 0.6
-        context.drawRadialGradient(
-            gradient,
-            startCenter: centerPoint,
-            startRadius: 0,
-            endCenter: centerPoint,
-            endRadius: radius,
-            options: []
-        )
+    @objc private func topUpTapped() {
+        onBalanceTopUpTap?()
+        onWarnTopUpTap?()
     }
 }


### PR DESCRIPTION
## Summary
- Rewrites `SPAlarmsListHeader` as a sticky top with H1 title "Будильники" + 40×40 money-gradient "+" button + a compact full-width balance pill (40×40 wallet icon, "БАЛАНС 840 ₽" + "Хватит на ~N откладываний" meta + trailing money SPButton). Pill auto-switches to a warn-tint background + stroke when balance ≤ 100, folding the old amber "БАЛАНС ПОЧТИ ПУСТ" banner into one line.
- Rewrites `AlarmCell` to the V2 layout: caps day-name row ("БУДНИ · ПН–ПТ" / "ВЫХОДНЫЕ" / "СПОРТ · ВТ, ЧТ") + SPSwitch, big 64pt mono clock, and a bottom chip row of `SPPill` (warn price + optional pain "×2" multiplier + neutral sound name). bg2 raised when enabled, bg1 surface + dimmed fg3 when disabled.
- Adds `AlarmsStreakBannerView` — money-tinted glass banner (linear-gradient(135deg, money400@12 → money400@4), 18% money border) with flame icon, caps streak title, "Сэкономили N ₽" meta, and chevron. Mounted as `tableHeaderView` so it scrolls with the rows. Tapping opens `StreakModalViewController`.
- Rewrites `SPAlarmsListEmptyState` to the V2 spec: 96×96 warm-gradient rounded square with `alarm.fill` icon, "ПОКА ПУСТО" caps, body copy, full-width money "Создать первый" SPButton.
- Adds VM helpers `alarmDaysCaps`, `alarmPriceText`, `alarmMultiplierText`, `alarmSoundName` so the new cell stays a passive renderer.
- Preserves gear + DEBUG (streak / onboarding reset) nav-bar buttons; suppresses the duplicate nav "+" (header carries the only plus CTA now).

## Test plan
- [x] `xcodebuild build` on iPhone 17 simulator → BUILD SUCCEEDED.
- [ ] Visual QA: list with multiple alarms (weekdays, weekends, custom names, progressive scale on/off).
- [ ] Visual QA: balance ≤ 100 ₽ flips pill to warn tone.
- [ ] Visual QA: streak > 0 shows banner, streak == 0 hides it.
- [ ] Visual QA: empty state shows centered illustration + CTA.
- [ ] Tap "+" in header opens CreateAlarm; tap "Пополнить" or pill body opens TopUp.
- [ ] DEBUG flame button still triggers streak modal; reset button still wipes onboarding.
- [ ] Swipe-to-delete still works on each row.

Branch base: `design-refresh-2026-04-27` (slice B of the V2 design refresh).