### PR TITLE
[ui][v2-forms] CreateAlarm + Edit + Delete + Sound/Theme/Volume pickers V2

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmThemePickerViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmThemePickerViewController.swift
@@ -36,6 +36,58 @@ final class AlarmThemePickerViewController: UIViewController {
 
     private var collectionView: UICollectionView!
 
+    /// V2 firing-screen preview block — sits above the grid and tracks the
+    /// currently-selected theme so the user sees a 180pt-tall stamp of what
+    /// the alarm-firing screen will look like before they pick. Matches
+    /// `SPMore2.jsx` lines 274-285.
+    private let previewContainer: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.layer.cornerRadius = AppRadius.lg
+        view.layer.masksToBounds = true
+        return view
+    }()
+
+    private var previewGradient: CAGradientLayer?
+
+    private let previewImageView: UIImageView = {
+        let view = UIImageView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.contentMode = .scaleAspectFill
+        view.clipsToBounds = true
+        view.isHidden = true
+        return view
+    }()
+
+    private let previewClockLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "7:00"
+        label.font = AppFonts.mono(.ultralight, 56)
+        label.textColor = .white
+        label.textAlignment = .center
+        // Subtle shadow so the clock stays legible against any gradient stop.
+        label.layer.shadowColor = UIColor.black.cgColor
+        label.layer.shadowOpacity = 0.4
+        label.layer.shadowOffset = .zero
+        label.layer.shadowRadius = 8
+        return label
+    }()
+
+    private let previewCapsLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.attributedText = NSAttributedString(
+            string: "ПРЕВЬЮ FIRING-SCREEN",
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.fg3
+            ]
+        )
+        return label
+    }()
+
     // MARK: - Init
 
     /// - Parameters:
@@ -62,30 +114,101 @@ final class AlarmThemePickerViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = "Тема"
         view.backgroundColor = AppColors.bg0
+        // V2 caps title — matches `SPMore2.jsx` lines 269 recipe.
+        let titleLabel = UILabel()
+        titleLabel.attributedText = NSAttributedString(
+            string: "Тема будильника".uppercased(),
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.fg3
+            ]
+        )
+        titleLabel.accessibilityLabel = "Тема будильника"
+        navigationItem.titleView = titleLabel
         setupCollectionView()
     }
 
     // MARK: - Setup
 
     private func setupCollectionView() {
+        // V2: preview block + grid, stacked vertically. The preview reflects
+        // the live `currentTheme` so the user gets a 180pt-tall sample of
+        // the firing screen as they cycle through tiles below.
+        previewContainer.addSubview(previewImageView)
+        previewContainer.addSubview(previewClockLabel)
+
+        view.addSubview(previewCapsLabel)
+        view.addSubview(previewContainer)
+
         let layout = makeLayout()
-        let view = UICollectionView(frame: .zero, collectionViewLayout: layout)
-        view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = .clear
-        view.alwaysBounceVertical = true
-        view.dataSource = self
-        view.delegate = self
-        view.register(AlarmThemeTileCell.self, forCellWithReuseIdentifier: AlarmThemeTileCell.reuseID)
-        self.view.addSubview(view)
+        let grid = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        grid.translatesAutoresizingMaskIntoConstraints = false
+        grid.backgroundColor = .clear
+        grid.alwaysBounceVertical = true
+        grid.dataSource = self
+        grid.delegate = self
+        grid.register(AlarmThemeTileCell.self, forCellWithReuseIdentifier: AlarmThemeTileCell.reuseID)
+        self.view.addSubview(grid)
+
         NSLayoutConstraint.activate([
-            view.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
-            view.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
-            view.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
-            view.bottomAnchor.constraint(equalTo: self.view.bottomAnchor)
+            previewCapsLabel.topAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.topAnchor, constant: AppSpacing.sp4
+            ),
+            previewCapsLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: AppSpacing.sp4),
+            previewCapsLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -AppSpacing.sp4),
+
+            previewContainer.topAnchor.constraint(equalTo: previewCapsLabel.bottomAnchor, constant: AppSpacing.sp2),
+            previewContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: AppSpacing.sp4),
+            previewContainer.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -AppSpacing.sp4),
+            previewContainer.heightAnchor.constraint(equalToConstant: 180),
+
+            previewImageView.topAnchor.constraint(equalTo: previewContainer.topAnchor),
+            previewImageView.leadingAnchor.constraint(equalTo: previewContainer.leadingAnchor),
+            previewImageView.trailingAnchor.constraint(equalTo: previewContainer.trailingAnchor),
+            previewImageView.bottomAnchor.constraint(equalTo: previewContainer.bottomAnchor),
+
+            previewClockLabel.centerXAnchor.constraint(equalTo: previewContainer.centerXAnchor),
+            previewClockLabel.centerYAnchor.constraint(equalTo: previewContainer.centerYAnchor),
+
+            grid.topAnchor.constraint(equalTo: previewContainer.bottomAnchor, constant: AppSpacing.sp3),
+            grid.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            grid.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+            grid.bottomAnchor.constraint(equalTo: self.view.bottomAnchor)
         ])
-        self.collectionView = view
+        self.collectionView = grid
+        renderPreview(for: currentTheme)
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        previewGradient?.frame = previewContainer.bounds
+    }
+
+    /// Re-render the preview block with the given theme's gradient or photo.
+    /// Called once on setup and again every time the user taps a tile.
+    private func renderPreview(for theme: AlarmTheme) {
+        previewGradient?.removeFromSuperlayer()
+        previewGradient = nil
+        previewImageView.image = nil
+        previewImageView.isHidden = true
+
+        if case .custom(let url) = theme, let image = AlarmThemeImageStore.loadImage(at: url) {
+            previewImageView.image = image
+            previewImageView.isHidden = false
+            return
+        }
+
+        guard let colors = AlarmThemeRendering.gradientColors(for: theme) else { return }
+        let gradient = CAGradientLayer()
+        gradient.colors = colors
+        gradient.locations = AlarmThemeRendering.gradientLocations(for: theme)
+        gradient.startPoint = CGPoint(x: 0.5, y: 0.0)
+        gradient.endPoint = CGPoint(x: 0.5, y: 1.0)
+        gradient.frame = previewContainer.bounds
+        previewContainer.layer.insertSublayer(gradient, at: 0)
+        previewGradient = gradient
     }
 
     /// Two-column compositional grid. Item ratio is 16:9 — width is whatever
