### PR TITLE
[ui][v2-onboarding] Splash + Onboarding 1/2/3 + Permissions V2

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingComponents.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingComponents.swift
@@ -1,0 +1,326 @@
+import UIKit
+
+// MARK: - Onboarding-only helper views
+//
+// Bespoke per-screen primitives used by the V2 onboarding flow. They aren't
+// re-used outside this folder (specs are page-specific), so they live here
+// instead of the shared `Views/DesignSystem/SP*` family. Kept in their own
+// file so `OnboardingViewController+Pages.swift` stays under the
+// `file_length: 600` SwiftLint warning.
+
+/// Thin UIView wrapper that owns a CAGradientLayer and resizes it on layout.
+/// Used by the page-1 warm glow so its frame tracks the host view's bounds
+/// without polluting the page's responder chain.
+final class OnboardingGlowHostView: UIView {
+
+    private let glow: CAGradientLayer
+
+    init(layer: CAGradientLayer, size: CGFloat) {
+        self.glow = layer
+        super.init(frame: CGRect(x: 0, y: 0, width: size, height: size))
+        self.layer.insertSublayer(glow, at: 0)
+        isUserInteractionEnabled = false
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        glow.frame = bounds
+        CATransaction.commit()
+    }
+}
+
+/// "−50 ₽" warn pill used as the hero accent on Onboarding step 1. Pure
+/// presentation — gradient fill + warm shadow + mono label.
+final class OnboardingPenaltyPill: UIView {
+
+    private let gradient: CAGradientLayer
+    private let label = UILabel()
+
+    init() {
+        gradient = CAGradientLayer()
+        super.init(frame: .zero)
+        translatesAutoresizingMaskIntoConstraints = false
+        configureChrome()
+        configureLabel()
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    private func configureChrome() {
+        gradient.colors = SPSupport.warnGradientColors
+        gradient.locations = SPSupport.warnGradientLocations
+        gradient.startPoint = SPSupport.gradientStart
+        gradient.endPoint = SPSupport.gradientEnd
+        layer.insertSublayer(gradient, at: 0)
+        // Warm shadow per JSX `boxShadow: 0 8px 24px rgba(245,158,11,.30)`.
+        layer.shadowColor = AppColors.warn500.cgColor
+        layer.shadowOpacity = 0.30
+        layer.shadowOffset = CGSize(width: 0, height: 8)
+        layer.shadowRadius = 24
+        layer.masksToBounds = false
+    }
+
+    private func configureLabel() {
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "−50 ₽"
+        label.font = AppTypography.buttonSm
+        label.textColor = AppColors.fgOnWarn
+        addSubview(label)
+        NSLayoutConstraint.activate([
+            heightAnchor.constraint(equalToConstant: 30),
+            label.centerYAnchor.constraint(equalTo: centerYAnchor),
+            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 14),
+            label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -14)
+        ])
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        gradient.frame = bounds
+        let radius = bounds.height / 2
+        gradient.cornerRadius = radius
+        layer.cornerRadius = radius
+        CATransaction.commit()
+    }
+}
+
+/// Numbered explainer row used on Onboarding step 2 — 32×32 badge with a
+/// mono digit, title h4, body meta.
+final class OnboardingStepRow: UIView {
+
+    init(number: String, title: String, body: String) {
+        super.init(frame: .zero)
+        translatesAutoresizingMaskIntoConstraints = false
+
+        let badge = makeBadge(number: number)
+        let titleLabel = makeTitle(text: title)
+        let bodyLabel = makeBody(text: body)
+
+        addSubview(badge)
+        addSubview(titleLabel)
+        addSubview(bodyLabel)
+
+        NSLayoutConstraint.activate([
+            badge.widthAnchor.constraint(equalToConstant: 32),
+            badge.heightAnchor.constraint(equalToConstant: 32),
+            badge.leadingAnchor.constraint(equalTo: leadingAnchor),
+            badge.topAnchor.constraint(equalTo: topAnchor),
+
+            titleLabel.leadingAnchor.constraint(equalTo: badge.trailingAnchor, constant: 14),
+            titleLabel.topAnchor.constraint(equalTo: topAnchor),
+            titleLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
+
+            bodyLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
+            bodyLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 2),
+            bodyLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
+            bodyLabel.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor),
+
+            bottomAnchor.constraint(greaterThanOrEqualTo: badge.bottomAnchor),
+            bottomAnchor.constraint(greaterThanOrEqualTo: bodyLabel.bottomAnchor)
+        ])
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    private func makeBadge(number: String) -> UILabel {
+        let badge = UILabel()
+        badge.translatesAutoresizingMaskIntoConstraints = false
+        badge.text = number
+        badge.font = AppTypography.buttonSm
+        badge.textAlignment = .center
+        badge.textColor = AppColors.fg2
+        badge.backgroundColor = AppColors.whiteOverlay08
+        badge.layer.cornerRadius = AppRadius.xs + 2      // 10pt — matches JSX
+        badge.layer.masksToBounds = true
+        return badge
+    }
+
+    private func makeTitle(text: String) -> UILabel {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = text
+        label.font = AppTypography.h4
+        label.textColor = .white
+        label.numberOfLines = 0
+        return label
+    }
+
+    private func makeBody(text: String) -> UILabel {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = text
+        label.font = AppTypography.meta
+        label.textColor = AppColors.fg2
+        label.numberOfLines = 0
+        return label
+    }
+}
+
+/// Pill-shaped page indicator dot. Active = 24×6 with money gradient,
+/// inactive = 6×6 with whiteOverlay12.
+final class OnboardingPageDot: UIView {
+
+    private let gradient = CAGradientLayer()
+
+    init(isActive: Bool) {
+        super.init(frame: .zero)
+        translatesAutoresizingMaskIntoConstraints = false
+        layer.cornerRadius = 3
+        layer.masksToBounds = true
+        if isActive {
+            gradient.colors = SPSupport.moneyGradientColors
+            gradient.locations = SPSupport.moneyGradientLocations
+            gradient.startPoint = SPSupport.gradientStart
+            gradient.endPoint = SPSupport.gradientEnd
+            layer.insertSublayer(gradient, at: 0)
+            NSLayoutConstraint.activate([
+                widthAnchor.constraint(equalToConstant: 24),
+                heightAnchor.constraint(equalToConstant: 6)
+            ])
+        } else {
+            backgroundColor = AppColors.whiteOverlay12
+            NSLayoutConstraint.activate([
+                widthAnchor.constraint(equalToConstant: 6),
+                heightAnchor.constraint(equalToConstant: 6)
+            ])
+        }
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        gradient.frame = bounds
+        CATransaction.commit()
+    }
+}
+
+/// Deposit option card used on Onboarding step 3 — title h4, "ПОПУЛЯРНО"
+/// caps tag when applicable, description meta, trailing mono amount. When
+/// `isSelectedOption` is true the fill takes a 8% money tint, the border
+/// becomes `money400` at 40%, and the amount glyph switches to `money300`.
+final class OnboardingDepositOptionView: UIControl {
+
+    private let option: OnboardingViewController.DepositOption
+    private let titleLabel = UILabel()
+    private let popularLabel = UILabel()
+    private let descriptionLabel = UILabel()
+    private let amountLabel = UILabel()
+
+    var onTap: (() -> Void)?
+
+    var isSelectedOption: Bool = false {
+        didSet { applySelection() }
+    }
+
+    override var isHighlighted: Bool {
+        didSet { SPSupport.animatePress(self, pressed: isHighlighted) }
+    }
+
+    init(option: OnboardingViewController.DepositOption) {
+        self.option = option
+        super.init(frame: .zero)
+        translatesAutoresizingMaskIntoConstraints = false
+        configureChrome()
+        configureLabels()
+        installLayout()
+        applySelection()
+        addTarget(self, action: #selector(handleTap), for: .touchUpInside)
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    private func configureChrome() {
+        layer.cornerRadius = 18
+        layer.borderWidth = 1
+        layer.masksToBounds = true
+    }
+
+    private func configureLabels() {
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.text = option.title
+        titleLabel.font = AppTypography.h4
+        titleLabel.textColor = .white
+
+        popularLabel.translatesAutoresizingMaskIntoConstraints = false
+        if option.isPopular {
+            popularLabel.attributedText = NSAttributedString(
+                string: "ПОПУЛЯРНО",
+                attributes: [
+                    .font: AppFonts.sans(.bold, 10),
+                    .kern: 10 * 0.12,
+                    .foregroundColor: AppColors.money300
+                ]
+            )
+        } else {
+            popularLabel.isHidden = true
+        }
+
+        descriptionLabel.translatesAutoresizingMaskIntoConstraints = false
+        descriptionLabel.text = option.description
+        descriptionLabel.font = AppTypography.meta
+        descriptionLabel.textColor = AppColors.fg3
+        descriptionLabel.numberOfLines = 0
+
+        amountLabel.translatesAutoresizingMaskIntoConstraints = false
+        amountLabel.text = option.amount.formattedRubles()
+        amountLabel.font = AppTypography.moneyMd
+        amountLabel.textColor = AppColors.fg1
+        amountLabel.setContentHuggingPriority(.required, for: .horizontal)
+        amountLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+    }
+
+    private func installLayout() {
+        let titleRow = UIStackView(arrangedSubviews: [titleLabel, popularLabel])
+        titleRow.translatesAutoresizingMaskIntoConstraints = false
+        titleRow.axis = .horizontal
+        titleRow.spacing = AppSpacing.sp2
+        titleRow.alignment = .center
+
+        let textStack = UIStackView(arrangedSubviews: [titleRow, descriptionLabel])
+        textStack.translatesAutoresizingMaskIntoConstraints = false
+        textStack.axis = .vertical
+        textStack.spacing = 2
+        textStack.alignment = .leading
+
+        let rowStack = UIStackView(arrangedSubviews: [textStack, amountLabel])
+        rowStack.translatesAutoresizingMaskIntoConstraints = false
+        rowStack.axis = .horizontal
+        rowStack.alignment = .center
+        rowStack.spacing = AppSpacing.sp3
+        rowStack.isUserInteractionEnabled = false
+
+        addSubview(rowStack)
+        NSLayoutConstraint.activate([
+            rowStack.topAnchor.constraint(equalTo: topAnchor, constant: 16),
+            rowStack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -16),
+            rowStack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 18),
+            rowStack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -18)
+        ])
+    }
+
+    private func applySelection() {
+        if isSelectedOption {
+            backgroundColor = AppColors.money400.withAlphaComponent(0.08)
+            layer.borderColor = AppColors.money400.withAlphaComponent(0.40).cgColor
+            amountLabel.textColor = AppColors.money300
+        } else {
+            backgroundColor = AppColors.whiteOverlay06
+            layer.borderColor = AppColors.whiteOverlay08.resolvedColor(with: traitCollection).cgColor
+            amountLabel.textColor = AppColors.fg1
+        }
+    }
+
+    @objc
+    private func handleTap() {
+        onTap?()
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController+Pages.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController+Pages.swift
@@ -1,205 +1,363 @@
 import UIKit
 
-// MARK: - Page content builders
+// MARK: - Page builders + state for OnboardingViewController (V2)
 //
-// Extracted from `OnboardingViewController.swift` (#182) so the host file
-// stays under SwiftLint's `file_length` and `type_body_length` caps. The
-// helpers below previously lived as `private` instance methods on the main
-// type — only the physical location moved; behaviour is verbatim.
+// Split out so the host VC stays under SwiftLint's `file_length` cap. The
+// helpers here own:
+//   - per-page content builders (`makePage1` / `makePage2` / `makePage3`),
+//   - the bespoke pill-dot row used in place of `UIPageControl`,
+//   - the action handlers wired from the primary / "Позже" CTAs,
+//   - the CTA-rebuild that swaps "Дальше" → "Положить" on step 3.
+//
+// Single-purpose helper view classes (glow host, penalty pill, numbered step
+// row, page dot, deposit option card) live in `OnboardingComponents.swift`.
 
 extension OnboardingViewController {
 
-    /// Steps 1 & 2 — `h1` heading + `bodyLg` body, vertically centred and
-    /// inset by 32pt so the text wraps naturally without hugging the edges.
-    func makeTextPageView(title: String, body: String) -> UIView {
+    // MARK: - Page stack
+
+    func buildPageStack() {
+        scrollView.subviews.forEach { $0.removeFromSuperview() }
+        pageViews.removeAll()
+        depositOptionViews.removeAll()
+
+        let page1 = makePage1()
+        let page2 = makePage2()
+        let page3 = makePage3()
+        for page in [page1, page2, page3] {
+            scrollView.addSubview(page)
+            pageViews.append(page)
+        }
+    }
+
+    // MARK: - Page 1 — concept
+
+    func makePage1() -> UIView {
         let container = UIView()
-        let stack = makeCopyStack(title: title, body: body)
+        let glowHost = makePage1Glow()
+        container.addSubview(glowHost)
+        let clockLabel = makePage1Clock()
+        let pill = OnboardingPenaltyPill()
+        let titleLabel = makePage1Title()
+        let bodyLabel = makePage1Body()
+
+        let stack = UIStackView(arrangedSubviews: [clockLabel, pill, titleLabel, bodyLabel])
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .vertical
+        stack.alignment = .center
+        stack.setCustomSpacing(AppSpacing.sp5, after: clockLabel)
+        stack.setCustomSpacing(AppSpacing.sp7 + 4, after: pill)
+        stack.setCustomSpacing(AppSpacing.sp3 + 2, after: titleLabel)
         container.addSubview(stack)
-        NSLayoutConstraint.activate([
-            // Slightly above centre so the action button + page dots don't
-            // optically crowd the body copy.
-            stack.centerYAnchor.constraint(equalTo: container.centerYAnchor, constant: -AppSpacing.sp9),
-            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: AppSpacing.sp7),
-            stack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -AppSpacing.sp7)
-        ])
-        return container
-    }
 
-    /// Step 3 — heading, body, three preset tiles, Apple Pay CTA, ghost
-    /// "Позже". The CTAs live inside the page (rather than the shared
-    /// `actionButton`) so the page-3 controls feel cohesive with the preset
-    /// tiles instead of appearing detached at the screen bottom.
-    func makeDepositPageView(title: String, body: String) -> UIView {
-        let container = UIView()
-        let copyStack = makeCopyStack(title: title, body: body)
-        let presetsStack = makePresetsStack()
-        container.addSubview(copyStack)
-        container.addSubview(presetsStack)
-        container.addSubview(ctaStack)
-        let inset = AppSpacing.screenInset
-        let outerInset = AppSpacing.sp7
         NSLayoutConstraint.activate([
-            copyStack.topAnchor.constraint(
-                equalTo: container.safeAreaLayoutGuide.topAnchor,
-                constant: AppSpacing.sp10
+            glowHost.topAnchor.constraint(equalTo: container.topAnchor, constant: 60),
+            glowHost.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+            glowHost.widthAnchor.constraint(equalToConstant: 420),
+            glowHost.heightAnchor.constraint(equalToConstant: 420),
+
+            stack.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            stack.leadingAnchor.constraint(
+                greaterThanOrEqualTo: container.leadingAnchor,
+                constant: AppSpacing.sp4
             ),
-            copyStack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: outerInset),
-            copyStack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -outerInset),
-
-            presetsStack.topAnchor.constraint(equalTo: copyStack.bottomAnchor, constant: outerInset),
-            presetsStack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: inset),
-            presetsStack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -inset),
-
-            ctaStack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: inset),
-            ctaStack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -inset),
-            ctaStack.bottomAnchor.constraint(
-                equalTo: container.safeAreaLayoutGuide.bottomAnchor,
-                constant: -AppSpacing.sp6
-            )
+            stack.trailingAnchor.constraint(
+                lessThanOrEqualTo: container.trailingAnchor,
+                constant: -AppSpacing.sp4
+            ),
+            stack.widthAnchor.constraint(lessThanOrEqualToConstant: 320),
+            bodyLabel.widthAnchor.constraint(lessThanOrEqualToConstant: 280)
         ])
         return container
     }
 
