### PR TITLE
[fix] Refund foreground snooze on schedule failure (#197)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+ViewLifecycle.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+ViewLifecycle.swift
@@ -46,10 +46,15 @@ extension AlarmFiringViewController {
         // scheduleCompletion surfaces a notification-center failure (revoked
         // permission, 64-pending-limit, malformed trigger) so the user
         // doesn't pay for a snooze that will never re-fire (#127 finding).
-        let success = viewModel.snooze { [weak self] result in
+        let success = viewModel.snooze { [weak self] outcome in
             guard let self else { return }
-            if case let .failure(error) = result {
+            switch outcome {
+            case .scheduled:
+                break
+            case .scheduleFailed(let error):
                 self.presentSnoozeScheduleFailureAlert(error: error)
+            case .scheduleFailedAndRefundFailed(let error):
+                self.presentSnoozeRefundFailedAlert(error: error)
             }
         }
         if success {
@@ -73,7 +78,26 @@ extension AlarmFiringViewController {
         let detail = error.errorDescription ?? error.localizedDescription
         let alert = UIAlertController(
             title: "Откладывание не запланировано",
-            message: "\(detail) Будильник не зазвенит повторно — установите запасной.",
+            message: "\(detail) Будильник не зазвенит повторно — установите запасной. "
+                + "Списанные деньги возвращены на баланс.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "Ок", style: .default))
+        present(alert, animated: true)
+    }
+
+    /// Stronger banner for the degraded case (#197): the snooze didn't schedule
+    /// AND the refund failed (locked ledger), so the user was billed with no
+    /// re-fire and no money back. Route them to support rather than implying
+    /// the penalty was returned.
+    func presentSnoozeRefundFailedAlert(
+        error: AlarmScheduler.SchedulingError
+    ) {
+        let detail = error.errorDescription ?? error.localizedDescription
+        let alert = UIAlertController(
+            title: "Не удалось вернуть списание",
+            message: "\(detail) Будильник не зазвенит повторно, а вернуть деньги автоматически не вышло. "
+                + "Напишите в поддержку — спишем вручную.",
             preferredStyle: .alert
         )
         alert.addAction(UIAlertAction(title: "Ок", style: .default))

--- a/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
@@ -5,9 +5,31 @@ import os
 /// Manages penalty calculation and balance deduction logic.
 final class AlarmFiringViewModel {
 
+    // MARK: - Outcome
+
+    /// Result of the in-app (firing VC) snooze, reported asynchronously once
+    /// the scheduler confirms whether the next trigger registered. Mirrors
+    /// `AlarmFiringCoordinator.SnoozeOutcome`'s failure semantics so the
+    /// foreground path and the notification-action path surface the same UX
+    /// (issue #197 — the foreground call site had no refund-on-failure).
+    enum SnoozeScheduleOutcome: Equatable {
+        /// Charge succeeded and the next snooze trigger registered.
+        case scheduled
+        /// Charge succeeded but the scheduler rejected the trigger. The penalty
+        /// has been **refunded** before this is reported — the user is not
+        /// billed for a snooze that won't re-fire. Surface a banner so they set
+        /// a backup alarm.
+        case scheduleFailed(AlarmScheduler.SchedulingError)
+        /// Charge succeeded, schedule failed, AND the offsetting refund also
+        /// failed (locked ledger from a corrupt blob). Wallet is degraded —
+        /// money taken, no re-fire, refund didn't land. Surface a stronger
+        /// "contact support" banner.
+        case scheduleFailedAndRefundFailed(AlarmScheduler.SchedulingError)
+    }
+
     // MARK: - Dependencies
 
-    private let balanceService: BalanceService
+    private let balanceService: AlarmFiringBalancing
     private let alarmRepository: AlarmRepository
     private let scheduler: AlarmScheduler
 
@@ -25,7 +47,7 @@ final class AlarmFiringViewModel {
     init(
         alarm: Alarm,
         snoozeCount: Int = 0,
-        balanceService: BalanceService = .shared,
+        balanceService: AlarmFiringBalancing = BalanceService.shared,
         alarmRepository: AlarmRepository = .shared,
         scheduler: AlarmScheduler = .shared
     ) {
@@ -98,23 +120,70 @@ final class AlarmFiringViewModel {
     /// user knows to set a backup alarm (or contact support for refund).
     /// Without consuming this completion the original silent-failure-class
     /// from #118 reappears in the snooze flow (silent-failure-hunter #127).
+    ///
+    /// On scheduler failure the penalty is **refunded** before the outcome is
+    /// reported (issue #197) — mirroring `AlarmFiringCoordinator`'s
+    /// notification-action path so the user is never billed for a snooze that
+    /// won't re-fire. `scheduleCompletion` therefore reports a richer
+    /// `SnoozeScheduleOutcome` (not the raw scheduler `Result`) so the VC can
+    /// distinguish a clean refund from a degraded "refund also failed" wallet.
     @discardableResult
     func snooze(
-        scheduleCompletion: ((Result<Void, AlarmScheduler.SchedulingError>) -> Void)? = nil
+        scheduleCompletion: ((SnoozeScheduleOutcome) -> Void)? = nil
     ) -> Bool {
         guard canSnooze else { return false }
 
-        let charged = balanceService.charge(amount: currentPenalty, alarmID: alarm.id)
+        // Capture the penalty for this snooze BEFORE bumping the count so the
+        // refund (if the schedule fails) returns the exact amount charged.
+        let penalty = currentPenalty
+        let charged = balanceService.charge(amount: penalty, alarmID: alarm.id)
         guard charged else { return false }
 
         snoozeCount += 1
-        scheduler.scheduleSnooze(
-            for: alarm,
-            snoozeCount: snoozeCount,
-            completion: scheduleCompletion
-        )
+        scheduler.scheduleSnooze(for: alarm, snoozeCount: snoozeCount) { [weak self] result in
+            self?.handleScheduleResult(result, penalty: penalty, completion: scheduleCompletion)
+        }
         onStateChanged?()
         return true
+    }
+
+    /// Resolves the async scheduler result, refunding the penalty on failure so
+    /// the foreground snooze path matches `AlarmFiringCoordinator
+    /// .handleScheduleResult` (issue #197). Extracted for a dedicated log seam.
+    private func handleScheduleResult(
+        _ result: Result<Void, AlarmScheduler.SchedulingError>,
+        penalty: Double,
+        completion: ((SnoozeScheduleOutcome) -> Void)?
+    ) {
+        switch result {
+        case .success:
+            completion?(.scheduled)
+        case .failure(let error):
+            // Refund via `topUp` (an offsetting ledger entry) rather than
+            // mutating storage directly, so transaction history shows both the
+            // charge and the refund and stats stay auditable.
+            let refunded = balanceService.topUp(amount: penalty)
+            let desc = error.errorDescription ?? error.localizedDescription
+            if refunded {
+                AppLogger.ui.error(
+                    """
+                    foreground snooze: schedule failed alarm=\(self.alarm.id, privacy: .private) \
+                    refunded=\(penalty, privacy: .public) reason=\(desc, privacy: .public)
+                    """
+                )
+                completion?(.scheduleFailed(error))
+            } else {
+                // Refund itself failed — wallet desync (charge recorded, refund
+                // didn't land — locked ledger from a corrupt blob, #72/#119).
+                AppLogger.ui.fault(
+                    """
+                    foreground snooze: schedule failed alarm=\(self.alarm.id, privacy: .private) \
+                    AND refund failed — wallet desync, manual reconciliation required
+                    """
+                )
+                completion?(.scheduleFailedAndRefundFailed(error))
+            }
+        }
     }
 
     /// Dismiss the alarm without charge.
@@ -136,3 +205,19 @@ final class AlarmFiringViewModel {
         }
     }
 }
+
+// MARK: - Billing seam
+
+/// The slice of `BalanceService` the firing VM depends on. Declaring it as a
+/// protocol lets tests inject a stub that can fail `topUp` independently of
+/// `charge` — the only way to exercise the `scheduleFailedAndRefundFailed`
+/// branch, since `BalanceService` / `TransactionRepository` are `final` and a
+/// locked ledger fails `charge` too (issue #197).
+protocol AlarmFiringBalancing: AnyObject {
+    var balance: Double { get }
+    func canAfford(_ amount: Double) -> Bool
+    @discardableResult func charge(amount: Double, alarmID: UUID?) -> Bool
+    @discardableResult func topUp(amount: Double) -> Bool
+}
+
+extension BalanceService: AlarmFiringBalancing {}

--- a/SnoozePay/SnoozePayTests/AlarmFiringSnoozeRefundTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmFiringSnoozeRefundTests.swift
@@ -1,0 +1,218 @@
+import XCTest
+import UserNotifications
+@testable import SnoozePay
+
+/// Issue #197 — the in-app (firing VC) snooze path must refund the penalty when
+/// the scheduler rejects the next trigger, mirroring `AlarmFiringCoordinator`'s
+/// notification-action path. Covers both the clean-refund and the degraded
+/// "refund also failed" branches.
+final class AlarmFiringSnoozeRefundTests: XCTestCase {
+
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "AlarmFiringSnoozeRefundTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    private func makeAlarm(penalty: Double = 50) -> Alarm {
+        Alarm(penaltyAmount: penalty)
+    }
+
+    /// A scheduler whose underlying notification center rejects `add(_:)`, so
+    /// `scheduleSnooze` resolves to `.failure(.system)`.
+    private func makeFailingScheduler() -> AlarmScheduler {
+        let center = FiringMockNotificationCenter()
+        center.addError = NSError(
+            domain: "UNErrorDomain",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Notifications are not allowed"]
+        )
+        return AlarmScheduler(notificationCenter: center)
+    }
+
+    /// A scheduler that registers the trigger successfully.
+    private func makeSucceedingScheduler() -> AlarmScheduler {
+        AlarmScheduler(notificationCenter: FiringMockNotificationCenter())
+    }
+
+    // MARK: - Clean refund (real ledger)
+
+    func testForegroundSnooze_scheduleFails_refundsBalanceAndReportsScheduleFailed() {
+        let balance = BalanceService(defaults: defaults)
+        balance.topUp(amount: 200)
+        let preCharge = balance.balance
+
+        let vm = AlarmFiringViewModel(
+            alarm: makeAlarm(penalty: 50),
+            balanceService: balance,
+            scheduler: makeFailingScheduler()
+        )
+
+        let exp = expectation(description: "schedule outcome")
+        var captured: AlarmFiringViewModel.SnoozeScheduleOutcome?
+        let charged = vm.snooze { outcome in
+            captured = outcome
+            exp.fulfill()
+        }
+        XCTAssertTrue(charged, "Snooze charges when the balance covers the penalty")
+        wait(for: [exp], timeout: 10)
+
+        guard case .scheduleFailed = captured else {
+            return XCTFail("Expected .scheduleFailed, got \(String(describing: captured))")
+        }
+        XCTAssertEqual(balance.balance, preCharge, accuracy: 0.001,
+                       "Penalty must be refunded so the user isn't billed for a snooze that won't fire")
+    }
+
+    func testForegroundSnooze_scheduleFails_ledgerRecordsChargeAndRefund() {
+        let repo = TransactionRepository(defaults: defaults)
+        let balance = BalanceService(defaults: defaults, transactionRepository: repo)
+        balance.topUp(amount: 200)
+        let preCount = repo.fetchAll().count
+
+        let vm = AlarmFiringViewModel(
+            alarm: makeAlarm(penalty: 50),
+            balanceService: balance,
+            scheduler: makeFailingScheduler()
+        )
+
+        let exp = expectation(description: "schedule outcome")
+        vm.snooze { _ in exp.fulfill() }
+        wait(for: [exp], timeout: 10)
+
+        // Charge + offsetting refund = two new ledger entries, so stats can
+        // reconcile the failed snooze.
+        XCTAssertEqual(repo.fetchAll().count, preCount + 2,
+                       "Both the charge and the refund must be recorded")
+    }
+
+    // MARK: - Degraded refund failure (stub billing)
+
+    func testForegroundSnooze_scheduleFails_refundFails_reportsDegradedOutcome() {
+        let billing = StubFiringBalance(balanceValue: 200, chargeResult: true, topUpResult: false)
+
+        let vm = AlarmFiringViewModel(
+            alarm: makeAlarm(penalty: 50),
+            balanceService: billing,
+            scheduler: makeFailingScheduler()
+        )
+
+        let exp = expectation(description: "schedule outcome")
+        var captured: AlarmFiringViewModel.SnoozeScheduleOutcome?
+        vm.snooze { outcome in
+            captured = outcome
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 10)
+
+        guard case .scheduleFailedAndRefundFailed = captured else {
+            return XCTFail("Expected .scheduleFailedAndRefundFailed, got \(String(describing: captured))")
+        }
+        XCTAssertEqual(billing.topUpCalls, [50], "A refund of the charged penalty must be attempted")
+        XCTAssertEqual(billing.chargeCalls, [50], "The penalty was charged before scheduling")
+    }
+
+    // MARK: - Success path
+
+    func testForegroundSnooze_scheduleSucceeds_reportsScheduledNoRefund() {
+        let billing = StubFiringBalance(balanceValue: 200, chargeResult: true, topUpResult: true)
+
+        let vm = AlarmFiringViewModel(
+            alarm: makeAlarm(penalty: 50),
+            balanceService: billing,
+            scheduler: makeSucceedingScheduler()
+        )
+
+        let exp = expectation(description: "schedule outcome")
+        var captured: AlarmFiringViewModel.SnoozeScheduleOutcome?
+        vm.snooze { outcome in
+            captured = outcome
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 10)
+
+        XCTAssertEqual(captured, .scheduled)
+        XCTAssertTrue(billing.topUpCalls.isEmpty, "No refund when the snooze schedules successfully")
+    }
+}
+
+// MARK: - Test doubles
+
+/// Stub `AlarmFiringBalancing` that lets `charge` and `topUp` resolve
+/// independently — the only way to exercise `scheduleFailedAndRefundFailed`
+/// (the real services are `final` and a locked ledger fails both calls).
+private final class StubFiringBalance: AlarmFiringBalancing {
+    private(set) var balance: Double
+    private let chargeResult: Bool
+    private let topUpResult: Bool
+    private(set) var chargeCalls: [Double] = []
+    private(set) var topUpCalls: [Double] = []
+
+    init(balanceValue: Double, chargeResult: Bool, topUpResult: Bool) {
+        self.balance = balanceValue
+        self.chargeResult = chargeResult
+        self.topUpResult = topUpResult
+    }
+
+    func canAfford(_ amount: Double) -> Bool { balance >= amount }
+
+    @discardableResult
+    func charge(amount: Double, alarmID: UUID?) -> Bool {
+        chargeCalls.append(amount)
+        guard chargeResult else { return false }
+        balance -= amount
+        return true
+    }
+
+    @discardableResult
+    func topUp(amount: Double) -> Bool {
+        topUpCalls.append(amount)
+        guard topUpResult else { return false }
+        balance += amount
+        return true
+    }
+}
+
+/// Minimal `NotificationScheduling` stub. `addError` forces `add(_:)` to fail so
+/// `scheduleSnooze` resolves to `.failure`.
+private final class FiringMockNotificationCenter: NotificationScheduling {
+    var addError: Error?
+    var pendingRequests: [UNNotificationRequest] = []
+
+    func add(
+        _ request: UNNotificationRequest,
+        withCompletionHandler completion: ((Error?) -> Void)?
+    ) {
+        completion?(addError)
+    }
+    func getPendingNotificationRequests(
+        completionHandler: @escaping ([UNNotificationRequest]) -> Void
+    ) {
+        completionHandler(pendingRequests)
+    }
+    func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {}
+    func removeDeliveredNotifications(withIdentifiers identifiers: [String]) {}
+    func getDeliveredNotifications(
+        completionHandler: @escaping ([UNNotification]) -> Void
+    ) {
+        completionHandler([])
+    }
+    func setNotificationCategories(_ categories: Set<UNNotificationCategory>) {}
+    func removeAllPendingNotificationRequests() {}
+    func requestAuthorization(
+        options: UNAuthorizationOptions,
+        completionHandler: @escaping (Bool, Error?) -> Void
+    ) {
+        completionHandler(false, nil)
+    }
+}

--- a/SnoozePay/SnoozePayTests/AlarmFiringViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmFiringViewModelTests.swift
@@ -246,7 +246,8 @@ final class AlarmFiringViewModelIOS011Tests: XCTestCase {
         let alarm = makeAlarm(penalty: 50)
         let vm = AlarmFiringViewModel(alarm: alarm, snoozeCount: 0)
 
-        XCTAssertEqual(vm.snoozeButtonTitle, "Отложить \u{00B7} 50 ₽")
+        // V2 copy: "+{minutes} минут · −{penalty} ₽" (default snooze = 9 min).
+        XCTAssertEqual(vm.snoozeButtonTitle, "+9 минут \u{00B7} −50 ₽")
     }
 
     func testSnoozeButtonTitle_whenCannotSnooze_showsEmpty() {


### PR DESCRIPTION
## Что

Закрывает money-loss баг #197: in-app (firing VC) путь «Поспать ещё» списывал штраф, но **не возвращал** его, если планировщик отклонял следующий триггер (revoked permission / 64-pending-limit / malformed trigger). Это тот же класс silent-failure, что уже починен для notification-action пути в `AlarmFiringCoordinator`, но параллельный foreground call-site не был обновлён.

## Как

- `AlarmFiringViewModel.snooze` теперь зеркалит `AlarmFiringCoordinator.handleScheduleResult`: на `.failure` рефандит через `BalanceService.topUp` и отдаёт богатый `SnoozeScheduleOutcome` (`.scheduled` / `.scheduleFailed` / `.scheduleFailedAndRefundFailed`).
- Узкий протокол `AlarmFiringBalancing` (BalanceService его реализует) — seam, чтобы юнит-тестить degraded-ветку «рефанд тоже не прошёл» (реальные сервисы `final`, залоченный ledger валит и charge).
- Firing VC показывает обычный баннер на `.scheduleFailed` (деньги возвращены) и **усиленный «обратитесь в поддержку»** на `.scheduleFailedAndRefundFailed`.
- Рефанд кладёт offsetting `.topup` запись — история показывает и списание, и возврат, статистика остаётся auditable.

## Тесты

- `AlarmFiringSnoozeRefundTests`: refund-success (баланс восстановлен), ledger double-entry (charge + refund), refund-failure (degraded outcome через stub), success path (no refund).
- Поправлен устаревший ассерт копирайта `snoozeButtonTitle` (V2-формулировка).

## Gates
- ✅ swiftlint (0 в затронутых файлах)
- ✅ build_sim (iPhone 17 Pro Max, iOS 26.5)
- ✅ test_sim: `AlarmFiringSnoozeRefundTests` 4/4, `AlarmFiringViewModelIOS011Tests` 20/20

Базовая ветка — `design-refresh-2026-04-27` (интеграционная для design-refresh, см. #245), НЕ main.

Fixes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)