@@ -127,11 +250,14 @@ final class AlarmThemePickerViewController: UIViewController {
     // MARK: - Selection
 
     /// Apply the selection and pop back. Built-in themes commit immediately;
-    /// `.custom` routes through the photo picker first.
+    /// `.custom` routes through the photo picker first. The preview block
+    /// refreshes inline so the user sees the firing-screen sample update
+    /// before the pop animation completes.
     private func selectItem(at indexPath: IndexPath) {
         switch items[indexPath.item] {
         case .theme(let theme):
             currentTheme = theme
+            renderPreview(for: theme)
             onSelect(theme)
             navigationController?.popViewController(animated: true)
         case .customSlot:

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/DayPickerCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/DayPickerCell.swift
@@ -1,13 +1,16 @@
 import UIKit
 
-/// Horizontal Пн-Вс day toggle row. Each weekday is rendered as a square button
-/// that toggles its selection state independently. The cell owns its buttons
-/// internally; the controller only supplies the current selection set.
+/// V2 horizontal Пн-Вс day toggle row. Each weekday button is a 36×36 round
+/// chip — selected = `money500` flat fill + `fgOnMoney` text (the JSX uses
+/// the money gradient; we collapse to the dominant stop because `UIButton`
+/// doesn't render a gradient inline). Unselected = `whiteOverlay06` chip with
+/// `fg3` text. Matches `SPScreensV2.jsx` lines 528-541.
 final class DayPickerCell: UITableViewCell {
 
     static let reuseID = "DayPickerCell"
 
     private static let dayNames = ["Пн", "Вт", "Ср", "Чт", "Пт", "Сб", "Вс"]
+    private static let buttonDiameter: CGFloat = 36
 
     // MARK: - UI
 
@@ -15,7 +18,7 @@ final class DayPickerCell: UITableViewCell {
         let stack = UIStackView()
         stack.axis = .horizontal
         stack.distribution = .fillEqually
-        stack.spacing = AppSpacing.sm
+        stack.spacing = AppSpacing.sp2
         stack.translatesAutoresizingMaskIntoConstraints = false
         return stack
     }()
@@ -44,27 +47,27 @@ final class DayPickerCell: UITableViewCell {
 
     private func setupUI() {
         selectionStyle = .none
-        backgroundColor = .secondarySystemBackground
+        backgroundColor = AppColors.bg1
 
         for index in 0..<Self.dayNames.count {
             let button = UIButton(type: .system)
             button.setTitle(Self.dayNames[index], for: .normal)
             button.tag = index
-            button.titleLabel?.font = UIFont.systemFont(ofSize: 13, weight: .semibold)
-            button.layer.cornerRadius = AppRadius.xs
+            button.titleLabel?.font = AppTypography.buttonSm
+            button.layer.cornerRadius = Self.buttonDiameter / 2
             button.layer.masksToBounds = true
             button.addTarget(self, action: #selector(dayTapped(_:)), for: .touchUpInside)
+            button.heightAnchor.constraint(equalToConstant: Self.buttonDiameter).isActive = true
             dayButtons.append(button)
             stackView.addArrangedSubview(button)
         }
 
         contentView.addSubview(stackView)
         NSLayoutConstraint.activate([
-            stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.lg),
-            stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.lg),
-            stackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: AppSpacing.sm),
-            stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -AppSpacing.sm),
-            stackView.heightAnchor.constraint(equalToConstant: 44)
+            stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.sp4),
+            stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.sp4),
+            stackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: AppSpacing.sp2),
+            stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -AppSpacing.sp2)
         ])
     }
 
@@ -82,22 +85,17 @@ final class DayPickerCell: UITableViewCell {
         }
     }
 
-    /// Selected — filled accent + white text, no border. Unselected — clear fill +
-    /// hairline `UIColor.separator` border + secondary label colour. Borders give
-    /// each weekday pill a visible affordance in light mode where a flat
-    /// `tertiarySystemBackground` was reading as one undifferentiated grey block.
+    /// V2: selected → `money500` fill + `fgOnMoney` text; unselected →
+    /// `whiteOverlay06` chip + `fg3` text. No border in either state.
     private func applyStyle(_ button: UIButton, isSelected: Bool) {
         if isSelected {
-            button.backgroundColor = AppColors.accentBlue
-            button.setTitleColor(.white, for: .normal)
-            button.layer.borderWidth = 0
-            button.layer.borderColor = UIColor.clear.cgColor
+            button.backgroundColor = AppColors.money500
+            button.setTitleColor(AppColors.fgOnMoney, for: .normal)
         } else {
-            button.backgroundColor = .clear
-            button.setTitleColor(AppColors.textSecondary, for: .normal)
-            button.layer.borderWidth = 1
-            button.layer.borderColor = UIColor.separator.cgColor
+            button.backgroundColor = AppColors.whiteOverlay06
+            button.setTitleColor(AppColors.fg3, for: .normal)
         }
+        button.layer.borderWidth = 0
         button.accessibilityValue = isSelected ? "выбрано" : "не выбрано"
     }
 

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/DeleteActionCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/DeleteActionCell.swift
@@ -1,9 +1,9 @@
 import UIKit
 
-/// Centred red "Удалить будильник" row, shown only in edit mode.
-/// Mirrors the iOS Settings destructive-row pattern (e.g. Calendar's
-/// "Delete Event" — selectionStyle = .default gives tactile feedback before
-/// the confirmation sheet appears).
+/// V2 destructive "Удалить будильник" row. Tinted `pain400` so the row reads
+/// as the same intent as the dedicated `ConfirmDeleteAlarmViewController` it
+/// presents on tap. Selection is left enabled so the user gets a brief
+/// highlight before the confirmation sheet animates up from the bottom.
 final class DeleteActionCell: UITableViewCell {
 
     static let reuseID = "DeleteActionCell"
@@ -11,10 +11,10 @@ final class DeleteActionCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         textLabel?.text = "Удалить будильник"
-        textLabel?.textColor = .systemRed
+        textLabel?.textColor = AppColors.pain400
         textLabel?.textAlignment = .center
-        textLabel?.font = UIFont.systemFont(ofSize: 17, weight: .regular)
-        backgroundColor = .secondarySystemBackground
+        textLabel?.font = AppFonts.sans(.semibold, 17)
+        backgroundColor = AppColors.bg1
         selectionStyle = .default
     }
 

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/PenaltyCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/PenaltyCell.swift
@@ -1,31 +1,51 @@
 import UIKit
 
-/// Penalty-amount slider with a live value label rounded to the nearest 10.
+/// V2 "Цена откладывания" preset row: 5 fixed-price chips (20 / 50 / 100 /
+/// 200 / 500) — replaces the prior 10...1000 slider so the user picks from
+/// the design's curated price ladder rather than landing on noisy values.
+///
+/// Layout follows `SPScreensV2.jsx` lines 594-615 — the selected chip wears
+/// the warn gradient (`fgOnWarn` text) and unselected chips read as the
+/// `whiteOverlay06` muted state. The active amount is mirrored in the cell's
+/// trailing accessory label so the host card's "right side" still surfaces
+/// the live amount alongside the chip selection.
 final class PenaltyCell: UITableViewCell {
 
     static let reuseID = "PenaltyCell"
 
+    /// V2 preset ladder. Tweak in lock-step with the JSX spec — these are
+    /// the only values the picker exposes.
+    static let presets: [Double] = [20, 50, 100, 200, 500]
+
     // MARK: - UI
 
-    private let slider: UISlider = {
-        let view = UISlider()
-        view.minimumValue = 10
-        view.maximumValue = 1000
-        view.translatesAutoresizingMaskIntoConstraints = false
-        return view
-    }()
-
+    /// Mono-font live "{N} ₽" label sitting above the chip row — pulls the
+    /// "ЦЕНА ОТКЛАДЫВАНИЯ" caps from the section header and uses the
+    /// `moneyMd` typography role tinted `warn400`.
     private let valueLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 17)
-        label.textColor = AppColors.accentOrange
+        label.font = AppTypography.moneyMd
+        label.textColor = AppColors.warn400
+        label.textAlignment = .right
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
 
+    private let presetStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.distribution = .fillEqually
+        stack.spacing = AppSpacing.sp2
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+
+    private var presetButtons: [UIButton] = []
+    private var currentAmount: Double = 0
+
     // MARK: - Callbacks
 
-    /// Fires whenever the slider settles on a new (10-rounded) value.
+    /// Fires when the user picks a new preset.
     var onValueChanged: ((Double) -> Void)?
 
     // MARK: - Init
@@ -33,30 +53,53 @@ final class PenaltyCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setupUI()
-        slider.addTarget(self, action: #selector(sliderChanged), for: .valueChanged)
+        if #available(iOS 17.0, *) {
+            registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (view: PenaltyCell, _) in
+                view.refreshAppearance()
+            }
+        }
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
+    @available(iOS, deprecated: 17.0, message: "Replaced by registerForTraitChanges; kept for iOS 15/16.")
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if #available(iOS 17.0, *) { return }
+        refreshAppearance()
+    }
+
     // MARK: - Setup
 
     private func setupUI() {
-        backgroundColor = .secondarySystemBackground
+        backgroundColor = AppColors.bg1
         selectionStyle = .none
 
-        let stack = UIStackView(arrangedSubviews: [slider, valueLabel])
-        stack.axis = .horizontal
-        stack.spacing = AppSpacing.md
-        stack.translatesAutoresizingMaskIntoConstraints = false
+        for amount in Self.presets {
+            let button = UIButton(type: .system)
+            button.setTitle(String(Int(amount)), for: .normal)
+            button.titleLabel?.font = AppFonts.mono(.semibold, 14)
+            button.layer.cornerRadius = AppRadius.sm
+            button.layer.masksToBounds = true
+            button.addTarget(self, action: #selector(presetTapped(_:)), for: .touchUpInside)
+            button.heightAnchor.constraint(equalToConstant: 40).isActive = true
+            presetButtons.append(button)
+            presetStack.addArrangedSubview(button)
+        }
 
-        contentView.addSubview(stack)
+        contentView.addSubview(valueLabel)
+        contentView.addSubview(presetStack)
+
         NSLayoutConstraint.activate([
-            stack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.lg),
-            stack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.lg),
-            stack.topAnchor.constraint(equalTo: contentView.topAnchor, constant: AppSpacing.md),
-            stack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -AppSpacing.md)
+            valueLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.lg),
+            valueLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: AppSpacing.sm),
+
+            presetStack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.lg),
+            presetStack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.lg),
+            presetStack.topAnchor.constraint(equalTo: valueLabel.bottomAnchor, constant: AppSpacing.sm),
+            presetStack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -AppSpacing.md)
         ])
     }
 