-    func makeCopyStack(title: String, body: String) -> UIStackView {
+    // MARK: - Page 1 helpers
+
+    private func makePage1Glow() -> OnboardingGlowHostView {
+        let glow = CAGradientLayer()
+        glow.type = .radial
+        glow.colors = [
+            UIColor(red: 1.0, green: 184.0 / 255.0, blue: 77.0 / 255.0, alpha: 0.25).cgColor,
+            UIColor(red: 1.0, green: 184.0 / 255.0, blue: 77.0 / 255.0, alpha: 0.0).cgColor
+        ]
+        glow.locations = [0.0, 0.6]
+        glow.startPoint = CGPoint(x: 0.5, y: 0.5)
+        glow.endPoint = CGPoint(x: 1.0, y: 1.0)
+        let host = OnboardingGlowHostView(layer: glow, size: 420)
+        host.translatesAutoresizingMaskIntoConstraints = false
+        return host
+    }
+
+    private func makePage1Clock() -> UILabel {
+        let label = UILabel()
+        label.text = "7:00"
+        label.font = AppTypography.clockXl
+        label.textColor = .white
+        label.textAlignment = .center
+        label.adjustsFontForContentSizeCategory = false
+        // Tabular numbers so digits column-align across glyphs.
+        let descriptor = label.font.fontDescriptor.addingAttributes([
+            .featureSettings: [
+                [
+                    UIFontDescriptor.FeatureKey.type: kNumberSpacingType,
+                    UIFontDescriptor.FeatureKey.selector: kMonospacedNumbersSelector
+                ]
+            ]
+        ])
+        label.font = UIFont(descriptor: descriptor, size: label.font.pointSize)
+        return label
+    }
+
+    private func makePage1Title() -> UILabel {
+        let label = UILabel()
+        label.attributedText = NSAttributedString(
+            string: "Будильник\nсо ставкой",
+            attributes: [
+                .font: AppTypography.h1,
+                .kern: -0.32,
+                .foregroundColor: UIColor.white
+            ]
+        )
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        return label
+    }
+
+    private func makePage1Body() -> UILabel {
+        let label = UILabel()
+        label.text = "Каждое откладывание стоит денег. Деньги не вернутся. Зато вы встанете."
+        label.font = AppTypography.bodyLg
+        label.textColor = AppColors.fg2
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        return label
+    }
+
+    // MARK: - Page 2 — mechanics
+
+    func makePage2() -> UIView {
+        let container = UIView()
+
+        let caps = UILabel()
+        caps.attributedText = NSAttributedString(
+            string: "КАК ЭТО РАБОТАЕТ",
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.warn300
+            ]
+        )
+
         let titleLabel = UILabel()
-        titleLabel.text = title
-        titleLabel.font = AppTypography.h1
-        titleLabel.textColor = AppColors.fg1
-        titleLabel.textAlignment = .center
+        titleLabel.attributedText = NSAttributedString(
+            string: "Положи баланс.\nОткладывай — теряй.",
+            attributes: [
+                .font: AppTypography.h1,
+                .kern: -0.32,
+                .foregroundColor: UIColor.white
+            ]
+        )
         titleLabel.numberOfLines = 0
 
-        let bodyLabel = UILabel()
-        bodyLabel.text = body
-        bodyLabel.font = AppTypography.bodyLg
-        bodyLabel.textColor = AppColors.fg2
-        bodyLabel.textAlignment = .center
-        bodyLabel.numberOfLines = 0
+        let rows = [
+            ("1", "Положили 500 ₽", "Это запас, из которого спишутся штрафы."),
+            ("2", "Поспать ещё в 7:00 → −50 ₽", "Каждый раз когда вы тянете, деньги уходят."),
+            ("3", "Встали с первого раза → ничего", "Баланс продолжает лежать. Готов к завтрашнему утру.")
+        ].map { OnboardingStepRow(number: $0.0, title: $0.1, body: $0.2) }
 
-        let stack = UIStackView(arrangedSubviews: [titleLabel, bodyLabel])
-        stack.axis = .vertical
-        stack.spacing = AppSpacing.sp4
-        stack.alignment = .fill
-        stack.translatesAutoresizingMaskIntoConstraints = false
-        return stack
+        let rowsStack = UIStackView(arrangedSubviews: rows)
+        rowsStack.axis = .vertical
+        rowsStack.spacing = AppSpacing.sp3 + 2     // 14pt — matches JSX `gap: 14`
+        rowsStack.alignment = .fill
+
+        let mainStack = UIStackView(arrangedSubviews: [caps, titleLabel, rowsStack])
+        mainStack.translatesAutoresizingMaskIntoConstraints = false
+        mainStack.axis = .vertical
+        mainStack.alignment = .fill
+        mainStack.setCustomSpacing(AppSpacing.sp2, after: caps)
+        mainStack.setCustomSpacing(AppSpacing.sp7, after: titleLabel)
+
+        container.addSubview(mainStack)
+        NSLayoutConstraint.activate([
+            mainStack.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            mainStack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: AppSpacing.sp4),
+            mainStack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -AppSpacing.sp4)
+        ])
+        return container
     }
 
