### PR TITLE
[fix] toggleAlarm mutates Alarm copy in place + consumes rollback persist result (#205)

### DIFF
--- a/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
@@ -26,6 +26,25 @@ final class AlarmsListViewModel {
     /// `errorDescription` is already user-facing Russian copy.
     var onLoadError: ((LocalizedError) -> Void)?
 
+    // MARK: - Errors
+
+    /// Surfaced via `onLoadError` when the disk rollback after a failed
+    /// schedule also fails (#205). In-memory and persisted `enabled` state
+    /// have diverged at that point — only a relaunch (which re-reads disk)
+    /// reconciles them, so the copy tells the user to re-check the list.
+    enum ToggleError: LocalizedError {
+        case rollbackPersistFailed
+
+        var errorDescription: String? {
+            switch self {
+            case .rollbackPersistFailed:
+                return "Не удалось включить будильник и откатить изменение — "
+                    + "данные могут быть в рассинхроне. Перезапустите приложение "
+                    + "и проверьте список будильников."
+            }
+        }
+    }
+
     // MARK: - Observers
 
     /// Owned observer token. Removed in `deinit` to prevent the
@@ -106,18 +125,12 @@ final class AlarmsListViewModel {
         // mutate after `setEnabled` returns, a sync mock would fire its
         // closure first, set `.enabled = !enabled`, then the post-call
         // mutation would clobber the rollback (#129).
-        alarms[index] = Alarm(
-            id: alarms[index].id,
-            time: alarms[index].time,
-            repeatDays: alarms[index].repeatDays,
-            name: alarms[index].name,
-            soundID: alarms[index].soundID,
-            vibrationEnabled: alarms[index].vibrationEnabled,
-            snoozeMinutes: alarms[index].snoozeMinutes,
-            penaltyAmount: alarms[index].penaltyAmount,
-            progressiveScale: alarms[index].progressiveScale,
-            enabled: enabled
-        )
+        //
+        // Mutate the stored value in place rather than rebuilding `Alarm`
+        // field-by-field — the manual rebuild silently dropped any field it
+        // didn't list (it reset `volume`/`volumeFadeIn`/`theme` from #150/#151
+        // to their defaults) and would do the same for every future field (#205).
+        alarms[index].enabled = enabled
 
         let didUpdate = alarmRepository.setEnabled(enabled, id: id) { [weak self] result in
             // Scheduling outcome only fires on the successful-persist path.
@@ -138,8 +151,28 @@ final class AlarmsListViewModel {
                 // re-trigger this closure on the rollback's own scheduler call
                 // (toggle-off does no schedule work; toggle-on rollback after
                 // a failed enable becomes a disable — also no schedule work).
-                _ = self.alarmRepository.setEnabled(!enabled, id: id, schedulingResult: nil)
-                self.onLoadError?(error)
+                let rollbackPersisted = self.alarmRepository.setEnabled(
+                    !enabled, id: id, schedulingResult: nil
+                )
+                if rollbackPersisted {
+                    self.onLoadError?(error)
+                } else {
+                    // The disk rollback itself failed (store locked mid-flight
+                    // or alarm deleted concurrently): in-memory now says
+                    // `!enabled` while UserDefaults still says `enabled`. On
+                    // the next cold launch the app re-reads enabled=true with
+                    // no notification registered — the silent regression #129
+                    // was designed to close. Surface a stronger banner than
+                    // the scheduling error alone and log at fault level so
+                    // the drift is visible in sysdiagnose (#205).
+                    AppLogger.repository.fault(
+                        """
+                        toggle rollback persist failed id=\(id, privacy: .private); \
+                        in-memory and disk enabled state diverged
+                        """
+                    )
+                    self.onLoadError?(ToggleError.rollbackPersistFailed)
+                }
                 self.onAlarmsUpdated?()
             }
         }

--- a/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
@@ -13,12 +13,17 @@ final class AlarmsListViewModelTests: XCTestCase {
         var scheduleResult: Result<Void, AlarmScheduler.SchedulingError> = .success(())
         private(set) var scheduledIDs: [UUID] = []
         private(set) var cancelledIDs: [UUID] = []
+        /// Fired synchronously inside `schedule` BEFORE the completion runs.
+        /// Lets tests sabotage the store between the optimistic persist and
+        /// the VM's failure-rollback persist (#205 rollback-fails path).
+        var onSchedule: (() -> Void)?
 
         func schedule(
             _ alarm: Alarm,
             completion: ((Result<Void, AlarmScheduler.SchedulingError>) -> Void)?
         ) {
             scheduledIDs.append(alarm.id)
+            onSchedule?()
             completion?(scheduleResult)
         }
 
@@ -182,12 +187,13 @@ final class AlarmsListViewModelTests: XCTestCase {
 
     // MARK: - Coverage gaps surfaced by pr-test-analyzer (#32)
 
-    /// `toggleAlarm` rebuilds the in-memory cache via the positional `Alarm(...)`
-    /// initializer. Every non-`enabled` field MUST round-trip unchanged — if a
-    /// future model field is added but the rebuild block is not updated, that
-    /// field would silently revert to the default on toggle (the suspected
-    /// root cause of #18). This is a regression fence: any new field plus a
-    /// changed default value will trip the assertion.
+    /// `toggleAlarm` mutates the cached `Alarm` copy in place (#205) — every
+    /// non-`enabled` field MUST round-trip unchanged. The previous manual
+    /// field-by-field `Alarm(...)` rebuild silently reset any field it didn't
+    /// list (it dropped `volume`/`volumeFadeIn`/`theme` from #150/#151 back to
+    /// their defaults — the failure mode suspected in #18). Non-default values
+    /// for ALL fields keep this a regression fence: a future revert to the
+    /// rebuild style trips the assertions immediately.
     func testToggleAlarm_persistsAndRebuildsCacheCorrectly() {
         let calendar = Calendar(identifier: .gregorian)
         let time = calendar.date(from: DateComponents(hour: 7, minute: 30))!
@@ -200,7 +206,10 @@ final class AlarmsListViewModelTests: XCTestCase {
             snoozeMinutes: 7,
             penaltyAmount: 250,
             progressiveScale: true,
-            enabled: true
+            enabled: true,
+            volume: 0.4,
+            volumeFadeIn: true,
+            theme: .ocean
         )
         repo.save(original)
 
@@ -219,6 +228,9 @@ final class AlarmsListViewModelTests: XCTestCase {
         XCTAssertEqual(cached.snoozeMinutes, original.snoozeMinutes)
         XCTAssertEqual(cached.penaltyAmount, original.penaltyAmount)
         XCTAssertEqual(cached.progressiveScale, original.progressiveScale)
+        XCTAssertEqual(cached.volume, original.volume, "#150 volume must survive a toggle")
+        XCTAssertEqual(cached.volumeFadeIn, original.volumeFadeIn, "#150 fade-in must survive a toggle")
+        XCTAssertEqual(cached.theme, original.theme, "#151 theme must survive a toggle")
         XCTAssertFalse(cached.enabled, "Only `enabled` should change")
 
         // Repository must mirror the in-memory state.
@@ -452,6 +464,51 @@ final class AlarmsListViewModelTests: XCTestCase {
         XCTAssertFalse(
             vm.alarms[0].enabled,
             "In-memory `enabled` must roll back to the pre-toggle state on schedule failure"
+        )
+    }
+
+    /// Issue #205: when the schedule fails AND the disk rollback `setEnabled`
+    /// call ALSO fails (store corrupted mid-flight / alarm deleted
+    /// concurrently), the VM must not swallow the rollback boolean. In-memory
+    /// says `enabled=false` while disk still says `enabled=true` — next cold
+    /// launch re-reads enabled=true with no notification scheduled, the exact
+    /// silent regression #129 closed. The VM must surface the stronger
+    /// `ToggleError.rollbackPersistFailed` banner instead of the plain
+    /// scheduling error.
+    func testToggleAlarm_rollbackPersistFails_surfacesToggleError() {
+        let alarm = Alarm(name: "RollbackFail", penaltyAmount: 50, enabled: false)
+        repo.save(alarm)
+
+        let vm = makeViewModel()
+        vm.loadData()
+        XCTAssertEqual(vm.alarms.count, 1)
+
+        // The optimistic persist (enabled=true) succeeds, then `schedule`
+        // corrupts the store BEFORE failing — so the VM's rollback
+        // `setEnabled(false)` hits a locked store and returns false.
+        stubScheduler.scheduleResult = .failure(.system(message: "denied"))
+        stubScheduler.onSchedule = { [testDefaults] in
+            testDefaults?.set(Data("garbage".utf8), forKey: "stored_alarms")
+        }
+
+        var receivedError: LocalizedError?
+        var rebindFired = false
+        vm.onLoadError = { receivedError = $0 }
+        vm.onAlarmsUpdated = { rebindFired = true }
+
+        vm.toggleAlarm(id: alarm.id, enabled: true)
+
+        XCTAssertTrue(rebindFired, "Failed toggle must still trigger a UI re-bind")
+        XCTAssertFalse(vm.alarms[0].enabled, "In-memory `enabled` must still roll back")
+        guard let typed = receivedError as? AlarmsListViewModel.ToggleError else {
+            return XCTFail(
+                "Expected ToggleError.rollbackPersistFailed, got \(String(describing: receivedError))"
+            )
+        }
+        XCTAssertEqual(typed, .rollbackPersistFailed)
+        XCTAssertNotNil(
+            typed.errorDescription,
+            "Rollback-failure banner must carry user-facing copy"
         )
     }
 


### PR DESCRIPTION
Fixes #205

## Что сделано
- `AlarmsListViewModel.toggleAlarm` больше не пересобирает `Alarm` вручную по полям — мутирует копию in place (`alarms[index].enabled = enabled`). Старый rebuild реально терял `volume`/`volumeFadeIn` (#150) и `theme` (#151) в in-memory кэше и молча терял бы любое будущее поле.
- Boolean от rollback-`setEnabled` больше не отбрасывается: при провале дискового отката (store locked / alarm удалён конкурентно) логируется `AppLogger.repository.fault` и через `onLoadError` всплывает новый `ToggleError.rollbackPersistFailed` с сильным баннером о рассинхроне кэша и диска.
- Тесты: regression fence `testToggleAlarm_persistsAndRebuildsCacheCorrectly` расширен non-default значениями volume/fade/theme (ловит откат к rebuild-стилю); новый `testToggleAlarm_rollbackPersistFails_surfacesToggleError` пинит путь «rollback тоже упал» через хук `StubScheduler.onSchedule`, портящий store между optimistic persist и rollback.

## Приёмка (из issue)
- [x] No manual field-by-field Alarm rebuild
- [x] Rollback failure surfaces UI + log
- [x] Test that pins the rollback-fails path

## Verify
- swiftlint: 0 violations (оба файла)
- xcodebuild build (generic/platform=iOS Simulator, CODE_SIGNING_ALLOWED=NO): succeeded
- xcodebuild build-for-testing: succeeded (тестовый таргет компилируется)
- test run: НЕ запускался по инструкции orchestrator (параллельная волна) — suite гоняет orchestrator перед merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)