@@ -68,17 +111,39 @@ final class PenaltyCell: UITableViewCell {
     // MARK: - Configure
 
     func configure(amount: Double) {
-        slider.value = Float(amount)
+        currentAmount = amount
         valueLabel.text = "\(Int(amount)) ₽"
+        refreshAppearance()
+    }
+
+    // MARK: - Appearance
+
+    /// Re-paint each chip according to the current selection. CALayer cgColor
+    /// properties don't auto-resolve dynamic UIColors, so this also runs on
+    /// theme flips.
+    private func refreshAppearance() {
+        for (index, button) in presetButtons.enumerated() {
+            let preset = Self.presets[index]
+            let isOn = abs(preset - currentAmount) < .ulpOfOne
+            if isOn {
+                button.backgroundColor = AppColors.warn500
+                button.setTitleColor(AppColors.fgOnWarn, for: .normal)
+                button.layer.borderWidth = 0
+            } else {
+                button.backgroundColor = AppColors.whiteOverlay06
+                button.setTitleColor(AppColors.fg2, for: .normal)
+                button.layer.borderWidth = 0
+            }
+        }
     }
 
     // MARK: - Actions
 
-    @objc private func sliderChanged() {
-        // Round to nearest 10 so the user never lands on noisy values like 137.
-        let rounded = (slider.value / 10).rounded() * 10
-        slider.value = rounded
-        valueLabel.text = "\(Int(rounded)) ₽"
-        onValueChanged?(Double(rounded))
+    @objc private func presetTapped(_ sender: UIButton) {
+        guard let index = presetButtons.firstIndex(of: sender) else { return }
+        let amount = Self.presets[index]
+        UISelectionFeedbackGenerator().selectionChanged()
+        configure(amount: amount)
+        onValueChanged?(amount)
     }
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/ProgressivePreviewCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/ProgressivePreviewCell.swift
@@ -1,19 +1,22 @@
 import UIKit
 
-/// Read-only preview row showing how penalties grow ("1-е: 50₽ → 2-е: 100₽ ...")
-/// when progressive scale is enabled. Surfaces only when `ProgressiveScaleCell`
-/// is toggled on.
+/// V2 progressive-mode preview row showing how penalties double on each
+/// snooze. Replaces the prior single-line text version with a mono "50 → 100
+/// → 200 → 400 ₽" sequence whose stops gradient from `warn400` (cheap) into
+/// `pain400` (painful) — matches `SPScreensV2.jsx` lines 628-638.
 final class ProgressivePreviewCell: UITableViewCell {
 
     static let reuseID = "ProgressivePreviewCell"
 
     // MARK: - UI
 
-    private let previewLabel: UILabel = {
+    private let sequenceLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 13)
-        label.textColor = AppColors.accentOrange
-        label.numberOfLines = 0
+        label.font = AppFonts.mono(.semibold, 14)
+        label.textColor = AppColors.warn400
+        label.numberOfLines = 1
+        label.adjustsFontSizeToFitWidth = true
+        label.minimumScaleFactor = 0.7
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
@@ -32,20 +35,90 @@ final class ProgressivePreviewCell: UITableViewCell {
     // MARK: - Setup
 
     private func setupUI() {
-        backgroundColor = .secondarySystemBackground
+        backgroundColor = AppColors.bg1
         selectionStyle = .none
-        contentView.addSubview(previewLabel)
+        contentView.addSubview(sequenceLabel)
         NSLayoutConstraint.activate([
-            previewLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.lg),
-            previewLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.lg),
-            previewLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: AppSpacing.sm),
-            previewLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -AppSpacing.sm)
+            sequenceLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.lg),
+            sequenceLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.lg),
+            sequenceLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: AppSpacing.sm),
+            sequenceLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -AppSpacing.md)
         ])
     }
 
     // MARK: - Configure
 
+    /// `text` arrives from `CreateAlarmViewModel.progressiveScalePreview` in
+    /// the legacy "1-е: 50₽ → 2-е: 100₽ → ..." format. We rebuild the V2
+    /// sequence here so the view-model output stays stable while the row's
+    /// presentation matches the JSX recipe (gradient stops + mono digits).
     func configure(text: String) {
-        previewLabel.text = text
+        // Parse the legacy preview output to recover the integer amounts.
+        // Each "1-е: 50₽" stop yields a single digit cluster after the
+        // colon — `components(separatedBy: ":")` + digit extraction is
+        // robust to the "₽" suffix and arrow separators.
+        let amounts: [Int] = text
+            .components(separatedBy: " → ")
+            .compactMap { stop -> Int? in
+                guard let colonIndex = stop.firstIndex(of: ":") else { return nil }
+                let tail = stop[stop.index(after: colonIndex)...]
+                let digits = tail.unicodeScalars
+                    .map { CharacterSet.decimalDigits.contains($0) ? Character($0) : " " }
+                let cluster = String(digits).split(separator: " ").first.map(String.init) ?? ""
+                return Int(cluster)
+            }
+
+        // Defensive: if parsing failed mid-stream, fall back to the raw text.
+        guard amounts.count >= 2 else {
+            sequenceLabel.attributedText = NSAttributedString(
+                string: text,
+                attributes: [
+                    .font: AppFonts.mono(.semibold, 14),
+                    .foregroundColor: AppColors.warn400
+                ]
+            )
+            return
+        }
+
+        sequenceLabel.attributedText = Self.makeSequence(amounts: Array(amounts.prefix(4)))
+    }
+
+    /// Compose the "50 → 100 → 200 → 400 ₽" attributed sequence. The first
+    /// two stops are `warn400`, the third painful, the fourth boldest pain.
+    private static func makeSequence(amounts: [Int]) -> NSAttributedString {
+        let stopColors: [UIColor] = [
+            AppColors.warn400,
+            AppColors.warn400,
+            AppColors.pain400,
+            AppColors.pain400
+        ]
+        let stopWeights: [AppFonts.Weight] = [.semibold, .semibold, .semibold, .bold]
+        let stopSizes: [CGFloat] = [14, 14, 14, 16]
+        let arrow = NSAttributedString(
+            string: "  →  ",
+            attributes: [
+                .font: AppFonts.mono(.regular, 14),
+                .foregroundColor: AppColors.fg4
+            ]
+        )
+        let composed = NSMutableAttributedString()
+        for (index, amount) in amounts.enumerated() {
+            let colorIndex = min(index, stopColors.count - 1)
+            let isLast = index == amounts.count - 1
+            let weight = stopWeights[colorIndex]
+            let size = stopSizes[colorIndex]
+            let text = isLast ? "\(amount) ₽" : "\(amount)"
+            composed.append(NSAttributedString(
+                string: text,
+                attributes: [
+                    .font: AppFonts.mono(weight, size),
+                    .foregroundColor: stopColors[colorIndex]
+                ]
+            ))
+            if !isLast {
+                composed.append(arrow)
+            }
+        }
+        return composed
     }
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/ProgressiveScaleCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/ProgressiveScaleCell.swift
@@ -1,19 +1,57 @@
 import UIKit
 
