### PR TITLE
[ui][v2-stats] Statistics V2 — heatmap + weekly chart + StreakModal + Referral + AlarmOffWarning

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Statistics/AlarmOffWarningViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Statistics/AlarmOffWarningViewController.swift
@@ -1,0 +1,381 @@
+import UIKit
+
+/// "Alarm off / disable warning" sheet — V2 design (`docs/design/v2-handoff/`
+/// `components/SPMore4.jsx` lines 325-395, `AlarmOffWarning()`).
+///
+/// Triggered when the user has slept through three mornings in a row. The
+/// V2 spec asks for a pain-tinted full-screen modal (or large sheet) with:
+///   - Top bar: small "Закрыть" `SPButton(.quiet, .sm)` on the left + caps
+///     "ВНИМАНИЕ" in pain400 centre.
+///   - 80×80 pain-gradient rounded square with the flame icon.
+///   - h1 headline "Вы поспали ещё 3 раза подряд".
+///   - bodyLg body with an inline pain-tinted mono amount.
+///   - Three suggestion rows: "Перенести будильник", "Снизить цену
+///     откладывания", "Выключить SnoozePay" — each on an `SPCard(.surface)`
+///     with leading icon + title + subtitle + trailing chevron.
+///   - Bottom ghost `SPButton(.ghost, .md)` "Всё в порядке, продолжаем".
+///
+/// Trigger wiring lands in a follow-up — this PR exposes a DEBUG button in
+/// the statistics screen so PM can preview the visual.
+final class AlarmOffWarningViewController: UIViewController {
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = AppColors.bg0
+        configureLayout()
+    }
+
+    // MARK: - Layout
+
+    private func configureLayout() {
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(scrollView)
+
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.alignment = .fill
+        stack.spacing = AppSpacing.sp5
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.addSubview(stack)
+
+        stack.addArrangedSubview(makeTopBar())
+        stack.addArrangedSubview(makeHero())
+        stack.addArrangedSubview(makeBody())
+        stack.addArrangedSubview(makeSuggestions())
+        stack.addArrangedSubview(makeFooterButton())
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+
+            stack.topAnchor.constraint(equalTo: scrollView.topAnchor, constant: AppSpacing.sp3),
+            stack.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor, constant: -AppSpacing.sp7),
+            stack.leadingAnchor.constraint(
+                equalTo: scrollView.leadingAnchor,
+                constant: AppSpacing.screenInset
+            ),
+            stack.trailingAnchor.constraint(
+                equalTo: scrollView.trailingAnchor,
+                constant: -AppSpacing.screenInset
+            ),
+            stack.widthAnchor.constraint(
+                equalTo: scrollView.widthAnchor,
+                constant: -AppSpacing.screenInset * 2
+            )
+        ])
+    }
+
+    // MARK: - Top bar
+
+    private func makeTopBar() -> UIView {
+        let closeButton = SPButton(title: "Закрыть", variant: .quiet, size: .sm)
+        closeButton.addTarget(self, action: #selector(dismissTapped), for: .touchUpInside)
+        closeButton.translatesAutoresizingMaskIntoConstraints = false
+
+        let caps = UILabel()
+        caps.attributedText = NSAttributedString(
+            string: "ВНИМАНИЕ",
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.pain400
+            ]
+        )
+        caps.textAlignment = .center
+        caps.translatesAutoresizingMaskIntoConstraints = false
+
+        // Right-side spacer mirrors the close button's width so the caps land
+        // visually centred.
+        let spacer = UIView()
+        spacer.translatesAutoresizingMaskIntoConstraints = false
+        spacer.widthAnchor.constraint(equalTo: closeButton.widthAnchor).isActive = true
+
+        let row = UIStackView(arrangedSubviews: [closeButton, caps, spacer])
+        row.axis = .horizontal
+        row.alignment = .center
+        row.distribution = .equalSpacing
+        row.spacing = AppSpacing.sp3
+        row.translatesAutoresizingMaskIntoConstraints = false
+        // Pin the caps to centerX of the row to defeat distribution drift on
+        // wide layouts.
+        let wrap = UIView()
+        wrap.translatesAutoresizingMaskIntoConstraints = false
+        wrap.addSubview(row)
+        NSLayoutConstraint.activate([
+            row.topAnchor.constraint(equalTo: wrap.topAnchor),
+            row.bottomAnchor.constraint(equalTo: wrap.bottomAnchor),
+            row.leadingAnchor.constraint(equalTo: wrap.leadingAnchor),
+            row.trailingAnchor.constraint(equalTo: wrap.trailingAnchor)
+        ])
+        return wrap
+    }
+
+    // MARK: - Hero
+
+    private func makeHero() -> UIView {
+        // 80×80 pain-gradient rounded square + flame icon.
+        let badge = UIView()
+        badge.translatesAutoresizingMaskIntoConstraints = false
+        badge.layer.cornerRadius = AppRadius.lg
+        badge.layer.cornerCurve = .continuous
+        badge.layer.masksToBounds = false
+        badge.layer.shadowColor = AppColors.pain500.cgColor
+        badge.layer.shadowOpacity = 0.40
+        badge.layer.shadowOffset = CGSize(width: 0, height: 16)
+        badge.layer.shadowRadius = 24
+
+        let gradient = CAGradientLayer()
+        gradient.colors = SPSupport.painGradientColors
+        gradient.locations = SPSupport.painGradientLocations
+        gradient.startPoint = SPSupport.gradientStart
+        gradient.endPoint = SPSupport.gradientEnd
+        gradient.cornerRadius = AppRadius.lg
+        badge.layer.insertSublayer(gradient, at: 0)
+        DispatchQueue.main.async {
+            gradient.frame = badge.bounds
+        }
+
+        let flame = UIImageView(
+            image: UIImage(
+                systemName: "flame.fill",
+                withConfiguration: UIImage.SymbolConfiguration(pointSize: 40, weight: .bold)
+            )
+        )
+        flame.tintColor = AppColors.fgOnPain
+        flame.contentMode = .scaleAspectFit
+        flame.translatesAutoresizingMaskIntoConstraints = false
+        badge.addSubview(flame)
+
+        NSLayoutConstraint.activate([
+            badge.widthAnchor.constraint(equalToConstant: 80),
+            badge.heightAnchor.constraint(equalToConstant: 80),
+            flame.centerXAnchor.constraint(equalTo: badge.centerXAnchor),
+            flame.centerYAnchor.constraint(equalTo: badge.centerYAnchor)
+        ])
+
+        // Align the badge to the leading edge of the stack — the JSX places
+        // it left-aligned at the top of the body.
+        let wrap = UIStackView(arrangedSubviews: [badge, UIView()])
+        wrap.axis = .horizontal
+        wrap.alignment = .center
+        wrap.translatesAutoresizingMaskIntoConstraints = false
+        return wrap
+    }
+
+    // MARK: - Body copy
+
+    private func makeBody() -> UIView {
+        let headline = UILabel()
+        headline.font = AppTypography.h1
+        headline.textColor = AppColors.fg1
+        headline.numberOfLines = 0
+        headline.text = "Вы поспали ещё 3 раза подряд"
+        headline.translatesAutoresizingMaskIntoConstraints = false
+
+        let body = UILabel()
+        body.font = AppTypography.bodyLg
+        body.textColor = AppColors.fg2
+        body.numberOfLines = 0
+        // Inline pain-tinted mono amount via NSAttributedString.
+        let prefix = "За эту неделю списано "
+        let amount = "−750 ₽"
+        let suffix = ". Возможно, что-то пошло не так. Что хотите сделать?"
+        let attr = NSMutableAttributedString(
+            string: prefix,
+            attributes: [
+                .font: AppTypography.bodyLg,
+                .foregroundColor: AppColors.fg2
+            ]
+        )
+        attr.append(NSAttributedString(
+            string: amount,
+            attributes: [
+                .font: AppFonts.mono(.bold, 17),
+                .foregroundColor: AppColors.pain400
+            ]
+        ))
+        attr.append(NSAttributedString(
+            string: suffix,
+            attributes: [
+                .font: AppTypography.bodyLg,
+                .foregroundColor: AppColors.fg2
+            ]
+        ))
+        body.attributedText = attr
+        body.translatesAutoresizingMaskIntoConstraints = false
+
+        let stack = UIStackView(arrangedSubviews: [headline, body])
+        stack.axis = .vertical
+        stack.spacing = AppSpacing.sp3
+        stack.alignment = .fill
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }
+
+    // MARK: - Suggestions
+
+    private func makeSuggestions() -> UIView {
+        let stack = UIStackView(arrangedSubviews: [
+            makeSuggestionRow(
+                icon: "clock.fill",
+                iconTint: AppColors.fg2,
+                iconBackground: AppColors.whiteOverlay06,
+                title: "Перенести будильник",
+                subtitle: "Сегодня поздно лёг — встаём в 8:00"
+            ),
+            makeSuggestionRow(
+                icon: "creditcard.fill",
+                iconTint: AppColors.warn400,
+                iconBackground: AppColors.warn500.withAlphaComponent(0.14),
+                title: "Снизить цену откладывания",
+                subtitle: "Сейчас 50 ₽ → попробовать 20 ₽"
+            ),
+            makeSuggestionRow(
+                icon: "xmark",
+                iconTint: AppColors.pain400,
+                iconBackground: AppColors.pain500.withAlphaComponent(0.14),
+                title: "Выключить SnoozePay",
+                subtitle: "Будильник останется обычным"
+            )
+        ])
+        stack.axis = .vertical
+        stack.spacing = AppSpacing.sp2
+        stack.alignment = .fill
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }
+
+    private func makeSuggestionRow(
+        icon: String,
+        iconTint: UIColor,
+        iconBackground: UIColor,
+        title: String,
+        subtitle: String
+    ) -> UIView {
+        let card = SPCard(tone: .surface, padding: AppSpacing.sp4)
+        let iconWell = makeIconWell(symbol: icon, tint: iconTint, background: iconBackground)
+        let textStack = makeSuggestionTextStack(title: title, subtitle: subtitle)
+        let chevron = makeChevron()
+
+        let row = UIStackView(arrangedSubviews: [iconWell, textStack, chevron])
+        row.axis = .horizontal
+        row.alignment = .center
+        row.spacing = AppSpacing.sp3
+        row.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(row)
+        NSLayoutConstraint.activate([
+            row.leadingAnchor.constraint(equalTo: card.layoutMarginsGuide.leadingAnchor),
+            row.trailingAnchor.constraint(equalTo: card.layoutMarginsGuide.trailingAnchor),
+            row.topAnchor.constraint(equalTo: card.layoutMarginsGuide.topAnchor),
+            row.bottomAnchor.constraint(equalTo: card.layoutMarginsGuide.bottomAnchor)
+        ])
+
+        let tap = UITapGestureRecognizer(target: self, action: #selector(suggestionTapped))
+        card.addGestureRecognizer(tap)
+        card.isUserInteractionEnabled = true
+        return card
+    }
+
+    /// 40×40 rounded square containing the suggestion's SF Symbol icon.
+    /// Lifted out of `makeSuggestionRow` to keep the row builder under the
+    /// SwiftLint function-body cap.
+    private func makeIconWell(symbol: String, tint: UIColor, background: UIColor) -> UIView {
+        let well = UIView()
+        well.translatesAutoresizingMaskIntoConstraints = false
+        well.backgroundColor = background
+        well.layer.cornerRadius = AppRadius.sm
+        well.layer.cornerCurve = .continuous
+
+        let image = UIImageView(
+            image: UIImage(
+                systemName: symbol,
+                withConfiguration: UIImage.SymbolConfiguration(pointSize: 18, weight: .semibold)
+            )
+        )
+        image.tintColor = tint
+        image.contentMode = .scaleAspectFit
+        image.translatesAutoresizingMaskIntoConstraints = false
+        well.addSubview(image)
+        NSLayoutConstraint.activate([
+            well.widthAnchor.constraint(equalToConstant: 40),
+            well.heightAnchor.constraint(equalToConstant: 40),
+            image.centerXAnchor.constraint(equalTo: well.centerXAnchor),
+            image.centerYAnchor.constraint(equalTo: well.centerYAnchor)
+        ])
+        return well
+    }
+
+    /// Two-line text column (h4 title + meta subtitle) used inside the
+    /// suggestion row.
+    private func makeSuggestionTextStack(title: String, subtitle: String) -> UIView {
+        let titleLabel = UILabel()
+        titleLabel.text = title
+        titleLabel.font = AppTypography.h4
+        titleLabel.textColor = AppColors.fg1
+        titleLabel.numberOfLines = 0
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        let subtitleLabel = UILabel()
+        subtitleLabel.text = subtitle
+        subtitleLabel.font = AppTypography.meta
+        subtitleLabel.textColor = AppColors.fg3
+        subtitleLabel.numberOfLines = 0
+        subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        let stack = UIStackView(arrangedSubviews: [titleLabel, subtitleLabel])
+        stack.axis = .vertical
+        stack.spacing = 2
+        stack.alignment = .leading
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }
+
+    /// 14pt right-pointing chevron used as the trailing accessory on each
+    /// suggestion card.
+    private func makeChevron() -> UIImageView {
+        let chevron = UIImageView(
+            image: UIImage(
+                systemName: "chevron.right",
+                withConfiguration: UIImage.SymbolConfiguration(pointSize: 14, weight: .semibold)
+            )
+        )
+        chevron.tintColor = AppColors.fg3
+        chevron.setContentHuggingPriority(.required, for: .horizontal)
+        chevron.translatesAutoresizingMaskIntoConstraints = false
+        return chevron
+    }
+
+    // MARK: - Footer
+
+    private func makeFooterButton() -> UIView {
+        let button = SPButton(
+            title: "Всё в порядке, продолжаем",
+            variant: .ghost,
+            size: .md,
+            fullWidth: true
+        )
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(dismissTapped), for: .touchUpInside)
+        return button
+    }
+
+    // MARK: - Actions
+
+    @objc private func dismissTapped() {
+        dismiss(animated: true)
+    }
+
+    @objc private func suggestionTapped() {
+        // No backend wiring yet — surface a haptic and dismiss so the user
+        // sees the tap registered. Follow-up issues will route the three
+        // suggestions to their respective screens (CreateAlarm, Settings,
+        // Disable confirmation).
+        let generator = UISelectionFeedbackGenerator()
+        generator.selectionChanged()
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Statistics/ReferralViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Statistics/ReferralViewController.swift
@@ -1,0 +1,481 @@
+import UIKit
+
+/// Referral programme screen — V2 design (`docs/design/v2-handoff/`
+/// `components/SPMore4.jsx` lines 228-323, `Referral()`).
+///
+/// Layout (top → bottom):
+///   1. Hero card with a money-toned dark gradient + radial corner glow.
+///      Caps "Реферальная программа" + h1 "+200 ₽ вам / +200 ₽ другу" +
+///      body explainer.
+///   2. "Ваш код" — caps caption + `SPCard(.surface)` containing the
+///      mono-spaced personal code + a "Копировать" `SPButton(.money, .sm)`
+///      that copies the code onto the pasteboard.
+///   3. "Код друга" — caps caption + `SPCard(.surface)` with a vanilla
+///      mono-font `UITextField` placeholder and an "Применить"
+///      `SPButton(.money, .sm)` that briefly flashes a success state.
+///   4. "Друзья" — caps caption + `SPCard(.surface)` listing three sample
+///      friend rows (avatar + name + status meta + trailing amount).
+///   5. Bottom primary CTA — `SPButton(.money, .lg, fullWidth: true)`
+///      "Поделиться кодом" that pops a `UIActivityViewController`.
+///
+/// Until a real referral backend exists the data is hard-coded (matching
+/// the JSX placeholders) so the screen still tells the V2 story end-to-end.
+final class ReferralViewController: UIViewController {
+
+    // MARK: - Constants
+
+    /// Placeholder personal code rendered until the referral backend lands.
+    /// Mono-spaced + uppercase per the JSX `font: var(--sp-font-mono)` recipe.
+    private static let personalCode = "WAKEUP-7K2"
+
+    // MARK: - Subviews
+
+    private let scrollView = UIScrollView()
+    private let contentStack = UIStackView()
+
+    private let friendCodeField = UITextField()
+    private let applyButton = SPButton(
+        title: "Применить",
+        variant: .quiet,
+        size: .sm
+    )
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Пригласить"
+        view.backgroundColor = AppColors.bg0
+        navigationItem.largeTitleDisplayMode = .never
+        configureContainers()
+        contentStack.addArrangedSubview(makeHeroCard())
+        contentStack.addArrangedSubview(makePersonalCodeSection())
+        contentStack.addArrangedSubview(makeFriendCodeSection())
+        contentStack.addArrangedSubview(makeFriendsSection())
+        contentStack.addArrangedSubview(makeShareButton())
+    }
+
+    // MARK: - Setup
+
+    private func configureContainers() {
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        contentStack.axis = .vertical
+        contentStack.spacing = AppSpacing.sp5
+        contentStack.alignment = .fill
+        contentStack.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentStack)
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            contentStack.topAnchor.constraint(equalTo: scrollView.topAnchor, constant: AppSpacing.sp4),
+            contentStack.leadingAnchor.constraint(
+                equalTo: scrollView.leadingAnchor,
+                constant: AppSpacing.screenInset
+            ),
+            contentStack.trailingAnchor.constraint(
+                equalTo: scrollView.trailingAnchor,
+                constant: -AppSpacing.screenInset
+            ),
+            contentStack.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor, constant: -AppSpacing.sp7),
+            contentStack.widthAnchor.constraint(
+                equalTo: scrollView.widthAnchor,
+                constant: -AppSpacing.screenInset * 2
+            )
+        ])
+    }
+
+    // MARK: - Hero card
+
+    /// Bespoke hero card — money-toned dark gradient + radial corner glow.
+    /// Built as a plain `UIView` rather than an `SPCard` because the
+    /// gradient recipe is unique to this screen (135° linear with three
+    /// brand-money stops instead of the canonical `SPSupport.money*`).
+    private func makeHeroCard() -> UIView {
+        let card = UIView()
+        card.translatesAutoresizingMaskIntoConstraints = false
+        card.layer.cornerRadius = AppRadius.xl
+        card.layer.cornerCurve = .continuous
+        card.layer.masksToBounds = true
+
+        // Background gradient — dark money camo (#1A2810 → #2C4A1F → #4F8A3A).
+        let gradient = CAGradientLayer()
+        gradient.colors = [
+            UIColor(red: 0x1A / 255.0, green: 0x28 / 255.0, blue: 0x10 / 255.0, alpha: 1).cgColor,
+            UIColor(red: 0x2C / 255.0, green: 0x4A / 255.0, blue: 0x1F / 255.0, alpha: 1).cgColor,
+            UIColor(red: 0x4F / 255.0, green: 0x8A / 255.0, blue: 0x3A / 255.0, alpha: 1).cgColor
+        ]
+        gradient.locations = [0.0, 0.5, 1.0]
+        gradient.startPoint = SPSupport.gradientStart
+        gradient.endPoint = SPSupport.gradientEnd
+        card.layer.insertSublayer(gradient, at: 0)
+
+        let caps = UILabel()
+        caps.attributedText = NSAttributedString(
+            string: "РЕФЕРАЛЬНАЯ ПРОГРАММА",
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: UIColor.white.withAlphaComponent(0.7)
+            ]
+        )
+        caps.numberOfLines = 0
+        caps.translatesAutoresizingMaskIntoConstraints = false
+
+        let headline = UILabel()
+        headline.font = AppTypography.h1
+        headline.textColor = .white
+        headline.numberOfLines = 0
+        headline.text = "+200 ₽ вам\n+200 ₽ другу"
+        headline.translatesAutoresizingMaskIntoConstraints = false
+
+        let body = UILabel()
+        body.text = "Когда друг продержится 7 дней — оба получаете бонус в баланс."
+        body.font = AppTypography.body
+        body.textColor = UIColor.white.withAlphaComponent(0.85)
+        body.numberOfLines = 0
+        body.translatesAutoresizingMaskIntoConstraints = false
+
+        let stack = UIStackView(arrangedSubviews: [caps, headline, body])
+        stack.axis = .vertical
+        stack.alignment = .leading
+        stack.spacing = AppSpacing.sp2
+        stack.setCustomSpacing(AppSpacing.sp3, after: headline)
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: card.topAnchor, constant: AppSpacing.sp7),
+            stack.bottomAnchor.constraint(equalTo: card.bottomAnchor, constant: -AppSpacing.sp7),
+            stack.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: AppSpacing.sp7),
+            stack.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -AppSpacing.sp7)
+        ])
+
+        // Resize the gradient sublayer on next runloop tick so it adopts the
+        // resolved bounds after Auto Layout settles.
+        DispatchQueue.main.async {
+            gradient.frame = card.bounds
+        }
+        // Keep the gradient frame in sync on bounds change via a tiny KVO-free
+        // helper layer: intercept layoutSubviews on a private subclass would
+        // be cleaner, but a single dispatched assignment + an extra one on
+        // device-rotation `viewWillTransition` covers the practical cases.
+        return card
+    }
+
+    // MARK: - "Ваш код"
+
+    private func makePersonalCodeSection() -> UIView {
+        let caps = makeSectionCaps("ВАШ КОД")
+        let card = SPCard(tone: .surface, padding: AppSpacing.sp4)
+
+        let codeLabel = UILabel()
+        codeLabel.font = AppFonts.mono(.bold, 20)
+        codeLabel.textColor = AppColors.fg1
+        codeLabel.text = Self.personalCode
+        codeLabel.adjustsFontSizeToFitWidth = true
+        codeLabel.minimumScaleFactor = 0.7
+        codeLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        let copyButton = SPButton(title: "Копировать", variant: .money, size: .sm)
+        copyButton.translatesAutoresizingMaskIntoConstraints = false
+        copyButton.addTarget(self, action: #selector(copyCodeTapped(_:)), for: .touchUpInside)
+
+        let row = UIStackView(arrangedSubviews: [codeLabel, copyButton])
+        row.axis = .horizontal
+        row.alignment = .center
+        row.spacing = AppSpacing.sp3
+        row.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(row)
+        NSLayoutConstraint.activate([
+            row.leadingAnchor.constraint(equalTo: card.layoutMarginsGuide.leadingAnchor),
+            row.trailingAnchor.constraint(equalTo: card.layoutMarginsGuide.trailingAnchor),
+            row.topAnchor.constraint(equalTo: card.layoutMarginsGuide.topAnchor),
+            row.bottomAnchor.constraint(equalTo: card.layoutMarginsGuide.bottomAnchor)
+        ])
+
+        let wrap = UIStackView(arrangedSubviews: [caps, card])
+        wrap.axis = .vertical
+        wrap.spacing = AppSpacing.sp2
+        wrap.alignment = .fill
+        wrap.translatesAutoresizingMaskIntoConstraints = false
+        return wrap
+    }
+
+    // MARK: - "Код друга"
+
+    private func makeFriendCodeSection() -> UIView {
+        let caps = makeSectionCaps("КОД ДРУГА")
+        let card = SPCard(tone: .surface, padding: AppSpacing.sp3)
+
+        friendCodeField.placeholder = "Например, WAKEUP-7K2"
+        friendCodeField.font = AppFonts.mono(.bold, 16)
+        friendCodeField.textColor = AppColors.fg1
+        friendCodeField.tintColor = AppColors.money500
+        friendCodeField.autocapitalizationType = .allCharacters
+        friendCodeField.autocorrectionType = .no
+        friendCodeField.translatesAutoresizingMaskIntoConstraints = false
+        friendCodeField.addTarget(self, action: #selector(friendCodeChanged(_:)), for: .editingChanged)
+
+        applyButton.translatesAutoresizingMaskIntoConstraints = false
+        applyButton.isEnabled = false
+        applyButton.addTarget(self, action: #selector(applyFriendCodeTapped), for: .touchUpInside)
+
+        let row = UIStackView(arrangedSubviews: [friendCodeField, applyButton])
+        row.axis = .horizontal
+        row.alignment = .center
+        row.spacing = AppSpacing.sp2
+        row.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(row)
+        NSLayoutConstraint.activate([
+            row.leadingAnchor.constraint(equalTo: card.layoutMarginsGuide.leadingAnchor),
+            row.trailingAnchor.constraint(equalTo: card.layoutMarginsGuide.trailingAnchor),
+            row.topAnchor.constraint(equalTo: card.layoutMarginsGuide.topAnchor),
+            row.bottomAnchor.constraint(equalTo: card.layoutMarginsGuide.bottomAnchor),
+            friendCodeField.heightAnchor.constraint(greaterThanOrEqualToConstant: 32)
+        ])
+
+        let hint = UILabel()
+        hint.text = "Можно ввести один раз. Бонус начисляется обоим, когда вы продержитесь 7 дней."
+        hint.font = AppTypography.meta
+        hint.textColor = AppColors.fg4
+        hint.numberOfLines = 0
+        hint.translatesAutoresizingMaskIntoConstraints = false
+
+        let wrap = UIStackView(arrangedSubviews: [caps, card, hint])
+        wrap.axis = .vertical
+        wrap.spacing = AppSpacing.sp2
+        wrap.alignment = .fill
+        wrap.translatesAutoresizingMaskIntoConstraints = false
+        return wrap
+    }
+
+    // MARK: - Friends list
+
+    private func makeFriendsSection() -> UIView {
+        let caps = makeSectionCaps("ДРУЗЬЯ")
+        let card = SPCard(tone: .surface, padding: AppSpacing.sp1)
+
+        // 1pt padding around the SPRow stack — rows already pay their own
+        // 16pt internal padding, so the card just wraps the divider rhythm.
+        let rowMasha = makeFriendRow(
+            FriendRowSpec(
+                initial: "М",
+                badgeColor: nil,
+                badgeGradient: SPSupport.moneyGradientColors,
+                badgeTextColor: AppColors.fgOnMoney,
+                title: "Маша К.",
+                subtitle: "Продержалась 7 дней",
+                trailing: makeAmountLabel(text: "+200 ₽", color: AppColors.money400),
+                divider: true
+            )
+        )
+        let rowDima = makeFriendRow(
+            FriendRowSpec(
+                initial: "Д",
+                badgeColor: UIColor(hex: 0xC97A06).withAlphaComponent(0.6),
+                badgeGradient: nil,
+                badgeTextColor: AppColors.warn300,
+                title: "Дима Р.",
+                subtitle: "День 4 из 7",
+                trailing: makeMetaLabel(text: "скоро", color: AppColors.warn400),
+                divider: true
+            )
+        )
+        let rowAnya = makeFriendRow(
+            FriendRowSpec(
+                initial: "А",
+                badgeColor: AppColors.whiteOverlay08,
+                badgeGradient: nil,
+                badgeTextColor: AppColors.fg3,
+                title: "Аня С.",
+                subtitle: "День 1 из 7",
+                trailing: makeMetaLabel(text: "в процессе", color: AppColors.fg3),
+                divider: false
+            )
+        )
+
+        let rows = UIStackView(arrangedSubviews: [rowMasha, rowDima, rowAnya])
+        rows.axis = .vertical
+        rows.spacing = 0
+        rows.alignment = .fill
+        rows.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(rows)
+        NSLayoutConstraint.activate([
+            rows.leadingAnchor.constraint(equalTo: card.layoutMarginsGuide.leadingAnchor),
+            rows.trailingAnchor.constraint(equalTo: card.layoutMarginsGuide.trailingAnchor),
+            rows.topAnchor.constraint(equalTo: card.layoutMarginsGuide.topAnchor),
+            rows.bottomAnchor.constraint(equalTo: card.layoutMarginsGuide.bottomAnchor)
+        ])
+
+        let wrap = UIStackView(arrangedSubviews: [caps, card])
+        wrap.axis = .vertical
+        wrap.spacing = AppSpacing.sp2
+        wrap.alignment = .fill
+        wrap.translatesAutoresizingMaskIntoConstraints = false
+        return wrap
+    }
+
+    /// Spec bundle for a single row in the "Друзья" list. Wraps the 8
+    /// parameters that previously sat on `makeFriendRow(...)` so SwiftLint's
+    /// `function_parameter_count` ceiling stays happy.
+    private struct FriendRowSpec {
+        let initial: String
+        let badgeColor: UIColor?
+        let badgeGradient: [CGColor]?
+        let badgeTextColor: UIColor
+        let title: String
+        let subtitle: String
+        let trailing: UIView
+        let divider: Bool
+    }
+
+    private func makeFriendRow(_ spec: FriendRowSpec) -> UIView {
+        let badge = UIView()
+        badge.translatesAutoresizingMaskIntoConstraints = false
+        badge.layer.cornerRadius = 18
+        badge.layer.masksToBounds = true
+        NSLayoutConstraint.activate([
+            badge.widthAnchor.constraint(equalToConstant: 36),
+            badge.heightAnchor.constraint(equalToConstant: 36)
+        ])
+        if let gradient = spec.badgeGradient {
+            let layer = CAGradientLayer()
+            layer.colors = gradient
+            layer.locations = SPSupport.moneyGradientLocations
+            layer.startPoint = SPSupport.gradientStart
+            layer.endPoint = SPSupport.gradientEnd
+            layer.cornerRadius = 18
+            badge.layer.insertSublayer(layer, at: 0)
+            DispatchQueue.main.async {
+                layer.frame = badge.bounds
+            }
+        } else {
+            badge.backgroundColor = spec.badgeColor
+        }
+        let initialLabel = UILabel()
+        initialLabel.text = spec.initial
+        initialLabel.font = AppTypography.h4
+        initialLabel.textColor = spec.badgeTextColor
+        initialLabel.textAlignment = .center
+        initialLabel.translatesAutoresizingMaskIntoConstraints = false
+        badge.addSubview(initialLabel)
+        NSLayoutConstraint.activate([
+            initialLabel.centerXAnchor.constraint(equalTo: badge.centerXAnchor),
+            initialLabel.centerYAnchor.constraint(equalTo: badge.centerYAnchor)
+        ])
+
+        return SPRow(
+            title: spec.title,
+            subtitle: spec.subtitle,
+            leading: badge,
+            trailing: spec.trailing,
+            divider: spec.divider
+        )
+    }
+
+    // MARK: - Bottom CTA
+
+    private func makeShareButton() -> UIView {
+        let button = SPButton(
+            title: "Поделиться кодом",
+            variant: .money,
+            size: .lg,
+            fullWidth: true
+        )
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(shareTapped), for: .touchUpInside)
+        return button
+    }
+
+    // MARK: - Helpers
+
+    private func makeSectionCaps(_ text: String) -> UILabel {
+        let label = UILabel()
+        label.attributedText = NSAttributedString(
+            string: text,
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.fg3
+            ]
+        )
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }
+
+    private func makeAmountLabel(text: String, color: UIColor) -> UILabel {
+        let label = UILabel()
+        label.font = AppTypography.moneySm
+        label.textColor = color
+        label.text = text
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }
+
+    private func makeMetaLabel(text: String, color: UIColor) -> UILabel {
+        let label = UILabel()
+        label.font = AppTypography.meta
+        label.textColor = color
+        label.text = text
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }
+
+    // MARK: - Actions
+
+    @objc private func copyCodeTapped(_ sender: SPButton) {
+        UIPasteboard.general.string = Self.personalCode
+        // Tiny in-place success cue — flip the title for ~1.4 s.
+        // (SPButton has no public title setter post-init; recreate trivially
+        //  via a one-shot UIView animation on the existing instance would
+        //  require a hook we don't have, so we surface feedback via haptics
+        //  only and let the user see "Скопировано" on the pasteboard.)
+        let generator = UINotificationFeedbackGenerator()
+        generator.notificationOccurred(.success)
+    }
+
+    @objc private func friendCodeChanged(_ sender: UITextField) {
+        if let text = sender.text {
+            sender.text = text.uppercased()
+            applyButton.isEnabled = !text.isEmpty
+        } else {
+            applyButton.isEnabled = false
+        }
+    }
+
+    @objc private func applyFriendCodeTapped() {
+        // No backend yet — surface a confirmation alert so the user sees the
+        // tap registered.
+        let alert = UIAlertController(
+            title: "Код применён",
+            message: "Бонус начислится, когда вы продержитесь 7 дней без откладываний.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
+    }
+
+    @objc private func shareTapped() {
+        let text = "Снузь меньше — копи больше. Используй мой код в SnoozePay: "
+            + "\(Self.personalCode) — оба получим +200 ₽ на баланс."
+        let activity = UIActivityViewController(activityItems: [text], applicationActivities: nil)
+        activity.popoverPresentationController?.sourceView = view
+        activity.popoverPresentationController?.sourceRect = view.bounds
+        present(activity, animated: true)
+    }
+}
+
+// MARK: - UIColor hex helper
+
+private extension UIColor {
+    convenience init(hex: UInt32, alpha: CGFloat = 1) {
+        let red = CGFloat((hex >> 16) & 0xFF) / 255.0
+        let green = CGFloat((hex >> 8) & 0xFF) / 255.0
+        let blue = CGFloat(hex & 0xFF) / 255.0
+        self.init(red: red, green: green, blue: blue, alpha: alpha)
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsViewController+Cards.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsViewController+Cards.swift
@@ -1,40 +1,246 @@
 import UIKit
 import SwiftUI
 
-/// Card-builder helpers for `StatisticsViewController`.
+/// Card-builder helpers for `StatisticsViewController` (V2 design).
 ///
 /// Lifted into an extension so the main type body stays under SwiftLint's
 /// `type_body_length` ceiling. Each `make…()` returns a fully-laid-out
-/// `SPCard`-rooted view ready for insertion into `dataStack`. The factories
-/// are non-private so the controller can call them from another file —
-/// internal access is enough to keep them out of the module's public surface.
+/// `SPCard`-rooted view ready for insertion into `dataStack`.
 extension StatisticsViewController {
 
-    // MARK: - Summary row
+    // MARK: - Hero "Серия" card
 
-    /// Two-column summary row: pain-tinted "Потрачено" + neutral "Откладываний".
-    /// Returns a horizontal `UIStackView` rather than a single SPCard so the
-    /// two values can sit side-by-side without nesting cards inside cards.
-    func makeSummaryRow() -> UIView {
-        let leftCard = makeSummaryTile(caption: "Потрачено", valueLabel: spentAmountLabel)
-        let rightCard = makeSummaryTile(caption: "Откладываний", valueLabel: snoozeCountLabel)
-        let row = UIStackView(arrangedSubviews: [leftCard, rightCard])
+    /// Top hero card — caps "Серия" + huge mono streak count + flame badge
+    /// on the right, and the GitHub-style heatmap rendered below the divider.
+    /// Tapping anywhere on the card triggers `streakTapped()`.
+    func makeHeroStreakCard() -> UIView {
+        let card = SPCard(tone: .raised, padding: AppSpacing.sp6, cornerRadius: AppRadius.xl)
+        let topRow = makeHeroTopRow()
+        let heatStack = makeHeroHeatmapStack()
+        let outer = UIStackView(arrangedSubviews: [topRow, heatStack])
+        outer.axis = .vertical
+        outer.spacing = AppSpacing.sp5
+        outer.alignment = .fill
+        outer.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(outer)
+        NSLayoutConstraint.activate([
+            outer.leadingAnchor.constraint(equalTo: card.layoutMarginsGuide.leadingAnchor),
+            outer.trailingAnchor.constraint(equalTo: card.layoutMarginsGuide.trailingAnchor),
+            outer.topAnchor.constraint(equalTo: card.layoutMarginsGuide.topAnchor),
+            outer.bottomAnchor.constraint(equalTo: card.layoutMarginsGuide.bottomAnchor)
+        ])
+        let tap = UITapGestureRecognizer(target: self, action: #selector(streakTapped))
+        card.addGestureRecognizer(tap)
+        card.isUserInteractionEnabled = true
+        return card
+    }
+
+    /// Top row of the hero card — text column on the left, flame badge on the
+    /// right. Lifted out of `makeHeroStreakCard` to keep function bodies
+    /// under SwiftLint's 60-line ceiling.
+    private func makeHeroTopRow() -> UIView {
+        let caps = makeCapsLabel("СЕРИЯ", color: AppColors.warn300)
+        let numberRow = UIStackView(arrangedSubviews: [streakBigLabel, streakBigWordLabel])
+        numberRow.axis = .horizontal
+        numberRow.alignment = .firstBaseline
+        numberRow.spacing = AppSpacing.sp2
+        numberRow.translatesAutoresizingMaskIntoConstraints = false
+
+        let textStack = UIStackView(arrangedSubviews: [caps, numberRow, streakMetaLabel])
+        textStack.axis = .vertical
+        textStack.spacing = AppSpacing.sp1
+        textStack.alignment = .leading
+        textStack.setCustomSpacing(AppSpacing.sp2, after: numberRow)
+        textStack.translatesAutoresizingMaskIntoConstraints = false
+
+        let row = UIStackView(arrangedSubviews: [textStack, makeFlameBadge()])
         row.axis = .horizontal
-        row.spacing = AppSpacing.sp3
-        row.distribution = .fillEqually
+        row.alignment = .top
+        row.spacing = AppSpacing.sp4
         row.translatesAutoresizingMaskIntoConstraints = false
         return row
     }
 
-    /// One tile inside the summary row — caps caption above a `moneyMd`
-    /// numeric value, both inside an `SPCard(.surface)` with the standard
-    /// 16pt internal padding.
-    func makeSummaryTile(caption: String, valueLabel: UILabel) -> UIView {
-        let card = SPCard(tone: .surface, padding: AppSpacing.sp4)
+    /// Heatmap section of the hero card — caps caption + heatmap grid + a
+    /// "раньше · сегодня" range hint row underneath.
+    private func makeHeroHeatmapStack() -> UIView {
+        let heatmapCaps = makeCapsLabel("КАЛЕНДАРЬ ОТКЛАДЫВАНИЙ", color: AppColors.fg3)
+        let rangeLeft = makeMetaLabel("раньше", alignment: .left)
+        let rangeRight = makeMetaLabel("сегодня", alignment: .right)
+        let rangeRow = UIStackView(arrangedSubviews: [rangeLeft, rangeRight])
+        rangeRow.axis = .horizontal
+        rangeRow.distribution = .fillEqually
+        rangeRow.translatesAutoresizingMaskIntoConstraints = false
 
+        let stack = UIStackView(arrangedSubviews: [heatmapCaps, heatmapView, rangeRow])
+        stack.axis = .vertical
+        stack.spacing = AppSpacing.sp2
+        stack.alignment = .fill
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }
+
+    /// Convenience caps-styled label constructor used across the hero card.
+    private func makeCapsLabel(_ text: String, color: UIColor) -> UILabel {
+        let label = UILabel()
+        label.attributedText = NSAttributedString(
+            string: text,
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: color
+            ]
+        )
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }
+
+    /// Meta-styled label constructor — 13pt fg3 with configurable alignment.
+    private func makeMetaLabel(_ text: String, alignment: NSTextAlignment) -> UILabel {
+        let label = UILabel()
+        label.font = AppTypography.meta
+        label.textColor = AppColors.fg3
+        label.text = text
+        label.textAlignment = alignment
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }
+
+    /// 56×56 rounded square with the warn gradient + flame icon. Matches
+    /// the JSX recipe (radius 18, warn gradient, warn-tinted shadow).
+    private func makeFlameBadge() -> UIView {
+        let container = UIView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+        container.layer.cornerRadius = 18
+        container.layer.masksToBounds = false
+        container.layer.shadowColor = AppColors.warn500.cgColor
+        container.layer.shadowOpacity = 0.30
+        container.layer.shadowOffset = CGSize(width: 0, height: 8)
+        container.layer.shadowRadius = 16
+
+        let gradient = CAGradientLayer()
+        gradient.colors = SPSupport.warnGradientColors
+        gradient.locations = SPSupport.warnGradientLocations
+        gradient.startPoint = SPSupport.gradientStart
+        gradient.endPoint = SPSupport.gradientEnd
+        gradient.cornerRadius = 18
+        container.layer.insertSublayer(gradient, at: 0)
+
+        let flame = UIImageView(
+            image: UIImage(
+                systemName: "flame.fill",
+                withConfiguration: UIImage.SymbolConfiguration(pointSize: 26, weight: .semibold)
+            )
+        )
+        flame.tintColor = AppColors.fgOnWarn
+        flame.contentMode = .scaleAspectFit
+        flame.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(flame)
+        NSLayoutConstraint.activate([
+            container.widthAnchor.constraint(equalToConstant: 56),
+            container.heightAnchor.constraint(equalToConstant: 56),
+            flame.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+            flame.centerYAnchor.constraint(equalTo: container.centerYAnchor)
+        ])
+
+        // Resize the gradient sublayer on layout so it tracks bounds even when
+        // the badge gets repositioned by stacks.
+        container.layoutIfNeeded()
+        DispatchQueue.main.async {
+            gradient.frame = container.bounds
+        }
+        return container
+    }
+
+    // MARK: - Weekly bar-chart card
+
+    /// "Эта неделя" — caps + meta hint + Apple-Charts bar chart + summary row
+    /// with Сэкономили / Потратили / Чистый. Wrapped in an `SPCard(.surface)`.
+    func makeWeeklyCard() -> UIView {
+        let card = SPCard(tone: .surface, padding: AppSpacing.sp5)
+
+        let caps = UILabel()
+        caps.attributedText = NSAttributedString(
+            string: "ЭТА НЕДЕЛЯ",
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.fg3
+            ]
+        )
+        caps.translatesAutoresizingMaskIntoConstraints = false
+
+        let hint = UILabel()
+        hint.font = AppTypography.meta
+        hint.textColor = AppColors.fg3
+        hint.text = "зелёное — копится · красное — теряется"
+        hint.numberOfLines = 0
+        hint.translatesAutoresizingMaskIntoConstraints = false
+
+        // Hosting controller for the SwiftUI chart.
+        let chartView = WeekdayChartView(bars: [])
+        let hosting = UIHostingController(rootView: chartView)
+        hosting.view.translatesAutoresizingMaskIntoConstraints = false
+        hosting.view.backgroundColor = .clear
+        addChild(hosting)
+        hosting.didMove(toParent: self)
+        chartHostingController = hosting
+
+        let topRow = UIStackView(arrangedSubviews: [caps, hint])
+        topRow.axis = .vertical
+        topRow.alignment = .leading
+        topRow.spacing = AppSpacing.sp1
+        topRow.translatesAutoresizingMaskIntoConstraints = false
+
+        // Summary row — 3 columns with caps caption + mono number.
+        let summary = makeWeeklySummaryRow()
+
+        let stack = UIStackView(arrangedSubviews: [topRow, hosting.view, summary])
+        stack.axis = .vertical
+        stack.spacing = AppSpacing.sp4
+        stack.alignment = .fill
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        card.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: card.layoutMarginsGuide.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: card.layoutMarginsGuide.trailingAnchor),
+            stack.topAnchor.constraint(equalTo: card.layoutMarginsGuide.topAnchor),
+            stack.bottomAnchor.constraint(equalTo: card.layoutMarginsGuide.bottomAnchor),
+            hosting.view.heightAnchor.constraint(equalToConstant: 140)
+        ])
+        return card
+    }
+
+    private func makeWeeklySummaryRow() -> UIView {
+        let separator = UIView()
+        separator.backgroundColor = AppColors.stroke1
+        separator.translatesAutoresizingMaskIntoConstraints = false
+        separator.heightAnchor.constraint(equalToConstant: 1).isActive = true
+
+        let savedColumn = makeSummaryColumn(caption: "СЭКОНОМИЛИ", valueLabel: savedAmountLabel)
+        let spentColumn = makeSummaryColumn(caption: "ПОТРАТИЛИ", valueLabel: spentAmountLabel)
+        let netColumn = makeSummaryColumn(caption: "ЧИСТЫЙ", valueLabel: netAmountLabel)
+
+        let columns = UIStackView(arrangedSubviews: [savedColumn, spentColumn, netColumn])
+        columns.axis = .horizontal
+        columns.distribution = .fillEqually
+        columns.alignment = .top
+        columns.spacing = AppSpacing.sp2
+        columns.translatesAutoresizingMaskIntoConstraints = false
+
+        let wrap = UIStackView(arrangedSubviews: [separator, columns])
+        wrap.axis = .vertical
+        wrap.spacing = AppSpacing.sp4
+        wrap.alignment = .fill
+        wrap.translatesAutoresizingMaskIntoConstraints = false
+        return wrap
+    }
+
+    private func makeSummaryColumn(caption: String, valueLabel: UILabel) -> UIView {
         let captionLabel = UILabel()
         captionLabel.attributedText = NSAttributedString(
-            string: caption.uppercased(),
+            string: caption,
             attributes: [
                 .font: AppTypography.caps,
                 .kern: AppTypography.capsKerning,
@@ -45,140 +251,139 @@ extension StatisticsViewController {
 
         let stack = UIStackView(arrangedSubviews: [captionLabel, valueLabel])
         stack.axis = .vertical
-        stack.spacing = AppSpacing.sp2
+        stack.spacing = 2
         stack.alignment = .leading
         stack.translatesAutoresizingMaskIntoConstraints = false
-        card.addSubview(stack)
-        NSLayoutConstraint.activate([
-            stack.leadingAnchor.constraint(equalTo: card.layoutMarginsGuide.leadingAnchor),
-            stack.trailingAnchor.constraint(equalTo: card.layoutMarginsGuide.trailingAnchor),
-            stack.topAnchor.constraint(equalTo: card.layoutMarginsGuide.topAnchor),
-            stack.bottomAnchor.constraint(equalTo: card.layoutMarginsGuide.bottomAnchor)
-        ])
-        return card
+        return stack
     }
 
-    // MARK: - Heatmap
+    // MARK: - Wake-time card
 
-    /// Heatmap card — title + 7-column heatmap grid wrapped in an SPCard.
-    func makeHeatmapCard() -> UIView {
-        let card = SPCard(tone: .surface, padding: AppSpacing.sp4)
-        let titleLabel = UILabel()
-        titleLabel.text = "Календарь"
-        titleLabel.font = AppTypography.h4
-        titleLabel.textColor = AppColors.fg1
-        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+    /// "Время подъёма" — three averaged mono numbers (В среднем / Раньше было /
+    /// Раньше на). Until the wake-time ledger lands the values render `--`
+    /// so the card still surfaces in the V2 layout.
+    func makeWakeTimeCard() -> UIView {
+        let card = SPCard(tone: .surface, padding: AppSpacing.sp5)
 
-        let stack = UIStackView(arrangedSubviews: [titleLabel, heatmapView])
-        stack.axis = .vertical
-        stack.spacing = AppSpacing.sp3
-        stack.alignment = .fill
-        stack.translatesAutoresizingMaskIntoConstraints = false
-
-        card.addSubview(stack)
-        NSLayoutConstraint.activate([
-            stack.leadingAnchor.constraint(equalTo: card.layoutMarginsGuide.leadingAnchor),
-            stack.trailingAnchor.constraint(equalTo: card.layoutMarginsGuide.trailingAnchor),
-            stack.topAnchor.constraint(equalTo: card.layoutMarginsGuide.topAnchor),
-            stack.bottomAnchor.constraint(equalTo: card.layoutMarginsGuide.bottomAnchor)
-        ])
-        return card
-    }
-
-    // MARK: - Chart
-
-    /// Chart card — title + Apple-Charts bar chart wrapped in an SPCard.
-    /// Stores the hosting controller on the VC so `refresh()` can swap the
-    /// rootView when the period changes without re-building the SwiftUI
-    /// hierarchy.
-    func makeChartCard() -> UIView {
-        let card = SPCard(tone: .surface, padding: AppSpacing.sp4)
-        let titleLabel = UILabel()
-        titleLabel.text = "Средний штраф по дням"
-        titleLabel.font = AppTypography.h4
-        titleLabel.textColor = AppColors.fg1
-        titleLabel.translatesAutoresizingMaskIntoConstraints = false
-
-        let chartView = WeekdayChartView(bars: [])
-        let hosting = UIHostingController(rootView: chartView)
-        hosting.view.translatesAutoresizingMaskIntoConstraints = false
-        hosting.view.backgroundColor = .clear
-        addChild(hosting)
-        hosting.didMove(toParent: self)
-        chartHostingController = hosting
-
-        let stack = UIStackView(arrangedSubviews: [titleLabel, hosting.view])
-        stack.axis = .vertical
-        stack.spacing = AppSpacing.sp3
-        stack.alignment = .fill
-        stack.translatesAutoresizingMaskIntoConstraints = false
-
-        card.addSubview(stack)
-        NSLayoutConstraint.activate([
-            stack.leadingAnchor.constraint(equalTo: card.layoutMarginsGuide.leadingAnchor),
-            stack.trailingAnchor.constraint(equalTo: card.layoutMarginsGuide.trailingAnchor),
-            stack.topAnchor.constraint(equalTo: card.layoutMarginsGuide.topAnchor),
-            stack.bottomAnchor.constraint(equalTo: card.layoutMarginsGuide.bottomAnchor),
-            hosting.view.heightAnchor.constraint(equalToConstant: 200)
-        ])
-        return card
-    }
-
-    // MARK: - Streak
-
-    /// Tappable streak card — flame icon + caption + current/best lines +
-    /// trailing chevron. Tapping anywhere on the card triggers
-    /// `streakTapped()` which presents `StreakModalViewController`.
-    func makeStreakCard() -> UIView {
-        let card = SPCard(tone: .surface, padding: AppSpacing.sp4)
-
-        let flameConfig = UIImage.SymbolConfiguration(pointSize: 24, weight: .semibold)
-        let flameView = UIImageView(image: UIImage(systemName: "flame.fill", withConfiguration: flameConfig))
-        flameView.tintColor = AppColors.money500
-        flameView.translatesAutoresizingMaskIntoConstraints = false
-        flameView.setContentHuggingPriority(.required, for: .horizontal)
-
-        let titleCaption = UILabel()
-        titleCaption.attributedText = NSAttributedString(
-            string: "ТЕКУЩАЯ СЕРИЯ",
+        let caps = UILabel()
+        caps.attributedText = NSAttributedString(
+            string: "ВРЕМЯ ПОДЪЁМА",
             attributes: [
                 .font: AppTypography.caps,
                 .kern: AppTypography.capsKerning,
                 .foregroundColor: AppColors.fg3
             ]
         )
-        titleCaption.translatesAutoresizingMaskIntoConstraints = false
+        caps.translatesAutoresizingMaskIntoConstraints = false
 
-        let textStack = UIStackView(arrangedSubviews: [titleCaption, streakValueLabel, streakBestLabel])
-        textStack.axis = .vertical
-        textStack.spacing = AppSpacing.sp1
-        textStack.alignment = .leading
-        textStack.translatesAutoresizingMaskIntoConstraints = false
-
-        let chevron = UIImageView(image: UIImage(systemName: "chevron.right"))
-        chevron.tintColor = AppColors.fg3
-        chevron.translatesAutoresizingMaskIntoConstraints = false
-        chevron.setContentHuggingPriority(.required, for: .horizontal)
-
-        let row = UIStackView(arrangedSubviews: [flameView, textStack, chevron])
-        row.axis = .horizontal
-        row.spacing = AppSpacing.sp3
-        row.alignment = .center
-        row.translatesAutoresizingMaskIntoConstraints = false
-
-        card.addSubview(row)
-        NSLayoutConstraint.activate([
-            row.leadingAnchor.constraint(equalTo: card.layoutMarginsGuide.leadingAnchor),
-            row.trailingAnchor.constraint(equalTo: card.layoutMarginsGuide.trailingAnchor),
-            row.topAnchor.constraint(equalTo: card.layoutMarginsGuide.topAnchor),
-            row.bottomAnchor.constraint(equalTo: card.layoutMarginsGuide.bottomAnchor),
-            flameView.widthAnchor.constraint(equalToConstant: 32),
-            flameView.heightAnchor.constraint(equalToConstant: 32)
+        let columns = UIStackView(arrangedSubviews: [
+            wakeColumn(caption: "В СРЕДНЕМ", value: "--", valueColor: AppColors.fg1),
+            wakeColumn(
+                caption: "РАНЬШЕ БЫЛО",
+                value: "--",
+                valueColor: AppColors.fg3,
+                strike: true
+            ),
+            wakeColumn(caption: "РАНЬШЕ НА", value: "--", valueColor: AppColors.money400)
         ])
+        columns.axis = .horizontal
+        columns.distribution = .fillEqually
+        columns.alignment = .top
+        columns.spacing = AppSpacing.sp2
+        columns.translatesAutoresizingMaskIntoConstraints = false
 
-        let tap = UITapGestureRecognizer(target: self, action: #selector(streakTapped))
-        card.addGestureRecognizer(tap)
-        card.isUserInteractionEnabled = true
+        let stack = UIStackView(arrangedSubviews: [caps, columns])
+        stack.axis = .vertical
+        stack.spacing = AppSpacing.sp3
+        stack.alignment = .fill
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        card.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: card.layoutMarginsGuide.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: card.layoutMarginsGuide.trailingAnchor),
+            stack.topAnchor.constraint(equalTo: card.layoutMarginsGuide.topAnchor),
+            stack.bottomAnchor.constraint(equalTo: card.layoutMarginsGuide.bottomAnchor)
+        ])
         return card
     }
+
+    private func wakeColumn(
+        caption: String,
+        value: String,
+        valueColor: UIColor,
+        strike: Bool = false
+    ) -> UIView {
+        let captionLabel = UILabel()
+        captionLabel.attributedText = NSAttributedString(
+            string: caption,
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.fg3
+            ]
+        )
+        captionLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        let valueLabel = UILabel()
+        valueLabel.font = AppTypography.moneySm
+        valueLabel.textColor = valueColor
+        if strike {
+            valueLabel.attributedText = NSAttributedString(
+                string: value,
+                attributes: [
+                    .font: AppTypography.moneySm,
+                    .foregroundColor: valueColor,
+                    .strikethroughStyle: NSUnderlineStyle.single.rawValue,
+                    .strikethroughColor: valueColor
+                ]
+            )
+        } else {
+            valueLabel.text = value
+        }
+        valueLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        let stack = UIStackView(arrangedSubviews: [captionLabel, valueLabel])
+        stack.axis = .vertical
+        stack.spacing = 2
+        stack.alignment = .leading
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }
+
+    // MARK: - Debug
+
+    #if DEBUG
+    /// Three-row DEBUG section that exposes the StreakModalV2 / Referral /
+    /// AlarmOff modals while we don't have real trigger plumbing. Drops out
+    /// of release builds via the `#if DEBUG` gate.
+    func makeDebugButtonsRow() -> UIView {
+        let caps = UILabel()
+        caps.attributedText = NSAttributedString(
+            string: "DEBUG · MODALS",
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.fg3
+            ]
+        )
+        caps.translatesAutoresizingMaskIntoConstraints = false
+
+        let streakBtn = SPButton(title: "Streak modal", variant: .money, size: .md, fullWidth: true)
+        streakBtn.addTarget(self, action: #selector(debugStreakTapped), for: .touchUpInside)
+
+        let referralBtn = SPButton(title: "Реферальная программа", variant: .quiet, size: .md, fullWidth: true)
+        referralBtn.addTarget(self, action: #selector(debugReferralTapped), for: .touchUpInside)
+
+        let alarmOffBtn = SPButton(title: "AlarmOff warning", variant: .pain, size: .md, fullWidth: true)
+        alarmOffBtn.addTarget(self, action: #selector(debugAlarmOffTapped), for: .touchUpInside)
+
+        let stack = UIStackView(arrangedSubviews: [caps, streakBtn, referralBtn, alarmOffBtn])
+        stack.axis = .vertical
+        stack.spacing = AppSpacing.sp2
+        stack.alignment = .fill
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }
+    #endif
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsViewController.swift
@@ -2,26 +2,23 @@ import UIKit
 import SwiftUI
 import Charts
 
-/// Statistics screen — design-refresh 2026-04-27 rewrite (#147).
-///
-/// Vertical stack of:
+/// Statistics screen — V2 design (`docs/design/v2-handoff/components/SPMore4.jsx`
+/// `Stats()` lines 6-120). Vertical stack of:
 ///   1. Period segmented (Неделя / Месяц / Всё время) — drives the VM.
-///   2. Two-column summary (Потрачено · Откладываний) on `SPCard(.surface)`s
-///      with caps + moneyMd typography.
-///   3. GitHub-style heatmap calendar — 7 columns × N rows of money-tinted
-///      squares. Tap a square → toast with date + amount.
-///   4. Apple-Charts bar chart of average penalty by weekday (Пн → Вс).
-///   5. Streak SPCard with 🔥 + current days + lifetime best — tap to open
-///      `StreakModalViewController`.
-///   6. Empty state when there are no transactions in the selected period.
+///   2. Hero "Серия" card on `SPCard(.raised)` — caps + huge mono streak
+///      count + flame badge + GitHub-style heatmap below.
+///   3. "Эта неделя" bar-chart card (`SPCard(.surface)`) with money/pain bars
+///      per weekday + a small summary row (Сэкономили / Потратили / Чистый).
+///   4. "Время подъёма" card with three averaged numbers — V2 spec
+///      placeholders; values fall back to `--` while we have no wake-time
+///      ledger.
+///   5. Empty state when there are no transactions in the selected period.
+///   6. DEBUG buttons for presenting StreakModalV2, ReferralVC, AlarmOff —
+///      gated behind `#if DEBUG` so production builds drop them.
 ///
-/// Backed by the existing `StatisticsViewModel`; new heatmap / weekday-bar /
-/// `hasData` accessors land in the same file so the chart, heatmap, streak
-/// card, and empty state all read from one source of truth.
-///
-/// Card-building helpers (`makeSummaryRow()`, `makeHeatmapCard()`, ...) live
-/// in `StatisticsViewController+Cards.swift` so the main type body stays
-/// under SwiftLint's `type_body_length` ceiling.
+/// Backed by `StatisticsViewModel`. Card-building helpers live in
+/// `StatisticsViewController+Cards.swift` so the main type body stays under
+/// SwiftLint's `type_body_length` ceiling.
 final class StatisticsViewController: UIViewController {
 
     // MARK: - ViewModel
@@ -32,8 +29,8 @@ final class StatisticsViewController: UIViewController {
 
     let scrollView = UIScrollView()
     let contentStack = UIStackView()
-    /// Stack of "data" sections (summary + heatmap + chart + streak).
-    /// Hidden as a unit when the empty state takes over.
+    /// Stack of "data" sections (hero, bars, time). Hidden as a unit when the
+    /// empty state takes over.
     let dataStack = UIStackView()
     var emptyStateView: StatisticsEmptyStateView?
 
@@ -54,26 +51,35 @@ final class StatisticsViewController: UIViewController {
         return segment
     }()
 
-    // MARK: - Summary tiles
+    // MARK: - Hero "Серия"
 
-    /// Pain-tinted "Потрачено" amount. Drawn with the pain-text gradient via
-    /// `UILabel.applyGradientMask(_:)` so the value glyphs track the brand
-    /// red sweep.
-    let spentAmountLabel: UILabel = {
+    /// Big mono streak count drawn at `moneyLg` (32pt). Sits inside the hero
+    /// raised SPCard alongside the heatmap.
+    let streakBigLabel: UILabel = {
         let label = UILabel()
-        label.font = AppTypography.moneyMd
+        label.font = AppTypography.moneyLg
         label.textColor = AppColors.fg1
         label.adjustsFontForContentSizeCategory = false
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
-    let spentGradientLayer = CAGradientLayer()
 
-    let snoozeCountLabel: UILabel = {
+    /// Trailing "дня / дней / день" word next to the big streak number.
+    let streakBigWordLabel: UILabel = {
         let label = UILabel()
-        label.font = AppTypography.moneyMd
-        label.textColor = AppColors.fg1
-        label.adjustsFontForContentSizeCategory = false
+        label.font = AppTypography.h3
+        label.textColor = AppColors.fg3
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    /// Meta line below the streak count — "Последний срыв: 8 января" /
+    /// "Лучший результат: 12 дней".
+    let streakMetaLabel: UILabel = {
+        let label = UILabel()
+        label.font = AppTypography.meta
+        label.textColor = AppColors.fg3
+        label.numberOfLines = 0
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
@@ -102,25 +108,33 @@ final class StatisticsViewController: UIViewController {
         return label
     }()
 
-    // MARK: - Bar chart
+    // MARK: - Weekly bar chart
 
     var chartHostingController: UIHostingController<WeekdayChartView>?
 
-    // MARK: - Streak card
-
-    let streakValueLabel: UILabel = {
+    /// "Сэкономили" — money tinted.
+    let savedAmountLabel: UILabel = {
         let label = UILabel()
-        label.font = AppTypography.moneyMd
-        label.textColor = AppColors.fg1
+        label.font = AppTypography.moneySm
+        label.textColor = AppColors.money400
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
 
-    let streakBestLabel: UILabel = {
+    /// "Потратили" — pain tinted.
+    let spentAmountLabel: UILabel = {
         let label = UILabel()
-        label.font = AppTypography.meta
-        label.textColor = AppColors.fg3
-        label.numberOfLines = 0
+        label.font = AppTypography.moneySm
+        label.textColor = AppColors.pain400
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    /// "Чистый" — fg1 neutral.
+    let netAmountLabel: UILabel = {
+        let label = UILabel()
+        label.font = AppTypography.moneySm
+        label.textColor = AppColors.fg1
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
@@ -132,7 +146,6 @@ final class StatisticsViewController: UIViewController {
         title = "Статистика"
         navigationController?.navigationBar.prefersLargeTitles = true
         view.backgroundColor = AppColors.bg0
-        configureGradientLayers()
         setupLayout()
         bindViewModel()
     }
@@ -144,19 +157,7 @@ final class StatisticsViewController: UIViewController {
         viewModel.loadData(period: period)
     }
 
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        spentAmountLabel.applyGradientMask(spentGradientLayer)
-    }
-
     // MARK: - Setup
-
-    private func configureGradientLayers() {
-        spentGradientLayer.colors = SPSupport.painGradientColors
-        spentGradientLayer.locations = SPSupport.painGradientLocations
-        spentGradientLayer.startPoint = SPSupport.gradientStart
-        spentGradientLayer.endPoint = SPSupport.gradientEnd
-    }
 
     private func setupLayout() {
         configureContainers()
@@ -164,10 +165,12 @@ final class StatisticsViewController: UIViewController {
         installToastConstraints()
         contentStack.addArrangedSubview(periodSegment)
         contentStack.addArrangedSubview(dataStack)
-        dataStack.addArrangedSubview(makeSummaryRow())
-        dataStack.addArrangedSubview(makeHeatmapCard())
-        dataStack.addArrangedSubview(makeChartCard())
-        dataStack.addArrangedSubview(makeStreakCard())
+        dataStack.addArrangedSubview(makeHeroStreakCard())
+        dataStack.addArrangedSubview(makeWeeklyCard())
+        dataStack.addArrangedSubview(makeWakeTimeCard())
+        #if DEBUG
+        dataStack.addArrangedSubview(makeDebugButtonsRow())
+        #endif
         heatmapView.onCellTap = { [weak self] cell in
             self?.presentHeatmapToast(for: cell)
         }
@@ -176,10 +179,10 @@ final class StatisticsViewController: UIViewController {
     private func configureContainers() {
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         contentStack.axis = .vertical
-        contentStack.spacing = AppSpacing.sp5
+        contentStack.spacing = AppSpacing.sp4
         contentStack.translatesAutoresizingMaskIntoConstraints = false
         dataStack.axis = .vertical
-        dataStack.spacing = AppSpacing.sp5
+        dataStack.spacing = AppSpacing.sp3
         dataStack.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(scrollView)
         scrollView.addSubview(contentStack)
@@ -252,12 +255,16 @@ final class StatisticsViewController: UIViewController {
     }
 
     private func refresh() {
-        // Summary row.
-        spentAmountLabel.text = viewModel.totalSpentFormatted
-        snoozeCountLabel.text = viewModel.snoozeCountFormatted
-        // The pain-gradient mask renders the "spent" value glyph-by-glyph;
-        // refresh after text updates so the mask matches the new string.
-        view.setNeedsLayout()
+        // Hero streak card.
+        let streak = viewModel.streak
+        streakBigLabel.text = "\(streak)"
+        streakBigWordLabel.text = StreakModalViewController.dayWord(for: streak)
+        if streak > 0 {
+            streakMetaLabel.text = "Лучший результат: \(viewModel.bestStreak) "
+                + "\(StreakModalViewController.dayWord(for: viewModel.bestStreak))"
+        } else {
+            streakMetaLabel.text = "Серия начнётся, как только вы перестанете откладывать."
+        }
 
         // Heatmap.
         heatmapView.cells = viewModel.heatmapCells
@@ -268,10 +275,18 @@ final class StatisticsViewController: UIViewController {
         }
         chartHostingController?.rootView = WeekdayChartView(bars: chartBars)
 
-        // Streak card.
-        streakValueLabel.text = "\(viewModel.streak) \(StreakModalViewController.dayWord(for: viewModel.streak))"
-        streakBestLabel.text = "Лучший результат: \(viewModel.bestStreak) "
-            + "\(StreakModalViewController.dayWord(for: viewModel.bestStreak))"
+        // Weekly summary numbers — VM exposes `totalSpent` only, so the
+        // "saved" line uses a coarse-but-defendable heuristic: best-streak
+        // days * default penalty for the same period. This matches the
+        // spirit of the V2 JSX (a hero green number) without inventing a
+        // new ledger column.
+        let spent = viewModel.totalSpent
+        let saved = Double(max(viewModel.streak, 0)) * 50.0   // 50 ₽/day fallback
+        let net = saved - spent
+        savedAmountLabel.text = saved > 0 ? "+\(Int(saved)) ₽" : "+0 ₽"
+        spentAmountLabel.text = spent > 0 ? "−\(Int(spent)) ₽" : "0 ₽"
+        let netPrefix = net >= 0 ? "+" : "−"
+        netAmountLabel.text = "\(netPrefix)\(Int(abs(net))) ₽"
 
         // Empty state — VM handles the empty-period detection.
         setEmptyStateVisible(!viewModel.hasData)
@@ -303,15 +318,37 @@ final class StatisticsViewController: UIViewController {
     @objc func streakTapped() {
         let alarms = (try? AlarmRepository.shared.fetchAllChecked()) ?? []
         let saved = StreakModalViewController.estimatedSavings(
-            for: viewModel.streak,
+            for: max(viewModel.streak, 1),
             alarms: alarms
         )
         let modal = StreakModalViewController(
-            streakDays: viewModel.streak,
+            streakDays: max(viewModel.streak, 1),
             savedAmount: saved
         )
         present(modal, animated: true)
     }
+
+    #if DEBUG
+    @objc func debugStreakTapped() {
+        let modal = StreakModalViewController(streakDays: 7, savedAmount: 350)
+        present(modal, animated: true)
+    }
+
+    @objc func debugReferralTapped() {
+        let vc = ReferralViewController()
+        navigationController?.pushViewController(vc, animated: true)
+    }
+
+    @objc func debugAlarmOffTapped() {
+        let vc = AlarmOffWarningViewController()
+        vc.modalPresentationStyle = .pageSheet
+        if let sheet = vc.sheetPresentationController {
+            sheet.detents = [.large()]
+            sheet.preferredCornerRadius = AppRadius.xl
+        }
+        present(vc, animated: true)
+    }
+    #endif
 
     private func createAlarmTapped() {
         let createVC = CreateAlarmViewController(alarm: nil)

--- a/SnoozePay/SnoozePay/ViewControllers/Statistics/StreakModalViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Statistics/StreakModalViewController.swift
@@ -1,33 +1,30 @@
-// swiftlint:disable file_length
 import UIKit
 
-/// Streak celebration modal — section "28 · Streak модалка" in
-/// `docs/design/snoozepay-2026-04-27/project/SnoozePay - All Screens.html`.
+/// Streak celebration modal — V2 design (`docs/design/v2-handoff/components/`
+/// `SPScreensV2.jsx` lines 653-732, `StreakModalV2()`).
 ///
 /// Visual recipe:
-/// - `pageSheet` with a medium detent (~440pt) and a 28pt top corner radius
-///   so the sheet reads as one of the brand `r-sheet` surfaces (matches
-///   `--sp-radius-xl` from `tokens.css`).
-/// - 🔥 flame icon with the money tint at the top.
-/// - Big amount line ("+350 ₽") drawn at `AppTypography.moneyXl` and masked
-///   with the money gradient, reusing the same CALayer + image-mask trick
-///   from `SPBalanceCard.applyValueGradient(...)` so the gradient tracks
-///   the rendered glyph outlines.
-/// - Caption "{D} дней без откладываний" in `AppTypography.body` / `fg2`.
-/// - 7-day visualizer: a horizontal stack of 7 squares.
-///   * `completed` days are filled with the money gradient.
-///   * `today` is outline-only with a 2pt money stroke and the day number
-///     drawn in money tint.
-///   * `future` days fall back to `whiteOverlay08` so they read as muted.
-/// - A primary `SPButton(.money, .lg, fullWidth: true)` "Отлично, продолжаю"
-///   dismisses the sheet.
+/// - Black 92% overlay + radial money green glow background painted over the
+///   underlying screen. Implemented with a custom-presentation host: backdrop
+///   view + sheet card on top.
+/// - Sheet anchored to the bottom with `bg2` fill, 28pt corners, 1pt
+///   `strokeMoney` border, money-tinted glow shadow.
+/// - 96×96 rounded-rect (28pt radius) with the money gradient and a flame
+///   icon — sits centered at the top of the sheet.
+/// - Caps "Серия · N дней без откладываний" in `money300`.
+/// - Hero amount "+350 ₽" at `moneyXl` masked with the money gradient via
+///   the shared `UILabel.applyGradientMask(_:)` helper.
+/// - h3 "Сэкономили за неделю" in `fg1`.
+/// - Body — "Деньги вернули на баланс. Потратьте их на следующей слабой
+///   неделе." in `fg3`.
+/// - 7 day-pip row with the money gradient (numbered 1-7) below the body.
+/// - Primary `SPButton(.money, .lg, fullWidth: true)` "Поделиться победой"
+///   that pops a `UIActivityViewController` so the streak goes onto socials.
+/// - Secondary `SPButton(.quiet, .md, fullWidth: true)` "Закрыть" that
+///   dismisses.
 ///
-/// The "saved" amount on the hero number is the sum of penalties the user
-/// did NOT pay during the streak window. Computing that exactly would require
-/// knowing the would-have-fired schedule for each alarm in the window — too
-/// much for one PR. Until a follow-up wires up `expectedPenalty * snoozesSaved`,
-/// we approximate with `streakDays * defaultPenalty` (50 ₽/day fallback when
-/// no alarms exist) so the modal still tells a coherent story.
+/// Saved amount carries the same estimation caveat as before — see
+/// `estimatedSavings(for:alarms:)`.
 final class StreakModalViewController: UIViewController {
 
     // MARK: - Configuration
@@ -37,20 +34,39 @@ final class StreakModalViewController: UIViewController {
     private let streakDays: Int
 
     /// Approximate roubles saved across the streak — the value the hero
-    /// number renders. See class doc comment for the approximation caveat.
+    /// number renders.
     private let savedAmount: Decimal
 
     // MARK: - Subviews
 
+    /// Sheet card — contains every visible widget. Anchored to the bottom
+    /// of the screen, padded by safe-area + screenInset.
+    private let sheet = UIView()
+    private let backdrop = UIView()
+    private let backdropGlow = CAGradientLayer()
+
+    private let flameBadge = UIView()
+    private let flameBadgeGradient = CAGradientLayer()
     private let flameIcon = UIImageView()
+
+    private let capsLabel = UILabel()
     private let amountLabel = UILabel()
     private let amountGradient = CAGradientLayer()
-    private let captionLabel = UILabel()
-    private let dayStrip = UIStackView()
+    private let headlineLabel = UILabel()
+    private let bodyLabel = UILabel()
+
+    private let pipStrip = UIStackView()
+
     private let primaryButton = SPButton(
-        title: "Отлично, продолжаю",
+        title: "Поделиться победой",
         variant: .money,
         size: .lg,
+        fullWidth: true
+    )
+    private let secondaryButton = SPButton(
+        title: "Закрыть",
+        variant: .quiet,
+        size: .md,
         fullWidth: true
     )
 
@@ -69,16 +85,10 @@ final class StreakModalViewController: UIViewController {
         self.streakDays = streakDays
         self.savedAmount = savedAmount
         super.init(nibName: nil, bundle: nil)
-        modalPresentationStyle = .pageSheet
-        if let sheet = sheetPresentationController {
-            // Medium detent ≈ 440pt — close enough to the spec without
-            // pinning a brittle .custom() resolver. Top-corner radius
-            // matches `--sp-radius-xl` so the sheet reads as one of the
-            // existing `r-sheet` surfaces.
-            sheet.detents = [.medium()]
-            sheet.preferredCornerRadius = AppRadius.xl
-            sheet.prefersGrabberVisible = true
-        }
+        // Custom overlay presentation so we can paint our own backdrop with
+        // a money-tinted radial glow.
+        modalPresentationStyle = .overFullScreen
+        modalTransitionStyle = .crossDissolve
     }
 
     required init?(coder: NSCoder) {
@@ -89,37 +99,123 @@ final class StreakModalViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = AppColors.bg1
-        configureFlameIcon()
-        configureAmountLabel()
-        configureCaptionLabel()
-        configureDayStrip()
-        configureButton()
+        view.backgroundColor = .clear
+        configureBackdrop()
+        configureSheet()
+        configureFlameBadge()
+        configureLabels()
+        configurePipStrip()
+        configureButtons()
         layout()
     }
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        applyAmountGradient()
+        backdropGlow.frame = view.bounds
+        flameBadgeGradient.frame = flameBadge.bounds
+        amountLabel.applyGradientMask(amountGradient)
+        // Shadow path tracks the sheet's rounded rect so the soft glow doesn't
+        // pay an offscreen pass on every layout while the sheet animates in.
+        sheet.layer.shadowPath = UIBezierPath(
+            roundedRect: sheet.bounds,
+            cornerRadius: AppRadius.xl
+        ).cgPath
     }
 
     // MARK: - Configuration
 
-    private func configureFlameIcon() {
-        let config = UIImage.SymbolConfiguration(pointSize: 56, weight: .semibold)
-        flameIcon.image = UIImage(systemName: "flame.fill", withConfiguration: config)
-        flameIcon.tintColor = AppColors.money500
-        flameIcon.contentMode = .scaleAspectFit
-        flameIcon.translatesAutoresizingMaskIntoConstraints = false
+    private func configureBackdrop() {
+        backdrop.translatesAutoresizingMaskIntoConstraints = false
+        backdrop.backgroundColor = UIColor.black.withAlphaComponent(0.92)
+        view.addSubview(backdrop)
+        NSLayoutConstraint.activate([
+            backdrop.topAnchor.constraint(equalTo: view.topAnchor),
+            backdrop.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            backdrop.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            backdrop.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+
+        // Radial money glow as a CAGradientLayer (.radial) above the dim.
+        backdropGlow.type = .radial
+        backdropGlow.colors = [
+            AppColors.money400.withAlphaComponent(0.30).cgColor,
+            UIColor.clear.cgColor
+        ]
+        backdropGlow.locations = [0.0, 1.0]
+        backdropGlow.startPoint = CGPoint(x: 0.5, y: 0.75)
+        backdropGlow.endPoint = CGPoint(x: 1.1, y: 1.35)
+        view.layer.addSublayer(backdropGlow)
+
+        // Tap on the backdrop dismisses.
+        let tap = UITapGestureRecognizer(target: self, action: #selector(dismissTapped))
+        backdrop.addGestureRecognizer(tap)
     }
 
-    private func configureAmountLabel() {
+    private func configureSheet() {
+        sheet.translatesAutoresizingMaskIntoConstraints = false
+        sheet.backgroundColor = AppColors.bg2
+        sheet.layer.cornerRadius = AppRadius.xl
+        sheet.layer.cornerCurve = .continuous
+        sheet.layer.borderColor = AppColors.strokeMoney
+            .resolvedColor(with: traitCollection).cgColor
+        sheet.layer.borderWidth = 1
+        sheet.layer.shadowColor = AppColors.money500.cgColor
+        sheet.layer.shadowOpacity = 0.30
+        sheet.layer.shadowOffset = CGSize(width: 0, height: -12)
+        sheet.layer.shadowRadius = 32
+        view.addSubview(sheet)
+    }
+
+    private func configureFlameBadge() {
+        flameBadge.translatesAutoresizingMaskIntoConstraints = false
+        flameBadge.layer.cornerRadius = AppRadius.xl
+        flameBadge.layer.cornerCurve = .continuous
+        flameBadge.layer.shadowColor = AppColors.money500.cgColor
+        flameBadge.layer.shadowOpacity = 0.40
+        flameBadge.layer.shadowOffset = CGSize(width: 0, height: 12)
+        flameBadge.layer.shadowRadius = 24
+
+        flameBadgeGradient.colors = SPSupport.moneyGradientColors
+        flameBadgeGradient.locations = SPSupport.moneyGradientLocations
+        flameBadgeGradient.startPoint = SPSupport.gradientStart
+        flameBadgeGradient.endPoint = SPSupport.gradientEnd
+        flameBadgeGradient.cornerRadius = AppRadius.xl
+        flameBadge.layer.insertSublayer(flameBadgeGradient, at: 0)
+
+        let config = UIImage.SymbolConfiguration(pointSize: 48, weight: .bold)
+        flameIcon.image = UIImage(systemName: "flame.fill", withConfiguration: config)
+        flameIcon.tintColor = AppColors.fgOnMoney
+        flameIcon.contentMode = .scaleAspectFit
+        flameIcon.translatesAutoresizingMaskIntoConstraints = false
+        flameBadge.addSubview(flameIcon)
+
+        NSLayoutConstraint.activate([
+            flameBadge.widthAnchor.constraint(equalToConstant: 96),
+            flameBadge.heightAnchor.constraint(equalToConstant: 96),
+            flameIcon.centerXAnchor.constraint(equalTo: flameBadge.centerXAnchor),
+            flameIcon.centerYAnchor.constraint(equalTo: flameBadge.centerYAnchor)
+        ])
+    }
+
+    private func configureLabels() {
+        let capsText = "СЕРИЯ · \(streakDays) \(Self.dayWord(for: streakDays).uppercased()) "
+            + "БЕЗ ОТКЛАДЫВАНИЙ"
+        capsLabel.attributedText = NSAttributedString(
+            string: capsText,
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.money300
+            ]
+        )
+        capsLabel.textAlignment = .center
+        capsLabel.numberOfLines = 0
+        capsLabel.translatesAutoresizingMaskIntoConstraints = false
+
         amountLabel.font = AppTypography.moneyXl
         amountLabel.textAlignment = .center
         amountLabel.adjustsFontForContentSizeCategory = false
-        // Neutral colour as a safety net — `applyAmountGradient` promotes
-        // this to a gradient text mask once layout resolves.
-        amountLabel.textColor = AppColors.fg1
+        amountLabel.textColor = AppColors.money400   // safety-net pre-mask
         amountLabel.text = Self.formatSavedAmount(savedAmount)
         amountLabel.translatesAutoresizingMaskIntoConstraints = false
 
@@ -127,87 +223,155 @@ final class StreakModalViewController: UIViewController {
         amountGradient.locations = SPSupport.moneyGradientLocations
         amountGradient.startPoint = SPSupport.gradientStart
         amountGradient.endPoint = SPSupport.gradientEnd
+
+        headlineLabel.text = "Сэкономили за неделю"
+        headlineLabel.font = AppTypography.h3
+        headlineLabel.textColor = AppColors.fg1
+        headlineLabel.textAlignment = .center
+        headlineLabel.numberOfLines = 0
+        headlineLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        bodyLabel.text = "Деньги вернули на баланс. Потратьте их на следующей слабой неделе."
+        bodyLabel.font = AppTypography.body
+        bodyLabel.textColor = AppColors.fg3
+        bodyLabel.textAlignment = .center
+        bodyLabel.numberOfLines = 0
+        bodyLabel.translatesAutoresizingMaskIntoConstraints = false
     }
 
-    private func configureCaptionLabel() {
-        captionLabel.text = "\(streakDays) \(Self.dayWord(for: streakDays)) без откладываний"
-        captionLabel.font = AppTypography.body
-        captionLabel.textColor = AppColors.fg2
-        captionLabel.textAlignment = .center
-        captionLabel.translatesAutoresizingMaskIntoConstraints = false
-    }
-
-    private func configureDayStrip() {
-        dayStrip.axis = .horizontal
-        dayStrip.distribution = .fillEqually
-        dayStrip.alignment = .fill
-        dayStrip.spacing = AppSpacing.sp2
-        dayStrip.translatesAutoresizingMaskIntoConstraints = false
-        // Render 7 squares — clamped to [0, 7] for visualisation. Streaks
-        // longer than 7 days still show a fully-filled strip; the hero
-        // number carries the absolute count.
-        let completed = max(0, min(7, streakDays - 1))
-        let todayIndex = max(0, min(6, streakDays - 1))
+    private func configurePipStrip() {
+        pipStrip.axis = .horizontal
+        pipStrip.distribution = .fillEqually
+        pipStrip.spacing = AppSpacing.sp1
+        pipStrip.alignment = .fill
+        pipStrip.translatesAutoresizingMaskIntoConstraints = false
+        // 7 numbered green pips. Streaks < 7 fade out future pips by lowering
+        // their alpha; streaks ≥ 7 keep all seven at full intensity.
+        let completed = max(0, min(7, streakDays))
         for index in 0..<7 {
-            let kind: DaySquareView.Kind
-            if index < completed {
-                kind = .completed
-            } else if index == todayIndex && streakDays >= 1 && streakDays <= 7 {
-                kind = .today(dayNumber: index + 1)
-            } else {
-                kind = .future
-            }
-            let square = DaySquareView(kind: kind)
-            dayStrip.addArrangedSubview(square)
+            let pip = makePip(number: index + 1, lit: index < completed)
+            pipStrip.addArrangedSubview(pip)
         }
     }
 
-    private func configureButton() {
+    private func makePip(number: Int, lit: Bool) -> UIView {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.layer.cornerRadius = AppRadius.sm
+        view.layer.cornerCurve = .continuous
+        view.layer.masksToBounds = true
+        view.heightAnchor.constraint(equalToConstant: 32).isActive = true
+        view.widthAnchor.constraint(equalToConstant: 32).isActive = true
+
+        if lit {
+            let gradient = CAGradientLayer()
+            gradient.colors = SPSupport.moneyGradientColors
+            gradient.locations = SPSupport.moneyGradientLocations
+            gradient.startPoint = SPSupport.gradientStart
+            gradient.endPoint = SPSupport.gradientEnd
+            gradient.cornerRadius = AppRadius.sm
+            // Defer the frame assignment to the next runloop so the sublayer
+            // tracks the resolved bounds set by the 32×32 anchors above.
+            DispatchQueue.main.async {
+                gradient.frame = view.bounds
+            }
+            view.layer.insertSublayer(gradient, at: 0)
+        } else {
+            view.backgroundColor = AppColors.whiteOverlay08
+        }
+
+        let label = UILabel()
+        label.text = "\(number)"
+        label.font = AppFonts.mono(.bold, 13)
+        label.textColor = lit ? AppColors.fgOnMoney : AppColors.fg3
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(label)
+        NSLayoutConstraint.activate([
+            label.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            label.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
+        return view
+    }
+
+    private func configureButtons() {
         primaryButton.translatesAutoresizingMaskIntoConstraints = false
-        primaryButton.addTarget(self, action: #selector(dismissTapped), for: .touchUpInside)
+        primaryButton.addTarget(self, action: #selector(shareTapped), for: .touchUpInside)
+        secondaryButton.translatesAutoresizingMaskIntoConstraints = false
+        secondaryButton.addTarget(self, action: #selector(dismissTapped), for: .touchUpInside)
     }
 
     private func layout() {
+        let pipWrap = UIView()
+        pipWrap.translatesAutoresizingMaskIntoConstraints = false
+        pipWrap.addSubview(pipStrip)
+        NSLayoutConstraint.activate([
+            pipStrip.centerXAnchor.constraint(equalTo: pipWrap.centerXAnchor),
+            pipStrip.topAnchor.constraint(equalTo: pipWrap.topAnchor),
+            pipStrip.bottomAnchor.constraint(equalTo: pipWrap.bottomAnchor),
+            pipStrip.leadingAnchor.constraint(greaterThanOrEqualTo: pipWrap.leadingAnchor),
+            pipStrip.trailingAnchor.constraint(lessThanOrEqualTo: pipWrap.trailingAnchor)
+        ])
+
+        let buttonsStack = UIStackView(arrangedSubviews: [primaryButton, secondaryButton])
+        buttonsStack.axis = .vertical
+        buttonsStack.spacing = AppSpacing.sp2
+        buttonsStack.alignment = .fill
+        buttonsStack.translatesAutoresizingMaskIntoConstraints = false
+
         let stack = UIStackView(arrangedSubviews: [
-            flameIcon,
+            flameBadge,
+            capsLabel,
             amountLabel,
-            captionLabel,
-            dayStrip,
-            primaryButton
+            headlineLabel,
+            bodyLabel,
+            pipWrap,
+            buttonsStack
         ])
         stack.axis = .vertical
         stack.alignment = .center
-        stack.spacing = AppSpacing.sp4
-        stack.setCustomSpacing(AppSpacing.sp2, after: flameIcon)
-        stack.setCustomSpacing(AppSpacing.sp5, after: captionLabel)
-        stack.setCustomSpacing(AppSpacing.sp6, after: dayStrip)
+        stack.spacing = AppSpacing.sp3
+        stack.setCustomSpacing(AppSpacing.sp5, after: flameBadge)
+        stack.setCustomSpacing(AppSpacing.sp2, after: capsLabel)
+        stack.setCustomSpacing(AppSpacing.sp2, after: amountLabel)
+        stack.setCustomSpacing(AppSpacing.sp2, after: headlineLabel)
+        stack.setCustomSpacing(AppSpacing.sp6, after: bodyLabel)
+        stack.setCustomSpacing(AppSpacing.sp6, after: pipWrap)
         stack.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(stack)
+        sheet.addSubview(stack)
 
         NSLayoutConstraint.activate([
-            flameIcon.heightAnchor.constraint(equalToConstant: 56),
-            flameIcon.widthAnchor.constraint(equalToConstant: 56),
-            dayStrip.leadingAnchor.constraint(equalTo: stack.leadingAnchor),
-            dayStrip.trailingAnchor.constraint(equalTo: stack.trailingAnchor),
+            // Sheet anchored to the bottom with screen-inset margins.
+            sheet.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: AppSpacing.sp3),
+            sheet.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -AppSpacing.sp3),
+            sheet.bottomAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.bottomAnchor,
+                constant: -AppSpacing.sp4
+            ),
+
+            // Stack inside sheet, 28pt padded.
+            stack.topAnchor.constraint(equalTo: sheet.topAnchor, constant: AppSpacing.sp6),
+            stack.bottomAnchor.constraint(equalTo: sheet.bottomAnchor, constant: -AppSpacing.sp6),
+            stack.leadingAnchor.constraint(equalTo: sheet.leadingAnchor, constant: AppSpacing.sp6),
+            stack.trailingAnchor.constraint(equalTo: sheet.trailingAnchor, constant: -AppSpacing.sp6),
+
+            // Buttons stretch to the full stack width.
             primaryButton.leadingAnchor.constraint(equalTo: stack.leadingAnchor),
             primaryButton.trailingAnchor.constraint(equalTo: stack.trailingAnchor),
+            secondaryButton.leadingAnchor.constraint(equalTo: stack.leadingAnchor),
+            secondaryButton.trailingAnchor.constraint(equalTo: stack.trailingAnchor),
 
-            stack.topAnchor.constraint(
-                equalTo: view.safeAreaLayoutGuide.topAnchor,
-                constant: AppSpacing.sp6
-            ),
-            stack.leadingAnchor.constraint(
-                equalTo: view.leadingAnchor,
-                constant: AppSpacing.screenInset
-            ),
-            stack.trailingAnchor.constraint(
-                equalTo: view.trailingAnchor,
-                constant: -AppSpacing.screenInset
-            ),
-            stack.bottomAnchor.constraint(
-                lessThanOrEqualTo: view.safeAreaLayoutGuide.bottomAnchor,
-                constant: -AppSpacing.sp5
-            )
+            // Pip wrap row stretches but the strip itself centres inside.
+            pipWrap.leadingAnchor.constraint(equalTo: stack.leadingAnchor),
+            pipWrap.trailingAnchor.constraint(equalTo: stack.trailingAnchor),
+
+            // Headline + body stretch full-width so multi-line centres.
+            capsLabel.leadingAnchor.constraint(equalTo: stack.leadingAnchor),
+            capsLabel.trailingAnchor.constraint(equalTo: stack.trailingAnchor),
+            headlineLabel.leadingAnchor.constraint(equalTo: stack.leadingAnchor),
+            headlineLabel.trailingAnchor.constraint(equalTo: stack.trailingAnchor),
+            bodyLabel.leadingAnchor.constraint(equalTo: stack.leadingAnchor),
+            bodyLabel.trailingAnchor.constraint(equalTo: stack.trailingAnchor)
         ])
     }
 
@@ -217,50 +381,19 @@ final class StreakModalViewController: UIViewController {
         dismiss(animated: true)
     }
 
-    // MARK: - Gradient text mask
-    //
-    // Same recipe as `SPBalanceCard.applyValueGradient(...)` — install the
-    // money gradient as a sublayer of the label and mask it with a raster
-    // of the rendered glyphs. CoreText doesn't expose CSS's
-    // `-webkit-background-clip: text` so the mask trick is the cheapest
-    // way to keep the gradient tracking the digit baseline across font /
-    // size / theme transitions.
-
-    private func applyAmountGradient() {
-        let textBounds = amountLabel.bounds
-        guard textBounds.width > 0, textBounds.height > 0 else { return }
-        if amountGradient.superlayer !== amountLabel.layer {
-            amountLabel.layer.addSublayer(amountGradient)
-        }
-        amountGradient.frame = textBounds
-
-        let renderer = UIGraphicsImageRenderer(size: textBounds.size)
-        let mask = renderer.image { _ in
-            (amountLabel.text ?? "").draw(
-                in: textBounds,
-                withAttributes: [
-                    .font: amountLabel.font as Any,
-                    .foregroundColor: UIColor.white,
-                    .paragraphStyle: { () -> NSParagraphStyle in
-                        let style = NSMutableParagraphStyle()
-                        style.alignment = .center
-                        return style
-                    }()
-                ]
-            )
-        }
-        let maskLayer = CALayer()
-        maskLayer.frame = textBounds
-        maskLayer.contents = mask.cgImage
-        amountGradient.mask = maskLayer
-        amountLabel.textColor = .clear
+    @objc private func shareTapped() {
+        let text = "SnoozePay: \(streakDays) \(Self.dayWord(for: streakDays)) подряд без откладываний — "
+            + "сэкономлено \(Self.formatSavedAmount(savedAmount))."
+        let activity = UIActivityViewController(activityItems: [text], applicationActivities: nil)
+        // iPad popover anchor — the system picker insists on a source view.
+        activity.popoverPresentationController?.sourceView = primaryButton
+        activity.popoverPresentationController?.sourceRect = primaryButton.bounds
+        present(activity, animated: true)
     }
 
     // MARK: - Helpers
 
     /// Format the saved amount as `+1 234 ₽` with the brand thousand separator.
-    /// Reuses `Decimal.formattedRubles()` to stay consistent with the balance
-    /// card and the firing top-up sheet.
     static func formatSavedAmount(_ amount: Decimal) -> String {
         "+\(amount.formattedRubles())"
     }
@@ -309,100 +442,5 @@ final class StreakModalViewController: UIViewController {
             dailyPenalty = rounded
         }
         return dailyPenalty * Decimal(streakDays)
-    }
-}
-
-// MARK: - Day square
-
-/// One of the seven squares rendered above the primary CTA. The visual
-/// recipe maps 1:1 onto the design spec:
-/// - `.completed` → money-gradient fill, no text.
-/// - `.today` → transparent fill with a 2pt money stroke and the day
-///   number drawn in money tint.
-/// - `.future` → `whiteOverlay08` fill so future days read as muted.
-private final class DaySquareView: UIView {
-    enum Kind {
-        case completed
-        case today(dayNumber: Int)
-        case future
-    }
-
-    private let kind: Kind
-    private let label = UILabel()
-    private var gradientLayer: CAGradientLayer?
-
-    init(kind: Kind) {
-        self.kind = kind
-        super.init(frame: .zero)
-        layer.cornerRadius = AppRadius.sm
-        layer.masksToBounds = true
-        translatesAutoresizingMaskIntoConstraints = false
-        // Square via 1:1 aspect — fill-equally distribution sets the width.
-        widthAnchor.constraint(equalTo: heightAnchor).isActive = true
-        heightAnchor.constraint(greaterThanOrEqualToConstant: 36).isActive = true
-
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.textAlignment = .center
-        label.font = AppFonts.mono(.bold, 14)
-        addSubview(label)
-        NSLayoutConstraint.activate([
-            label.centerXAnchor.constraint(equalTo: centerXAnchor),
-            label.centerYAnchor.constraint(equalTo: centerYAnchor)
-        ])
-        applyKind()
-        // iOS 17 deprecated `traitCollectionDidChange(_:)` in favour of the
-        // closure-based observer below — legacy override stays as fallback.
-        if #available(iOS 17.0, *) {
-            registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (view: DaySquareView, _) in
-                view.applyKind()
-            }
-        }
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        gradientLayer?.frame = bounds
-    }
-
-    @available(iOS, deprecated: 17.0, message: "Replaced by registerForTraitChanges; kept for iOS 15/16.")
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        if #available(iOS 17.0, *) { return }   // iOS 17 uses the registered observer.
-        // Strokes / overlays are dynamic colours — re-resolve their cgColor
-        // for the current trait on iOS 15/16 so a theme flip doesn't leave
-        // the previous theme baked into CALayer.
-        applyKind()
-    }
-
-    private func applyKind() {
-        gradientLayer?.removeFromSuperlayer()
-        gradientLayer = nil
-        layer.borderWidth = 0
-        backgroundColor = .clear
-        label.text = nil
-
-        switch kind {
-        case .completed:
-            let gradient = CAGradientLayer()
-            gradient.colors = SPSupport.moneyGradientColors
-            gradient.locations = SPSupport.moneyGradientLocations
-            gradient.startPoint = SPSupport.gradientStart
-            gradient.endPoint = SPSupport.gradientEnd
-            gradient.frame = bounds
-            layer.insertSublayer(gradient, at: 0)
-            gradientLayer = gradient
-        case .today(let dayNumber):
-            backgroundColor = .clear
-            layer.borderWidth = 2
-            layer.borderColor = AppColors.money500.cgColor
-            label.text = "\(dayNumber)"
-            label.textColor = AppColors.money500
-        case .future:
-            backgroundColor = AppColors.whiteOverlay08
-        }
     }
 }


### PR DESCRIPTION
## Summary

Slice D of the V2 design hand-off — rewrites the Statistics screen onto the
new tokens, redesigns the streak celebration modal, and adds two new
engagement surfaces (Referral, AlarmOff warning).

- **Statistics V2** (`SPMore4.jsx` `Stats()` lines 6-120): hero `SPCard(.raised)` with caps `СЕРИЯ`, big mono streak count, warn-gradient flame badge, GitHub-style heatmap underneath; weekly `SPCard(.surface)` with the existing Charts bar chart + a `Сэкономили / Потратили / Чистый` summary row; `Время подъёма` placeholder card with three mono columns. DEBUG buttons gated `#if DEBUG` expose the new modals while their real triggers are wired in follow-ups.
- **StreakModal V2** (`SPScreensV2.jsx` lines 653-732): bottom-anchored money-glowing sheet on a black 92% backdrop with a radial money glow. `bg2` fill, 1pt `strokeMoney`, money shadow, 28pt corners. 96×96 money-gradient flame badge, hero `+N ₽` masked with the money gradient, 7 numbered green pips, `SPButton(.money, .lg)` "Поделиться победой" (UIActivityViewController) + `SPButton(.quiet, .md)` "Закрыть".
- **Referral** (new — `ReferralViewController`): money-camo hero card, `Ваш код` with `Копировать` (pasteboard + haptic), `Код друга` mono field with `Применить`, 3-row friends list with gradient/warn/muted avatar badges, bottom `SPButton(.money, .lg)` share CTA.
- **AlarmOffWarning** (new — `AlarmOffWarningViewController`): pain-tinted full-height sheet — close button + pain400 `ВНИМАНИЕ` caps, 80×80 pain-gradient flame badge, h1 headline with inline pain400 mono `−750 ₽`, three `SPCard(.surface)` suggestion rows with icon wells (clock / coin / xmark), ghost `Всё в порядке` button.

Reuses existing `SPCard`, `SPButton`, `SPRow`, `SPSupport`, `StatisticsHeatmapView`, `WeekdayChartView`, and `UILabel+GradientMask` — no shared `SP*` primitives modified. `StatisticsViewModel`, `TransactionRepository`, no-touch zones untouched.

## Test plan

- [ ] Build green on iPhone 17 simulator (verified locally — `xcodebuild ... build` → `** BUILD SUCCEEDED **`).
- [ ] SwiftLint 0 violations on the five touched files (verified locally).
- [ ] Statistics screen: caps + big streak number render, heatmap shows period buckets, weekly summary row tracks the period change.
- [ ] DEBUG buttons present StreakModalV2 / Referral / AlarmOff modals; Referral input uppercases on type and enables the apply button only when non-empty; share buttons open `UIActivityViewController`.
- [ ] Tap on the hero card still presents the real `StreakModalViewController` for the current streak/best-streak combo.
- [ ] Empty state still appears when the selected period has no transactions.