### PR TITLE
[ui][v2-firing] AlarmFiring V2 Dawn + NoBalance + TopUp presets sheet

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Layout.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Layout.swift
@@ -1,27 +1,33 @@
 import UIKit
 
-// MARK: - View-stack + constraint builders
+// MARK: - View-stack + constraint builders (V2 Dawn)
 //
-// Extracted from `AlarmFiringViewController.swift` (#182) so the host file
-// stays under SwiftLint's `file_length` and `type_body_length` caps. The
-// initial `setupUI` constructs the time/name/snooze/dismiss/banner stack and
-// hands it off to the +Progressive / +NoBalance extensions for their
-// respective overlays.
+// Extracted from `AlarmFiringViewController.swift` so the host file stays
+// under SwiftLint's `file_length` and `type_body_length` caps. V2 spec lives
+// in `docs/design/v2-handoff/components/SPScreensV2.jsx` lines 37–103
+// (FiringDawn) and `SPDawnV3.jsx` (FiringDawnV3) — top-bar with date + balance
+// pill, centered hero (clock + caps "Подъём"), bottom CTAs.
 
 extension AlarmFiringViewController {
 
     /// Build the firing-screen view stack and pin everything to the screen.
-    /// Called once from `viewDidLoad`. Behaviour mirrors the original
-    /// `setupUI()` — only the location moved.
+    /// Called once from `viewDidLoad`. Composes:
+    /// 1. Atmospheric `SPDawnBackgroundView` filling the bounds.
+    /// 2. Top header — date caps left, balance pill right.
+    /// 3. Centered hero — 96pt mono clock, "Подъём" caps, alarm name.
+    /// 4. Progressive chrome (only when alarm.progressiveScale).
+    /// 5. Audio warning banner, snooze CTA, ghost dismiss.
+    /// 6. No-balance stack (hidden by default).
     func buildFiringLayout() {
-        view.backgroundColor = AppColors.bg0
+        view.backgroundColor = .black
         installThemedBackground()
+        installTopHeader()
+        installHeroCenter()
 
         // VM exposes `currentPenalty` as `Double`; wrap in `Decimal` so
         // `SPSnoozePrice.formattedRubles()` does the locale-aware format.
-        // Pick the initial tone based on the alarm config — progressive
-        // alarms start at intensity 0 (still pure warn) and ramp up as the
-        // user snoozes.
+        // Tone defaults to warn; progressive alarms cross-fade toward pain
+        // as snoozeCount climbs.
         let initialTone: SPSnoozePrice.Tone = viewModel.isProgressiveActive
             ? .progressive(intensity: viewModel.progressiveIntensity)
             : .warn
@@ -29,28 +35,25 @@ extension AlarmFiringViewController {
             price: Decimal(viewModel.currentPenalty),
             minutes: viewModel.alarm.snoozeMinutes,
             tone: initialTone,
-            hint: nil
+            hint: snoozeHintText()
         )
         snooze.translatesAutoresizingMaskIntoConstraints = false
         snooze.onTap = { [weak self] in self?.snoozeTapped() }
         view.addSubview(snooze)
         snoozeCTA = snooze
 
-        view.addSubview(timeLabel)
-        view.addSubview(nameLabel)
-
         dismissButton.translatesAutoresizingMaskIntoConstraints = false
         dismissButton.addTarget(self, action: #selector(dismissTapped), for: .touchUpInside)
         view.addSubview(dismissButton)
         view.addSubview(audioWarningBanner)
 
-        let inset: CGFloat = AppSpacing.sp5      // 20pt — Dawn spec
-        let gap: CGFloat = AppSpacing.sp3         // 12pt — Dawn spec
+        let inset: CGFloat = AppSpacing.sp4      // 16pt — V2 spec uses sp4 edge padding
+        let gap: CGFloat = 10                     // 10pt CTA gap — matches SPScreensV2 line 91 ("gap: 12")
 
         // Progressive escalation chrome — only mounted for alarms with the
-        // doubling-penalty toggle. The default flow stays exactly as #138.
-        // Anchor the audio-fallback banner to the chrome's top so the banner
-        // never overlaps the indicator when both are on screen.
+        // doubling-penalty toggle. The default flow stays clean. Anchor the
+        // audio-fallback banner to the chrome's top so the banner never
+        // overlaps the indicator when both are on screen.
         let bannerBottomAnchor: NSLayoutYAxisAnchor
         if viewModel.isProgressiveActive {
             let stack = installProgressiveStack(inset: inset)
@@ -67,15 +70,70 @@ extension AlarmFiringViewController {
         // No-balance stack overlays the same bottom area as the snooze CTA +
         // dismiss group. Initially hidden — `updateUI()` flips visibility
         // based on `viewModel.canSnooze`. Building it eagerly keeps the
-        // affordability swap a single property toggle (no constraint churn)
-        // when the user tops up mid-firing and crosses the threshold.
-        installNoBalanceStack(inset: inset, gap: gap)
+        // affordability swap a single property toggle (no constraint churn).
+        installNoBalanceStack(inset: inset, gap: AppSpacing.sp3)
 
         updateUI()
     }
 
+    /// Install the atmospheric Dawn background — fills the full bounds and
+    /// sits at the bottom of the view tree.
+    private func installDawnBackground() {
+        view.insertSubview(dawnBackgroundView, at: 0)
+        NSLayoutConstraint.activate([
+            dawnBackgroundView.topAnchor.constraint(equalTo: view.topAnchor),
+            dawnBackgroundView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            dawnBackgroundView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            dawnBackgroundView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+
+    /// Install the top-bar row: caps date label left, balance pill right.
+    /// Both elements are added unconditionally; the +Theme extension can
+    /// hide the whole row when a custom-photo theme is in effect.
+    private func installTopHeader() {
+        let dateString = Self.dateFormatter.string(from: Date())
+        dateLabel.attributedText = NSAttributedString(
+            string: dateString.uppercased(),
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: UIColor.white.withAlphaComponent(0.55)
+            ]
+        )
+
+        // Initial balance pill — money tone with current balance. Re-built in
+        // `updateBalancePill()` when the tone needs to flip to pain (zero).
+        let balance = Int(viewModel.balance.rounded())
+        let initialTone: SPPill.Tone = balance == 0 ? .pain : .money
+        let pill = SPPill(text: "Баланс \(balance) ₽", tone: initialTone)
+        pill.translatesAutoresizingMaskIntoConstraints = false
+        balancePill = pill
+
+        topHeaderRow.addArrangedSubview(dateLabel)
+        topHeaderRow.addArrangedSubview(pill)
+        view.addSubview(topHeaderRow)
+
+        NSLayoutConstraint.activate([
+            topHeaderRow.topAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.topAnchor,
+                constant: AppSpacing.sp4
+            ),
+            topHeaderRow.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: AppSpacing.sp4),
+            topHeaderRow.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -AppSpacing.sp4)
+        ])
+    }
+
+    /// Install the centered hero: clock + "Подъём" caps + optional name.
+    /// The caps label is below the clock with 12pt gap per spec line 81.
+    private func installHeroCenter() {
+        view.addSubview(timeLabel)
+        view.addSubview(wakeUpCapsLabel)
+        view.addSubview(nameLabel)
+    }
+
     /// Pin every always-mounted element. Split out of `buildFiringLayout` so
-    /// neither function trips SwiftLint's function_body_length (#182).
+    /// neither function trips SwiftLint's function_body_length.
     private func activateMainConstraints(
         snooze: SPSnoozePrice,
         bannerBottomAnchor: NSLayoutYAxisAnchor,
@@ -83,19 +141,24 @@ extension AlarmFiringViewController {
         gap: CGFloat
     ) {
         NSLayoutConstraint.activate([
+            // Center the clock + caps stack vertically — pull it slightly
+            // above geometric center so the bottom CTAs have generous room.
             timeLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            timeLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: -80),
+            timeLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: -60),
             timeLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
             timeLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
 
-            nameLabel.topAnchor.constraint(equalTo: timeLabel.bottomAnchor, constant: AppSpacing.sp2),
+            wakeUpCapsLabel.topAnchor.constraint(equalTo: timeLabel.bottomAnchor, constant: AppSpacing.sp3),
+            wakeUpCapsLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+
+            nameLabel.topAnchor.constraint(equalTo: wakeUpCapsLabel.bottomAnchor, constant: AppSpacing.sp2),
             nameLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             nameLabel.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: inset),
             nameLabel.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor, constant: -inset),
 
             audioWarningBanner.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
             audioWarningBanner.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
-            audioWarningBanner.bottomAnchor.constraint(equalTo: bannerBottomAnchor, constant: -AppSpacing.sp4),
+            audioWarningBanner.bottomAnchor.constraint(equalTo: bannerBottomAnchor, constant: -AppSpacing.sp3),
 
             snooze.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
             snooze.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
@@ -105,25 +168,33 @@ extension AlarmFiringViewController {
             dismissButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
             dismissButton.bottomAnchor.constraint(
                 equalTo: view.safeAreaLayoutGuide.bottomAnchor,
-                constant: -AppSpacing.sp6
+                constant: -AppSpacing.sp7   // 32pt bottom inset per V2 spec
             )
         ])
     }
 
-    /// Update the warm-glow frame on every layout pass so the radial halo
-    /// stays anchored just below the bottom edge regardless of orientation
-    /// changes (the bounds-driven math used to live inline in
-    /// `viewDidLayoutSubviews`).
-    func updateGlowFrame() {
-        let bounds = view.bounds
-        let glowSize = CGSize(width: bounds.width * 1.2, height: bounds.height * 0.6)
-        warmGlowLayer.frame = CGRect(
-            x: -(glowSize.width - bounds.width) / 2,
-            y: bounds.height - glowSize.height * 0.55,
-            width: glowSize.width,
-            height: glowSize.height
-        )
+    // MARK: - Background install entry point
+    //
+    // The host VC's `viewDidLoad → buildFiringLayout` calls
+    // `installThemedBackground()` (in +Theme); for the default Dawn case the
+    // theme installer routes to `installDawnBackground()` here. Keeping the
+    // entry point in +Theme means custom-photo themes can fully replace the
+    // Dawn background by swapping the install path.
+    func installDawnAtmosphericBackground() {
+        installDawnBackground()
     }
+
+    // MARK: - Date formatter
+    //
+    // Captured once so we don't rebuild a `DateFormatter` on every firing.
+    // Locale fixed to `ru_RU` so "Пт · 27 апр" reads as in the spec; format
+    // "EEE · d MMM" matches `SPScreensV2.jsx` line 64.
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ru_RU")
+        formatter.dateFormat = "EEE · d MMM"
+        return formatter
+    }()
 }
 
 // MARK: - Hex helper