-/// Toggle row for the "Прогрессивная шкала" setting. Owns its switch privately —
-/// the previous shared-property design crashed UIKit when `reloadSections`
-/// tore down the host cell while the switch was still attached as accessoryView.
+/// V2 "Прогрессивный режим" toggle row with leading flame icon. The icon
+/// tints `pain400` when the toggle is on (matching `SPScreensV2.jsx` lines
+/// 622) and falls back to `fg3` when off so the row reads as "armed" /
+/// "disarmed" at a glance.
+///
+/// The row also surfaces the rationale subtitle ("Каждое откладывание — в 2
+/// раза дороже") so the user understands the cost ramp before flipping it.
 final class ProgressiveScaleCell: UITableViewCell {
 
     static let reuseID = "ProgressiveScaleCell"
 
     // MARK: - UI
 
-    private let toggle: UISwitch = {
-        let view = UISwitch()
-        view.onTintColor = AppColors.accentOrange
+    private let iconView: UIImageView = {
+        let image = UIImage(systemName: "flame.fill")?.withConfiguration(
+            UIImage.SymbolConfiguration(pointSize: 20, weight: .medium)
+        )
+        let view = UIImageView(image: image)
+        view.tintColor = AppColors.fg3
+        view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Прогрессивный режим"
+        label.font = AppTypography.bodyLg
+        label.textColor = AppColors.fg1
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Каждое откладывание — в 2 раза дороже"
+        label.font = AppTypography.meta
+        label.textColor = AppColors.fg3
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let textStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.alignment = .leading
+        stack.spacing = 2
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+
+    private let toggle = SPSwitch()
 
     // MARK: - Callbacks
 
@@ -23,15 +61,40 @@ final class ProgressiveScaleCell: UITableViewCell {
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        textLabel?.text = "Прогрессивная шкала"
-        backgroundColor = .secondarySystemBackground
-        selectionStyle = .none
-        accessoryView = toggle
+        setupUI()
         toggle.addTarget(self, action: #selector(toggled), for: .valueChanged)
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupUI() {
+        backgroundColor = AppColors.bg1
+        selectionStyle = .none
+
+        toggle.translatesAutoresizingMaskIntoConstraints = false
+        textStack.addArrangedSubview(titleLabel)
+        textStack.addArrangedSubview(subtitleLabel)
+
+        contentView.addSubview(iconView)
+        contentView.addSubview(textStack)
+        contentView.addSubview(toggle)
+
+        NSLayoutConstraint.activate([
+            iconView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.sp4),
+            iconView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 14),
+            iconView.widthAnchor.constraint(equalToConstant: 24),
+            iconView.heightAnchor.constraint(equalToConstant: 24),
+
+            textStack.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: AppSpacing.sp3),
+            textStack.topAnchor.constraint(equalTo: contentView.topAnchor, constant: AppSpacing.sp3),
+            textStack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -AppSpacing.sp3),
+
+            toggle.leadingAnchor.constraint(greaterThanOrEqualTo: textStack.trailingAnchor, constant: AppSpacing.sp3),
+            toggle.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.sp4),
+            toggle.centerYAnchor.constraint(equalTo: contentView.centerYAnchor)
+        ])
     }
 
     override func prepareForReuse() {
@@ -43,11 +106,13 @@ final class ProgressiveScaleCell: UITableViewCell {
 
     func configure(isOn: Bool) {
         toggle.isOn = isOn
+        iconView.tintColor = isOn ? AppColors.pain400 : AppColors.fg3
     }
 
     // MARK: - Actions
 
     @objc private func toggled() {
+        iconView.tintColor = toggle.isOn ? AppColors.pain400 : AppColors.fg3
         onToggled?(toggle.isOn)
     }
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/SnoozeSliderCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/SnoozeSliderCell.swift
@@ -21,9 +21,10 @@ final class SnoozeSliderCell: UITableViewCell {
         let view = UISlider()
         view.minimumValue = Float(SnoozeSliderCell.minMinutes)
         view.maximumValue = Float(SnoozeSliderCell.maxMinutes)
-        // Brand-tint the track to match the volume slider on the same screen
-        // (#179) — the system blue clashes with the SP money palette.
-        view.minimumTrackTintColor = AppColors.money500
+        // V2: tint the track `warn500` so the snooze-duration slider reads
+        // as "amber affordance" matching the JSX recipe in `SPScreensV2.jsx`
+        // line 563.
+        view.minimumTrackTintColor = AppColors.warn500
         view.setThumbImage(SnoozeSliderCell.makeThumb(diameter: 28), for: .normal)
         view.setThumbImage(SnoozeSliderCell.makeThumb(diameter: 30), for: .highlighted)
         view.translatesAutoresizingMaskIntoConstraints = false
@@ -32,7 +33,9 @@ final class SnoozeSliderCell: UITableViewCell {
 
     private let valueLabel: UILabel = {
         let label = UILabel()
-        label.font = AppTypography.body
+        // V2: mono `moneyMd` so the "{N} мин" reading column-aligns with the
+        // penalty preset row's amount on the same screen.
+        label.font = AppTypography.moneyMd
         label.textColor = AppColors.fg1
         label.textAlignment = .right
         label.translatesAutoresizingMaskIntoConstraints = false

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/SoundCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/SoundCell.swift
@@ -1,41 +1,40 @@
 import UIKit
 
-/// Sound row: title on the left, current sound name + play button + chevron
-/// disclosure on the right. Tapping the row pushes `SoundPickerViewController`
-/// (handled by the controller's `didSelectRowAt`); tapping the play button
-/// fires a preview without leaving the screen.
+/// V2 "Звук" row: leading sound icon + title + trailing sound name (meta) +
+/// chevron. The inline preview play button is dropped — the dedicated
+/// `SoundPickerViewController` exposes per-row previews so the form-level
+/// row stays clean. Matches `SPScreensV2.jsx` lines 574-578.
 final class SoundCell: UITableViewCell {
 
     static let reuseID = "SoundCell"
 
     // MARK: - UI
 
+    private let iconView: UIImageView = {
+        let image = UIImage(systemName: "speaker.wave.2.fill")?.withConfiguration(
+            UIImage.SymbolConfiguration(pointSize: 20, weight: .medium)
+        )
+        let view = UIImageView(image: image)
+        view.tintColor = AppColors.fg3
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.text = "Звук"
-        label.font = UIFont.systemFont(ofSize: 17)
-        label.textColor = .label
+        label.font = AppTypography.bodyLg
+        label.textColor = AppColors.fg1
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
 
     private let soundNameLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 17)
-        label.textColor = .secondaryLabel
+        label.font = AppTypography.meta
+        label.textColor = AppColors.fg3
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
-    }()
-
-    private let playButton: UIButton = {
-        let button = UIButton(type: .system)
-        let image = UIImage(systemName: "play.circle.fill")?.withConfiguration(
-            UIImage.SymbolConfiguration(pointSize: 24, weight: .medium)
-        )
-        button.setImage(image, for: .normal)
-        button.tintColor = AppColors.accentBlue
-        button.translatesAutoresizingMaskIntoConstraints = false
-        return button
     }()
 
     private let chevronView: UIImageView = {
@@ -43,13 +42,15 @@ final class SoundCell: UITableViewCell {
             UIImage.SymbolConfiguration(pointSize: 13, weight: .semibold)
         )
         let view = UIImageView(image: image)
-        view.tintColor = .tertiaryLabel
+        view.tintColor = AppColors.fg3
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
 
     // MARK: - Callbacks
 
+    /// Retained for backwards compatibility — preview now ships on the
+    /// dedicated picker screen, so this fires only if the host wires it.
     var onPreviewTapped: (() -> Void)?
 
     // MARK: - Init
@@ -57,7 +58,6 @@ final class SoundCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setupUI()
-        playButton.addTarget(self, action: #selector(previewTapped), for: .touchUpInside)
     }
 
     required init?(coder: NSCoder) {
@@ -67,35 +67,33 @@ final class SoundCell: UITableViewCell {
     // MARK: - Setup
 
     private func setupUI() {
-        backgroundColor = .secondarySystemBackground
-        // Use the system selection so the row briefly highlights on tap before
-        // navigating to the sound picker.
+        backgroundColor = AppColors.bg1
         selectionStyle = .default
 
+        contentView.addSubview(iconView)
         contentView.addSubview(titleLabel)
         contentView.addSubview(chevronView)
-        contentView.addSubview(playButton)
         contentView.addSubview(soundNameLabel)
 
         NSLayoutConstraint.activate([
-            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.lg),
+            iconView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.sp4),
+            iconView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            iconView.widthAnchor.constraint(equalToConstant: 24),
+            iconView.heightAnchor.constraint(equalToConstant: 24),
+
+            titleLabel.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: AppSpacing.sp3),
             titleLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
 
-            chevronView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.lg),
+            chevronView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.sp4),
             chevronView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
 
-            playButton.trailingAnchor.constraint(equalTo: chevronView.leadingAnchor, constant: -AppSpacing.sm),
-            playButton.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-
-            soundNameLabel.trailingAnchor.constraint(
-                equalTo: playButton.leadingAnchor, constant: -AppSpacing.sm
-            ),
+            soundNameLabel.trailingAnchor.constraint(equalTo: chevronView.leadingAnchor, constant: -AppSpacing.sp2),
             soundNameLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
             soundNameLabel.leadingAnchor.constraint(
-                greaterThanOrEqualTo: titleLabel.trailingAnchor, constant: AppSpacing.sm
+                greaterThanOrEqualTo: titleLabel.trailingAnchor, constant: AppSpacing.sp2
             ),
 
-            contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: 44)
+            contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: 48)
         ])
     }
 
@@ -108,11 +106,5 @@ final class SoundCell: UITableViewCell {
 
     func configure(soundName: String) {
         soundNameLabel.text = soundName
-    }
-
-    // MARK: - Actions
-
-    @objc private func previewTapped() {
-        onPreviewTapped?()
     }
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/ThemeRowCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/ThemeRowCell.swift
@@ -1,16 +1,38 @@
 import UIKit
 
-/// "Тема будильника" disclosure row used by `CreateAlarmViewController` (#143).
-///
-/// Layout matches the SPRow primitive: title on the leading side, current
-/// value + chevron on the trailing side. Tapping the row is wired by the
-/// hosting controller via `didSelectRowAt`. The full picker lands in #151;
-/// until then the controller stubs the navigation as a no-op.
+/// V2 "Тема" disclosure row: leading 28×28 gradient thumbnail + title +
+/// trailing theme-name meta + chevron. Matches `SPScreensV2.jsx` lines
+/// 579-584. The thumbnail tracks the currently-selected theme so the user
+/// sees a live preview of what they've picked without having to enter the
+/// theme picker.
 final class ThemeRowCell: UITableViewCell {
 
     static let reuseID = "ThemeRowCell"
 
     // MARK: - UI
+
+    /// Thumbnail container — 28×28 with a theme gradient (or photo) drawn
+    /// inside. Rounded `AppRadius.xs` corners so the chip reads as a
+    /// "stamp" of the firing screen.
+    private let thumbnail: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.layer.cornerRadius = AppRadius.xs
+        view.layer.masksToBounds = true
+        view.backgroundColor = AppColors.bg2
+        return view
+    }()
+
+    private let thumbnailImageView: UIImageView = {
+        let view = UIImageView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.contentMode = .scaleAspectFill
+        view.clipsToBounds = true
+        view.isHidden = true
+        return view
+    }()
+
+    private var thumbnailGradient: CAGradientLayer?
 
     private let titleLabel: UILabel = {
         let label = UILabel()
@@ -23,7 +45,7 @@ final class ThemeRowCell: UITableViewCell {
 
     private let valueLabel: UILabel = {
         let label = UILabel()
-        label.font = AppTypography.bodyLg
+        label.font = AppTypography.meta
         label.textColor = AppColors.fg3
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
@@ -50,38 +72,81 @@ final class ThemeRowCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        thumbnailGradient?.frame = thumbnail.bounds
+    }
+
     // MARK: - Setup
 
     private func setupUI() {
         backgroundColor = AppColors.bg1
-        // Match SoundCell — let the system briefly highlight the row on tap
-        // so the user gets feedback before the picker pushes onto the stack.
         selectionStyle = .default
 
+        thumbnail.addSubview(thumbnailImageView)
+
+        contentView.addSubview(thumbnail)
         contentView.addSubview(titleLabel)
         contentView.addSubview(chevronView)
         contentView.addSubview(valueLabel)
 
         NSLayoutConstraint.activate([
-            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.lg),
+            thumbnail.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.sp4),
+            thumbnail.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            thumbnail.widthAnchor.constraint(equalToConstant: 28),
+            thumbnail.heightAnchor.constraint(equalToConstant: 28),
+
+            thumbnailImageView.topAnchor.constraint(equalTo: thumbnail.topAnchor),
+            thumbnailImageView.leadingAnchor.constraint(equalTo: thumbnail.leadingAnchor),
+            thumbnailImageView.trailingAnchor.constraint(equalTo: thumbnail.trailingAnchor),
+            thumbnailImageView.bottomAnchor.constraint(equalTo: thumbnail.bottomAnchor),
+
+            titleLabel.leadingAnchor.constraint(equalTo: thumbnail.trailingAnchor, constant: AppSpacing.sp3),
             titleLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
 
-            chevronView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.lg),
+            chevronView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.sp4),
             chevronView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
 
-            valueLabel.trailingAnchor.constraint(equalTo: chevronView.leadingAnchor, constant: -AppSpacing.sm),
+            valueLabel.trailingAnchor.constraint(equalTo: chevronView.leadingAnchor, constant: -AppSpacing.sp2),
             valueLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
             valueLabel.leadingAnchor.constraint(
-                greaterThanOrEqualTo: titleLabel.trailingAnchor, constant: AppSpacing.sm
+                greaterThanOrEqualTo: titleLabel.trailingAnchor, constant: AppSpacing.sp2
             ),
 
-            contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: 44)
+            contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: 48)
         ])
     }
 
     // MARK: - Configure
 