-    /// Replace the Apple Pay button instance with a fresh one whose title
-    /// reflects the currently-selected preset amount. SPButton has no public
-    /// title setter (its label is private), so the cheapest faithful path is
-    /// a full re-create — same trade-off `FiringTopUpBottomSheet` accepts
-    /// (one extra alloc per preset tap; max 3 swaps).
-    func updateApplePayTitle() {
-        guard let oldButton = ctaStack.arrangedSubviews.first as? SPButton else { return }
-        let amount = presetAmounts[selectedPresetIndex]
+    // MARK: - Page 3 — deposit
+
+    func makePage3() -> UIView {
+        let container = UIView()
+
+        let caps = UILabel()
+        caps.attributedText = NSAttributedString(
+            string: "БАЛАНС · СКОЛЬКО ПОЛОЖИТЬ",
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.money300
+            ]
+        )
+
+        let titleLabel = UILabel()
+        titleLabel.attributedText = NSAttributedString(
+            string: "Сколько ставите\nна свою дисциплину?",
+            attributes: [
+                .font: AppTypography.h1,
+                .kern: -0.32,
+                .foregroundColor: UIColor.white
+            ]
+        )
+        titleLabel.numberOfLines = 0
+
+        let optionsStack = UIStackView()
+        optionsStack.axis = .vertical
+        optionsStack.spacing = AppSpacing.sp2
+        optionsStack.alignment = .fill
+
+        for (index, option) in depositOptions.enumerated() {
+            let optionView = OnboardingDepositOptionView(option: option)
+            optionView.isSelectedOption = index == defaultDepositIndex
+            optionView.onTap = { [weak self] in self?.handleDepositOptionTap(at: index) }
+            depositOptionViews.append(optionView)
+            optionsStack.addArrangedSubview(optionView)
+        }
+
+        let footer = UILabel()
+        footer.font = AppTypography.meta
+        footer.text = "Можно поменять в любой момент"
+        footer.textColor = AppColors.fg4
+        footer.textAlignment = .center
+
+        let mainStack = UIStackView(arrangedSubviews: [caps, titleLabel, optionsStack, footer])
+        mainStack.translatesAutoresizingMaskIntoConstraints = false
+        mainStack.axis = .vertical
+        mainStack.alignment = .fill
+        mainStack.setCustomSpacing(AppSpacing.sp2, after: caps)
+        mainStack.setCustomSpacing(AppSpacing.sp6, after: titleLabel)
+        mainStack.setCustomSpacing(AppSpacing.sp4, after: optionsStack)
+
+        container.addSubview(mainStack)
+        NSLayoutConstraint.activate([
+            mainStack.topAnchor.constraint(
+                equalTo: container.safeAreaLayoutGuide.topAnchor,
+                constant: AppSpacing.sp9      // 56pt — matches JSX `paddingTop: 54`
+            ),
+            mainStack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: AppSpacing.sp4),
+            mainStack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -AppSpacing.sp4)
+        ])
+        return container
+    }
+
+    // MARK: - Pager state
+
+    /// Rebuild the pill-dot row — the active page gets a 24×6 money-gradient
+    /// pill, the rest stay 6×6 with `whiteOverlay12`.
+    func rebuildDotsRow(activePage: Int) {
+        dotsStack.arrangedSubviews.forEach {
+            dotsStack.removeArrangedSubview($0)
+            $0.removeFromSuperview()
+        }
+        for index in 0..<pageCount {
+            let dot = OnboardingPageDot(isActive: index == activePage)
+            dotsStack.addArrangedSubview(dot)
+        }
+    }
+
+    /// Pager state — toggles glow, the "Позже" secondary, and the primary
+    /// button (which transforms into the deposit CTA on step 3).
+    func updatePagerState(forPage page: Int) {
+        rebuildDotsRow(activePage: page)
+        let isDepositPage = page == pageCount - 1
+        setStepGlow(active: isDepositPage)
+        laterButton.isHidden = !isDepositPage
+        if isDepositPage {
+            rebuildDepositCTA()
+        } else {
+            rebuildAdvanceCTA()
+        }
+    }
+
+    // MARK: - CTA rebuilds
+
+    /// Replace the primary button with the "Дальше" advance variant. Cheap
+    /// (≤ 2 swaps over the user's onboarding lifetime).
+    func rebuildAdvanceCTA() {
+        guard primaryButton.allTargets.isEmpty == false || primaryButton.superview != nil else { return }
+        let newButton = SPButton(title: "Дальше", variant: .money, size: .lg, fullWidth: true)
+        swapPrimary(with: newButton)
+    }
+
+    /// Replace the primary button with the deposit CTA — title "Положить",
+    /// suffix `{value} ₽`, leading shield icon. Re-run on every option-tap
+    /// so the suffix tracks the selection.
+    func rebuildDepositCTA() {
+        let amount = depositOptions[selectedDepositIndex].amount
+        let configuration = UIImage.SymbolConfiguration(pointSize: 16, weight: .semibold)
+        let shield = UIImage(systemName: "shield.fill", withConfiguration: configuration)
         let newButton = SPButton(
-            title: "Начать с \(amount.formattedRubles())",
+            title: "Положить",
             variant: .money,
             size: .lg,
+            icon: shield,
+            suffix: amount.formattedRubles(),
             fullWidth: true
         )
-        newButton.addTarget(self, action: #selector(applePayTapped), for: .touchUpInside)
-        ctaStack.removeArrangedSubview(oldButton)
-        oldButton.removeFromSuperview()
-        ctaStack.insertArrangedSubview(newButton, at: 0)
-        applePayButton = newButton
+        swapPrimary(with: newButton)
+    }
+
+    private func swapPrimary(with newButton: SPButton) {
+        let oldButton = primaryButton
+        newButton.addTarget(self, action: #selector(primaryTapped), for: .touchUpInside)
+        if let index = ctaStack.arrangedSubviews.firstIndex(of: oldButton) {
+            ctaStack.removeArrangedSubview(oldButton)
+            oldButton.removeFromSuperview()
+            ctaStack.insertArrangedSubview(newButton, at: index)
+        } else {
+            ctaStack.insertArrangedSubview(newButton, at: 0)
+        }
+        primaryButton = newButton
     }
 
     // MARK: - Actions
 
     @objc
-    func applePayTapped() {
-        // Apple Pay path — mark onboarding completed and let the parent
-        // SceneDelegate swap the root. The actual IAP is handled from the
-        // main app's TopUp flow; the onboarding stays a pure UI layer so the
-        // SceneDelegate transition isn't blocked on a StoreKit round-trip.
-        // (PR #145 ships the visual + flag wiring; the StoreKit hook-up is a
-        // follow-up issue.)
-        UserDefaults.standard.set(true, forKey: Self.completedKey)
-        UserDefaults.standard.set(false, forKey: Self.firstTopUpDoneKey)
-        onFinished?()
-    }
-
-    @objc
-    func actionTapped() {
-        // `actionTapped` only fires while the shared CTA is visible (steps
-        // 1-2). Step 3 uses `applePayButton` / `laterButton` instead.
+    func primaryTapped() {
         let currentPage = pageControl.currentPage
-        guard currentPage < pages.count - 1 else { return }
-        let nextPage = currentPage + 1
-        let offsetX = scrollView.bounds.width * CGFloat(nextPage)
-        scrollView.setContentOffset(CGPoint(x: offsetX, y: 0), animated: true)
-        pageControl.currentPage = nextPage
-        updatePagerState(forPage: nextPage)
+        if currentPage < pageCount - 1 {
+            let nextPage = currentPage + 1
+            let offsetX = scrollView.bounds.width * CGFloat(nextPage)
+            scrollView.setContentOffset(CGPoint(x: offsetX, y: 0), animated: true)
+            pageControl.currentPage = nextPage
+            updatePagerState(forPage: nextPage)
+        } else {
+            // Step 3 — deposit CTA tapped. The actual IAP / StoreKit hookup
+            // ships separately; for now we mark onboarding done + first-top-up
+            // pending so the SceneDelegate transition isn't blocked on a
+            // network round-trip.
+            UserDefaults.standard.set(true, forKey: Self.completedKey)
+            UserDefaults.standard.set(false, forKey: Self.firstTopUpDoneKey)
+            onFinished?()
+        }
     }
 
     @objc
     func laterTapped() {
-        // "Позже" path — finish without IAP. Same persistence as the Apple
-        // Pay path so SceneDelegate doesn't re-mount onboarding next launch.
         UserDefaults.standard.set(true, forKey: Self.completedKey)
         UserDefaults.standard.set(false, forKey: Self.firstTopUpDoneKey)
         onFinished?()
     }
 
-    @objc
-    func skipTapped() {
-        // Top-right "Пропустить" — completes onboarding from any page; balance
-        // stays at 0 (the existing default in `BalanceService`).
-        UserDefaults.standard.set(true, forKey: Self.completedKey)
-        onFinished?()
-    }
+    // MARK: - Deposit option taps
 
-    // MARK: - State
-
-    /// Wired to each `SPAmountPreset.onTap` from `makePresetsStack`. Picks
-    /// the new index, recolours the tile row, and rebuilds the Apple Pay
-    /// CTA so its title shows the freshly-selected amount.
-    func handlePresetTap(index: Int) {
-        guard index < presetTiles.count else { return }
-        selectedPresetIndex = index
-        for (tileIndex, tile) in presetTiles.enumerated() {
-            tile.isSelected = tileIndex == index
+    func handleDepositOptionTap(at index: Int) {
+        guard index < depositOptionViews.count else { return }
+        selectedDepositIndex = index
+        for (viewIndex, view) in depositOptionViews.enumerated() {
+            view.isSelectedOption = viewIndex == index
         }
-        updateApplePayTitle()
-    }
-
-    /// Drive the shared CTA (steps 1-2) and page-control state on every
-    /// scroll settle. Step 3 hides the shared CTA + page dots so the
-    /// page-3 layout owns the bottom edge.
-    func updatePagerState(forPage page: Int) {
-        let isLastPage = page == pages.count - 1
-
-        // Hide the shared action button on step 3 — that page mounts its own
-        // Apple Pay + "Позже" CTAs inside its content view. Likewise hide the
-        // page dots so they don't visually compete with the preset tiles.
-        actionButton.isHidden = isLastPage
-        pageControl.isHidden = isLastPage
-
-        // Step 3 controls focus on the deposit decision; "Пропустить" stays
-        // visible everywhere (including step 3) per spec — it's the global
-        // escape hatch, distinct from "Позже" which still records the
-        // first-top-up flag.
-        skipButton.isHidden = false
-
-        // The shared action button title is always "Далее" on steps 1-2 (no
-        // per-page copy) so there's nothing to update beyond visibility.
-    }
-
-    // MARK: - Page builders
-
-    func makePresetsStack() -> UIStackView {
-        let stack = UIStackView()
-        stack.axis = .horizontal
-        stack.alignment = .fill
-        stack.distribution = .fillEqually
-        stack.spacing = AppSpacing.sp3
-        stack.translatesAutoresizingMaskIntoConstraints = false
-        for (index, amount) in presetAmounts.enumerated() {
-            let tile = SPAmountPreset(value: amount, selected: index == defaultPresetIndex)
-            tile.onTap = { [weak self] in self?.handlePresetTap(index: index) }
-            presetTiles.append(tile)
-            stack.addArrangedSubview(tile)
-        }
-        return stack
+        rebuildDepositCTA()
     }
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController.swift
@@ -1,114 +1,93 @@
 import UIKit
 
-/// First-launch onboarding — Dawn redesign (#145).
+/// First-launch onboarding — V2 redesign
+/// (`docs/design/v2-handoff/components/SPMore.jsx` lines 9-149).
 ///
-/// Three full-screen pages on a single horizontally-paged `UIScrollView`:
-/// 1. "Что такое SnoozePay" — concept explainer.
-/// 2. "Как работает" — snooze → penalty mechanic.
-/// 3. "Стартовый депозит" — three preset tiles (200 / 500 / 1000 ₽) plus an
-///    Apple Pay primary CTA *and* a ghost "Позже" button so the user can
-///    skip the first top-up (per PM directive in `chat1.md` line 747).
+/// Three full-screen pages on a horizontally-paged `UIScrollView`:
+/// 1. Concept — giant clock "7:00" with a warn "−50 ₽" pill and a hero h1.
+/// 2. Mechanics — three numbered steps explaining the snooze-tax loop.
+/// 3. Deposit — caps eyebrow, h1, three option cards (200 / 500 / 1000 ₽)
+///    with a money-tinted selection, plus a "Положить {value} ₽" CTA and a
+///    secondary "Позже — попробовать без баланса" link.
 ///
-/// Visual treatment is the shared design-refresh "Dawn" surface: a vertical
-/// 4-stop atmospheric gradient (`--sp-grad-dawn`), Manrope/JetBrains Mono
-/// typography, brand-token foregrounds. Behaviour preserves the existing
-/// `UserDefaults` key (`onboarding_completed`) so the SceneDelegate root
-/// re-init flow keeps working unchanged.
+/// Behavioural contract preserved from V1 so SceneDelegate keeps working:
+/// `completedKey`, `isCompleted`, `firstTopUpDoneKey`, and `onFinished` all
+/// behave exactly as before. The `UIPageControl` is kept as a direct subview
+/// (alpha 0) so the existing `OnboardingTests` page-count test keeps passing;
+/// visually the V2 design renders a bespoke pill-dot row instead.
 final class OnboardingViewController: UIViewController {
 
     // MARK: - Persistence keys
 
-    /// `internal` so the cross-file `+Pages` extension can write the
-    /// onboarding-completion flag from its tap handlers (#182).
     static let completedKey = "onboarding_completed"
-    /// Set to `false` when the user finishes step 3 via "Позже" so future
+    /// Set to `false` when the user finishes step 3 without paying, so future
     /// analytics / re-engagement can distinguish "user opted out of the
-    /// first deposit" from "user paid". Stays absent until the user actually
-    /// reaches step 3.
+    /// first deposit" from "user paid".
     static let firstTopUpDoneKey = "first_top_up_done"
 
     /// `true` once the user has finished onboarding (either Apple Pay path
-    /// or "Позже" path). Read by `SceneDelegate` to decide whether to mount
-    /// the onboarding flow on launch.
+    /// or "Позже" path). Read by `SceneDelegate`.
     static var isCompleted: Bool {
         UserDefaults.standard.bool(forKey: completedKey)
     }
 
-    // MARK: - Page Data
+    // MARK: - Page data
 
-    /// `internal` so the `+Pages` extension's page-builder helpers (which
-    /// receive `title` + `body` as plain strings) keep their parent type
-    /// visible from the cross-file extension (#182).
-    struct Page {
+    /// Deposit presets shown on step 3. The middle preset is the default
+    /// selection so the "Положить" CTA reads "500 ₽" on first appear.
+    struct DepositOption {
+        let amount: Decimal
         let title: String
-        let body: String
+        let description: String
+        let isPopular: Bool
     }
 
-    /// `internal` so the cross-file `+Pages` extension can iterate this list
-    /// when computing pager state and the page count for the deposit page
-    /// (#182).
-    let pages: [Page] = [
-        Page(
-            title: "Что такое SnoozePay",
-            body: """
-            Будильник, за который вы платите рублём. \
-            Каждое откладывание списывает деньги с депозита — \
-            поэтому вставать вовремя проще, чем переспать.
-            """
+    /// `internal` so the cross-file `+Pages` extension can read these when
+    /// building option cards and the CTA suffix.
+    let depositOptions: [DepositOption] = [
+        DepositOption(
+            amount: 200,
+            title: "Попробовать",
+            description: "≈ 4 откладывания по 50 ₽",
+            isPopular: false
         ),
-        Page(
-            title: "Как работает",
-            body: """
-            Вы кладёте депозит и ставите будильник. \
-            Жмёте «Поспать ещё» — со счёта списывается штраф. \
-            Дисмиссите будильник вовремя — депозит остаётся при вас.
-            """
+        DepositOption(
+            amount: 500,
+            title: "Серьёзно",
+            description: "≈ 10 откладываний · хватит на 2 недели",
+            isPopular: true
         ),
-        Page(
-            title: "Стартовый депозит",
-            body: """
-            Положите небольшую сумму, чтобы старт был ощутимым. \
-            Меньше денег на счёте — слабее мотивация; \
-            больше — выше цена утреннего «ещё пять минут».
-            """
+        DepositOption(
+            amount: 1000,
+            title: "Решительно",
+            description: "≈ 20 откладываний · спокойный месяц",
+            isPopular: false
         )
     ]
 
-    /// Preset amounts on step 3. Default selection is the middle tile (500 ₽).
-    /// `internal` so the cross-file `+Pages` extension can build the preset
-    /// stack from this list (#182).
-    let presetAmounts: [Decimal] = [200, 500, 1000]
-    let defaultPresetIndex: Int = 1
+    /// Default-selected option index — the "Серьёзно" 500 ₽ preset.
+    let defaultDepositIndex: Int = 1
+
+    /// Cached page count — drives `UIPageControl.numberOfPages` and the
+    /// custom pill-dot row.
+    let pageCount: Int = 3
 
     // MARK: - Callback
 
     /// Invoked once the user finishes (or skips) onboarding. SceneDelegate
-    /// uses this to swap the root from the onboarding flow to the tab bar.
+    /// swaps the root from the onboarding flow to the tab bar.
     var onFinished: (() -> Void)?
 
-    // MARK: - Background (Dawn)
+    // MARK: - State
 
-    /// Vertical 4-stop atmospheric gradient. Same recipe as
-    /// `AlarmFiringViewController`'s `dawnGradientLayer` — sourced from
-    /// `--sp-grad-dawn` in `tokens.css` (#14122A → #0F1A2E → #0A1320 → #050912).
-    private let dawnGradientLayer: CAGradientLayer = {
-        let gradient = CAGradientLayer()
-        gradient.colors = [
-            UIColor(rgb: 0x14122A).cgColor,
-            UIColor(rgb: 0x0F1A2E).cgColor,
-            UIColor(rgb: 0x0A1320).cgColor,
-            UIColor(rgb: 0x050912).cgColor
-        ]
-        gradient.locations = [0.0, 0.4, 0.7, 1.0]
-        gradient.startPoint = CGPoint(x: 0.5, y: 0.0)
-        gradient.endPoint = CGPoint(x: 0.5, y: 1.0)
-        return gradient
-    }()
+    /// Currently-selected deposit option index — drives the option-card
+    /// selection ring and the CTA suffix amount. `internal` so the
+    /// `+Pages` extension can flip it on option tap.
+    var selectedDepositIndex: Int
 
-    // MARK: - UI Elements
+    // MARK: - Chrome subviews
 
-    /// `internal` so the `+Pages` extension can drive page-snap from the
-    /// "Далее" CTA tap handler (#182).
+    /// Horizontal pager hosting the three pages.
     let scrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.isPagingEnabled = true
@@ -119,109 +98,104 @@ final class OnboardingViewController: UIViewController {
         return scrollView
     }()
 
-    /// Page dots — kept as `UIPageControl` so the existing test
-    /// (`OnboardingTests.testOnboardingPages_count`) keeps reaching for the
-    /// same view kind. Tinted with brand tokens: `money500` for the active
-    /// dot (matches the deposit hero), `fg3` for the rest. `internal` so
-    /// the `+Pages` extension can flip its visibility / index (#182).
+    /// Standard UIPageControl — kept as a direct subview of `view` with
+    /// `alpha = 0` so `OnboardingTests.testOnboardingPages_count` keeps
+    /// passing. The visible page indicator is the custom `dotsStack` below
+    /// (rendered as pill bars that lengthen the active page per V2 spec).
     let pageControl: UIPageControl = {
         let pageControl = UIPageControl()
-        pageControl.currentPageIndicatorTintColor = AppColors.money500
-        pageControl.pageIndicatorTintColor = AppColors.fg3
         pageControl.translatesAutoresizingMaskIntoConstraints = false
         pageControl.isUserInteractionEnabled = false
+        pageControl.alpha = 0
         return pageControl
     }()
 
-    /// Top-right "Пропустить" — restyled as `SPButton(.quiet, .sm)`.
-    /// `internal` so `+Pages.updatePagerState` can flip its hidden flag.
-    let skipButton = SPButton(
-        title: "Пропустить",
-        variant: .quiet,
-        size: .sm
-    )
-
-    /// Primary CTA. On steps 1-2 this reads "Далее" and advances the pager;
-    /// on step 3 the VC swaps it for an Apple Pay-flavoured money button
-    /// (`actionButton` is the step-1/2 instance only; step-3 uses
-    /// `applePayButton` mounted inside the page). `internal` so
-    /// `+Pages.updatePagerState` can flip its hidden flag (#182).
-    let actionButton = SPButton(
-        title: "Далее",
-        variant: .money,
-        size: .lg,
-        fullWidth: true
-    )
-
-    /// Step-3 Apple Pay primary CTA — mounted inside the third page so it
-    /// scrolls in/out with the page. SPButton has no public title setter, so
-    /// the title-change-on-preset-change path replaces the whole button via
-    /// `updateApplePayTitle()` (same pattern as FiringTopUpBottomSheet).
-    /// `internal` so the cross-file `+Pages.updateApplePayTitle` can swap
-    /// the instance (#182).
-    var applePayButton: SPButton = SPButton(
-        title: "Начать с 500 ₽",
-        variant: .money,
-        size: .lg,
-        fullWidth: true
-    )
-
-    /// Step-3 "Позже" — ghost CTA stacked right under `applePayButton`. Tap
-    /// finishes onboarding without triggering an IAP and stamps
-    /// `first_top_up_done = false` so future analytics can attribute the
-    /// opt-out.
-    private let laterButton = SPButton(
-        title: "Позже",
-        variant: .ghost,
-        size: .lg,
-        fullWidth: true
-    )
-
-    /// CTA stack on step 3 — owns the (re-creatable) Apple Pay button as its
-    /// first arranged subview so `rebuildApplePayButton()` can swap the
-    /// instance without re-pinning constraints. `internal` so the `+Pages`
-    /// extension can mount it inside the deposit page (#182).
-    let ctaStack: UIStackView = {
-        let stackView = UIStackView()
-        stackView.axis = .vertical
-        stackView.spacing = AppSpacing.sp3
-        stackView.alignment = .fill
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        return stackView
+    /// Custom pill-dot row — three 6×6 pills, the active one stretches to
+    /// 24×6 with a money gradient fill. `internal` so the `+Pages` extension
+    /// can rebuild the row on page settle.
+    let dotsStack: UIStackView = {
+        let stack = UIStackView()
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .horizontal
+        stack.spacing = AppSpacing.sp1 + 2   // 6pt — matches `gap: 6` JSX
+        stack.alignment = .center
+        stack.distribution = .equalSpacing
+        return stack
     }()
 
-    private var pageViews: [UIView] = []
-    /// `internal` so the `+Pages` extension can append to the same array
-    /// during the page-build pass (#182).
-    var presetTiles: [SPAmountPreset] = []
+    /// Primary CTA visible on every page. On pages 1 & 2 the title reads
+    /// "Дальше"; on page 3 the VC swaps the instance via
+    /// `rebuildDepositCTA()` so the title becomes "Положить" with a money
+    /// suffix and a leading shield icon. `internal` so the `+Pages` extension
+    /// can swap the live instance + re-pin the constraints.
+    var primaryButton = SPButton(
+        title: "Дальше",
+        variant: .money,
+        size: .lg,
+        fullWidth: true
+    )
 
-    /// Currently-selected preset index on step 3. Initialised to
-    /// `defaultPresetIndex` (500 ₽). Drives both the Apple Pay CTA title and
-    /// which tile renders selected. `internal` so the cross-file `+Pages`
-    /// extension can read the current selection inside `updateApplePayTitle`.
-    lazy var selectedPresetIndex: Int = defaultPresetIndex
+    /// Secondary "Позже — попробовать без баланса" link rendered only on
+    /// step 3. Lives in `secondaryStack` so the layout shifts cleanly when
+    /// the user pages back to steps 1/2.
+    let laterButton = SPButton(
+        title: "Позже — попробовать без баланса",
+        variant: .quiet,
+        size: .md,
+        fullWidth: true
+    )
+
+    /// Vertical stack hosting [primaryButton, laterButton] at the bottom of
+    /// the screen. The "later" button is hidden on steps 1/2.
+    let ctaStack: UIStackView = {
+        let stack = UIStackView()
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .vertical
+        stack.spacing = AppSpacing.sp2
+        stack.alignment = .fill
+        return stack
+    }()
+
+    /// Stored so we can mark step 3 entry — soft-orange glow at the
+    /// top-left corner per JSX (rgba(46,219,159,.25) radial). Painted
+    /// directly on `view.layer` once and toggled via `setStepGlow(active:)`.
+    private var stepGlowLayer: CAGradientLayer?
+
+    /// Internal page containers managed by `+Pages.buildPageStack()`.
+    var pageViews: [UIView] = []
+    /// Option cards rendered on page 3 — owned so we can recolour them on
+    /// selection change.
+    var depositOptionViews: [OnboardingDepositOptionView] = []
+
+    // MARK: - Init
+
+    init() {
+        self.selectedDepositIndex = 1
+        super.init(nibName: nil, bundle: nil)
+        self.selectedDepositIndex = defaultDepositIndex
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     // MARK: - Lifecycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        // Force dark — onboarding canvas is canonically dark per V2.
+        overrideUserInterfaceStyle = .dark
         view.backgroundColor = AppColors.bg0
-        view.layer.insertSublayer(dawnGradientLayer, at: 0)
+        installStepGlow()
         setupUI()
         updatePagerState(forPage: 0)
     }
 
     override var prefersStatusBarHidden: Bool { true }
-
-    /// Force dark UI so the Dawn gradient + brand foregrounds read correctly
-    /// regardless of the user's system theme. Same approach as
-    /// AlarmFiringViewController so onboarding doesn't flash light-mode tiles
-    /// on first launch.
     override var preferredStatusBarStyle: UIStatusBarStyle { .lightContent }
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        // Recalculate page widths after layout.
         let width = scrollView.bounds.width
         let height = scrollView.bounds.height
         guard width > 0, height > 0 else { return }
@@ -233,12 +207,13 @@ final class OnboardingViewController: UIViewController {
                 height: height
             )
         }
-        scrollView.contentSize = CGSize(width: width * CGFloat(pages.count), height: height)
-        // Disable implicit animation so the gradient layer doesn't crossfade
-        // on each rotation / size-class change.
+        scrollView.contentSize = CGSize(width: width * CGFloat(pageCount), height: height)
+
         CATransaction.begin()
         CATransaction.setDisableActions(true)
-        dawnGradientLayer.frame = view.bounds
+        // Glow positioning depends on the current page — keep its bounds
+        // resolved here so size-class flips don't strand the layer.
+        layoutStepGlow()
         CATransaction.commit()
     }
 
@@ -246,93 +221,89 @@ final class OnboardingViewController: UIViewController {
 
     private func setupUI() {
         view.addSubview(scrollView)
-        view.addSubview(skipButton)
         view.addSubview(pageControl)
-        view.addSubview(actionButton)
+        view.addSubview(dotsStack)
+        view.addSubview(ctaStack)
 
-        pageControl.numberOfPages = pages.count
+        pageControl.numberOfPages = pageCount
         pageControl.currentPage = 0
 
-        activateChromeConstraints()
+        ctaStack.addArrangedSubview(primaryButton)
+        ctaStack.addArrangedSubview(laterButton)
+        laterButton.isHidden = true
+
+        installLayoutConstraints()
         wireActionTargets()
+        rebuildDotsRow(activePage: 0)
         buildPageStack()
     }
 
-    /// Pin skip button, scroll view, action button, and page control to the
-    /// view edges. Split off `setupUI` so the function body stays under
-    /// SwiftLint's `function_body_length` cap (#182).
-    private func activateChromeConstraints() {
+    private func installLayoutConstraints() {
+        let inset = AppSpacing.sp4   // 16pt — matches JSX `padding: ... 16px`
         NSLayoutConstraint.activate([
-            // Skip button — top right.
-            skipButton.topAnchor.constraint(
-                equalTo: view.safeAreaLayoutGuide.topAnchor,
-                constant: AppSpacing.sp2
-            ),
-            skipButton.trailingAnchor.constraint(
-                equalTo: view.trailingAnchor,
-                constant: -AppSpacing.screenInset
-            ),
-
-            // Scroll view — full screen behind everything.
             scrollView.topAnchor.constraint(equalTo: view.topAnchor),
             scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: ctaStack.topAnchor),
 
-            // Action button — bottom, full width with margins.
-            actionButton.leadingAnchor.constraint(
-                equalTo: view.leadingAnchor,
-                constant: AppSpacing.screenInset
-            ),
-            actionButton.trailingAnchor.constraint(
-                equalTo: view.trailingAnchor,
-                constant: -AppSpacing.screenInset
-            ),
-            actionButton.bottomAnchor.constraint(
+            ctaStack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
+            ctaStack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
+            ctaStack.bottomAnchor.constraint(
                 equalTo: view.safeAreaLayoutGuide.bottomAnchor,
-                constant: -AppSpacing.sp6
+                constant: -AppSpacing.sp4
             ),
 
-            // Page control — above the action button.
-            pageControl.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            pageControl.bottomAnchor.constraint(
-                equalTo: actionButton.topAnchor,
+            dotsStack.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            dotsStack.bottomAnchor.constraint(
+                equalTo: ctaStack.topAnchor,
                 constant: -AppSpacing.sp4
-            )
+            ),
+            dotsStack.heightAnchor.constraint(equalToConstant: 6),
+
+            pageControl.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            pageControl.bottomAnchor.constraint(equalTo: dotsStack.topAnchor)
         ])
     }
 
-    /// Wire scrollView delegate + every CTA's target/action. Pulled out of
-    /// `setupUI` so its body fits SwiftLint's function-length cap (#182).
     private func wireActionTargets() {
         scrollView.delegate = self
-        skipButton.addTarget(self, action: #selector(skipTapped), for: .touchUpInside)
-        actionButton.addTarget(self, action: #selector(actionTapped), for: .touchUpInside)
-        applePayButton.addTarget(self, action: #selector(applePayTapped), for: .touchUpInside)
+        primaryButton.addTarget(self, action: #selector(primaryTapped), for: .touchUpInside)
         laterButton.addTarget(self, action: #selector(laterTapped), for: .touchUpInside)
-
-        ctaStack.addArrangedSubview(applePayButton)
-        ctaStack.addArrangedSubview(laterButton)
     }
 
-    /// Build page content — first two pages share one layout, step 3 is a
-    /// bespoke "deposit" page with preset tiles + dual CTAs. Page builders
-    /// live in `OnboardingViewController+Pages.swift` (#182).
-    private func buildPageStack() {
-        for (index, page) in pages.enumerated() {
-            let pageView: UIView
-            if index == pages.count - 1 {
-                pageView = makeDepositPageView(title: page.title, body: page.body)
-            } else {
-                pageView = makeTextPageView(title: page.title, body: page.body)
-            }
-            scrollView.addSubview(pageView)
-            pageViews.append(pageView)
-        }
+    // MARK: - Step glow
+
+    /// Mount a money-tinted radial glow at the top-left corner — shown on
+    /// step 3 per JSX. Top-glow on step 1 (warn) is rendered inside the page
+    /// container itself; step 2 has no glow.
+    private func installStepGlow() {
+        let gradient = CAGradientLayer()
+        gradient.type = .radial
+        gradient.colors = [
+            AppColors.money400.withAlphaComponent(0.25).cgColor,
+            AppColors.money400.withAlphaComponent(0.0).cgColor
+        ]
+        gradient.locations = [0.0, 0.6]
+        gradient.startPoint = CGPoint(x: 0.5, y: 0.5)
+        gradient.endPoint = CGPoint(x: 1.0, y: 1.0)
+        gradient.opacity = 0
+        view.layer.insertSublayer(gradient, at: 0)
+        stepGlowLayer = gradient
     }
 
-    // Actions, preset-tap handler, and pager state live in
-    // `OnboardingViewController+Pages.swift` (#182).
+    private func layoutStepGlow() {
+        guard let glow = stepGlowLayer else { return }
+        // 320pt radius positioned top-left, slightly offscreen so the soft
+        // edge falls naturally onto the canvas — matches JSX `top: -120; left: -60`.
+        glow.frame = CGRect(x: -60, y: -120, width: 320, height: 320)
+    }
+
+    func setStepGlow(active: Bool) {
+        CATransaction.begin()
+        CATransaction.setAnimationDuration(SPSupport.durationBase)
+        stepGlowLayer?.opacity = active ? 1 : 0
+        CATransaction.commit()
+    }
 }
 
 // MARK: - UIScrollViewDelegate
@@ -342,19 +313,5 @@ extension OnboardingViewController: UIScrollViewDelegate {
         let page = Int(round(scrollView.contentOffset.x / scrollView.bounds.width))
         pageControl.currentPage = page
         updatePagerState(forPage: page)
-    }
-}
-
-// MARK: - Hex helper
-
-private extension UIColor {
-    /// `0xRRGGBB` literal initializer so the Dawn gradient stops read as in
-    /// `tokens.css`. Local copy mirroring the (private) helper in AppColors —
-    /// kept file-local to match the AlarmFiringViewController convention.
-    convenience init(rgb: UInt32, alpha: CGFloat = 1) {
-        let red = CGFloat((rgb >> 16) & 0xFF) / 255.0
-        let green = CGFloat((rgb >> 8) & 0xFF) / 255.0
-        let blue = CGFloat(rgb & 0xFF) / 255.0
-        self.init(red: red, green: green, blue: blue, alpha: alpha)
     }
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/PermissionCardView.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/PermissionCardView.swift
@@ -1,12 +1,13 @@
 import UIKit
 
-/// Single permission row mounted inside `PermissionsViewController` (#149).
-/// Visually a `.surface` SPCard with a leading SF-Symbol icon, a title +
-/// body copy stack, and a trailing affordance (SPButton or SPPill) that the
-/// parent VC swaps via `apply(status:)`.
+/// Single permission row mounted inside `PermissionsViewController` (V2).
 ///
-/// Kept in its own file so the parent VC stays under SwiftLint's 400-line
-/// file-length budget.
+/// Visual (V2 spec, `docs/design/v2-handoff/components/SPMore2.jsx` lines
+/// 39-59): a `.surface` SPCard with 14pt internal spacing — leading 40×40
+/// rounded-rect icon (money gradient when granted, `whiteOverlay08` otherwise),
+/// title `h4` + subtitle `meta` (`fg3`), trailing checkmark (`money400`) when
+/// granted or caps "Дать" (`warn400`) when actionable. Whole card is tappable
+/// when actionable, otherwise tap interaction is disabled.
 enum PermissionKind {
     case notifications
     case criticalAlerts
@@ -15,42 +16,42 @@ enum PermissionKind {
     var iconName: String {
         switch self {
         case .notifications: return "bell.fill"
-        case .criticalAlerts: return "exclamationmark.triangle.fill"
-        case .sound: return "speaker.wave.2.fill"
+        case .criticalAlerts: return "speaker.wave.3.fill"
+        case .sound: return "clock.badge.fill"
         }
     }
 
     var title: String {
         switch self {
         case .notifications: return "Уведомления"
-        case .criticalAlerts: return "Критические оповещения"
-        case .sound: return "Звук в беззвучном режиме"
+        case .criticalAlerts: return "Critical Alerts"
+        case .sound: return "Фоновый режим"
         }
     }
 
     var body: String {
         switch self {
         case .notifications:
-            return "Чтобы будильник звонил даже когда телефон в фоне"
+            return "Чтобы показать будильник на экране"
         case .criticalAlerts:
-            return "Чтобы будильник звонил даже в режиме «Не беспокоить»"
+            return "Чтобы звук прошёл через беззвучный режим"
         case .sound:
-            return "Чтобы будильник звонил вслух даже если выключен звук"
+            return "Чтобы таймеры не убивались системой"
         }
     }
 }
 
 /// Visual state of a permission card's trailing affordance.
 enum PermissionStatus {
-    /// Show "Разрешить" SPButton. Tap triggers a real grant.
+    /// Show "Дать" caps + ungranted icon. Tap triggers a real grant.
     case actionable
-    /// Show "Разрешено" pill — granted by the user.
+    /// Show check glyph + money-tinted icon. User granted.
     case granted
-    /// Show "Включено" pill — auto-configured (no user action needed),
-    /// e.g. AVAudioSession `.playback + .duckOthers`.
+    /// Show check glyph + money-tinted icon — capability is auto-on (e.g.
+    /// AVAudioSession config). Behaviourally identical to `.granted`.
     case enabled
-    /// Show "Недоступно" pill — entitlement / capability missing. The
-    /// user can't fix this from the app.
+    /// Show neutral "—" + ungranted icon — entitlement is missing and the
+    /// user can't fix this from the app. Tap is a no-op.
     case unavailable
 }
 
@@ -58,19 +59,24 @@ final class PermissionCardView: UIView {
 
     // MARK: - Public API
 
+    /// Invoked when the whole card is tapped *and* the current status is
+    /// `.actionable`. Other statuses ignore the tap (no-ops) so the user
+    /// doesn't get a spurious permission prompt.
     var onPrimaryTap: (() -> Void)?
 
     // MARK: - Subviews
 
-    private let card = SPCard(tone: .surface)
+    private let card = SPCard(tone: .surface, padding: 16, cornerRadius: AppRadius.md)
+    private let iconHost = UIView()
     private let iconView = UIImageView()
     private let titleLabel = UILabel()
     private let bodyLabel = UILabel()
-    /// Container for the trailing affordance — either an SPButton (actionable)
-    /// or an SPPill (granted / enabled / unavailable). We keep a stable host
-    /// view and replace its subview on `apply(status:)` so the surrounding
-    /// constraints don't churn.
     private let trailingHost = UIView()
+    private let tapGesture = UITapGestureRecognizer()
+
+    /// Cached so re-applying status can swap the host fill / icon tint
+    /// without rebuilding the layout.
+    private var currentStatus: PermissionStatus = .actionable
 
     // MARK: - Init
 
@@ -89,22 +95,40 @@ final class PermissionCardView: UIView {
     private func configure(kind: PermissionKind) {
         card.translatesAutoresizingMaskIntoConstraints = false
         addSubview(card)
-        NSLayoutConstraint.activate([
-            card.topAnchor.constraint(equalTo: topAnchor),
-            card.bottomAnchor.constraint(equalTo: bottomAnchor),
-            card.leadingAnchor.constraint(equalTo: leadingAnchor),
-            card.trailingAnchor.constraint(equalTo: trailingAnchor)
-        ])
+        configureSubviewProperties(kind: kind)
+        let copyStack = UIStackView(arrangedSubviews: [titleLabel, bodyLabel])
+        copyStack.translatesAutoresizingMaskIntoConstraints = false
+        copyStack.axis = .vertical
+        copyStack.alignment = .fill
+        copyStack.spacing = 2
+
+        card.addSubview(iconHost)
+        iconHost.addSubview(iconView)
+        card.addSubview(copyStack)
+        card.addSubview(trailingHost)
+        activateLayout(copyStack: copyStack)
+
+        tapGesture.addTarget(self, action: #selector(cardTapped))
+        addGestureRecognizer(tapGesture)
+        isUserInteractionEnabled = true
+    }
+
+    private func configureSubviewProperties(kind: PermissionKind) {
+        iconHost.translatesAutoresizingMaskIntoConstraints = false
+        iconHost.layer.cornerRadius = AppRadius.sm    // 12pt — matches JSX
+        iconHost.layer.masksToBounds = true
+        iconHost.backgroundColor = AppColors.whiteOverlay08
 
         iconView.translatesAutoresizingMaskIntoConstraints = false
-        iconView.image = UIImage(systemName: kind.iconName)?.withRenderingMode(.alwaysTemplate)
-        iconView.tintColor = AppColors.money500
+        iconView.image = UIImage(systemName: kind.iconName)?
+            .withRenderingMode(.alwaysTemplate)
+        iconView.tintColor = AppColors.fg3
         iconView.contentMode = .scaleAspectFit
 
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.text = kind.title
         titleLabel.font = AppTypography.h4
-        titleLabel.textColor = AppColors.fg1
+        titleLabel.textColor = .white
         titleLabel.numberOfLines = 0
 
         bodyLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -114,29 +138,29 @@ final class PermissionCardView: UIView {
         bodyLabel.numberOfLines = 0
 
         trailingHost.translatesAutoresizingMaskIntoConstraints = false
-        // Ensure the trailing column reserves visual room even before the
-        // first `apply(status:)` call lands.
         trailingHost.setContentHuggingPriority(.required, for: .horizontal)
         trailingHost.setContentCompressionResistancePriority(.required, for: .horizontal)
+    }
 
-        let copyStack = UIStackView(arrangedSubviews: [titleLabel, bodyLabel])
-        copyStack.translatesAutoresizingMaskIntoConstraints = false
-        copyStack.axis = .vertical
-        copyStack.alignment = .fill
-        copyStack.spacing = AppSpacing.sp1
-
+    private func activateLayout(copyStack: UIStackView) {
         let cardContent = card.layoutMarginsGuide
-        card.addSubview(iconView)
-        card.addSubview(copyStack)
-        card.addSubview(trailingHost)
-
         NSLayoutConstraint.activate([
-            iconView.leadingAnchor.constraint(equalTo: cardContent.leadingAnchor),
-            iconView.topAnchor.constraint(equalTo: cardContent.topAnchor, constant: 2),
-            iconView.widthAnchor.constraint(equalToConstant: 28),
-            iconView.heightAnchor.constraint(equalToConstant: 28),
+            card.topAnchor.constraint(equalTo: topAnchor),
+            card.bottomAnchor.constraint(equalTo: bottomAnchor),
+            card.leadingAnchor.constraint(equalTo: leadingAnchor),
+            card.trailingAnchor.constraint(equalTo: trailingAnchor),
 
-            copyStack.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: AppSpacing.sp3),
+            iconHost.leadingAnchor.constraint(equalTo: cardContent.leadingAnchor),
+            iconHost.centerYAnchor.constraint(equalTo: cardContent.centerYAnchor),
+            iconHost.widthAnchor.constraint(equalToConstant: 40),
+            iconHost.heightAnchor.constraint(equalToConstant: 40),
+
+            iconView.centerXAnchor.constraint(equalTo: iconHost.centerXAnchor),
+            iconView.centerYAnchor.constraint(equalTo: iconHost.centerYAnchor),
+            iconView.widthAnchor.constraint(equalToConstant: 20),
+            iconView.heightAnchor.constraint(equalToConstant: 20),
+
+            copyStack.leadingAnchor.constraint(equalTo: iconHost.trailingAnchor, constant: 14),
             copyStack.topAnchor.constraint(equalTo: cardContent.topAnchor),
             copyStack.bottomAnchor.constraint(equalTo: cardContent.bottomAnchor),
             copyStack.trailingAnchor.constraint(
@@ -151,40 +175,70 @@ final class PermissionCardView: UIView {
 
     // MARK: - Status rendering
 
-    /// Replace the trailing affordance to match the supplied status. Idempotent
-    /// — re-application with the same status simply rebuilds the trailing
-    /// view (cheap; max 3 swaps over the screen's lifetime).
+    /// Replace the trailing affordance + icon fill to match the supplied
+    /// status. Idempotent — re-application with the same status simply
+    /// rebuilds the trailing view (cheap; max a handful of swaps over the
+    /// screen's lifetime).
     func apply(status: PermissionStatus) {
-        // Remove the previous trailing view first so multi-call sequences
-        // don't stack.
+        currentStatus = status
         trailingHost.subviews.forEach { $0.removeFromSuperview() }
 
-        let trailingView: UIView
         switch status {
+        case .granted, .enabled:
+            iconHost.backgroundColor = AppColors.money500
+            iconView.tintColor = AppColors.fgOnMoney
+            let configuration = UIImage.SymbolConfiguration(pointSize: 18, weight: .bold)
+            let imageView = UIImageView(
+                image: UIImage(systemName: "checkmark", withConfiguration: configuration)?
+                    .withRenderingMode(.alwaysTemplate)
+            )
+            imageView.tintColor = AppColors.money400
+            imageView.contentMode = .scaleAspectFit
+            mount(imageView)
+            tapGesture.isEnabled = false
         case .actionable:
-            let button = SPButton(title: "Разрешить", variant: .money, size: .sm)
-            button.addTarget(self, action: #selector(primaryTapped), for: .touchUpInside)
-            trailingView = button
-        case .granted:
-            trailingView = SPPill(text: "Разрешено", tone: .money)
-        case .enabled:
-            trailingView = SPPill(text: "Включено", tone: .money)
+            iconHost.backgroundColor = AppColors.whiteOverlay08
+            iconView.tintColor = AppColors.fg3
+            mount(capsLabel(text: "Дать", color: AppColors.warn400))
+            tapGesture.isEnabled = true
         case .unavailable:
-            trailingView = SPPill(text: "Недоступно", tone: .neutral)
+            iconHost.backgroundColor = AppColors.whiteOverlay08
+            iconView.tintColor = AppColors.fg3
+            mount(capsLabel(text: "Недоступно", color: AppColors.fg3))
+            tapGesture.isEnabled = false
         }
+    }
 
-        trailingView.translatesAutoresizingMaskIntoConstraints = false
-        trailingHost.addSubview(trailingView)
+    // MARK: - Helpers
+
+    private func capsLabel(text: String, color: UIColor) -> UILabel {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.attributedText = NSAttributedString(
+            string: text.uppercased(),
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: color
+            ]
+        )
+        return label
+    }
+
+    private func mount(_ view: UIView) {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        trailingHost.addSubview(view)
         NSLayoutConstraint.activate([
-            trailingView.leadingAnchor.constraint(equalTo: trailingHost.leadingAnchor),
-            trailingView.trailingAnchor.constraint(equalTo: trailingHost.trailingAnchor),
-            trailingView.topAnchor.constraint(equalTo: trailingHost.topAnchor),
-            trailingView.bottomAnchor.constraint(equalTo: trailingHost.bottomAnchor)
+            view.leadingAnchor.constraint(equalTo: trailingHost.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: trailingHost.trailingAnchor),
+            view.topAnchor.constraint(equalTo: trailingHost.topAnchor),
+            view.bottomAnchor.constraint(equalTo: trailingHost.bottomAnchor)
         ])
     }
 
     @objc
-    private func primaryTapped() {
+    private func cardTapped() {
+        guard currentStatus == .actionable else { return }
         onPrimaryTap?()
     }
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/PermissionsViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/PermissionsViewController.swift
@@ -1,39 +1,39 @@
 import UIKit
 import UserNotifications
 
-/// Permissions screen — shown once after Onboarding finishes, before the main
-/// alarms list. Three permission cards (Notifications, Critical Alerts, Sound
-/// in silent mode) plus a "Позже" footer.
+/// Permissions screen — V2 redesign (`docs/design/v2-handoff/components/SPMore2.jsx`
+/// lines 26-65). Shown once after Onboarding finishes, before the main alarms
+/// list. Caps "последний шаг" eyebrow → h1 "Чтобы будильник работал" → body
+/// copy → three permission cards (Notifications, Critical Alerts, Background)
+/// → "Готово" CTA.
 ///
-/// Flow:
-/// 1. Notifications card → tapping "Разрешить" calls
-///    `UNUserNotificationCenter.requestAuthorization` with the same option set
-///    `AlarmScheduler.requestPermission` uses (`alert + sound + badge +
-///    criticalAlert`). On result the cards refresh.
-/// 2. Critical Alerts — hard-gated on the entitlement living in
+/// Flow preserves the V1 wiring:
+/// 1. Notifications card → tapping the card calls
+///    `AlarmScheduler.requestPermission` with the same option ladder used at
+///    AppDelegate launch.
+/// 2. Critical Alerts — hard-gated on the entitlement in
 ///    `SnoozePay.entitlements`. The entitlement is currently commented out
-///    (PM-only), so the card surfaces a neutral "Недоступно" pill until it
-///    lands. Once flipped, the same notification authorisation grant covers
-///    both, so this card mirrors notifications status.
-/// 3. Sound — `AVAudioSession` `.playback + .duckOthers`, no system permission
-///    needed. `AudioService.configureAudioSession` already installs that
-///    recipe on every alarm, so this card is informational ("Включено").
+///    (PM-only edit), so the card surfaces a neutral "Недоступно" caption
+///    until it lands. Once flipped, this card mirrors the notification grant.
+/// 3. Background — `UIBackgroundModes` is declared in Info.plist for the
+///    audio playback / processing categories, so this card is informational
+///    and renders as granted.
 ///
 /// Persistence: `permissions_screen_shown` UserDefaults key prevents re-show
-/// on subsequent launches even when the user picks "Позже". Future grants /
-/// revocations happen through Settings; the screen does not nag.
+/// on subsequent launches even when the user picks "Готово" without granting
+/// anything. Future grants / revocations happen through Settings; the screen
+/// does not nag.
 final class PermissionsViewController: UIViewController {
 
     // MARK: - Persistence keys
 
-    /// `UserDefaults` key tracking whether the permissions screen has been
-    /// dismissed at least once. Exposed at module-level so the debug "reset
-    /// onboarding" entry in AlarmsListVC can clear it alongside the
-    /// onboarding-completed flag.
+    /// Tracks whether the permissions screen has been dismissed at least
+    /// once. Exposed at module-level so the debug "reset onboarding" entry in
+    /// AlarmsListVC can clear it alongside the onboarding-completed flag.
     static let hasBeenShownKey = "permissions_screen_shown"
 
     /// `true` once the user has dismissed the permissions screen at least
-    /// once (either by granting or via "Позже"). Read by SceneDelegate to
+    /// once (either by granting or via "Готово"). Read by SceneDelegate to
     /// decide whether to present the screen on a given launch.
     static var hasBeenShown: Bool {
         UserDefaults.standard.bool(forKey: hasBeenShownKey)
@@ -41,89 +41,75 @@ final class PermissionsViewController: UIViewController {
 
     // MARK: - Callback
 
-    /// Invoked once the user finishes (grant complete or "Позже"). SceneDelegate
+    /// Invoked once the user finishes (grant complete or "Готово"). SceneDelegate
     /// uses this to swap the root from this VC to the tab bar.
     var onFinished: (() -> Void)?
 
-    // MARK: - Background (Dawn)
-
-    private let dawnGradientLayer: CAGradientLayer = {
-        let gradient = CAGradientLayer()
-        gradient.colors = [
-            UIColor(permRGB: 0x14122A).cgColor,
-            UIColor(permRGB: 0x0F1A2E).cgColor,
-            UIColor(permRGB: 0x0A1320).cgColor,
-            UIColor(permRGB: 0x050912).cgColor
-        ]
-        gradient.locations = [0.0, 0.4, 0.7, 1.0]
-        gradient.startPoint = CGPoint(x: 0.5, y: 0.0)
-        gradient.endPoint = CGPoint(x: 0.5, y: 1.0)
-        return gradient
-    }()
-
     // MARK: - State
 
-    /// Latest `UNNotificationSettings.authorizationStatus`. Drives the
-    /// Notifications + Critical Alerts cards. Refreshed in `viewWillAppear`
-    /// so a return-from-Settings flips the cards without manual re-launch.
     private var notificationStatus: UNAuthorizationStatus = .notDetermined
-
-    /// Whether the Critical Alerts entitlement is *available* at all (i.e.
-    /// the entitlement key is present in `.entitlements`). Detected via the
-    /// `criticalAlertSetting` field on `UNNotificationSettings` — `.notSupported`
-    /// means the entitlement isn't there, anything else means it is.
-    ///
-    /// Currently the entitlement is commented out in `SnoozePay.entitlements`
-    /// (PM-only edit), so we expect `.notSupported` at runtime. Once PM
-    /// uncomments the key, this will start tracking the actual grant state.
     private var criticalAlertsAvailable: Bool = false
     private var criticalAlertsGranted: Bool = false
 
-    // MARK: - UI Elements
+    // MARK: - Subviews
 
-    private let scrollView: UIScrollView = {
-        let scrollView = UIScrollView()
-        scrollView.translatesAutoresizingMaskIntoConstraints = false
-        scrollView.alwaysBounceVertical = true
-        scrollView.showsVerticalScrollIndicator = false
-        return scrollView
-    }()
-
-    private let contentStack: UIStackView = {
-        let stack = UIStackView()
-        stack.translatesAutoresizingMaskIntoConstraints = false
-        stack.axis = .vertical
-        stack.spacing = AppSpacing.sp4
-        stack.alignment = .fill
-        return stack
+    private let capsLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.attributedText = NSAttributedString(
+            string: "ПОСЛЕДНИЙ ШАГ",
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.warn300
+            ]
+        )
+        return label
     }()
 
     private let titleLabel: UILabel = {
         let label = UILabel()
-        label.text = "Разрешения"
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "Чтобы будильник работал"
         label.font = AppTypography.h1
-        label.textColor = AppColors.fg1
-        label.textAlignment = .left
+        label.textColor = .white
         label.numberOfLines = 0
+        label.adjustsFontForContentSizeCategory = false
+        // -0.02em at 32pt ≈ -0.64; clamp to -0.32 per spec direction so it
+        // tightens without bleeding into adjacent glyphs.
+        label.attributedText = NSAttributedString(
+            string: "Чтобы будильник работал",
+            attributes: [
+                .font: AppTypography.h1,
+                .kern: -0.32,
+                .foregroundColor: UIColor.white
+            ]
+        )
         return label
     }()
 
-    private let subtitleLabel: UILabel = {
+    private let bodyLabel: UILabel = {
         let label = UILabel()
-        label.text = "Чтобы будильник работал — нужны несколько разрешений"
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "Без этих разрешений iOS не разбудит вас в нужное время — даже если телефон беззвучный."
         label.font = AppTypography.bodyLg
         label.textColor = AppColors.fg2
-        label.textAlignment = .left
         label.numberOfLines = 0
         return label
     }()
 
-    /// Footer "Позже" — keeps the screen escapable even if the user never
-    /// grants. Same persistence as the grant path so the screen does not
-    /// re-show on next launch.
-    private let laterButton = SPButton(
-        title: "Позже",
-        variant: .ghost,
+    private let cardsStack: UIStackView = {
+        let stack = UIStackView()
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .vertical
+        stack.spacing = AppSpacing.sp3
+        stack.alignment = .fill
+        return stack
+    }()
+
+    private let ctaButton = SPButton(
+        title: "Готово",
+        variant: .money,
         size: .lg,
         fullWidth: true
     )
@@ -136,14 +122,13 @@ final class PermissionsViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        // Force dark — onboarding flow is canonically dark regardless of the
+        // system theme so the warn / money brand stops read consistently.
+        overrideUserInterfaceStyle = .dark
         view.backgroundColor = AppColors.bg0
-        view.layer.insertSublayer(dawnGradientLayer, at: 0)
         setupUI()
-        // Detect whether the Critical Alerts entitlement is even present
-        // before we start fetching settings — `criticalAlertSetting` on a
-        // missing entitlement is `.notSupported`.
         refreshNotificationSettings()
-        laterButton.addTarget(self, action: #selector(laterTapped), for: .touchUpInside)
+        ctaButton.addTarget(self, action: #selector(ctaTapped), for: .touchUpInside)
     }
 
     override var prefersStatusBarHidden: Bool { false }
@@ -156,74 +141,53 @@ final class PermissionsViewController: UIViewController {
         refreshNotificationSettings()
     }
 
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        CATransaction.begin()
-        CATransaction.setDisableActions(true)
-        dawnGradientLayer.frame = view.bounds
-        CATransaction.commit()
-    }
-
     // MARK: - Setup
 
     private func setupUI() {
-        view.addSubview(scrollView)
-        scrollView.addSubview(contentStack)
-        view.addSubview(laterButton)
-        laterButton.translatesAutoresizingMaskIntoConstraints = false
-        installLayoutConstraints()
-        populateContent()
-    }
+        view.addSubview(capsLabel)
+        view.addSubview(titleLabel)
+        view.addSubview(bodyLabel)
+        view.addSubview(cardsStack)
+        view.addSubview(ctaButton)
+        ctaButton.translatesAutoresizingMaskIntoConstraints = false
 
-    private func installLayoutConstraints() {
-        let inset = AppSpacing.sp5
+        let inset = AppSpacing.sp4   // 16pt — matches JSX `padding: 54px 16px 32px`
         NSLayoutConstraint.activate([
-            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            scrollView.bottomAnchor.constraint(equalTo: laterButton.topAnchor, constant: -AppSpacing.sp4),
-
-            contentStack.topAnchor.constraint(
-                equalTo: scrollView.contentLayoutGuide.topAnchor,
+            capsLabel.topAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.topAnchor,
                 constant: AppSpacing.sp6
             ),
-            contentStack.leadingAnchor.constraint(
-                equalTo: scrollView.contentLayoutGuide.leadingAnchor,
-                constant: inset
-            ),
-            contentStack.trailingAnchor.constraint(
-                equalTo: scrollView.contentLayoutGuide.trailingAnchor,
+            capsLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
+            capsLabel.trailingAnchor.constraint(
+                lessThanOrEqualTo: view.trailingAnchor,
                 constant: -inset
-            ),
-            contentStack.bottomAnchor.constraint(
-                equalTo: scrollView.contentLayoutGuide.bottomAnchor,
-                constant: -AppSpacing.sp6
-            ),
-            contentStack.widthAnchor.constraint(
-                equalTo: scrollView.frameLayoutGuide.widthAnchor,
-                constant: -inset * 2
             ),
 
-            laterButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
-            laterButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
-            laterButton.bottomAnchor.constraint(
+            titleLabel.topAnchor.constraint(equalTo: capsLabel.bottomAnchor, constant: AppSpacing.sp2),
+            titleLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
+            titleLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
+
+            bodyLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: AppSpacing.sp3),
+            bodyLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
+            bodyLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
+
+            cardsStack.topAnchor.constraint(equalTo: bodyLabel.bottomAnchor, constant: AppSpacing.sp7),
+            cardsStack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
+            cardsStack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
+
+            ctaButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
+            ctaButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
+            ctaButton.bottomAnchor.constraint(
                 equalTo: view.safeAreaLayoutGuide.bottomAnchor,
-                constant: -inset
+                constant: -AppSpacing.sp6
             )
         ])
-    }
-
-    private func populateContent() {
-        contentStack.addArrangedSubview(titleLabel)
-        contentStack.addArrangedSubview(subtitleLabel)
-        contentStack.setCustomSpacing(AppSpacing.sp2, after: titleLabel)
-        contentStack.setCustomSpacing(AppSpacing.sp6, after: subtitleLabel)
 
         for kind in [PermissionKind.notifications, .criticalAlerts, .sound] {
             let card = PermissionCardView(kind: kind)
             card.onPrimaryTap = { [weak self] in self?.handleGrantTap(for: kind) }
             cardViews[kind] = card
-            contentStack.addArrangedSubview(card)
+            cardsStack.addArrangedSubview(card)
         }
     }
 
@@ -238,9 +202,8 @@ final class PermissionsViewController: UIViewController {
                 guard let self = self else { return }
                 self.notificationStatus = settings.authorizationStatus
                 // `.notSupported` means the Critical Alerts entitlement is
-                // absent (e.g. it's commented out in `.entitlements`). Any
-                // other value means the capability is wired and reflects the
-                // actual user-grant state.
+                // absent (commented out in `.entitlements`). Any other value
+                // means the capability is wired and reflects the user-grant.
                 self.criticalAlertsAvailable = settings.criticalAlertSetting != .notSupported
                 self.criticalAlertsGranted = settings.criticalAlertSetting == .enabled
                 self.applyStatusToCards()
@@ -258,12 +221,9 @@ final class PermissionsViewController: UIViewController {
         switch notificationStatus {
         case .authorized, .provisional, .ephemeral:
             return .granted
-        case .denied:
-            // Once denied, the OS won't show the prompt again — the user
-            // must flip the toggle in Settings. Surface the "Разрешить"
-            // affordance anyway; the tap handler routes to Settings.
-            return .actionable
-        case .notDetermined:
+        case .denied, .notDetermined:
+            // Once denied, iOS won't show the prompt again — the tap handler
+            // routes the user to Settings instead.
             return .actionable
         @unknown default:
             return .actionable
@@ -273,17 +233,16 @@ final class PermissionsViewController: UIViewController {
     private func criticalAlertsStatus() -> PermissionStatus {
         guard criticalAlertsAvailable else {
             // Entitlement is missing from `.entitlements` — user cannot grant
-            // this from the app. Documented in the PR description as a
-            // follow-up for PM to flip the entitlement key.
+            // this from the app. Documented as a follow-up for PM to flip the
+            // entitlement key once Critical Alerts is approved.
             return .unavailable
         }
         return criticalAlertsGranted ? .granted : .actionable
     }
 
     private func soundStatus() -> PermissionStatus {
-        // `AudioService.configureAudioSession` installs `.playback` +
-        // `.duckOthers` every time an alarm starts ringing, so this is
-        // always-on for the user. No system permission lives behind it.
+        // `UIBackgroundModes` is declared in Info.plist for audio playback /
+        // processing — the system grants it implicitly. No user action exists.
         .enabled
     }
 
@@ -294,29 +253,23 @@ final class PermissionsViewController: UIViewController {
         case .notifications, .criticalAlerts:
             handleNotificationsTap()
         case .sound:
-            // Sound card is informational — no tap path. `actionable` never
-            // resolves for `.sound`, but guard defensively.
+            // Background mode card is informational — no tap path.
             break
         }
     }
 
     private func handleNotificationsTap() {
-        // If the user already denied once, iOS won't re-prompt — open
-        // Settings instead so they have a way to flip the toggle.
         if notificationStatus == .denied {
             openAppSettings()
             return
         }
-
         // Route through `AlarmScheduler.requestPermission` so the same
         // critical-alert-with-fallback request ladder runs as on AppDelegate
-        // launch — and the `AlarmScheduler.criticalAlertsAvailable` static
-        // flag stays in sync (it's `private(set)` so only the scheduler can
-        // mutate it).
+        // launch — keeping `AlarmScheduler.criticalAlertsAvailable` in sync.
         AlarmScheduler.shared.requestPermission { [weak self] _ in
             // Refresh from settings rather than trusting the `granted` flag
-            // alone — `criticalAlertSetting` may resolve differently from
-            // the headline grant on legacy iOS versions.
+            // alone — `criticalAlertSetting` may resolve differently on
+            // legacy iOS versions.
             self?.refreshNotificationSettings()
         }
     }
@@ -326,28 +279,11 @@ final class PermissionsViewController: UIViewController {
         UIApplication.shared.open(url)
     }
 
-    // MARK: - Footer actions
+    // MARK: - CTA
 
     @objc
-    private func laterTapped() {
-        finish()
-    }
-
-    private func finish() {
+    private func ctaTapped() {
         UserDefaults.standard.set(true, forKey: Self.hasBeenShownKey)
         onFinished?()
-    }
-}
-
-// MARK: - Hex helper
-
-private extension UIColor {
-    /// `0xRRGGBB` literal initialiser, file-prefixed name to avoid collisions
-    /// with the same helper inside Onboarding / Splash.
-    convenience init(permRGB: UInt32, alpha: CGFloat = 1) {
-        let red = CGFloat((permRGB >> 16) & 0xFF) / 255.0
-        let green = CGFloat((permRGB >> 8) & 0xFF) / 255.0
-        let blue = CGFloat(permRGB & 0xFF) / 255.0
-        self.init(red: red, green: green, blue: blue, alpha: alpha)
     }
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/SplashViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/SplashViewController.swift
@@ -1,173 +1,192 @@
 import UIKit
 
-/// First-frame splash — covers the gap between `LaunchScreen.storyboard` (which
-/// is the system-controlled static frame iOS shows during process bring-up) and
-/// the real root SceneDelegate installs (Onboarding / Permissions / TabBar).
+/// First-frame splash — V2 redesign. Covers the gap between
+/// `LaunchScreen.storyboard` (signing-bound) and the real root SceneDelegate
+/// installs (Onboarding / Permissions / TabBar).
 ///
-/// Visual: full-screen Dawn gradient (`--sp-grad-dawn`) with the SnoozePay text
-/// logo masked by the money brand gradient, mirroring the
-/// `SPBalanceCard.applyValueGradient` recipe so the wordmark reads as the same
-/// "money-glow" primitive used on the balance hero.
+/// Visual (V2, `docs/design/v2-handoff/components/SPMore2.jsx` lines 6-23):
+/// dark `bg0` background, soft radial warm glow at centre, 96×96 rounded-rect
+/// (radius 28) painted with the warn gradient and overlaid by a bell icon
+/// (`bell.fill` tinted `fgOnWarn`), "SnoozePay" h1 white below, "Будильник со
+/// ставкой" meta caption underneath.
 ///
-/// We deliberately keep `LaunchScreen.storyboard` unchanged (it is part of the
-/// signing/Info.plist contract and the no-touch contract treats storyboard +
-/// signing related files as PM-owned). Instead this VC is shown for ~`displayDuration`
-/// before SceneDelegate calls `onFinished` and crossfades to the real root.
-/// That keeps the "branded launch" outcome without touching the static
-/// storyboard.
+/// `displayDuration` + `onFinished` semantics are preserved from V1 so
+/// SceneDelegate keeps working unchanged.
 final class SplashViewController: UIViewController {
 
     // MARK: - Configuration
 
-    /// How long the splash is shown after the scene becomes active before the
-    /// root is replaced. 200ms matches the spec; long enough for the gradient
-    /// + wordmark to register, short enough not to feel like an explicit
-    /// loading screen.
+    /// Display interval before the handoff fires. 200ms matches the original
+    /// spec — long enough for the glyph + glow to register, short enough not
+    /// to read as a "loading" screen.
     private static let displayDuration: TimeInterval = 0.20
 
-    /// Invoked after `displayDuration` elapses. SceneDelegate uses this to
-    /// crossfade into Onboarding / Permissions / TabBar depending on user
-    /// state. `nil` is safe — without a callback the splash simply sits.
+    /// Invoked once `displayDuration` elapses. SceneDelegate uses this to
+    /// crossfade into Onboarding / Permissions / TabBar.
     var onFinished: (() -> Void)?
 
-    // MARK: - Background (Dawn)
+    // MARK: - Layers
 
-    /// Same 4-stop atmospheric gradient as `OnboardingViewController` so the
-    /// crossfade between the two screens has no perceptible seam.
-    private let dawnGradientLayer: CAGradientLayer = {
+    /// Soft 480pt radial glow (warn 30% → transparent) centred behind the
+    /// brand glyph. CSS equivalent: `radial-gradient(circle, rgba(255,184,77,
+    /// .30) 0%, transparent 60%) blur(40px)`.
+    private let glowLayer: CAGradientLayer = {
         let gradient = CAGradientLayer()
+        gradient.type = .radial
         gradient.colors = [
-            UIColor(splashRGB: 0x14122A).cgColor,
-            UIColor(splashRGB: 0x0F1A2E).cgColor,
-            UIColor(splashRGB: 0x0A1320).cgColor,
-            UIColor(splashRGB: 0x050912).cgColor
+            UIColor(red: 1.0, green: 184.0 / 255.0, blue: 77.0 / 255.0, alpha: 0.30).cgColor,
+            UIColor(red: 1.0, green: 184.0 / 255.0, blue: 77.0 / 255.0, alpha: 0.0).cgColor
         ]
-        gradient.locations = [0.0, 0.4, 0.7, 1.0]
-        gradient.startPoint = CGPoint(x: 0.5, y: 0.0)
-        gradient.endPoint = CGPoint(x: 0.5, y: 1.0)
+        gradient.locations = [0.0, 0.6]
+        gradient.startPoint = CGPoint(x: 0.5, y: 0.5)
+        gradient.endPoint = CGPoint(x: 1.0, y: 1.0)
         return gradient
     }()
 
-    // MARK: - Wordmark
+    /// 135° warn gradient on the 96×96 brand tile (`--sp-grad-warn`).
+    private let tileGradient: CAGradientLayer = {
+        let gradient = CAGradientLayer()
+        gradient.colors = SPSupport.warnGradientColors
+        gradient.locations = SPSupport.warnGradientLocations
+        gradient.startPoint = SPSupport.gradientStart
+        gradient.endPoint = SPSupport.gradientEnd
+        gradient.cornerRadius = AppRadius.xl  // 28pt — matches JSX
+        return gradient
+    }()
 
-    /// "SnoozePay" rendered with the money gradient mask. The label paints
-    /// `clear` once `applyWordmarkGradient()` runs (same pattern as
-    /// `SPBalanceCard.applyValueGradient`) so we don't double-stack the
-    /// solid label colour under the gradient.
-    private let wordmarkLabel: UILabel = {
+    // MARK: - Subviews
+
+    /// 96×96 rounded-rect tile that hosts the bell glyph. Background paints
+    /// clear because `tileGradient` is inserted at the bottom of its layer
+    /// tree by `viewDidLoad` and resized in `viewDidLayoutSubviews`.
+    private let tileView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = .clear
+        view.layer.cornerRadius = AppRadius.xl
+        view.layer.masksToBounds = false
+        // Warm-tinted shadow so the tile pops off the dark surface — matches
+        // `boxShadow: 0 16px 48px rgba(245,158,11,.40)` from JSX.
+        view.layer.shadowColor = AppColors.warn500.cgColor
+        view.layer.shadowOpacity = 0.40
+        view.layer.shadowOffset = CGSize(width: 0, height: 16)
+        view.layer.shadowRadius = 24
+        return view
+    }()
+
+    /// Bell icon centred inside `tileView`. SF Symbol so the tile reads
+    /// crisply at any scale; size 48pt per JSX spec, tinted `fgOnWarn`.
+    private let bellIconView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        let configuration = UIImage.SymbolConfiguration(pointSize: 44, weight: .semibold)
+        imageView.image = UIImage(systemName: "bell.fill", withConfiguration: configuration)?
+            .withRenderingMode(.alwaysTemplate)
+        imageView.tintColor = AppColors.fgOnWarn
+        imageView.contentMode = .scaleAspectFit
+        return imageView
+    }()
+
+    private let titleLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.text = "SnoozePay"
         label.font = AppTypography.h1
-        label.textColor = AppColors.fg1
+        label.textColor = .white
         label.textAlignment = .center
         label.adjustsFontForContentSizeCategory = false
         return label
     }()
 
-    /// Gradient layer that the wordmark glyphs mask — installed as a sublayer
-    /// of `wordmarkLabel.layer` once layout resolves so size / theme switches
-    /// re-rasterise cheaply.
-    private let wordmarkGradient: CAGradientLayer = {
-        let gradient = CAGradientLayer()
-        gradient.colors = SPSupport.moneyGradientColors
-        gradient.locations = SPSupport.moneyGradientLocations
-        gradient.startPoint = SPSupport.gradientStart
-        gradient.endPoint = SPSupport.gradientEnd
-        return gradient
+    private let subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "Будильник со ставкой"
+        label.font = AppTypography.meta
+        label.textColor = AppColors.fg3
+        label.textAlignment = .center
+        label.adjustsFontForContentSizeCategory = false
+        return label
     }()
 
     // MARK: - Lifecycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Solid base under the gradient so any flash before CALayer commits
-        // matches the bottom stop instead of the system bg.
+        // Force dark — splash is always rendered against the dark canvas
+        // regardless of the system theme, so the glow + tile read consistently.
+        overrideUserInterfaceStyle = .dark
         view.backgroundColor = AppColors.bg0
-        view.layer.insertSublayer(dawnGradientLayer, at: 0)
-        view.addSubview(wordmarkLabel)
+        view.layer.insertSublayer(glowLayer, at: 0)
+        tileView.layer.insertSublayer(tileGradient, at: 0)
+
+        view.addSubview(tileView)
+        view.addSubview(titleLabel)
+        view.addSubview(subtitleLabel)
+        tileView.addSubview(bellIconView)
+
         NSLayoutConstraint.activate([
-            wordmarkLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            wordmarkLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-            wordmarkLabel.leadingAnchor.constraint(
+            tileView.widthAnchor.constraint(equalToConstant: 96),
+            tileView.heightAnchor.constraint(equalToConstant: 96),
+            tileView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            // Stack lives optically centred — nudge slightly above geometric
+            // centre so the subtitle has breathing room above the home indicator.
+            tileView.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: -AppSpacing.sp7),
+
+            bellIconView.centerXAnchor.constraint(equalTo: tileView.centerXAnchor),
+            bellIconView.centerYAnchor.constraint(equalTo: tileView.centerYAnchor),
+            bellIconView.widthAnchor.constraint(equalToConstant: 48),
+            bellIconView.heightAnchor.constraint(equalToConstant: 48),
+
+            titleLabel.topAnchor.constraint(equalTo: tileView.bottomAnchor, constant: AppSpacing.sp5),
+            titleLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            titleLabel.leadingAnchor.constraint(
                 greaterThanOrEqualTo: view.leadingAnchor,
                 constant: AppSpacing.screenInset
             ),
-            wordmarkLabel.trailingAnchor.constraint(
+            titleLabel.trailingAnchor.constraint(
                 lessThanOrEqualTo: view.trailingAnchor,
                 constant: -AppSpacing.screenInset
-            )
+            ),
+
+            subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: AppSpacing.sp3),
+            subtitleLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor)
         ])
     }
 
     override var prefersStatusBarHidden: Bool { true }
-
-    /// Force light status bar so the dark Dawn gradient reads correctly
-    /// regardless of the user's system appearance.
     override var preferredStatusBarStyle: UIStatusBarStyle { .lightContent }
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        // Disable implicit animation so size / orientation changes don't
+        // Disable implicit animation so size/orientation changes don't
         // crossfade the gradient stops.
         CATransaction.begin()
         CATransaction.setDisableActions(true)
-        dawnGradientLayer.frame = view.bounds
+        // Position the radial glow centred on the screen; 480pt diameter
+        // matches JSX so the falloff reaches roughly the upper third / lower
+        // third boundary on a standard iPhone 6.1" canvas.
+        let glowSize: CGFloat = 480
+        glowLayer.frame = CGRect(
+            x: view.bounds.midX - glowSize / 2,
+            y: view.bounds.midY - glowSize / 2,
+            width: glowSize,
+            height: glowSize
+        )
+        tileGradient.frame = tileView.bounds
+        tileView.layer.shadowPath = UIBezierPath(
+            roundedRect: tileView.bounds,
+            cornerRadius: AppRadius.xl
+        ).cgPath
         CATransaction.commit()
-        applyWordmarkGradient()
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         // Schedule the handoff once the view is on-screen — viewDidLoad would
-        // fire `onFinished` before the user's first frame has even composited.
+        // fire `onFinished` before the user's first frame has composited.
         DispatchQueue.main.asyncAfter(deadline: .now() + Self.displayDuration) { [weak self] in
             self?.onFinished?()
         }
-    }
-
-    // MARK: - Wordmark gradient mask
-
-    /// Mask `wordmarkGradient` to the rendered glyph outline — CSS equivalent
-    /// of `-webkit-background-clip: text`. Lifted from
-    /// `SPBalanceCard.applyValueGradient` so the visual treatment between the
-    /// hero balance and the splash wordmark stays in sync.
-    private func applyWordmarkGradient() {
-        let textBounds = wordmarkLabel.bounds
-        guard textBounds.width > 0, textBounds.height > 0 else { return }
-        if wordmarkGradient.superlayer !== wordmarkLabel.layer {
-            wordmarkLabel.layer.addSublayer(wordmarkGradient)
-        }
-        wordmarkGradient.frame = textBounds
-
-        let renderer = UIGraphicsImageRenderer(size: textBounds.size)
-        let mask = renderer.image { _ in
-            (wordmarkLabel.text ?? "").draw(
-                in: textBounds,
-                withAttributes: [
-                    .font: wordmarkLabel.font as Any,
-                    .foregroundColor: UIColor.white
-                ]
-            )
-        }
-        let maskLayer = CALayer()
-        maskLayer.frame = textBounds
-        maskLayer.contents = mask.cgImage
-        wordmarkGradient.mask = maskLayer
-        wordmarkLabel.textColor = .clear
-    }
-}
-
-// MARK: - Hex helper
-
-private extension UIColor {
-    /// `0xRRGGBB` literal initialiser — local copy mirroring the (private)
-    /// helpers in AppColors / OnboardingViewController. File-prefixed so it
-    /// can't collide with the other private extensions in the module.
-    convenience init(splashRGB: UInt32, alpha: CGFloat = 1) {
-        let red = CGFloat((splashRGB >> 16) & 0xFF) / 255.0
-        let green = CGFloat((splashRGB >> 8) & 0xFF) / 255.0
-        let blue = CGFloat(splashRGB & 0xFF) / 255.0
-        self.init(red: red, green: green, blue: blue, alpha: alpha)
     }
 }


### PR DESCRIPTION
## Summary

Implements **slice A** of the V2 design refresh — full visual rewrite of the onboarding flow against `docs/design/v2-handoff/components/SPMore.jsx` + `SPMore2.jsx`.

- **Splash** (`SPMore2.jsx` L6-23) — dark `bg0` canvas, soft radial warm glow at centre, 96×96 rounded-rect tile (radius 28, warn gradient + warm shadow) with an SF-Symbol bell glyph, `h1` "SnoozePay" wordmark + `meta` subtitle. The earlier text-gradient wordmark is gone — the brand tile now carries the warmth.
- **Onboarding 1/3** (`SPMore.jsx` L9-45) — hero "7:00" mono clock (`clockXl`, tabular numbers), warn "−50 ₽" pill with warm shadow, `h1` "Будильник со ставкой", body copy, pill-dot row (1st active), "Дальше" money CTA.
- **Onboarding 2/3** (`SPMore.jsx` L47-87) — `warn300` caps "КАК ЭТО РАБОТАЕТ", `h1` two-line headline, three numbered explainer rows (32×32 `whiteOverlay08` badge + h4 title + meta body), 2nd dot active, same "Дальше" CTA.
- **Onboarding 3/3** (`SPMore.jsx` L89-149) — `money300` caps, `h1` "Сколько ставите на свою дисциплину?", three deposit option cards (200 / 500 / 1000 ₽) with "ПОПУЛЯРНО" tag on 500, selection paints a `money400` 8% fill + 40% border + `money300` amount, 3rd dot active, "Положить {amount} ₽" CTA with shield icon, secondary `quiet` "Позже — попробовать без баланса", `money400` radial glow top-left.
- **Permissions** (`SPMore2.jsx` L26-65) — `warn300` caps "ПОСЛЕДНИЙ ШАГ", `h1` "Чтобы будильник работал", body copy, three permission cards (40×40 rounded icon tile — money gradient when granted, `whiteOverlay08` otherwise; h4 title + meta body; trailing `money400` check or `warn400` caps "Дать"), "Готово" money CTA replaces the previous "Позже" footer.

## Behavioural contract preserved

- `OnboardingViewController.isCompleted`, `completedKey`, `firstTopUpDoneKey`, `onFinished` callback semantics unchanged → SceneDelegate keeps working.
- `PermissionsViewController.hasBeenShown`, `hasBeenShownKey`, `onFinished` likewise unchanged.
- `UIPageControl` is still a direct subview of `OnboardingViewController.view` (alpha 0) so the existing `OnboardingTests.testOnboardingPages_count` test keeps passing. The visible page indicator is the new custom pill-dot row (`OnboardingPageDot`).
- Notification permission flow still routes through `AlarmScheduler.requestPermission` (keeps `criticalAlertsAvailable` in sync); denied-state still routes the user to Settings.

## Files

- `SplashViewController.swift` — rewritten.
- `OnboardingViewController.swift` — rewritten (chrome / lifecycle / glow).
- `OnboardingViewController+Pages.swift` — rewritten (page builders + state).
- `OnboardingComponents.swift` — new file housing single-purpose helper views (`OnboardingGlowHostView`, `OnboardingPenaltyPill`, `OnboardingStepRow`, `OnboardingPageDot`, `OnboardingDepositOptionView`).
- `PermissionsViewController.swift` — rewritten.
- `PermissionCardView.swift` — rewritten (V2 horizontal layout).

All files under 400 lines; SwiftLint clean on the Onboarding folder.

## Test plan

- [x] `xcrun xcodebuild ... build` succeeds on iPhone 17 simulator (no errors / no warnings introduced).
- [x] `xcrun xcodebuild ... -only-testing:SnoozePayTests/OnboardingTests test` passes (3/3).
- [x] `swiftlint lint SnoozePay/SnoozePay/ViewControllers/Onboarding/` — zero violations on this slice's files.
- [ ] Manual: launch app on fresh sim with `onboarding_completed` cleared → Splash → Onboarding pages 1/2/3 swipe / advance / option-select / "Положить" → Permissions → "Готово" → AlarmsList.
- [ ] Manual: re-launch — Splash → straight into AlarmsList (no onboarding re-show).