@@ -131,7 +202,7 @@ extension AlarmFiringViewController {
 private extension UIColor {
     /// `0xRRGGBB` literal initializer mirrored from
     /// `AlarmFiringViewController.swift`. `private` is file-scope in Swift,
-    /// so each file that needs the helper carries its own copy (#182).
+    /// so each file that needs the helper carries its own copy.
     convenience init(rgb: UInt32, alpha: CGFloat = 1) {
         let red = CGFloat((rgb >> 16) & 0xFF) / 255.0
         let green = CGFloat((rgb >> 8) & 0xFF) / 255.0

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+NoBalance.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+NoBalance.swift
@@ -2,55 +2,44 @@ import StoreKit
 import UIKit
 import os
 
-/// No-balance ("Баланс закончился") state for the firing screen — issue #140,
-/// closes the silent-failure UX from #26.
+/// No-balance ("Баланса не осталось") state for the firing screen — V2 spec.
 ///
-/// When `viewModel.canSnooze == false` the snooze CTA + dismiss group is
-/// swapped for a four-row stack:
-/// 1. Disabled `SPSnoozePrice` (warn tone, alpha 0.45) with the hint
-///    "Баланса не хватает · нужно ≥ N ₽" — keeps the visual continuity so
-///    the user sees what they were trying to do.
-/// 2. `SPButton(.money, .lg, fullWidth)` "Apple Pay · 500 ₽" — single-tap
-///    purchase via `StoreKitService.purchase` against SKU
-///    `com.snooze_pay.balance.499`. Falls back to `BalanceService.topUp`
-///    when the StoreKit product list hasn't loaded (debug / unit-test
-///    paths) so the wallet still credits end-to-end. PM directive
-///    (`Questions answered: no_balance_button`) was an explicit
-///    "Apple Pay в один тап на дефолтную сумму (500 ₽), без выбора".
-/// 3. `SPButton(.ghost, .lg, fullWidth)` "Я встал — выключить" — BIG
-///    button per PM directive (chat1.md line 1180): "должна быть большой",
-///    not a small text link. Reuses the host VC's `dismissTapped` so the
-///    repeat-day disable + scheduler.cancel paths are identical.
-/// 4. `SPButton(.quiet, .sm, fullWidth)` "Выбрать другую сумму" — opens
-///    the bottom sheet from #141 for users who want a different amount.
+/// V2 (`SPScreensV2.jsx` lines 228–276, `FiringNoBalanceV2`):
+/// - Background tone flips to "drained" (handled by the host VC's
+///   `updateAtmosphereTone`).
+/// - Top-right balance pill switches to pain (also host-handled).
+/// - Center adds a pain-tinted shield pill "БАЛАНСА НЕ ОСТАЛОСЬ" plus the
+///   body "Откладывать больше не получится. Только встать." (lines 239–251).
+/// - Bottom CTAs:
+///   1. Disabled `SPSnoozePrice` (hint "Недостаточно средств") — visual
+///      continuity so the user sees what they wanted to tap.
+///   2. `SPButton(.money, .lg, fullWidth)` "Apple Pay · 500 ₽" — single-tap
+///      purchase via StoreKitService.
+///   3. `SPButton(.ghost, .lg, fullWidth)` "Я встал — выключить".
 ///
 /// Auto-recovery: `BalanceService.balanceChangedNotification` triggers a
 /// `refreshNoBalanceVisibility()` flip back to the normal Dawn snooze CTA
-/// once the user crosses the affordability threshold (purchase success,
-/// external charge in another tab, manual debug top-up).
+/// once the user crosses the affordability threshold.
 extension AlarmFiringViewController {
 
     /// SKU resolved by the no-balance Apple Pay tap. Hard-coded to the
     /// 499 ₽ tier rather than a 500 ₽ SKU because the latter doesn't yet
-    /// exist in App Store Connect. PM follow-up tracked: register an exact
-    /// `com.snooze_pay.balance.500` SKU and swap this constant when it's
-    /// ready (mirrors the same caveat documented in
-    /// `FiringTopUpBottomSheetViewController.Preset.productID`).
+    /// exist in App Store Connect.
     static var noBalanceProductID: String { "com.snooze_pay.balance.499" }
 
-    /// Display amount (₽) for the no-balance Apple Pay button title. Kept
-    /// separate from the SKU because the SKU and the UI label diverge
-    /// today (499 SKU surfaced as "500 ₽" copy per PM spec) and we don't
-    /// want the title to drift if the SKU mapping changes.
+    /// Display amount (₽) for the no-balance Apple Pay button title.
     static var noBalanceDisplayAmount: Int { 500 }
 
     // MARK: - Setup
 
-    /// Build the four-row no-balance stack and pin it to the bottom of the
-    /// screen using the same insets / gap as the normal snooze CTA. The
-    /// stack starts hidden — `refreshNoBalanceVisibility()` toggles it
+    /// Build the no-balance stack and the center "Баланса не осталось" block.
+    /// All views start hidden; `refreshNoBalanceVisibility()` toggles them
     /// based on `viewModel.canSnooze`.
     func installNoBalanceStack(inset: CGFloat, gap: CGFloat) {
+        // Center pain pill + body — anchored to the hero name label so it
+        // tucks under the clock when the no-balance state is on.
+        installNoBalanceCenterPill(inset: inset)
+
         let disabledCard = makeNoBalanceDisabledCard()
         let payButton = makeNoBalanceApplePayButton()
         let ghostDismiss = makeNoBalanceGhostDismissButton()
@@ -66,10 +55,9 @@ extension AlarmFiringViewController {
         ])
         stack.translatesAutoresizingMaskIntoConstraints = false
         stack.axis = .vertical
-        // Custom spacing per pair so the disabled card → Apple Pay gap
-        // matches the spec's 12pt while the Apple Pay → ghost gap also
-        // reads as 12pt and the ghost → quiet link tightens to 8pt
-        // (the link is intentionally subordinate to the ghost CTA).
+        // 12pt gap between primary stack items, tightened to 8pt before the
+        // quiet "choose amount" link so the link reads as subordinate to the
+        // ghost dismiss CTA.
         stack.spacing = gap
         stack.setCustomSpacing(AppSpacing.sp2, after: ghostDismiss)
         stack.alignment = .fill
@@ -77,17 +65,51 @@ extension AlarmFiringViewController {
         view.addSubview(stack)
         noBalanceContainer = stack
 
-        // Pin to the same bottom anchor as the normal-state dismissButton
-        // so the stack lands in the same screen region. Leading/trailing
-        // pinned to the same insets so the disabled card and Apple Pay
-        // button visually inherit the snooze CTA's footprint.
         NSLayoutConstraint.activate([
             stack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
             stack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
             stack.bottomAnchor.constraint(
                 equalTo: view.safeAreaLayoutGuide.bottomAnchor,
-                constant: -AppSpacing.sp6
+                constant: -AppSpacing.sp7   // 32pt bottom inset per V2 spec
             )
+        ])
+    }
+
+    /// Build the center "БАЛАНСА НЕ ОСТАЛОСЬ" pill + body text. Pinned below
+    /// the hero name label so it slots into the centered column when the
+    /// no-balance state activates. Mirrors `SPScreensV2.jsx` lines 239–251.
+    private func installNoBalanceCenterPill(inset: CGFloat) {
+        // Pain-tinted shield pill — wider than a stock SPPill (custom padding)
+        // so the V2 spec's "10px 18px" reads correctly.
+        let shieldPill = SPPill(
+            text: "Баланса не осталось",
+            tone: .pain,
+            icon: UIImage(systemName: "shield.fill")
+        )
+        shieldPill.translatesAutoresizingMaskIntoConstraints = false
+
+        let body = UILabel()
+        body.translatesAutoresizingMaskIntoConstraints = false
+        body.font = AppTypography.bodyLg
+        body.textColor = UIColor.white.withAlphaComponent(0.7)
+        body.textAlignment = .center
+        body.numberOfLines = 0
+        body.text = "Откладывать больше не получится. Только встать."
+
+        let block = UIStackView(arrangedSubviews: [shieldPill, body])
+        block.translatesAutoresizingMaskIntoConstraints = false
+        block.axis = .vertical
+        block.alignment = .center
+        block.spacing = AppSpacing.sp4
+        block.isHidden = true
+        view.addSubview(block)
+        noBalanceCenterBlock = block
+
+        NSLayoutConstraint.activate([
+            block.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            block.topAnchor.constraint(equalTo: nameLabel.bottomAnchor, constant: AppSpacing.sp6),
+            block.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: inset),
+            block.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor, constant: -inset)
         ])
     }
 
@@ -96,7 +118,7 @@ extension AlarmFiringViewController {
             price: Decimal(viewModel.currentPenalty),
             minutes: viewModel.alarm.snoozeMinutes,
             tone: .warn,
-            hint: noBalanceHintText()
+            hint: "Недостаточно средств"
         )
         card.translatesAutoresizingMaskIntoConstraints = false
         card.isEnabled = false
@@ -109,11 +131,15 @@ extension AlarmFiringViewController {
     }
 
     private func makeNoBalanceApplePayButton() -> SPButton {
+        // V2 spec line 258–266: money variant with apple-logo icon, "Apple Pay"
+        // title, suffix "500 ₽". The suffix uses the mono font so the amount
+        // reads as a money column.
         let button = SPButton(
-            title: "Apple Pay · \(Self.noBalanceDisplayAmount) ₽",
+            title: "Apple Pay",
             variant: .money,
             size: .lg,
             icon: UIImage(systemName: "applelogo"),
+            suffix: "\(Self.noBalanceDisplayAmount) ₽",
             fullWidth: true
         )
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -169,16 +195,17 @@ extension AlarmFiringViewController {
     func refreshNoBalanceVisibility() {
         let needsNoBalance = !viewModel.canSnooze
         // Refresh the disabled card's hint + price each pass so progressive
-        // alarms (#139) show the correct "нужно ≥ N ₽" amount even after
-        // snoozeCount has bumped the next penalty.
+        // alarms show the correct disabled value even after snoozeCount has
+        // bumped the next penalty.
         if let card = noBalanceSnoozeCard {
             card.update(
                 price: Decimal(viewModel.currentPenalty),
                 minutes: viewModel.alarm.snoozeMinutes,
-                hint: noBalanceHintText()
+                hint: "Недостаточно средств"
             )
         }
         noBalanceContainer?.isHidden = !needsNoBalance
+        noBalanceCenterBlock?.isHidden = !needsNoBalance
         // Hide the normal-state group when the no-balance stack takes over.
         // The progressive stack is also hidden (it sits above the snooze
         // CTA and would orphan above a hidden card otherwise).
@@ -208,9 +235,8 @@ extension AlarmFiringViewController {
             self.applePayNoBalanceButton?.isEnabled = true
         }
         // Surface StoreKit failures (Ask-to-Buy declined, purchase cancelled
-        // by parent, ledger locked) as a UIAlert so the user knows the tap
-        // didn't actually credit. Success is implicit — the balanceChanged
-        // observer above handles UI recovery for that path.
+        // by parent, ledger locked) as a UIAlert. Success is implicit — the
+        // balanceChanged observer above handles UI recovery for that path.
         let messageKey = StoreKitService.messageUserInfoKey
         purchaseFailedObserver = NotificationCenter.default.addObserver(
             forName: StoreKitService.purchaseFailedNotification,
@@ -245,21 +271,14 @@ extension AlarmFiringViewController {
             return
         }
 
-        // Product list hasn't loaded yet — fall back to a direct top-up so
-        // we still recover the user's flow. The fallback amount mirrors
-        // the displayed copy (500 ₽), not the underlying SKU price (499 ₽),
-        // because that's what the user agreed to in the button label.
+        // Product list hasn't loaded yet — fall back to a direct top-up.
         AppLogger.storeKit.notice(
             "noBalanceApplePayTapped: product \(productID, privacy: .public) not loaded — fallback to topUp"
         )
         let amount = Double(Self.noBalanceDisplayAmount)
         if BalanceService.shared.topUp(amount: amount) {
-            // BalanceService posts `balanceChangedNotification` synchronously
-            // here, which trips the observer and resets in-flight state.
             return
         }
-        // Ledger locked / corrupt — surface the same copy StoreKitService
-        // would post so the user gets a consistent error message.
         noBalancePurchaseInFlight = false
         applePayNoBalanceButton?.isEnabled = true
         presentNoBalancePurchaseFailureAlert(
@@ -267,20 +286,12 @@ extension AlarmFiringViewController {
         )
     }
 
-    /// "Выбрать другую сумму" tap. Routes to the existing #141 bottom
-    /// sheet so the rich preset / Apple Pay flow handles the choice.
+    /// "Выбрать другую сумму" tap. Routes to the presets bottom sheet.
     @objc func noBalanceChooseAmountTapped() {
         presentTopUpSheet()
     }
 
     // MARK: - Helpers
-
-    /// Hint copy for the disabled snooze card. Uses the current penalty so
-    /// progressive alarms surface the doubled amount they actually need.
-    private func noBalanceHintText() -> String {
-        let needed = Int(viewModel.currentPenalty.rounded())
-        return "Баланса не хватает · нужно ≥ \(needed) ₽"
-    }
 
     private func presentNoBalancePurchaseFailureAlert(message: String?) {
         let alert = UIAlertController(
@@ -290,5 +301,35 @@ extension AlarmFiringViewController {
         )
         alert.addAction(UIAlertAction(title: "Ок", style: .default))
         present(alert, animated: true)
+    }
+}
+
+// MARK: - Center block storage
+//
+// Extending the host VC with a stored property is illegal in Swift, so we
+// route the "Баланса не осталось" center block through an associated-object
+// keyed accessor. Single storage slot keyed by a unique pointer; reads /
+// writes happen on the main thread only (firing screen is main-only).
+
+private var noBalanceCenterBlockKey: UInt8 = 0
+
+extension AlarmFiringViewController {
+    /// Reference to the center "Баланса не осталось" pill + body stack. We
+    /// store it via associated objects rather than a stored property because
+    /// the main VC body is already on the SwiftLint type_body_length limit;
+    /// adding another property would push it over and the file split has
+    /// been the recurring fix for this VC.
+    var noBalanceCenterBlock: UIStackView? {
+        get {
+            objc_getAssociatedObject(self, &noBalanceCenterBlockKey) as? UIStackView
+        }
+        set {
+            objc_setAssociatedObject(
+                self,
+                &noBalanceCenterBlockKey,
+                newValue,
+                .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+            )
+        }
     }
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Progressive.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Progressive.swift
@@ -4,10 +4,11 @@ import UIKit
 /// `AlarmFiringViewController` so the main type stays under SwiftLint's
 /// `type_body_length` cap (mirrors the same pattern used by the +Audio file).
 ///
-/// Issue #139 — when `alarm.progressiveScale == true` the firing screen mounts
-/// an indicator pill ("Прогрессив · N-е откладывание") above the snooze CTA, a single
-/// line history ticker ("сегодня: −50 → −100 → −200 ₽") below it, and
-/// cross-fades the snooze gradient from warn → pain as the user keeps
+/// V2 spec (`SPDawnV3.jsx` lines 215–225): when `alarm.progressiveScale ==
+/// true` the firing screen mounts an indicator pill ("Прогрессив · N-е
+/// откладывание") above the snooze CTA, with a pain300 PulseDot to its left,
+/// and a single-line history ticker ("сегодня: −50 → −100 → −200 ₽") below.
+/// The snooze CTA itself cross-fades from warn → pain as the user keeps
 /// snoozing. None of this is touched for default alarms — the +Progressive
 /// installer is a no-op via guard at the call site.
 extension AlarmFiringViewController {
@@ -17,17 +18,18 @@ extension AlarmFiringViewController {
     /// dot is started here once — no need to restart on `updateUI()`.
     /// Returns the stack so `setupUI` can wire it into the bottom layout.
     func installProgressiveStack(inset: CGFloat) -> UIStackView {
-        // Pill: caps text. The leading dot is drawn as a sibling 8pt circle
-        // view inside a horizontal wrapper rather than via `SPPill(icon:)`,
-        // because we need the dot to host its own pulse animation while the
-        // pill keeps its background/text styling.
-        let pill = SPPill(text: "Прогрессив · 1-е откладывание", tone: .warn)
+        // Pill: pain-toned per V2 spec line 217–222. Caps text re-titled on
+        // every updateUI. The leading dot is drawn as a sibling 8pt circle
+        // view rather than via `SPPill(icon:)` because we need the dot to
+        // host its own pulse animation while the pill keeps its background
+        // / text styling untouched.
+        let pill = SPPill(text: "Прогрессив · 1-е откладывание", tone: .pain)
         pill.translatesAutoresizingMaskIntoConstraints = false
         progressivePill = pill
 
         let dot = UIView()
         dot.translatesAutoresizingMaskIntoConstraints = false
-        dot.backgroundColor = AppColors.warn300
+        dot.backgroundColor = AppColors.pain300
         dot.layer.cornerRadius = 4
         dot.isUserInteractionEnabled = false
         progressivePulseDot = dot

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Theme.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Theme.swift
@@ -1,29 +1,27 @@
 import UIKit
 
-/// Background recipes for the alarm-firing screen, split out by theme (#151).
+/// Background recipes for the alarm-firing screen, split out by theme.
 ///
-/// The default Dawn flow stays exactly as #138 — vertical 4-stop gradient with
-/// the warm radial glow breathing below it. Built-in themes (Mountains,
-/// Ocean, Abstract) swap the gradient stops while keeping the rest of the
-/// screen identical. `.custom(imagePath:)` replaces the gradient + glow with
-/// a full-bleed user photo plus a 45% black dim so the 96pt clock + warn
-/// snooze CTA stay legible.
+/// V2 spec: the default Dawn flow uses `SPDawnBackgroundView` — a three-layer
+/// atmospheric composition (base + radial overlay + breathing sun). Built-in
+/// themes other than `.dawn` (Mountains, Ocean, Abstract) still ship as
+/// vertical gradient backgrounds — they fall back to a single CAGradientLayer
+/// installed in place of the Dawn view. `.custom(imagePath:)` replaces the
+/// gradient + glow with a full-bleed user photo plus a 45% black dim so the
+/// 96pt clock + warn snooze CTA stay legible against arbitrary imagery.
 extension AlarmFiringViewController {
 
     /// Install the background appropriate to the alarm's theme. Called once
-    /// from `setupUI`. Falls back to Dawn if `.custom`'s on-disk file is
-    /// gone (Caches purge) so the firing screen is never blank.
+    /// from `buildFiringLayout`. Falls back to Dawn if `.custom`'s on-disk
+    /// file is gone (Caches purge) so the firing screen is never blank.
     func installThemedBackground() {
         let theme = viewModel.alarm.theme
 
-        // Always insert the gradient + glow at the bottom of the layer tree
-        // so they sit beneath any subsequently added content. The image view
-        // and its dim are added as subviews so they stack above the gradient
-        // automatically.
-        view.layer.insertSublayer(themeGradientLayer, at: 0)
-        view.layer.insertSublayer(warmGlowLayer, at: 1)
-        view.insertSubview(themeImageView, at: 0)
-        view.insertSubview(themeImageDimView, aboveSubview: themeImageView)
+        // Mount the photo image view + dim as an always-present subview pair
+        // so the +Layout subviews stack above them automatically. Hidden by
+        // default; revealed only when `.custom` resolves a real on-disk file.
+        view.addSubview(themeImageView)
+        view.addSubview(themeImageDimView)
 
         NSLayoutConstraint.activate([
             themeImageView.topAnchor.constraint(equalTo: view.topAnchor),
@@ -38,28 +36,66 @@ extension AlarmFiringViewController {
         ])
 
         if case .custom(let url) = theme, let image = AlarmThemeImageStore.loadImage(at: url) {
+            // Custom photo path — hide the Dawn background and surface the
+            // photo + dim. Don't install the dawnBackgroundView at all.
             themeImageView.image = image
             themeImageView.isHidden = false
             themeImageDimView.isHidden = false
-            // Hide the gradient + warm glow — the photo is the background of
-            // record and we don't want the amber halo bleeding through.
-            themeGradientLayer.isHidden = true
-            warmGlowLayer.isHidden = true
+        } else if case .dawn = theme {
+            // Default Dawn path — install the V2 atmospheric view.
+            installDawnAtmosphericBackground()
+            themeImageView.isHidden = true
+            themeImageDimView.isHidden = true
         } else {
-            // Built-in (or .custom with missing file) → vertical gradient.
-            // Default to Dawn when the gradient lookup misses (defensive —
-            // every built-in case currently returns colours).
-            let resolved: AlarmTheme = {
-                if case .custom = theme { return .dawn }
-                return theme
-            }()
-            themeGradientLayer.colors = AlarmThemeRendering.gradientColors(for: resolved)
+            // Mountains / Ocean / Abstract — vertical gradient using the
+            // shared `AlarmThemeRendering` stops. Built on a plain
+            // SPGradientView-like CAGradientLayer hosted on a UIView so the
+            // +Layout subview ordering still works.
+            let gradient = CAGradientLayer()
+            gradient.startPoint = CGPoint(x: 0.5, y: 0.0)
+            gradient.endPoint = CGPoint(x: 0.5, y: 1.0)
+            gradient.colors = AlarmThemeRendering.gradientColors(for: theme)
                 ?? AlarmThemeRendering.gradientColors(for: .dawn)
-            themeGradientLayer.locations = AlarmThemeRendering.gradientLocations(for: resolved)
+            gradient.locations = AlarmThemeRendering.gradientLocations(for: theme)
                 ?? AlarmThemeRendering.gradientLocations(for: .dawn)
-            themeGradientLayer.isHidden = false
+
+            let container = ThemeGradientContainerView(gradient: gradient)
+            container.translatesAutoresizingMaskIntoConstraints = false
+            view.insertSubview(container, at: 0)
+            NSLayoutConstraint.activate([
+                container.topAnchor.constraint(equalTo: view.topAnchor),
+                container.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                container.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+                container.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+            ])
             themeImageView.isHidden = true
             themeImageDimView.isHidden = true
         }
+    }
+}
+
+// MARK: - Plain gradient host for non-Dawn built-in themes
+//
+// A minimal CALayer host so the +Theme installer can drop in a gradient that
+// fills bounds and reflows on layout. Lives in this file so it's not exposed
+// to other VCs that don't need it.
+
+final class ThemeGradientContainerView: UIView {
+    private let gradientLayer: CAGradientLayer
+
+    init(gradient: CAGradientLayer) {
+        self.gradientLayer = gradient
+        super.init(frame: .zero)
+        layer.addSublayer(gradientLayer)
+        isUserInteractionEnabled = false
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        gradientLayer.frame = bounds
     }
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+ViewLifecycle.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+ViewLifecycle.swift
@@ -25,8 +25,10 @@ extension AlarmFiringViewController {
 
     // MARK: Glow breathing
 
-    /// 4s ease-in-out autoreverse opacity pulse on the warm glow. Driven via
-    /// CABasicAnimation because the glow is a CAGradientLayer (not a view).
+    /// 4s ease-in-out autoreverse opacity pulse on the Dawn background's sun
+    /// layer. Driven via CABasicAnimation because the sun is a CAGradientLayer
+    /// (not a view). V2 spec retains the "breathing" character from V1 — the
+    /// warm radial just lives inside `SPDawnBackgroundView.sunLayer` now.
     func startGlowBreathing() {
         let animation = CABasicAnimation(keyPath: "opacity")
         animation.fromValue = 0.55
@@ -35,7 +37,7 @@ extension AlarmFiringViewController {
         animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
         animation.autoreverses = true
         animation.repeatCount = .infinity
-        warmGlowLayer.add(animation, forKey: "breathing")
+        dawnBackgroundView.sunLayer.add(animation, forKey: "breathing")
     }
 
     // MARK: Actions

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
@@ -1,19 +1,20 @@
 import UIKit
 import os
 
-/// Fullscreen alarm firing screen — Dawn redesign (#138).
+/// Fullscreen alarm firing screen — V2 Dawn redesign.
 ///
-/// Replaces the previous iOS-blur + decorative purple circles with the
-/// design-refresh "Dawn" treatment: a vertical 4-stop atmospheric gradient
-/// (`--sp-grad-dawn`), a slow-breathing warm radial glow at the bottom, a
-/// 96pt mono clock, and a large warn-toned snooze CTA backed by
-/// `SPSnoozePrice`. The dismiss action degrades to a ghost button below
-/// the snooze so the visual hierarchy steers the half-asleep user toward
-/// the paid action while keeping "Я встал" reachable.
+/// V2 (`docs/design/v2-handoff/components/SPDawnV3.jsx` + `SPScreensV2.jsx`
+/// `FiringDawn`) elevates the original Dawn treatment with a three-layer
+/// atmospheric background (base gradient + radial overlay + breathing sun)
+/// plus a top header that surfaces the date and balance pill, and a centered
+/// hero block with a 96pt mono clock and a "Подъём" caps label. The bottom
+/// CTAs preserve the warn-tone snooze + ghost dismiss pair from #138 with a
+/// tighter 10pt gap and 32pt bottom inset.
 ///
-/// Existing audio + coordinator wiring (AudioService stacking guard,
-/// vibration-fallback banner, snooze schedule failure alert) is preserved
-/// verbatim — this PR is a visual rework, not a behaviour change.
+/// All existing audio + coordinator wiring (AudioService stacking guard,
+/// vibration-fallback banner, snooze schedule failure alert, no-balance
+/// recovery observer) is preserved verbatim from the V1 implementation —
+/// this rewrite is the visual layer only, not a behaviour change.
 class AlarmFiringViewController: UIViewController {
 
     // MARK: - ViewModel
@@ -22,20 +23,14 @@ class AlarmFiringViewController: UIViewController {
     /// can read VM state during their UI updates.
     let viewModel: AlarmFiringViewModel
 
-    // MARK: - Background layers
+    // MARK: - Background
 
-    /// Theme-driven gradient layer. For `.dawn` this matches the original
-    /// `--sp-grad-dawn` recipe (#138); other built-in themes pull their stops
-    /// from `AlarmThemeRendering`. The layer is replaced/recoloured in
-    /// `installThemedBackground` based on `viewModel.alarm.theme` (#151).
-    /// `internal` so the +Theme / +Layout extensions in sibling files can
-    /// configure it.
-    let themeGradientLayer: CAGradientLayer = {
-        let gradient = CAGradientLayer()
-        gradient.startPoint = CGPoint(x: 0.5, y: 0.0)
-        gradient.endPoint = CGPoint(x: 0.5, y: 1.0)
-        return gradient
-    }()
+    /// V2 atmospheric background — three CAGradientLayers (base, overlay,
+    /// breathing sun). Replaces the V1 `themeGradientLayer` + `warmGlowLayer`
+    /// pair. `internal` so the +Theme extension can swap its tone when the
+    /// alarm has a custom theme, and so +ViewLifecycle can attach the
+    /// 4-second opacity breathing animation to the sun layer.
+    let dawnBackgroundView = SPDawnBackgroundView(tone: .calm)
 
     /// Image view used when `viewModel.alarm.theme == .custom(_)`. Lives on
     /// the layer tree even when not in use (hidden) so the theme swap is a
@@ -61,36 +56,70 @@ class AlarmFiringViewController: UIViewController {
         return view
     }()
 
-    /// Warm radial glow anchored below the bottom edge — a warn500-flavoured
-    /// halo that "breathes" via a 4s opacity animation. `internal` so the
-    /// +Theme extension can hide it for `.custom` photo backgrounds.
-    let warmGlowLayer: CAGradientLayer = {
-        let gradient = CAGradientLayer()
-        gradient.type = .radial
-        gradient.colors = [
-            UIColor(rgb: 0xF59E0B, alpha: 0.22).cgColor,
-            UIColor(rgb: 0xF59E0B, alpha: 0.10).cgColor,
-            UIColor(rgb: 0xF59E0B, alpha: 0.0).cgColor
-        ]
-        gradient.locations = [0.0, 0.5, 1.0]
-        gradient.startPoint = CGPoint(x: 0.5, y: 0.5)
-        gradient.endPoint = CGPoint(x: 1.0, y: 1.0)
-        return gradient
+    // MARK: - Top header (V2)
+
+    /// Top-bar caps label "Пт · 27 апр" rendered left of the balance pill.
+    /// Date is computed once on `viewDidLoad` (per spec — the firing screen
+    /// is a snapshot of "when the alarm rang", not a live tick).
+    let dateLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = AppTypography.caps
+        label.textColor = UIColor.white.withAlphaComponent(0.55)
+        label.numberOfLines = 1
+        return label
     }()
 
-    // MARK: - Content
+    /// "Баланс N ₽" pill on the right side of the top bar. Tone flips between
+    /// `.money` (positive) and `.pain` (balance == 0). Re-rendered on every
+    /// `updateUI()` because the balance is decremented mid-firing when the
+    /// user snoozes (the firing flow dismisses on success, but for the
+    /// progressive path the count climbs in place).
+    var balancePill: SPPill?
 
-    /// 96pt mono clock — `AppTypography.clockXl` with `.monospacedDigit()`
-    /// so digit columns don't reflow on each tick. `internal` so the
-    /// `+Layout` / `+ViewLifecycle` extensions can pin + update it (#182).
+    /// Container holding `dateLabel` + `balancePill`. `internal` so the
+    /// +Theme extension can hide it when a `.custom` photo background is in
+    /// use (the user picked a hero image; we don't want chrome over it).
+    let topHeaderRow: UIStackView = {
+        let stack = UIStackView()
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .horizontal
+        stack.alignment = .center
+        stack.distribution = .equalSpacing
+        return stack
+    }()
+
+    // MARK: - Center hero
+
+    /// 96pt mono clock — `AppTypography.clockXl` ultralight. `tabular-nums`
+    /// equivalent applied via `.monospacedDigit()` so digit columns don't
+    /// reflow on each tick. `internal` so the `+Layout` / `+ViewLifecycle`
+    /// extensions can pin + update it.
     let timeLabel: UILabel = {
         let label = UILabel()
         label.font = AppTypography.clockXl.monospacedDigit()
-        label.textColor = AppColors.fg1
+        label.textColor = .white
         label.textAlignment = .center
         label.adjustsFontSizeToFitWidth = true
         label.minimumScaleFactor = 0.7
         label.translatesAutoresizingMaskIntoConstraints = false
+        // Text shadow ≈ "0 4px 60px rgba(255,184,77,.20)" warm halo.
+        label.layer.shadowColor = UIColor(red: 1.0, green: 184.0 / 255.0, blue: 77.0 / 255.0, alpha: 1).cgColor
+        label.layer.shadowOpacity = 0.20
+        label.layer.shadowRadius = 30
+        label.layer.shadowOffset = CGSize(width: 0, height: 4)
+        label.layer.masksToBounds = false
+        return label
+    }()
+
+    /// Caps "Подъём" subtitle below the clock. Hidden when the alarm name is
+    /// non-empty (the V1 nameLabel handled that case); the V2 layout still
+    /// surfaces the alarm name underneath the caps row when present.
+    let wakeUpCapsLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textAlignment = .center
+        label.numberOfLines = 1
         return label
     }()
 
@@ -98,7 +127,7 @@ class AlarmFiringViewController: UIViewController {
     let nameLabel: UILabel = {
         let label = UILabel()
         label.font = AppTypography.bodyLg
-        label.textColor = AppColors.fg2
+        label.textColor = UIColor.white.withAlphaComponent(0.55)
         label.textAlignment = .center
         label.numberOfLines = 1
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -109,27 +138,29 @@ class AlarmFiringViewController: UIViewController {
     /// VM-derived price + minutes that aren't valid at property-init time.
     /// Tone defaults to `.warn`; for `progressiveScale == true` alarms the
     /// VC swaps it to `.progressive(intensity:)` and bumps the intensity on
-    /// every snooze tap (#139). `internal` so the +Progressive extension
-    /// can re-tone it on `updateUI()`.
+    /// every snooze tap. `internal` so the +Progressive extension can re-tone
+    /// it on `updateUI()`.
     var snoozeCTA: SPSnoozePrice?
 
     /// `internal` so the +NoBalance extension can hide / show this when
     /// swapping between the normal (balance OK) and no-balance layouts.
+    /// V2 spec calls for the full "Я встал — выключить" copy, ghost variant,
+    /// lg size, full-width — matches `SPScreensV2.jsx` line 98.
     let dismissButton = SPButton(
-        title: "Я встал",
+        title: "Я встал — выключить",
         variant: .ghost,
         size: .lg,
         fullWidth: true
     )
 
-    // MARK: - No-balance UI (#140) — shown when `viewModel.canSnooze == false`.
+    // MARK: - No-balance UI — shown when `viewModel.canSnooze == false`.
     //
     // The no-balance state replaces the snooze CTA + dismiss group with a
-    // disabled snooze card on top, an Apple Pay 500 ₽ primary CTA, a big
-    // ghost "Я встал" secondary, and a small "Выбрать другую сумму" link.
-    // All four are mounted unconditionally so swapping is just a visibility
-    // flip — saves us from rebuilding constraints when the user tops up
-    // mid-firing and crosses the affordability threshold (#26 silent UX).
+    // disabled snooze card on top, an Apple Pay 500 ₽ primary CTA, and a big
+    // ghost "Я встал — выключить" secondary. All three are mounted
+    // unconditionally so swapping is just a visibility flip — saves us from
+    // rebuilding constraints when the user tops up mid-firing and crosses
+    // the affordability threshold.
 
     /// Disabled snooze card shown above the Apple Pay CTA. Mirrors the
     /// `.warn` tone of the live card so the visual continuity reads as
@@ -143,19 +174,19 @@ class AlarmFiringViewController: UIViewController {
     var applePayNoBalanceButton: SPButton?
 
     /// Big ghost "Я встал — выключить" secondary. Calls `viewModel.dismiss()`
-    /// the same way the normal-state dismissButton does — PM directive
-    /// (chat1.md line 1180) was that this MUST be a full-width lg button,
-    /// not a small text link, so the half-asleep user can find it.
+    /// the same way the normal-state dismissButton does — PM directive was
+    /// that this MUST be a full-width lg button, not a small text link, so
+    /// the half-asleep user can find it.
     var noBalanceDismissButton: SPButton?
 
-    /// Small `.quiet/.sm` link "Выбрать другую сумму" rendered below the
-    /// ghost dismiss. Routes to the existing `presentTopUpSheet()` from #141
-    /// for users who want a different amount than the 500 ₽ default.
+    /// Small quiet/sm link "Выбрать другую сумму" rendered below the ghost
+    /// dismiss. Routes to the existing `presentTopUpSheet()` for users who
+    /// want a different amount than the 500 ₽ default.
     var chooseAmountLink: SPButton?
 
-    /// Container stacking the four no-balance views vertically. Hidden when
-    /// the user can afford the next snooze; shown otherwise. Membership lets
-    /// the +NoBalance extension hide a single view rather than four.
+    /// Container stacking the no-balance views vertically. Hidden when the
+    /// user can afford the next snooze; shown otherwise. Membership lets the
+    /// +NoBalance extension hide a single view rather than four.
     var noBalanceContainer: UIStackView?
 
     /// Observer token for `BalanceService.balanceChangedNotification`. Drives
@@ -170,27 +201,24 @@ class AlarmFiringViewController: UIViewController {
     var purchaseFailedObserver: NSObjectProtocol?
 
     /// Re-entrancy guard for the Apple Pay tap so a double-tap can't kick
-    /// off two purchases (StoreKit would reject the second, but the UI
-    /// would briefly look like two purchases were attempted).
+    /// off two purchases.
     var noBalancePurchaseInFlight: Bool = false
 
-    // MARK: - Progressive UI (#139) — only mounted when `alarm.progressiveScale`.
-    //
-    // Layout + animation logic lives in `AlarmFiringViewController+Progressive.swift`;
-    // these stored handles are accessed from the extension via `internal` so the
-    // type body of the main VC stays under SwiftLint's `type_body_length` cap.
+    // MARK: - Progressive UI — only mounted when `alarm.progressiveScale`.
 
     /// Container holding the indicator pill + history ticker. Built lazily
-    /// inside `setupUI` so the default firing flow (#138) skips both views
+    /// inside `setupUI` so the default firing flow skips both views
     /// entirely — they never enter the layout pass.
     var progressiveStack: UIStackView?
 
-    /// "Прогрессив · N-е откладывание" pill above the snooze CTA. Re-titled on every
-    /// `updateUI()` so the label tracks `snoozeCount + 1` (the next snooze).
+    /// "Прогрессив · N-е откладывание" pill above the snooze CTA. Re-titled
+    /// on every `updateUI()` so the label tracks `snoozeCount + 1`. V2 spec
+    /// uses pain tone with an inline pulsing dot.
     var progressivePill: SPPill?
 
-    /// Pulsing dot rendered inside `progressivePill`. CABasicAnimation lives
-    /// on its `layer.opacity` (autoreverse, infinite, 900ms — `--sp-dur-anxious`).
+    /// Pulsing dot rendered to the left of `progressivePill`. CABasicAnimation
+    /// drives a 0.4 → 1.0 opacity autoreverse pulse on 900ms cadence
+    /// (`durationAnxious`).
     var progressivePulseDot: UIView?
 
     /// Single-line ticker rendered between the pill and the snooze CTA.
@@ -199,8 +227,9 @@ class AlarmFiringViewController: UIViewController {
     var historyTicker: UILabel?
 
     /// Banner shown when AudioService falls back to vibration / silent mode.
-    /// Hidden by default; surfaces only on `.silentBecauseConfigFailed` or `.vibrationOnly`.
-    /// `internal` so the AudioState extension in the sibling file can update it.
+    /// Hidden by default; surfaces only on `.silentBecauseConfigFailed` or
+    /// `.vibrationOnly`. `internal` so the AudioState extension in the
+    /// sibling file can update it.
     let audioWarningBanner: UILabel = {
         let label = UILabel()
         label.font = AppTypography.meta
@@ -255,9 +284,9 @@ class AlarmFiringViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Per `tokens.css` lines 109–112 and reaffirmed by #136: the firing
-        // screen is intentionally exempt from the brand light theme. Pin
-        // `.dark` so the system theme can't bleed through.
+        // Per `tokens.css` and the V2 spec: the firing screen is intentionally
+        // exempt from the brand light theme. Pin `.dark` so the system theme
+        // can't bleed through.
         overrideUserInterfaceStyle = .dark
         buildFiringLayout()
         bindViewModel()
@@ -266,9 +295,9 @@ class AlarmFiringViewController: UIViewController {
         startClockTicker()
         startGlowBreathing()
 
-        // Pass `alarmID` so a stacking-replace race (#116) does not silence
-        // the next alarm when this VC's `viewDidDisappear` fires.
-        // Volume + fade-in honour the per-alarm settings introduced in #150.
+        // Pass `alarmID` so a stacking-replace race does not silence the next
+        // alarm when this VC's `viewDidDisappear` fires. Volume + fade-in
+        // honour the per-alarm settings.
         AudioService.shared.startAlarmSound(
             soundID: viewModel.alarm.soundID,
             alarmID: viewModel.alarm.id,
@@ -284,11 +313,11 @@ class AlarmFiringViewController: UIViewController {
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         clockTimer?.invalidate()
-        warmGlowLayer.removeAllAnimations()
+        dawnBackgroundView.sunLayer.removeAllAnimations()
 
         // Stop alarm sound only if AudioService still belongs to *this*
         // alarm. Stacking handoff (alarm B fires while A is on-screen)
-        // could otherwise silence B (#116).
+        // could otherwise silence B.
         if AudioService.shared.currentAlarmID == viewModel.alarm.id {
             AudioService.shared.stopAlarmSound()
         } else {
@@ -308,16 +337,8 @@ class AlarmFiringViewController: UIViewController {
     //
     // The view-stack + constraint composition lives in
     // `AlarmFiringViewController+Layout.swift` so this file stays under
-    // SwiftLint's `file_length` cap (#182). `viewDidLoad` calls
+    // SwiftLint's `file_length` cap. `viewDidLoad` calls
     // `buildFiringLayout()` which is the verbatim former `setupUI()`.
-
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        themeGradientLayer.frame = view.bounds
-        // Glow anchored below the bottom edge — only the upper hemisphere
-        // of the radial bleeds into view.
-        updateGlowFrame()
-    }
 
     private func bindViewModel() {
         viewModel.onStateChanged = { [weak self] in
@@ -330,11 +351,13 @@ class AlarmFiringViewController: UIViewController {
 
         // Refresh snooze CTA — VM may have bumped `snoozeCount` (progressive
         // scaling) since the last update, which changes `currentPenalty`.
+        // The hint surfaces "Следующее откладывание: N ₽" when progressive
+        // is active and not at max, mirroring `SPScreensV2.jsx` line 96.
         if let snooze = snoozeCTA {
             snooze.update(
                 price: Decimal(viewModel.currentPenalty),
                 minutes: viewModel.alarm.snoozeMinutes,
-                hint: nil
+                hint: snoozeHintText()
             )
             snooze.isEnabled = viewModel.canSnooze
             if viewModel.isProgressiveActive {
@@ -349,15 +372,93 @@ class AlarmFiringViewController: UIViewController {
             updateProgressiveChrome()
         }
 
+        updateBalancePill()
+        updateAtmosphereTone()
+
         // Swap between the normal snooze + dismiss group and the no-balance
         // (Apple Pay 500 ₽) stack based on affordability. `canSnooze` is
-        // the single source of truth — it accounts for both insufficient
-        // funds AND a corrupted balance latch (#119), so the no-balance
-        // path also catches the corruption case (the price hint then reads
-        // "Баланса не хватает · нужно ≥ N ₽" which is technically wrong for
-        // corruption but the corruption alert from BalanceService is its
-        // own modal that supersedes; not blocking #140).
+        // the single source of truth.
         refreshNoBalanceVisibility()
+    }
+
+    /// Build the "Подъём" / "только встать" caps copy below the clock.
+    /// Mirrors `SPScreensV2.jsx` line 81 (normal) + `SPDawnV3.jsx` line 212
+    /// (no-balance drops to "только встать").
+    func wakeUpCapsText() -> String {
+        viewModel.canSnooze ? "Подъём" : "Только встать"
+    }
+
+    /// Snooze CTA hint — "Следующее откладывание: N ₽" when progressive is
+    /// active and not at the price ceiling. Mirrors `SPScreensV2.jsx` line 96.
+    /// V1 passed nil here; V2 surfaces the escalating cost so the user can
+    /// see what they're agreeing to.
+    func snoozeHintText() -> String? {
+        guard viewModel.isProgressiveActive else { return nil }
+        // Probe the alarm's penalty schedule one step ahead. The double-snooze
+        // rule produces `currentPenalty * 2`, but we route through the model
+        // so caps / custom schedules pick up the right "next" value.
+        let next = viewModel.alarm.penalty(forSnoozeCount: viewModel.snoozeCount + 2)
+        let nextInt = Int(next.rounded())
+        return "Следующее откладывание: \(nextInt) ₽"
+    }
+
+    /// Refresh the top-right balance pill so the displayed amount + tone
+    /// track the live balance. Called from `updateUI` (every VM tick) and
+    /// implicitly from the balance observer (which calls `updateUI`).
+    private func updateBalancePill() {
+        let balance = Int(viewModel.balance.rounded())
+        let tone: SPPill.Tone = balance == 0 ? .pain : .money
+        guard let pill = balancePill else { return }
+        pill.setText("Баланс \(balance) ₽")
+        // SPPill's `tone` is `let` (constructor-only), so we re-build when
+        // the tone needs to flip between money and pain. Cheap — pill is a
+        // 26pt-tall capsule with two labels.
+        if pill.tone != tone {
+            rebuildBalancePill(tone: tone, text: "Баланс \(balance) ₽")
+        }
+    }
+
+    /// Replace the existing balance pill with a new instance using the
+    /// supplied tone. Used when the balance crosses the 0 ↔ positive
+    /// boundary and the chip needs to flip from money → pain or back.
+    private func rebuildBalancePill(tone: SPPill.Tone, text: String) {
+        guard let old = balancePill else { return }
+        let new = SPPill(text: text, tone: tone)
+        new.translatesAutoresizingMaskIntoConstraints = false
+        if let index = topHeaderRow.arrangedSubviews.firstIndex(of: old) {
+            topHeaderRow.removeArrangedSubview(old)
+            old.removeFromSuperview()
+            topHeaderRow.insertArrangedSubview(new, at: index)
+        }
+        balancePill = new
+    }
+
+    /// Sync the Dawn background tone with the current VM state. Drained when
+    /// the user can't afford the next snooze; tense when the snooze price
+    /// has escalated past the warn → pain threshold; calm otherwise.
+    private func updateAtmosphereTone() {
+        let tone: SPDawnBackgroundView.Tone
+        if !viewModel.canSnooze {
+            tone = .drained
+        } else if viewModel.isProgressiveActive && viewModel.progressiveIntensity >= 0.5 {
+            tone = .tense
+        } else {
+            tone = .calm
+        }
+        dawnBackgroundView.setTone(tone)
+
+        // The "Подъём" caps colour flips with the tone — pain300 when drained
+        // (matches the SPDawnV3 spec line 212).
+        wakeUpCapsLabel.attributedText = NSAttributedString(
+            string: wakeUpCapsText().uppercased(),
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: viewModel.canSnooze
+                    ? UIColor.white.withAlphaComponent(0.5)
+                    : AppColors.pain300
+            ]
+        )
     }
 
     // MARK: - Actions
@@ -371,7 +472,7 @@ class AlarmFiringViewController: UIViewController {
 
     // Clock ticking, glow breathing, snooze tap handler, top-up sheet, and
     // the snooze-failure alert live in
-    // `AlarmFiringViewController+ViewLifecycle.swift` (#182).
+    // `AlarmFiringViewController+ViewLifecycle.swift`.
 }
 
 // MARK: - Hex helper
@@ -382,7 +483,7 @@ private extension UIColor {
     /// AppColors — duplicated as `fileprivate` in
     /// `AlarmFiringViewController+Layout.swift` because `private` means
     /// file-scope, not type-scope, and the +Layout extension also needs the
-    /// helper for `UIColor(rgb: 0x050912)` in its background fill.
+    /// helper for atmospheric stops in its background fill.
     convenience init(rgb: UInt32, alpha: CGFloat = 1) {
         let red = CGFloat((rgb >> 16) & 0xFF) / 255.0
         let green = CGFloat((rgb >> 8) & 0xFF) / 255.0

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/FiringTopUpBottomSheetViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/FiringTopUpBottomSheetViewController.swift
@@ -5,11 +5,11 @@ import os
 /// Bottom-sheet presented over `AlarmFiringViewController` when the user wants
 /// to top up the wallet mid-alarm so they can keep snoozing.
 ///
-/// Spec: `docs/design/snoozepay-2026-04-27/project/components/SPTopUp.jsx`
-/// (variant `B · Bottom sheet с пресетами`) and the matching section in
-/// `SnoozePay - All Screens.html`. Three preset tiles (200 / 500 / 1000 ₽)
-/// drive a single Apple Pay primary CTA; the secondary "Отменить" ghost
-/// button dismisses without charging.
+/// V2 spec: `docs/design/v2-handoff/components/SPTopUp.jsx`
+/// `FiringTopUpPresets` (lines 103–197). Three preset rows (200 / 500 popular
+/// / 1000 ₽) feed a single Apple Pay primary CTA. Visuals match the V2 design
+/// system — bg2 surface, 28pt top corners, caps "ПОПОЛНИТЬ" + close X header,
+/// SPAmountPreset row, money-toned Apple Pay button, footer meta.
 ///
 /// Side effects beyond pixel layout:
 /// - On `viewWillAppear` the alarm audio + escalation timer are paused via
@@ -19,47 +19,40 @@ import os
 ///   "+N ₽" success state and auto-dismisses after 2 seconds.
 /// - On dismissal (any path: cancel, success-auto, 60s-timeout) the audio
 ///   resumes unless the alarm was already stopped externally.
-///
-/// `FiringTopUpBottomSheetPresetIDs` exposes the StoreKit product IDs the
-/// presets currently map to so tests can assert the wiring without parsing
-/// the controller's private state.
 final class FiringTopUpBottomSheetViewController: UIViewController {
 
     // MARK: - Preset model
 
     /// One of the three top-up tiles. `productID` points at the closest existing
     /// IAP SKU in StoreKitService (149 / 499 / 999) — once PM registers exact
-    /// 200 / 500 / 1000 ₽ SKUs in App Store Connect, swap these mappings to
-    /// the matching product IDs (tracked as a follow-up in #141 description).
+    /// 200 / 500 / 1000 ₽ SKUs in App Store Connect, swap these mappings.
     struct Preset {
         let amount: Int
         let label: String
-        /// StoreKit product ID. Resolved against `StoreKitService.shared.products`
-        /// when the user taps Apple Pay. If the product hasn't been loaded yet
-        /// the controller falls back to `BalanceService.topUp(amount:)` so the
-        /// debug flow still credits the wallet end-to-end.
+        let popular: Bool
+        /// StoreKit product ID. Falls back to `BalanceService.topUp(amount:)`
+        /// when not loaded so debug paths still credit the wallet.
         let productID: String
     }
 
     /// Default preset list — see `Preset.productID` for the SKU mapping caveat.
     static let defaultPresets: [Preset] = [
-        Preset(amount: 200, label: "ровно на сейчас", productID: "com.snooze_pay.balance.149"),
-        Preset(amount: 500, label: "на пару дней", productID: "com.snooze_pay.balance.499"),
-        Preset(amount: 1000, label: "забыть про баланс", productID: "com.snooze_pay.balance.999")
+        Preset(amount: 200, label: "ровно на сейчас", popular: false, productID: "com.snooze_pay.balance.149"),
+        Preset(amount: 500, label: "на пару дней", popular: true, productID: "com.snooze_pay.balance.499"),
+        Preset(amount: 1000, label: "забыть про баланс", popular: false, productID: "com.snooze_pay.balance.999")
     ]
 
     // MARK: - Configuration
 
     private let presets: [Preset]
 
-    /// Auto-resume timeout. Spec is 60 seconds (#141). Exposed as a stored
-    /// property so the controller doesn't re-read a magic literal in three
-    /// places (timer setup, label seed, countdown formatting).
+    /// Auto-resume timeout. Spec is 60 seconds. Stored as a constant so the
+    /// controller doesn't re-read a magic literal across timer setup, label
+    /// seed, and countdown formatting.
     private let autoResumeTimeout: TimeInterval = 60
 
-    /// Fired when the sheet is dismissed for any reason. Owner (the firing VC
-    /// presenter) uses this to resume the escalation timer / refresh snooze
-    /// affordance once the wallet has settled.
+    /// Fired when the sheet is dismissed for any reason. Owner uses this to
+    /// resume the escalation timer / refresh snooze affordance.
     var onDismiss: (() -> Void)?
 
     // MARK: - State
@@ -70,7 +63,7 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
     /// doesn't yank the sheet out from under the StoreKit dialog.
     private var purchaseInFlight: Bool = false
 
-    /// Flips when StoreKit reports a successful credit. Drives the success-
+    /// Flips when StoreKit reports a successful credit. Drives the success
     /// state UI swap + the 2-second auto-dismiss timer.
     private var successAmount: Int?
 
@@ -85,7 +78,7 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
     /// 1Hz countdown timer feeding `pauseLabel`.
     private var countdownTimer: Timer?
 
-    /// Notification observer tokens so we tear them down in `deinit`.
+    /// Notification observer tokens torn down in `deinit`.
     private var purchaseCompletedObserver: NSObjectProtocol?
     private var purchaseFailedObserver: NSObjectProtocol?
 
@@ -99,28 +92,19 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
         return view
     }()
 
-    private let pauseDot: UIView = {
-        let view = UIView()
-        view.backgroundColor = AppColors.warn400
-        view.layer.cornerRadius = 4
-        view.translatesAutoresizingMaskIntoConstraints = false
-        return view
-    }()
-
-    private let pauseLabel: UILabel = {
+    /// Caps "ПОПОЛНИТЬ" header — fg3 colour matches `SPTopUp.jsx` line 137.
+    private let titleCapsLabel: UILabel = {
         let label = UILabel()
-        label.font = AppTypography.caps
-        label.textColor = AppColors.warn300
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
 
-    private let titleLabel: UILabel = {
+    /// Optional pause countdown label "Будильник на паузе · 00:54". Rendered
+    /// inline with the title row. Mirrors SPTopUp line 137.
+    private let pauseLabel: UILabel = {
         let label = UILabel()
-        label.font = AppTypography.h2
-        label.textColor = AppColors.fg1
-        label.text = "Пополнить баланс"
         label.translatesAutoresizingMaskIntoConstraints = false
+        label.numberOfLines = 1
         return label
     }()
 
@@ -144,7 +128,8 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
         return label
     }()
 
-    /// Three-tile horizontal stack of `SPAmountPreset`s.
+    /// Horizontal row of `SPAmountPreset` tiles. V2 spec arranges three
+    /// presets edge-to-edge with equal width — `distribution = .fillEqually`.
     private var presetTiles: [SPAmountPreset] = []
     private let presetStack: UIStackView = {
         let stack = UIStackView()
@@ -155,34 +140,26 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
         return stack
     }()
 
-    /// Apple Pay primary CTA. Title is rebuilt whenever selection changes.
-    private lazy var applePayButton: SPButton = {
-        let button = SPButton(
-            title: "Apple Pay · \(selectedAmount) ₽",
-            variant: .money,
-            size: .lg,
-            icon: UIImage(systemName: "applelogo"),
-            fullWidth: true
-        )
-        button.addTarget(self, action: #selector(applePayTapped), for: .touchUpInside)
-        button.translatesAutoresizingMaskIntoConstraints = false
-        return button
+    /// Apple Pay primary CTA. Money tone with applelogo icon + suffix that
+    /// tracks the selected preset. Rebuilt on every selection because
+    /// SPButton title/suffix is immutable post-init.
+    private lazy var applePayButton: SPButton = makeApplePayButton(amount: selectedAmount)
+
+    /// Footer meta line — "Зачислится мгновенно. Откладывание будет доступно
+    /// сразу." Replaces the V1 cancel button (the close X in the header
+    /// covers the same affordance).
+    private let footerMetaLabel: UILabel = {
+        let label = UILabel()
+        label.font = AppTypography.meta
+        label.textColor = AppColors.fg3
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.text = "Зачислится мгновенно. Откладывание будет доступно сразу."
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
     }()
 
-    private lazy var cancelButton: SPButton = {
-        let button = SPButton(
-            title: "Отменить",
-            variant: .ghost,
-            size: .lg,
-            fullWidth: true
-        )
-        button.addTarget(self, action: #selector(cancelTapped), for: .touchUpInside)
-        button.translatesAutoresizingMaskIntoConstraints = false
-        return button
-    }()
-
-    /// Full-screen overlay shown after a successful purchase. Holds the green
-    /// checkmark + "+N ₽" copy. Hidden until `successAmount` is set.
+    /// Full-screen overlay shown after a successful purchase.
     private let successContainer: UIView = {
         let view = UIView()
         view.isHidden = true
@@ -227,25 +204,26 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
 
     init(presets: [Preset] = defaultPresets) {
         self.presets = presets
-        // Default-select the cheapest preset (200 ₽ — minimum cost of a single
-        // snooze per the spec's "amount_default" copy).
-        self.selectedAmount = presets.first?.amount ?? 200
+        // Default-select the "popular" preset (500 ₽) per V2 spec line 107;
+        // fall back to the first preset if none are marked popular.
+        self.selectedAmount = presets.first(where: { $0.popular })?.amount
+            ?? presets.first?.amount ?? 200
         self.remainingSeconds = 60
         super.init(nibName: nil, bundle: nil)
         modalPresentationStyle = .pageSheet
         if let sheet = sheetPresentationController {
-            // Custom ~360pt detent matches the design comp height. Falls back
-            // to the system `.medium` detent on iOS < 16 so we don't crash on
-            // older devices that the project still supports (15.1+).
+            // Custom ~440pt detent matches the design comp height (header +
+            // preset row + apple pay + footer). Falls back to .medium on
+            // older runtimes.
             if #available(iOS 16.0, *) {
                 let custom = UISheetPresentationController.Detent.custom(
                     identifier: UISheetPresentationController.Detent.Identifier("snoozepay.topup")
-                ) { _ in 360 }
+                ) { _ in 440 }
                 sheet.detents = [custom, .large()]
             } else {
                 sheet.detents = [.medium(), .large()]
             }
-            sheet.prefersGrabberVisible = false  // We render our own drag handle
+            sheet.prefersGrabberVisible = false  // we render our own drag handle
             sheet.preferredCornerRadius = AppRadius.xl
         }
     }
@@ -269,10 +247,10 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = AppColors.bg1
+        view.backgroundColor = AppColors.bg2
         // Per the spec the firing screen overlay is dark; pin the sheet to
-        // dark so the SPAmountPreset / SPButton tokens resolve against the
-        // same palette as the host VC.
+        // dark so SPAmountPreset / SPButton tokens resolve against the same
+        // palette as the host VC.
         overrideUserInterfaceStyle = .dark
         setupUI()
         setupPresetTiles()
@@ -281,8 +259,8 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        // Pause audio + escalation as soon as the sheet is about to render so
-        // the user isn't fighting the alarm sound while choosing a preset.
+        // Pause audio + escalation immediately so the user isn't fighting
+        // the alarm sound while choosing a preset.
         AudioService.shared.pauseAlarmSound()
         AlarmFiringCoordinator.shared.pauseEscalation()
         startAutoResumeTimer()
@@ -297,9 +275,8 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
         countdownTimer?.invalidate()
         countdownTimer = nil
 
-        // If the user dismissed without buying — resume audio + escalation so
-        // the alarm picks up where it left off. Skip resume on success path
-        // because the host VC may have already torn down the firing flow.
+        // Resume audio + escalation unless we got here via success path —
+        // the host VC may have already torn down the firing flow on success.
         if successAmount == nil {
             AudioService.shared.resumeAlarmSound()
             AlarmFiringCoordinator.shared.resumeEscalation()
@@ -310,42 +287,50 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
     // MARK: - Setup
 
     private func setupUI() {
-        let contentStack = UIStackView()
-        contentStack.axis = .vertical
-        contentStack.spacing = AppSpacing.sp4
-        contentStack.translatesAutoresizingMaskIntoConstraints = false
+        // Header row: caps title + pause countdown stacked vertically on
+        // the left, close X on the right.
+        titleCapsLabel.attributedText = NSAttributedString(
+            string: "ПОПОЛНИТЬ",
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.fg3
+            ]
+        )
+
+        let headerLeftStack = UIStackView(arrangedSubviews: [titleCapsLabel, pauseLabel])
+        headerLeftStack.translatesAutoresizingMaskIntoConstraints = false
+        headerLeftStack.axis = .vertical
+        headerLeftStack.spacing = 2
+        headerLeftStack.alignment = .leading
+
+        let headerRow = UIStackView(arrangedSubviews: [headerLeftStack, closeButton])
+        headerRow.translatesAutoresizingMaskIntoConstraints = false
+        headerRow.axis = .horizontal
+        headerRow.alignment = .top
+        headerRow.distribution = .equalSpacing
 
         view.addSubview(dragHandle)
-
-        // Header row: pause indicator on the left, close button on the right.
-        let pauseRow = UIStackView()
-        pauseRow.axis = .horizontal
-        pauseRow.alignment = .center
-        pauseRow.spacing = AppSpacing.sp2
-        pauseRow.translatesAutoresizingMaskIntoConstraints = false
-        pauseRow.addArrangedSubview(pauseDot)
-        pauseRow.addArrangedSubview(pauseLabel)
-        let spacer = UIView()
-        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        pauseRow.addArrangedSubview(spacer)
-        pauseRow.addArrangedSubview(closeButton)
-
-        view.addSubview(pauseRow)
-        view.addSubview(titleLabel)
+        view.addSubview(headerRow)
         view.addSubview(subtitleLabel)
         view.addSubview(presetStack)
         view.addSubview(applePayButton)
-        view.addSubview(cancelButton)
+        view.addSubview(footerMetaLabel)
         view.addSubview(successContainer)
 
-        // Success overlay — same surface, hidden until a purchase completes.
         successContainer.addSubview(successCheck)
         successContainer.addSubview(successAmountLabel)
         successContainer.addSubview(successCaption)
 
-        closeButton.addTarget(self, action: #selector(cancelTapped), for: .touchUpInside)
+        closeButton.addTarget(self, action: #selector(closeTapped), for: .touchUpInside)
 
-        let inset = AppSpacing.sp5
+        activateConstraints(headerRow: headerRow)
+    }
+
+    /// Pin every subview to its final geometry. Split out of `setupUI` so
+    /// neither function trips SwiftLint's `function_body_length` cap.
+    private func activateConstraints(headerRow: UIStackView) {
+        let inset = AppSpacing.sp5  // 20pt
 
         NSLayoutConstraint.activate([
             // Drag handle
@@ -354,22 +339,16 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
             dragHandle.widthAnchor.constraint(equalToConstant: 36),
             dragHandle.heightAnchor.constraint(equalToConstant: 4),
 
-            // Pause row + close button
-            pauseRow.topAnchor.constraint(equalTo: dragHandle.bottomAnchor, constant: AppSpacing.sp4),
-            pauseRow.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
-            pauseRow.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
-            pauseDot.widthAnchor.constraint(equalToConstant: 8),
-            pauseDot.heightAnchor.constraint(equalToConstant: 8),
+            // Header row
+            headerRow.topAnchor.constraint(equalTo: dragHandle.bottomAnchor, constant: AppSpacing.sp4),
+            headerRow.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
+            headerRow.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
+
             closeButton.widthAnchor.constraint(equalToConstant: 32),
             closeButton.heightAnchor.constraint(equalToConstant: 32),
 
-            // Title
-            titleLabel.topAnchor.constraint(equalTo: pauseRow.bottomAnchor, constant: AppSpacing.sp2),
-            titleLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
-            titleLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
-
             // Subtitle
-            subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: AppSpacing.sp1),
+            subtitleLabel.topAnchor.constraint(equalTo: headerRow.bottomAnchor, constant: AppSpacing.sp2),
             subtitleLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
             subtitleLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
 
@@ -383,12 +362,20 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
             applePayButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
             applePayButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
 
-            // Cancel
-            cancelButton.topAnchor.constraint(equalTo: applePayButton.bottomAnchor, constant: AppSpacing.sp2),
-            cancelButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
-            cancelButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
+            // Footer meta
+            footerMetaLabel.topAnchor.constraint(equalTo: applePayButton.bottomAnchor, constant: AppSpacing.sp3),
+            footerMetaLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
+            footerMetaLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset)
+        ])
 
-            // Success overlay
+        activateSuccessConstraints(inset: inset)
+    }
+
+    /// Pin the post-purchase success overlay. Kept separate so the main
+    /// constraint activation reads top-to-bottom without intermixing the
+    /// always-mounted overlay block.
+    private func activateSuccessConstraints(inset: CGFloat) {
+        NSLayoutConstraint.activate([
             successContainer.topAnchor.constraint(equalTo: view.topAnchor),
             successContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             successContainer.trailingAnchor.constraint(equalTo: view.trailingAnchor),
@@ -414,13 +401,31 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
             let tile = SPAmountPreset(
                 value: Decimal(preset.amount),
                 label: preset.label,
-                selected: preset.amount == selectedAmount
+                selected: preset.amount == selectedAmount,
+                popular: preset.popular
             ) { [weak self] in
                 self?.selectAmount(preset.amount)
             }
             presetStack.addArrangedSubview(tile)
             presetTiles.append(tile)
         }
+    }
+
+    /// Build a fresh Apple Pay button for the supplied amount. SPButton's
+    /// title / suffix are immutable post-init, so selection changes rebuild
+    /// the button instance. Cheap — three presets, max three swaps.
+    private func makeApplePayButton(amount: Int) -> SPButton {
+        let button = SPButton(
+            title: "Apple Pay",
+            variant: .money,
+            size: .lg,
+            icon: UIImage(systemName: "applelogo"),
+            suffix: "\(amount) ₽",
+            fullWidth: true
+        )
+        button.addTarget(self, action: #selector(applePayTapped), for: .touchUpInside)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
     }
 
     // MARK: - StoreKit observers
@@ -464,33 +469,20 @@ extension FiringTopUpBottomSheetViewController {
         for (tile, preset) in zip(presetTiles, presets) {
             tile.isSelected = preset.amount == amount
         }
-        // Rebuild the Apple Pay title — SPButton doesn't expose a setter so we
-        // re-create the button title via configuration on its private label
-        // path. Cheapest path: replace the button entirely. Tradeoff: a tiny
-        // extra alloc per tap. Acceptable here (3 presets, max 3 swaps).
         rebuildApplePayButton()
     }
 
     private func rebuildApplePayButton() {
         let oldButton = applePayButton
-        let newButton = SPButton(
-            title: "Apple Pay · \(selectedAmount) ₽",
-            variant: .money,
-            size: .lg,
-            icon: UIImage(systemName: "applelogo"),
-            fullWidth: true
-        )
-        newButton.addTarget(self, action: #selector(applePayTapped), for: .touchUpInside)
-        newButton.translatesAutoresizingMaskIntoConstraints = false
+        let newButton = makeApplePayButton(amount: selectedAmount)
         view.insertSubview(newButton, aboveSubview: oldButton)
         NSLayoutConstraint.activate([
             newButton.topAnchor.constraint(equalTo: presetStack.bottomAnchor, constant: AppSpacing.sp4),
             newButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: AppSpacing.sp5),
             newButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -AppSpacing.sp5)
         ])
-        // Re-pin cancel button below the replacement so the layout stays
-        // anchored to it.
-        cancelButton.topAnchor.constraint(equalTo: newButton.bottomAnchor, constant: AppSpacing.sp2).isActive = true
+        // Re-pin the footer meta below the replacement so it stays anchored.
+        footerMetaLabel.topAnchor.constraint(equalTo: newButton.bottomAnchor, constant: AppSpacing.sp3).isActive = true
         oldButton.removeFromSuperview()
         applePayButton = newButton
     }
@@ -508,10 +500,6 @@ extension FiringTopUpBottomSheetViewController {
             return
         }
 
-        // Resolve the StoreKit product if it's already loaded; otherwise fall
-        // back to a direct top-up so the debug flow still credits the wallet
-        // end-to-end (production path goes through StoreKitService once PM
-        // registers the exact 200/500/1000 SKUs in App Store Connect).
         if let product = StoreKitService.shared.products.first(where: { $0.id == preset.productID }) {
             Task { @MainActor in
                 await StoreKitService.shared.purchase(product)
@@ -530,7 +518,7 @@ extension FiringTopUpBottomSheetViewController {
         }
     }
 
-    @objc private func cancelTapped() {
+    @objc private func closeTapped() {
         dismiss(animated: true)
     }
 
@@ -546,14 +534,13 @@ extension FiringTopUpBottomSheetViewController {
 
         successAmountLabel.text = "+\(amount) ₽"
         successContainer.isHidden = false
-        // Cross-fade the form out so the success card reads as a swap rather
-        // than a stack.
         UIView.animate(withDuration: SPSupport.durationBase) {
-            self.titleLabel.alpha = 0
+            self.titleCapsLabel.alpha = 0
+            self.pauseLabel.alpha = 0
             self.subtitleLabel.alpha = 0
             self.presetStack.alpha = 0
             self.applePayButton.alpha = 0
-            self.cancelButton.alpha = 0
+            self.footerMetaLabel.alpha = 0
         }
 
         autoResumeTimer?.invalidate()
@@ -615,10 +602,9 @@ extension FiringTopUpBottomSheetViewController {
         let seconds = remainingSeconds % 60
         let countdown = String(format: "%02d:%02d", minutes, seconds)
         let attributed = NSAttributedString(
-            string: "БУДИЛЬНИК НА ПАУЗЕ · \(countdown)",
+            string: "На паузе · \(countdown)",
             attributes: [
-                .font: AppTypography.caps,
-                .kern: AppTypography.capsKerning,
+                .font: AppTypography.meta.monospacedDigit(),
                 .foregroundColor: AppColors.warn300
             ]
         )

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPDawnBackgroundView.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPDawnBackgroundView.swift
@@ -1,0 +1,222 @@
+import UIKit
+
+/// Atmospheric "Dawn" background view used by the V2 firing screen.
+///
+/// Spec — `docs/design/v2-handoff/components/SPScreensV2.jsx` lines 37–276 and
+/// `SPDawnV3.jsx` (DawnAtmosphere). Three layers stacked under the content:
+/// 1. **Base** — vertical linear gradient. The default Dawn recipe is
+///    `#0A0E1A → #0E1320 → #1A1410` (cool night to warm horizon); the
+///    no-balance "drained" variant collapses to `#0E1320 → #160B0B` so the
+///    screen reads as colder + redder when the wallet is empty.
+/// 2. **Overlay** — radial gradient anchored at the bottom centre (50% 100%),
+///    blending warn-amber rgba(245,158,11,.22) → pain rgba(244,82,63,.10) →
+///    transparent at 60%. Sells the "rising heat" cue.
+/// 3. **Sun** — 320×320pt blurred circle anchored 120pt below the bottom edge.
+///    Driven by either the warn or pain radial palette depending on `tone`.
+///
+/// The view owns three CAGradientLayers (base, overlay, sun) and reflows them
+/// on every layout pass so rotation / safe-area changes work without per-frame
+/// recompute. The sun layer hosts the 4s opacity breathing animation so
+/// `AlarmFiringViewController.startGlowBreathing()` keeps working unchanged.
+final class SPDawnBackgroundView: UIView {
+
+    // MARK: - Tone
+
+    /// Atmospheric variant. Matches the JSX `DawnAtmosphere({ tone })` cases.
+    enum Tone {
+        /// Default calm Dawn — warm amber sun + cool night base.
+        case calm
+        /// Progressive escalation — pain coral sun + slightly redder base.
+        case tense
+        /// No-balance ("drained") — cold blue-grey sun, colder base.
+        case drained
+    }
+
+    private(set) var tone: Tone
+
+    // MARK: - Layers
+
+    /// Vertical 3-stop base. Spec colours come from JSX `palettes[tone].base`.
+    private let baseLayer: CAGradientLayer = {
+        let gradient = CAGradientLayer()
+        gradient.type = .axial
+        gradient.startPoint = CGPoint(x: 0.5, y: 0.0)
+        gradient.endPoint = CGPoint(x: 0.5, y: 1.0)
+        return gradient
+    }()
+
+    /// Radial "warm rising" overlay at 50% 100%, blends warn → pain → transparent.
+    /// CALayer can render radial gradients via `.type = .radial` since iOS 12.
+    private let overlayLayer: CAGradientLayer = {
+        let gradient = CAGradientLayer()
+        gradient.type = .radial
+        gradient.startPoint = CGPoint(x: 0.5, y: 1.0)
+        gradient.endPoint = CGPoint(x: 1.4, y: 1.8)  // 140% radius / 70% height per spec
+        return gradient
+    }()
+
+    /// 320×320 sun circle, anchored ~120pt below the bottom edge. Public so
+    /// the firing VC can attach the 4s opacity breathing animation.
+    let sunLayer: CAGradientLayer = {
+        let gradient = CAGradientLayer()
+        gradient.type = .radial
+        gradient.startPoint = CGPoint(x: 0.5, y: 0.5)
+        gradient.endPoint = CGPoint(x: 1.0, y: 1.0)
+        // 320pt circle anchored ~120pt below the bottom edge — the upper
+        // hemisphere bleeds into the screen as the rising warmth.
+        return gradient
+    }()
+
+    // MARK: - Init
+
+    init(tone: Tone = .calm) {
+        self.tone = tone
+        super.init(frame: .zero)
+        translatesAutoresizingMaskIntoConstraints = false
+        clipsToBounds = true
+        isUserInteractionEnabled = false
+        layer.addSublayer(baseLayer)
+        layer.addSublayer(overlayLayer)
+        layer.addSublayer(sunLayer)
+        applyTone()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Public API
+
+    /// Swap the atmospheric palette in place. Used by the firing VC when the
+    /// progressive snooze count crosses the "tense" threshold or when the
+    /// balance drains to zero ("drained").
+    func setTone(_ newTone: Tone) {
+        guard newTone != tone else { return }
+        tone = newTone
+        applyTone()
+    }
+
+    // MARK: - Layout
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        let bounds = bounds
+        baseLayer.frame = bounds
+        overlayLayer.frame = bounds
+
+        // Sun: 320×320pt anchored 120pt below the bottom edge. Centered
+        // horizontally. The upper hemisphere reads as the rising glow.
+        let sunSize: CGFloat = 320
+        let sunY = bounds.height - 120
+        sunLayer.frame = CGRect(
+            x: (bounds.width - sunSize) / 2,
+            y: sunY,
+            width: sunSize,
+            height: sunSize
+        )
+        sunLayer.cornerRadius = sunSize / 2
+    }
+
+    // MARK: - Internals
+
+    private func applyTone() {
+        // Disable implicit CAAction animations during tone swap so the
+        // colours snap rather than cross-fade slowly on every setTone call.
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        defer { CATransaction.commit() }
+
+        switch tone {
+        case .calm: applyCalmTone()
+        case .tense: applyTenseTone()
+        case .drained: applyDrainedTone()
+        }
+    }
+
+    private func applyCalmTone() {
+        // Base: #0A0E1A → #0E1320 → #1A1410
+        baseLayer.colors = [
+            UIColor(dawnRGB: 0x0A0E1A).cgColor,
+            UIColor(dawnRGB: 0x0E1320).cgColor,
+            UIColor(dawnRGB: 0x1A1410).cgColor
+        ]
+        baseLayer.locations = [0.0, 0.6, 1.0]
+        // Overlay: warn 22% → pain 10% → transparent
+        overlayLayer.colors = [
+            UIColor(dawnRGB: 0xF59E0B, alpha: 0.22).cgColor,
+            UIColor(dawnRGB: 0xF4523F, alpha: 0.10).cgColor,
+            UIColor(dawnRGB: 0xF59E0B, alpha: 0.0).cgColor
+        ]
+        overlayLayer.locations = [0.0, 0.3, 0.6]
+        // Sun: warm amber radial
+        sunLayer.colors = [
+            UIColor(dawnRGB: 0xFFB84D, alpha: 0.45).cgColor,
+            UIColor(dawnRGB: 0xF59E0B, alpha: 0.10).cgColor,
+            UIColor(dawnRGB: 0xF59E0B, alpha: 0.0).cgColor
+        ]
+        sunLayer.locations = [0.0, 0.35, 0.7]
+    }
+
+    private func applyTenseTone() {
+        // Base shifts red: #0A0E1A → #14101C → #240C0C
+        baseLayer.colors = [
+            UIColor(dawnRGB: 0x0A0E1A).cgColor,
+            UIColor(dawnRGB: 0x14101C).cgColor,
+            UIColor(dawnRGB: 0x240C0C).cgColor
+        ]
+        baseLayer.locations = [0.0, 0.5, 1.0]
+        // Overlay leans pain
+        overlayLayer.colors = [
+            UIColor(dawnRGB: 0xF4523F, alpha: 0.24).cgColor,
+            UIColor(dawnRGB: 0xD43A28, alpha: 0.12).cgColor,
+            UIColor(dawnRGB: 0xF4523F, alpha: 0.0).cgColor
+        ]
+        overlayLayer.locations = [0.0, 0.3, 0.6]
+        // Sun: pain radial
+        sunLayer.colors = [
+            UIColor(dawnRGB: 0xF4523F, alpha: 0.42).cgColor,
+            UIColor(dawnRGB: 0xD43A28, alpha: 0.12).cgColor,
+            UIColor(dawnRGB: 0xF4523F, alpha: 0.0).cgColor
+        ]
+        sunLayer.locations = [0.0, 0.35, 0.7]
+    }
+
+    private func applyDrainedTone() {
+        // Base: cold blue-grey gradient, #0E1320 → #160B0B
+        // (matches FiringNoBalanceV2 spec line 230)
+        baseLayer.colors = [
+            UIColor(dawnRGB: 0x0E1320).cgColor,
+            UIColor(dawnRGB: 0x160B0B).cgColor
+        ]
+        baseLayer.locations = [0.0, 1.0]
+        // Overlay: faint pain wash so the empty state still has heat
+        overlayLayer.colors = [
+            UIColor(dawnRGB: 0xF4523F, alpha: 0.10).cgColor,
+            UIColor(dawnRGB: 0xF4523F, alpha: 0.04).cgColor,
+            UIColor(dawnRGB: 0xF4523F, alpha: 0.0).cgColor
+        ]
+        overlayLayer.locations = [0.0, 0.3, 0.6]
+        // Sun: cold blue-grey halo
+        sunLayer.colors = [
+            UIColor(dawnRGB: 0x788CB4, alpha: 0.18).cgColor,
+            UIColor(dawnRGB: 0x3C5078, alpha: 0.06).cgColor,
+            UIColor(dawnRGB: 0x788CB4, alpha: 0.0).cgColor
+        ]
+        sunLayer.locations = [0.0, 0.35, 0.7]
+    }
+}
+
+// MARK: - Hex helper
+
+private extension UIColor {
+    /// `0xRRGGBB` initializer mirrored from sibling AlarmFiring files —
+    /// `private` is file-scope in Swift, so each file that uses hex literals
+    /// carries its own copy. Keeps the JSX spec → Swift literal mapping
+    /// readable.
+    convenience init(dawnRGB rgb: UInt32, alpha: CGFloat = 1) {
+        let red = CGFloat((rgb >> 16) & 0xFF) / 255.0
+        let green = CGFloat((rgb >> 8) & 0xFF) / 255.0
+        let blue = CGFloat(rgb & 0xFF) / 255.0
+        self.init(red: red, green: green, blue: blue, alpha: alpha)
+    }
+}


### PR DESCRIPTION
## Summary

Slice F of the V2 design refresh — restyles the alarm firing screen and its top-up affordance to match the V2 handoff prototypes:
- `docs/design/v2-handoff/components/SPDawnV3.jsx`
- `SPScreensV2.jsx` (lines 37–276)
- `SPTopUp.jsx` (lines 103–197, `FiringTopUpPresets`)

### Visual changes

- **New `SPDawnBackgroundView` primitive** — three-layer atmospheric composition (base linear gradient + radial overlay + breathing sun) with `calm` / `tense` / `drained` tones that swap with the VM state (normal / progressive at intensity ≥ 0.5 / no-balance).
- **AlarmFiring main screen**: top header with date caps left ("Пт · 27 апр") + balance pill right, centered 96pt mono clock with warm-orange text shadow, "Подъём" caps below clock, 10pt CTA gap, 32pt bottom inset. Snooze CTA picks up the "Следующее откладывание: N ₽" hint when progressive is active.
- **Progressive chrome** retones the indicator pill to pain (was warn) per V2 spec `SPDawnV3.jsx` line 217. Dot uses `pain300`.
- **No-balance state** adds a centered shield pill "БАЛАНСА НЕ ОСТАЛОСЬ" + body copy ("Откладывать больше не получится. Только встать.") above the bottom CTAs. Apple Pay button now uses `suffix="500 ₽"` formatting per V2 spec.
- **FiringTopUp bottom sheet** rewritten — caps "ПОПОЛНИТЬ" + close X header, three horizontal `SPAmountPreset` tiles (200 / 500 popular / 1000 ₽), single Apple Pay money button with selected-amount suffix, footer meta "Зачислится мгновенно. Откладывание будет доступно сразу." Custom 440pt detent.

### Preserved business logic

Audio start/stop, payload validation, AudioService stacking guard (#116), snooze coordinator, vibration-fallback banner (#77), snooze-schedule-failure alert (#127), StoreKit purchase + BalanceService.topUp fallback, no-balance recovery observer, 60s auto-resume timer, purchase-success cross-fade — all preserved verbatim from V1.

## Test plan

- [x] `xcrun xcodebuild build` — succeeds clean
- [x] `xcrun xcodebuild build-for-testing` — succeeds clean
- [x] `swiftlint lint` on all changed files — 0 violations
- [ ] Launch alarm firing screen via simulator — verify top bar / clock / "Подъём" caps render
- [ ] Trigger progressive alarm — verify pain-tinted pill + history ticker, gradient cross-fades warn → pain
- [ ] Drain balance to 0 — verify atmosphere flips to `.drained`, pain-tinted shield pill + body copy appear, Apple Pay button replaces snooze CTA
- [ ] Tap "Выбрать другую сумму" — verify FiringTopUp sheet renders with three preset tiles (500 selected), Apple Pay suffix tracks selection
- [ ] Verify 60s auto-resume timer + countdown in pause label still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)