+    /// Legacy two-arg signature retained for the existing `+Sections` call
+    /// sites. The thumbnail falls back to the default Dawn gradient.
     func configure(themeName: String) {
+        configure(theme: .dawn, themeName: themeName)
+    }
+
+    /// V2 signature: render the theme's actual gradient/photo into the
+    /// leading thumbnail so the row reads as a live preview of the current
+    /// selection.
+    func configure(theme: AlarmTheme, themeName: String) {
         valueLabel.text = themeName
+        thumbnailGradient?.removeFromSuperlayer()
+        thumbnailGradient = nil
+        thumbnailImageView.image = nil
+        thumbnailImageView.isHidden = true
+
+        if case .custom(let url) = theme, let image = AlarmThemeImageStore.loadImage(at: url) {
+            thumbnailImageView.image = image
+            thumbnailImageView.isHidden = false
+        } else if let colors = AlarmThemeRendering.gradientColors(for: theme) {
+            let layer = CAGradientLayer()
+            layer.colors = colors
+            layer.locations = AlarmThemeRendering.gradientLocations(for: theme)
+            layer.startPoint = CGPoint(x: 0.0, y: 0.0)
+            layer.endPoint = CGPoint(x: 1.0, y: 1.0)
+            layer.frame = thumbnail.bounds
+            thumbnail.layer.insertSublayer(layer, at: 0)
+            thumbnailGradient = layer
+        }
     }
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/VibrationCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/VibrationCell.swift
@@ -1,17 +1,34 @@
 import UIKit
 
-/// Toggle row for the "Вибрация" setting.
+/// V2 "Вибрация" toggle row. Uses the brand `SPSwitch` so the on-state reads
+/// money-tinted instead of the platform green, matching the V2 settings group
+/// in `SPScreensV2.jsx` lines 585-590.
 final class VibrationCell: UITableViewCell {
 
     static let reuseID = "VibrationCell"
 
     // MARK: - UI
 
-    private let toggle: UISwitch = {
-        let view = UISwitch()
-        view.onTintColor = AppColors.accentGreen
+    private let iconView: UIImageView = {
+        let image = UIImage(systemName: "bell")?.withConfiguration(
+            UIImage.SymbolConfiguration(pointSize: 20, weight: .medium)
+        )
+        let view = UIImageView(image: image)
+        view.tintColor = AppColors.fg3
+        view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Вибрация"
+        label.font = AppTypography.bodyLg
+        label.textColor = AppColors.fg1
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let toggle = SPSwitch()
 
     // MARK: - Callbacks
 
@@ -21,15 +38,37 @@ final class VibrationCell: UITableViewCell {
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        textLabel?.text = "Вибрация"
-        backgroundColor = .secondarySystemBackground
-        selectionStyle = .none
-        accessoryView = toggle
+        setupUI()
         toggle.addTarget(self, action: #selector(toggled), for: .valueChanged)
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupUI() {
+        backgroundColor = AppColors.bg1
+        selectionStyle = .none
+        toggle.translatesAutoresizingMaskIntoConstraints = false
+
+        contentView.addSubview(iconView)
+        contentView.addSubview(titleLabel)
+        contentView.addSubview(toggle)
+
+        NSLayoutConstraint.activate([
+            iconView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.sp4),
+            iconView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            iconView.widthAnchor.constraint(equalToConstant: 24),
+            iconView.heightAnchor.constraint(equalToConstant: 24),
+
+            titleLabel.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: AppSpacing.sp3),
+            titleLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+
+            toggle.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.sp4),
+            toggle.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+
+            contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: 48)
+        ])
     }
 
     override func prepareForReuse() {

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/VolumeCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/VolumeCell.swift
@@ -1,32 +1,39 @@
 import UIKit
 
-/// "Громкость" row on the create / edit alarm form (#150).
-///
-/// Mirrors the chrome of `SoundCell` so the new row reads as the same
-/// primitive — title on the left, current volume + optional fade-in label
-/// on the right, chevron disclosure. Tapping pushes the
-/// `VolumePickerViewController` (handled by the parent `didSelectRowAt`).
+/// V2 "Громкость" row: leading volume icon + title + trailing "{N}%" meta +
+/// chevron. Matches the settings-group row pattern from `SPScreensV2.jsx`.
+/// Tapping pushes `VolumePickerViewController` (wired by the parent).
 final class VolumeCell: UITableViewCell {
 
     static let reuseID = "VolumeCell"
 
     // MARK: - UI
 
+    private let iconView: UIImageView = {
+        let image = UIImage(systemName: "speaker.wave.3.fill")?.withConfiguration(
+            UIImage.SymbolConfiguration(pointSize: 20, weight: .medium)
+        )
+        let view = UIImageView(image: image)
+        view.tintColor = AppColors.fg3
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.text = "Громкость"
-        label.font = UIFont.systemFont(ofSize: 17)
-        label.textColor = .label
+        label.font = AppTypography.bodyLg
+        label.textColor = AppColors.fg1
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
 
     private let valueLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 17)
-        label.textColor = .secondaryLabel
-        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = AppTypography.meta
+        label.textColor = AppColors.fg3
         label.textAlignment = .right
+        label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
 
@@ -35,7 +42,7 @@ final class VolumeCell: UITableViewCell {
             UIImage.SymbolConfiguration(pointSize: 13, weight: .semibold)
         )
         let view = UIImageView(image: image)
-        view.tintColor = .tertiaryLabel
+        view.tintColor = AppColors.fg3
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
@@ -53,27 +60,33 @@ final class VolumeCell: UITableViewCell {
     }
 
     private func setupUI() {
-        backgroundColor = .secondarySystemBackground
+        backgroundColor = AppColors.bg1
         selectionStyle = .default
 
+        contentView.addSubview(iconView)
         contentView.addSubview(titleLabel)
         contentView.addSubview(chevronView)
         contentView.addSubview(valueLabel)
 
         NSLayoutConstraint.activate([
-            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.lg),
+            iconView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.sp4),
+            iconView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            iconView.widthAnchor.constraint(equalToConstant: 24),
+            iconView.heightAnchor.constraint(equalToConstant: 24),
+
+            titleLabel.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: AppSpacing.sp3),
             titleLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
 
-            chevronView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.lg),
+            chevronView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.sp4),
             chevronView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
 
-            valueLabel.trailingAnchor.constraint(equalTo: chevronView.leadingAnchor, constant: -AppSpacing.sm),
+            valueLabel.trailingAnchor.constraint(equalTo: chevronView.leadingAnchor, constant: -AppSpacing.sp2),
             valueLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
             valueLabel.leadingAnchor.constraint(
-                greaterThanOrEqualTo: titleLabel.trailingAnchor, constant: AppSpacing.sm
+                greaterThanOrEqualTo: titleLabel.trailingAnchor, constant: AppSpacing.sp2
             ),
 
-            contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: 44)
+            contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: 48)
         ])
     }
 

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/ConfirmDeleteAlarmViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/ConfirmDeleteAlarmViewController.swift
@@ -1,0 +1,193 @@
+import UIKit
+
+/// Bottom-sheet confirmation for destructive "Удалить будильник" (#163 / V2).
+///
+/// Replaces the UIAlertController-based action sheet so the destructive flow
+/// matches the SP design system (caps + h2 + meta + pain CTA). Presented
+/// modally with `.pageSheet` / `.formSheet` detents so the card slides up
+/// from the bottom edge of the create-alarm form.
+///
+/// Layout mirrors `SPMore2.jsx` lines 224-248 (`ConfirmDelete()`):
+///   - 64×64 pain-tinted square with X icon
+///   - h2 "Удалить будильник?" title
+///   - body copy line
+///   - `SPButton(.pain, .lg)` "Удалить"
+///   - `SPButton(.quiet, .md)` "Отмена"
+final class ConfirmDeleteAlarmViewController: UIViewController {
+
+    // MARK: - Callbacks
+
+    /// Invoked after the user taps "Удалить". The host VC handles the actual
+    /// delete + repository wiring; this sheet only owns the confirmation UI.
+    var onConfirm: (() -> Void)?
+
+    // MARK: - Body copy
+
+    /// Subtitle line shown below the headline. Defaults to the V2 copy "Деньги
+    /// с баланса не вернутся. Это безвозвратно."; the host can override to
+    /// surface alarm-specific context (name + repeat + time).
+    private let bodyCopy: String
+
+    // MARK: - UI
+
+    private let card: SPCard = {
+        let card = SPCard(tone: .raised, padding: AppSpacing.sp6, cornerRadius: AppRadius.xl)
+        card.translatesAutoresizingMaskIntoConstraints = false
+        return card
+    }()
+
+    private let iconBadge: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.layer.cornerRadius = AppRadius.md
+        view.layer.masksToBounds = true
+        view.backgroundColor = AppColors.pain500.withAlphaComponent(0.14)
+        view.layer.borderWidth = 1
+        view.layer.borderColor = AppColors.pain500.withAlphaComponent(0.30).cgColor
+        return view
+    }()
+
+    private let iconView: UIImageView = {
+        let image = UIImage(systemName: "xmark")?.withConfiguration(
+            UIImage.SymbolConfiguration(pointSize: 24, weight: .bold)
+        )
+        let view = UIImageView(image: image)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.tintColor = AppColors.pain400
+        view.contentMode = .center
+        return view
+    }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = AppTypography.h2
+        label.textColor = AppColors.fg1
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.text = "Удалить будильник?"
+        return label
+    }()
+
+    private let bodyLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = AppTypography.body
+        label.textColor = AppColors.fg2
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        return label
+    }()
+
+    private let deleteButton = SPButton(
+        title: "Удалить",
+        variant: .pain,
+        size: .lg,
+        fullWidth: true
+    )
+
+    private let cancelButton = SPButton(
+        title: "Отмена",
+        variant: .quiet,
+        size: .md,
+        fullWidth: true
+    )
+
+    // MARK: - Init
+
+    /// - Parameters:
+    ///   - body: Subtitle copy. Defaults to the V2 spec text. Pass a tailored
+    ///     line (e.g. "Будни · Пн–Пт · 7:00") when the alarm context is rich.
+    ///   - onConfirm: Closure invoked on the destructive tap. The sheet
+    ///     dismisses itself before firing the callback.
+    init(
+        body: String = "Деньги с баланса не вернутся. Это безвозвратно.",
+        onConfirm: (() -> Void)? = nil
+    ) {
+        self.bodyCopy = body
+        self.onConfirm = onConfirm
+        super.init(nibName: nil, bundle: nil)
+        // Custom presentation — slide up from the bottom on phones, render as
+        // a centred form sheet on iPad / large screens.
+        modalPresentationStyle = .pageSheet
+        if let sheet = sheetPresentationController {
+            sheet.detents = [.medium()]
+            sheet.preferredCornerRadius = AppRadius.xl
+            sheet.prefersGrabberVisible = true
+        }
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = AppColors.bg0
+        bodyLabel.text = bodyCopy
+        setupUI()
+        deleteButton.addTarget(self, action: #selector(confirmTapped), for: .touchUpInside)
+        cancelButton.addTarget(self, action: #selector(cancelTapped), for: .touchUpInside)
+    }
+
+    // MARK: - Setup
+
+    private func setupUI() {
+        view.addSubview(card)
+
+        iconBadge.addSubview(iconView)
+        card.addSubview(iconBadge)
+        card.addSubview(titleLabel)
+        card.addSubview(bodyLabel)
+        card.addSubview(deleteButton)
+        card.addSubview(cancelButton)
+
+        NSLayoutConstraint.activate([
+            card.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: AppSpacing.sp3),
+            card.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -AppSpacing.sp3),
+            card.centerYAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerYAnchor),
+
+            iconBadge.topAnchor.constraint(equalTo: card.layoutMarginsGuide.topAnchor),
+            iconBadge.centerXAnchor.constraint(equalTo: card.centerXAnchor),
+            iconBadge.widthAnchor.constraint(equalToConstant: 64),
+            iconBadge.heightAnchor.constraint(equalToConstant: 64),
+
+            iconView.centerXAnchor.constraint(equalTo: iconBadge.centerXAnchor),
+            iconView.centerYAnchor.constraint(equalTo: iconBadge.centerYAnchor),
+
+            titleLabel.topAnchor.constraint(equalTo: iconBadge.bottomAnchor, constant: AppSpacing.sp4),
+            titleLabel.leadingAnchor.constraint(equalTo: card.layoutMarginsGuide.leadingAnchor),
+            titleLabel.trailingAnchor.constraint(equalTo: card.layoutMarginsGuide.trailingAnchor),
+
+            bodyLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: AppSpacing.sp2),
+            bodyLabel.leadingAnchor.constraint(equalTo: card.layoutMarginsGuide.leadingAnchor),
+            bodyLabel.trailingAnchor.constraint(equalTo: card.layoutMarginsGuide.trailingAnchor),
+
+            deleteButton.topAnchor.constraint(equalTo: bodyLabel.bottomAnchor, constant: AppSpacing.sp5),
+            deleteButton.leadingAnchor.constraint(equalTo: card.layoutMarginsGuide.leadingAnchor),
+            deleteButton.trailingAnchor.constraint(equalTo: card.layoutMarginsGuide.trailingAnchor),
+
+            cancelButton.topAnchor.constraint(equalTo: deleteButton.bottomAnchor, constant: AppSpacing.sp2),
+            cancelButton.leadingAnchor.constraint(equalTo: card.layoutMarginsGuide.leadingAnchor),
+            cancelButton.trailingAnchor.constraint(equalTo: card.layoutMarginsGuide.trailingAnchor),
+            cancelButton.bottomAnchor.constraint(equalTo: card.layoutMarginsGuide.bottomAnchor)
+        ])
+    }
+
+    // MARK: - Actions
+
+    @objc private func confirmTapped() {
+        // Dismiss first so the host's onDelete + dismiss(animated:) chain
+        // doesn't race with the sheet's own dismissal animation.
+        dismiss(animated: true) { [weak self] in
+            self?.onConfirm?()
+        }
+    }
+
+    @objc private func cancelTapped() {
+        dismiss(animated: true)
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController+Pickers.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController+Pickers.swift
@@ -8,22 +8,21 @@ import UIKit
 
 extension CreateAlarmViewController {
 
-    /// Action-sheet confirmation before destroying the alarm being edited.
-    /// Mirrors the original `confirmDelete()` verbatim — including the iPad
-    /// popover sourceView dance that prevents the crash on regular size class.
+    /// V2 bottom-sheet confirmation before destroying the alarm being edited
+    /// (#163). Replaces the pre-refresh `UIAlertController.actionSheet` flow
+    /// with the brand-aligned `ConfirmDeleteAlarmViewController` so the
+    /// destructive copy reads in the same caps/h2/pain typography ramp as the
+    /// rest of the V2 surfaces. The actual `viewModel.delete()` + onDelete
+    /// + dismiss chain is unchanged — only the surface that asks "are you
+    /// sure?" moved.
     func confirmDelete() {
-        let alert = UIAlertController(
-            title: "Удалить будильник?",
-            message: "Это действие нельзя отменить.",
-            preferredStyle: .actionSheet
-        )
-        alert.addAction(UIAlertAction(title: "Удалить", style: .destructive) { [weak self] _ in
+        let sheet = ConfirmDeleteAlarmViewController { [weak self] in
             guard let self else { return }
-            // ViewModel.delete forwards to AlarmRepository.delete, which itself
+            // ViewModel.delete forwards to AlarmRepository.delete, which
             // cancels the scheduled UNNotificationRequests via AlarmScheduler.
             // Returns false when the store is locked due to a corrupt blob
             // (issue #72) — surface the failure rather than dismiss the
-            // sheet on a no-op delete.
+            // create-alarm form on a no-op delete.
             let didDelete = self.viewModel.delete()
             guard didDelete else {
                 self.presentSaveError(
@@ -34,15 +33,8 @@ extension CreateAlarmViewController {
             }
             self.onDelete?()
             self.dismiss(animated: true)
-        })
-        alert.addAction(UIAlertAction(title: "Отмена", style: .cancel))
-        // Without a sourceView the action sheet crashes on iPad popovers.
-        if let popover = alert.popoverPresentationController {
-            popover.sourceView = view
-            popover.sourceRect = CGRect(x: view.bounds.midX, y: view.bounds.midY, width: 0, height: 0)
-            popover.permittedArrowDirections = []
         }
-        present(alert, animated: true)
+        present(sheet, animated: true)
     }
 
     func showThemePicker() {
@@ -57,7 +49,7 @@ extension CreateAlarmViewController {
                 // that follows the imperative pop).
                 let indexPath = IndexPath(row: 0, section: themeSectionIndex)
                 if let cell = self.tableView.cellForRow(at: indexPath) as? ThemeRowCell {
-                    cell.configure(themeName: self.viewModel.alarmThemeName)
+                    cell.configure(theme: self.viewModel.theme, themeName: self.viewModel.alarmThemeName)
                 }
             }
         )

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController+Sections.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController+Sections.swift
@@ -132,7 +132,9 @@ extension CreateAlarmViewController {
     func makeThemeCell(_ tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: ThemeRowCell.reuseID, for: indexPath)
         if let cell = cell as? ThemeRowCell {
-            cell.configure(themeName: viewModel.alarmThemeName)
+            // V2 thumbnail variant: pass the live theme so the leading 28pt
+            // tile renders the matching gradient/photo (#163).
+            cell.configure(theme: viewModel.theme, themeName: viewModel.alarmThemeName)
         }
         return cell
     }

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
@@ -112,17 +112,51 @@ final class CreateAlarmViewController: UIViewController {
     // MARK: - Setup
 
     private func setupNavigationBar() {
-        navigationItem.leftBarButtonItem = UIBarButtonItem(
-            barButtonSystemItem: .cancel,
-            target: self,
-            action: #selector(cancelTapped)
+        // V2 nav bar — left X close chip, centered caps title, right `Готово`
+        // SPButton(.money, .sm). The UIKit navigation bar still owns layout
+        // (we keep `title` set on viewDidLoad for accessibility), but the
+        // left/right items are custom views so the brand styling sticks.
+        // Matches `SPScreensV2.jsx` lines 496-502.
+        let closeButton = UIButton(type: .system)
+        closeButton.setImage(
+            UIImage(systemName: "xmark")?.withConfiguration(
+                UIImage.SymbolConfiguration(pointSize: 16, weight: .semibold)
+            ),
+            for: .normal
         )
-        navigationItem.rightBarButtonItem = UIBarButtonItem(
-            title: "Сохранить",
-            style: .plain,
-            target: self,
-            action: #selector(saveTapped)
+        closeButton.tintColor = AppColors.fg1
+        closeButton.backgroundColor = AppColors.whiteOverlay06
+        closeButton.layer.cornerRadius = 18
+        closeButton.layer.masksToBounds = true
+        closeButton.translatesAutoresizingMaskIntoConstraints = false
+        closeButton.widthAnchor.constraint(equalToConstant: 36).isActive = true
+        closeButton.heightAnchor.constraint(equalToConstant: 36).isActive = true
+        closeButton.addTarget(self, action: #selector(cancelTapped), for: .touchUpInside)
+        closeButton.accessibilityLabel = "Закрыть"
+        navigationItem.leftBarButtonItem = UIBarButtonItem(customView: closeButton)
+
+        let saveButton = SPButton(
+            title: "Готово",
+            variant: .money,
+            size: .sm
         )
+        saveButton.addTarget(self, action: #selector(saveTapped), for: .touchUpInside)
+        navigationItem.rightBarButtonItem = UIBarButtonItem(customView: saveButton)
+
+        // V2 title sits in caps + tracking. UIKit nav titles don't support
+        // attributed text directly via `navigationItem.title`, so install a
+        // custom title view label.
+        let titleLabel = UILabel()
+        titleLabel.attributedText = NSAttributedString(
+            string: (viewModel.isEditing ? "Редактировать" : "Новый будильник").uppercased(),
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.fg3
+            ]
+        )
+        titleLabel.textAlignment = .center
+        navigationItem.titleView = titleLabel
     }
 
     private func setupTableView() {
@@ -316,7 +350,9 @@ extension CreateAlarmViewController: UITableViewDelegate {
         switch section {
         case .timePicker: return 200
         case .repeatDays: return 60
-        case .penalty: return 60
+        // V2 penalty row stacks a moneyMd value label above a 40pt chip row
+        // — the prior 60pt height clipped the chip ladder, so bump to 96pt.
+        case .penalty: return 96
         default: return UITableView.automaticDimension
         }
     }

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/SoundPickerViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/SoundPickerViewController.swift
@@ -77,8 +77,21 @@ final class SoundPickerViewController: UIViewController, UITableViewDataSource, 
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = "Выбор звука"
         view.backgroundColor = AppColors.bg0
+        // V2 caps title — accessibility label keeps the long "Выбор звука"
+        // string so VoiceOver still announces the screen purpose, while the
+        // visible label collapses to the JSX caps recipe.
+        let titleLabel = UILabel()
+        titleLabel.attributedText = NSAttributedString(
+            string: "Звук".uppercased(),
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.fg3
+            ]
+        )
+        titleLabel.accessibilityLabel = "Выбор звука"
+        navigationItem.titleView = titleLabel
         setupTableView()
     }
 

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/VolumePickerViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/VolumePickerViewController.swift
@@ -107,8 +107,19 @@ final class VolumePickerViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = "Громкость"
         view.backgroundColor = AppColors.bg0
+        // V2 caps title — matches `SPMore2.jsx` "Громкость" recipe.
+        let titleLabel = UILabel()
+        titleLabel.attributedText = NSAttributedString(
+            string: "Громкость".uppercased(),
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.fg3
+            ]
+        )
+        titleLabel.accessibilityLabel = "Громкость"
+        navigationItem.titleView = titleLabel
         setupUI()
         applyVolumeToUI()
         applyFadeToUI()


### PR DESCRIPTION
## Summary

V2 design slice for the alarm-form surfaces. Re-skins CreateAlarm / AlarmEdit
(the same VC handles both via `viewModel.isEditing`), adds the new
`ConfirmDeleteAlarmViewController` page sheet, and tunes Sound / Volume /
Theme pickers to the SP V2 caps + gradient recipe.

### Highlights
- **CreateAlarmViewController** — custom V2 nav bar: 36pt X close chip on
  the left, caps title in the centre, `SPButton(.money, .sm)` Готово on the
  right.
- **DayPickerCell** — 36×36 round pills, `money500` on selected with
  `fgOnMoney` text; unselected = `whiteOverlay06` chip + `fg3`.
- **SnoozeSliderCell** — track tinted `warn500`, value label switched to
  `moneyMd` mono.
- **PenaltyCell** — rebuilt as a 5-preset chip ladder (20 / 50 / 100 / 200
  / 500). Active preset wears `warn500`; the live amount sits above in the
  `moneyMd` role.
- **ProgressivePreviewCell** — mono "50 → 100 → 200 → 400 ₽" sequence with
  `warn400` → `pain400` gradient stops. Parses the existing view-model
  preview string so the model stays untouched.
- **ProgressiveScaleCell** — flame icon (pain400 on / fg3 off), title +
  rationale subtitle, `SPSwitch` trailing.
- **VibrationCell / SoundCell / VolumeCell / ThemeRowCell** — design-system
  rows: leading icon (or 28pt gradient thumbnail for theme) + bodyLg
  title + meta trailing + chevron.
- **DeleteActionCell** — `pain400` tinted destructive row.
- **ConfirmDeleteAlarmViewController** — new `.pageSheet` bottom card with
  64pt pain-tinted icon badge, `h2` headline, body meta, `SPButton(.pain,
  .lg)` "Удалить" + `SPButton(.quiet, .md)` "Отмена". Replaces the prior
  `UIAlertController.actionSheet` flow.
- **SoundPicker / VolumePicker / AlarmThemePicker** — caps title view in
  the nav bar with VoiceOver-friendly accessibility labels.
- **AlarmThemePicker** — 180pt firing-screen preview block above the grid
  that tracks the live `currentTheme`; renders the gradient or photo so the
  user sees the firing-screen sample update inline before the pop animation.

### Out of scope (per worktree brief)
- AlarmCell, AlarmsListViewController, Onboarding, Statistics, Wallet,
  Settings, AlarmFiringViewController* (other agents).
- SP* primitives are used, not modified — no new `SPSlider` proved
  necessary; `UISlider` with the existing money/warn-tinted thumb recipe
  matches the V2 spec.
- project.pbxproj — synchronized file groups auto-pick up the new
  `ConfirmDeleteAlarmViewController.swift`.

## Test plan
- [ ] Build green: `xcrun xcodebuild -project SnoozePay/SnoozePay.xcodeproj -scheme SnoozePay -destination 'platform=iOS Simulator,name=iPhone 17' build`
- [ ] Lint green: `swiftlint lint SnoozePay/SnoozePay/ViewControllers/Alarms/*.swift SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/*.swift`
- [ ] Manually: open Alarms → "+" → verify V2 nav bar, day pills, snooze slider, penalty preset chips, progressive flame, settings rows.
- [ ] Manually: edit an existing alarm → tap "Удалить будильник" → V2 confirm sheet animates up; "Удалить" deletes + dismisses, "Отмена" dismisses sheet only.
- [ ] Manually: from CreateAlarm tap Тема → grid + firing-screen preview block; pick another theme → preview updates before pop.
- [ ] Manually: tap Звук → caps title; tap Громкость → caps title, slider works.