### PR TITLE
[fix] Use reusable cells in Settings table, refresh balance row on reuse (#203)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Settings/ReferralRowCells.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/ReferralRowCells.swift
@@ -1,0 +1,219 @@
+import UIKit
+
+// MARK: - Referral section cells
+//
+// Dedicated reusable cell classes for the three `.referral` rows. Previously
+// each row was rebuilt as a `UITableViewCell(style:reuseIdentifier: nil)` on
+// every `cellForRowAt:`, so UITableView could never recycle them and every
+// `reloadData` (each `viewWillAppear`) accumulated fresh cell hierarchies (#203).
+
+/// Row 1 — "Ваш код" + the user's 6-char code + copy glyph. Tap handling
+/// stays in `didSelectRowAt:` so the whole row is the hit target.
+final class ReferralMyCodeCell: UITableViewCell {
+
+    static let reuseID = "ReferralMyCodeCell"
+
+    private let codeLabel: UILabel = {
+        let label = UILabel()
+        label.font = AppTypography.moneySm
+        label.textColor = AppColors.money500
+        label.setContentHuggingPriority(.required, for: .horizontal)
+        return label
+    }()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        backgroundColor = AppColors.bg1
+
+        let titleLabel = UILabel()
+        titleLabel.text = "Ваш код"
+        titleLabel.font = AppTypography.bodyLg
+        titleLabel.textColor = AppColors.fg1
+
+        let copyIcon = UIImageView(image: UIImage(systemName: "doc.on.clipboard"))
+        copyIcon.tintColor = AppColors.fg3
+        copyIcon.contentMode = .scaleAspectFit
+        copyIcon.translatesAutoresizingMaskIntoConstraints = false
+        copyIcon.widthAnchor.constraint(equalToConstant: 18).isActive = true
+        copyIcon.heightAnchor.constraint(equalToConstant: 18).isActive = true
+
+        let trailingStack = UIStackView(arrangedSubviews: [codeLabel, copyIcon])
+        trailingStack.axis = .horizontal
+        trailingStack.alignment = .center
+        trailingStack.spacing = AppSpacing.sm
+
+        let mainStack = UIStackView(arrangedSubviews: [titleLabel, trailingStack])
+        mainStack.axis = .horizontal
+        mainStack.alignment = .center
+        mainStack.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(mainStack)
+
+        NSLayoutConstraint.activate([
+            mainStack.leadingAnchor.constraint(
+                equalTo: contentView.leadingAnchor,
+                constant: AppSpacing.lg
+            ),
+            mainStack.trailingAnchor.constraint(
+                equalTo: contentView.trailingAnchor,
+                constant: -AppSpacing.lg
+            ),
+            mainStack.centerYAnchor.constraint(equalTo: contentView.centerYAnchor)
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(code: String) {
+        codeLabel.text = code
+    }
+}
+
+/// Row 2 — `SPInput` for the friend's code + "Применить" SPButton. The cell
+/// owns the controls; the VC injects the text-field delegate and the apply
+/// handler on each dequeue, and keeps a weak `friendCodeInput` reference for
+/// inline validation messages (unchanged from the pre-reuse behaviour).
+final class ReferralFriendInputCell: UITableViewCell {
+
+    static let reuseID = "ReferralFriendInputCell"
+
+    let input = SPInput(
+        label: "Код друга",
+        placeholder: "Введите 6 символов"
+    )
+
+    private let applyButton = SPButton(title: "Применить", variant: .money, size: .sm)
+
+    /// Forwarded on every apply-button tap. Dropped in `prepareForReuse` so a
+    /// recycled cell can't fire a stale owner's handler before reconfiguration.
+    private var onApply: (() -> Void)?
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        backgroundColor = AppColors.bg1
+        selectionStyle = .none
+
+        input.textField.autocapitalizationType = .allCharacters
+        input.textField.autocorrectionType = .no
+        input.textField.returnKeyType = .done
+        input.translatesAutoresizingMaskIntoConstraints = false
+
+        applyButton.translatesAutoresizingMaskIntoConstraints = false
+        applyButton.addTarget(self, action: #selector(applyTapped), for: .touchUpInside)
+
+        let stack = UIStackView(arrangedSubviews: [input, applyButton])
+        stack.axis = .horizontal
+        stack.alignment = .top
+        stack.spacing = AppSpacing.sm
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(
+                equalTo: contentView.leadingAnchor,
+                constant: AppSpacing.lg
+            ),
+            stack.trailingAnchor.constraint(
+                equalTo: contentView.trailingAnchor,
+                constant: -AppSpacing.lg
+            ),
+            stack.topAnchor.constraint(
+                equalTo: contentView.topAnchor,
+                constant: AppSpacing.md
+            ),
+            stack.bottomAnchor.constraint(
+                equalTo: contentView.bottomAnchor,
+                constant: -AppSpacing.md
+            )
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    /// If the user has already redeemed a code, render it pre-filled and
+    /// freeze further edits — the bonus is one-shot, and showing the code
+    /// keeps support able to ask the user what they entered.
+    func configure(
+        appliedCode: String?,
+        delegate: UITextFieldDelegate,
+        onApply: @escaping () -> Void
+    ) {
+        input.textField.delegate = delegate
+        self.onApply = onApply
+
+        if let applied = appliedCode {
+            input.textField.text = applied
+            input.textField.isEnabled = false
+            input.error = nil
+            input.hint = "Код уже применён"
+            applyButton.isEnabled = false
+        } else {
+            input.textField.isEnabled = true
+            input.error = nil
+            input.hint = nil
+            applyButton.isEnabled = true
+        }
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        onApply = nil
+    }
+
+    @objc private func applyTapped() {
+        onApply?()
+    }
+}
+
+/// Row 3 — small grey caption line. Modeled as a real cell rather than a
+/// section footer so it inherits the card-row styling applied in `willDisplay`.
+final class ReferralCaptionCell: UITableViewCell {
+
+    static let reuseID = "ReferralCaptionCell"
+
+    private let captionLabel: UILabel = {
+        let label = UILabel()
+        label.font = AppTypography.meta
+        label.textColor = AppColors.fg3
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        backgroundColor = AppColors.bg1
+        selectionStyle = .none
+
+        contentView.addSubview(captionLabel)
+        NSLayoutConstraint.activate([
+            captionLabel.leadingAnchor.constraint(
+                equalTo: contentView.leadingAnchor,
+                constant: AppSpacing.lg
+            ),
+            captionLabel.trailingAnchor.constraint(
+                equalTo: contentView.trailingAnchor,
+                constant: -AppSpacing.lg
+            ),
+            captionLabel.topAnchor.constraint(
+                equalTo: contentView.topAnchor,
+                constant: AppSpacing.md
+            ),
+            captionLabel.bottomAnchor.constraint(
+                equalTo: contentView.bottomAnchor,
+                constant: -AppSpacing.md
+            )
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(text: String) {
+        captionLabel.text = text
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsIconRowCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsIconRowCell.swift
@@ -1,0 +1,130 @@
+import UIKit
+
+/// Reusable icon + title row for the Settings table (history, balance, info,
+/// contact rows). Replaces the previous `makeIconRow` factory that built
+/// `UITableViewCell(style:reuseIdentifier: nil)` on every `cellForRowAt:` —
+/// nil-identifier cells are never recycled, so each reload leaked a fresh
+/// cell hierarchy (#203).
+///
+/// `configure` resets every mutable bit of state, so no `prepareForReuse`
+/// override is needed: a recycled cell is always fully re-specified before
+/// it re-enters the viewport.
+final class SettingsIconRowCell: UITableViewCell {
+
+    static let reuseID = "SettingsIconRowCell"
+
+    // MARK: - UI
+
+    private let iconContainer: UIView = {
+        let view = UIView()
+        view.layer.cornerRadius = 7
+        view.layer.masksToBounds = true
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let iconImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.tintColor = .white
+        imageView.contentMode = .scaleAspectFit
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = AppTypography.bodyLg
+        label.textColor = AppColors.fg1
+        return label
+    }()
+
+    private let subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.font = AppTypography.meta
+        label.textColor = AppColors.fg3
+        label.isHidden = true
+        return label
+    }()
+
+    /// Right-aligned value (the balance amount). Hidden unless configured.
+    private let trailingLabel: UILabel = {
+        let label = UILabel()
+        label.font = AppTypography.moneyMd
+        label.isHidden = true
+        label.setContentHuggingPriority(.required, for: .horizontal)
+        label.setContentCompressionResistancePriority(.required, for: .horizontal)
+        return label
+    }()
+
+    // MARK: - Init
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Setup
+
+    private func setupUI() {
+        backgroundColor = .secondarySystemBackground
+
+        iconContainer.addSubview(iconImageView)
+
+        let textStack = UIStackView(arrangedSubviews: [titleLabel, subtitleLabel])
+        textStack.axis = .vertical
+        textStack.spacing = 2
+
+        let mainStack = UIStackView(arrangedSubviews: [iconContainer, textStack, trailingLabel])
+        mainStack.axis = .horizontal
+        mainStack.spacing = AppSpacing.md
+        mainStack.alignment = .center
+        mainStack.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(mainStack)
+
+        NSLayoutConstraint.activate([
+            iconContainer.widthAnchor.constraint(equalToConstant: 30),
+            iconContainer.heightAnchor.constraint(equalToConstant: 30),
+            iconImageView.centerXAnchor.constraint(equalTo: iconContainer.centerXAnchor),
+            iconImageView.centerYAnchor.constraint(equalTo: iconContainer.centerYAnchor),
+
+            mainStack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.lg),
+            mainStack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.lg),
+            mainStack.centerYAnchor.constraint(equalTo: contentView.centerYAnchor)
+        ])
+    }
+
+    // MARK: - Configure
+
+    /// Fully re-specifies the row. Every property is written unconditionally
+    /// so state from a previous tenant of this cell can't survive recycling.
+    func configure(
+        systemName: String,
+        iconColor: UIColor,
+        title: String,
+        subtitle: String? = nil,
+        trailingText: String? = nil,
+        trailingColor: UIColor = AppColors.money500,
+        accessory: UITableViewCell.AccessoryType = .none,
+        selectionStyle: UITableViewCell.SelectionStyle = .default
+    ) {
+        iconContainer.backgroundColor = iconColor
+        iconImageView.image = UIImage(systemName: systemName)?.withConfiguration(
+            UIImage.SymbolConfiguration(pointSize: 15, weight: .medium)
+        )
+        titleLabel.text = title
+
+        subtitleLabel.text = subtitle
+        subtitleLabel.isHidden = subtitle == nil
+
+        trailingLabel.text = trailingText
+        trailingLabel.textColor = trailingColor
+        trailingLabel.isHidden = trailingText == nil
+
+        accessoryType = accessory
+        self.selectionStyle = selectionStyle
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController+Referral.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController+Referral.swift
@@ -16,9 +16,9 @@ extension SettingsViewController {
     func makeReferralCell(at indexPath: IndexPath) -> UITableViewCell {
         guard let row = ReferralRow(rawValue: indexPath.row) else { return UITableViewCell() }
         switch row {
-        case .myCode:      return makeMyCodeCell()
-        case .friendInput: return makeFriendInputCell()
-        case .caption:     return makeReferralCaptionCell()
+        case .myCode:      return makeMyCodeCell(at: indexPath)
+        case .friendInput: return makeFriendInputCell(at: indexPath)
+        case .caption:     return makeReferralCaptionCell(at: indexPath)
         }
     }
 
@@ -26,159 +26,52 @@ extension SettingsViewController {
     /// Tapping anywhere on the row copies the code (we forward the tap from
     /// `didSelectRowAt:` rather than wiring an inner tap-target so a bigger
     /// hit area falls out for free).
-    func makeMyCodeCell() -> UITableViewCell {
-        let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
-        cell.backgroundColor = AppColors.bg1
-
-        let titleLabel = UILabel()
-        titleLabel.text = "Ваш код"
-        titleLabel.font = AppTypography.bodyLg
-        titleLabel.textColor = AppColors.fg1
-
-        let codeLabel = UILabel()
-        codeLabel.text = referralService.getMyCode()
-        codeLabel.font = AppTypography.moneySm
-        codeLabel.textColor = AppColors.money500
-        codeLabel.setContentHuggingPriority(.required, for: .horizontal)
-
-        let copyIcon = UIImageView(image: UIImage(systemName: "doc.on.clipboard"))
-        copyIcon.tintColor = AppColors.fg3
-        copyIcon.contentMode = .scaleAspectFit
-        copyIcon.translatesAutoresizingMaskIntoConstraints = false
-        copyIcon.widthAnchor.constraint(equalToConstant: 18).isActive = true
-        copyIcon.heightAnchor.constraint(equalToConstant: 18).isActive = true
-
-        let trailingStack = UIStackView(arrangedSubviews: [codeLabel, copyIcon])
-        trailingStack.axis = .horizontal
-        trailingStack.alignment = .center
-        trailingStack.spacing = AppSpacing.sm
-        trailingStack.translatesAutoresizingMaskIntoConstraints = false
-
-        let mainStack = UIStackView(arrangedSubviews: [titleLabel, trailingStack])
-        mainStack.axis = .horizontal
-        mainStack.alignment = .center
-        mainStack.translatesAutoresizingMaskIntoConstraints = false
-        cell.contentView.addSubview(mainStack)
-
-        NSLayoutConstraint.activate([
-            mainStack.leadingAnchor.constraint(
-                equalTo: cell.contentView.leadingAnchor,
-                constant: AppSpacing.lg
-            ),
-            mainStack.trailingAnchor.constraint(
-                equalTo: cell.contentView.trailingAnchor,
-                constant: -AppSpacing.lg
-            ),
-            mainStack.centerYAnchor.constraint(equalTo: cell.contentView.centerYAnchor)
-        ])
-
-        cell.accessoryType = .none
+    func makeMyCodeCell(at indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(
+            withIdentifier: ReferralMyCodeCell.reuseID,
+            for: indexPath
+        ) as? ReferralMyCodeCell else {
+            assertionFailure("dequeueReusableCell returned wrong type for \(ReferralMyCodeCell.reuseID)")
+            return UITableViewCell()
+        }
+        cell.configure(code: referralService.getMyCode())
         return cell
     }
 
     /// Row 2 — `SPInput` for the friend's code + small "Применить" SPButton.
-    /// We disable selection on the cell because the interactive controls are
-    /// inside it; otherwise the cell would highlight on every tap inside the
-    /// text field.
-    func makeFriendInputCell() -> UITableViewCell {
-        let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
-        cell.backgroundColor = AppColors.bg1
-        cell.selectionStyle = .none
-
-        let input = SPInput(
-            label: "Код друга",
-            placeholder: "Введите 6 символов"
-        )
-        input.textField.autocapitalizationType = .allCharacters
-        input.textField.autocorrectionType = .no
-        input.textField.returnKeyType = .done
-        input.textField.delegate = self
-        input.translatesAutoresizingMaskIntoConstraints = false
-
-        // If the user has already redeemed a code, render it as the
-        // pre-filled value and freeze further edits — the bonus is one-shot,
-        // and showing the code keeps support able to ask the user what they
-        // entered.
-        if let applied = referralService.appliedFriendCode {
-            input.textField.text = applied
-            input.textField.isEnabled = false
-            input.hint = "Код уже применён"
+    /// The cell owns the controls; we re-point `friendCodeInput` at its input
+    /// on every dequeue so `handleApplyFriendCodeTapped` can surface inline
+    /// validation messages on the instance currently on screen.
+    func makeFriendInputCell(at indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(
+            withIdentifier: ReferralFriendInputCell.reuseID,
+            for: indexPath
+        ) as? ReferralFriendInputCell else {
+            assertionFailure("dequeueReusableCell returned wrong type for \(ReferralFriendInputCell.reuseID)")
+            return UITableViewCell()
         }
-        self.friendCodeInput = input
-
-        let applyButton = SPButton(title: "Применить", variant: .money, size: .sm)
-        applyButton.translatesAutoresizingMaskIntoConstraints = false
-        applyButton.isEnabled = referralService.appliedFriendCode == nil
-        applyButton.addTarget(
-            self,
-            action: #selector(handleApplyFriendCodeTapped),
-            for: .touchUpInside
-        )
-
-        let stack = UIStackView(arrangedSubviews: [input, applyButton])
-        stack.axis = .horizontal
-        stack.alignment = .top
-        stack.spacing = AppSpacing.sm
-        stack.translatesAutoresizingMaskIntoConstraints = false
-        cell.contentView.addSubview(stack)
-
-        NSLayoutConstraint.activate([
-            stack.leadingAnchor.constraint(
-                equalTo: cell.contentView.leadingAnchor,
-                constant: AppSpacing.lg
-            ),
-            stack.trailingAnchor.constraint(
-                equalTo: cell.contentView.trailingAnchor,
-                constant: -AppSpacing.lg
-            ),
-            stack.topAnchor.constraint(
-                equalTo: cell.contentView.topAnchor,
-                constant: AppSpacing.md
-            ),
-            stack.bottomAnchor.constraint(
-                equalTo: cell.contentView.bottomAnchor,
-                constant: -AppSpacing.md
-            )
-        ])
-
+        cell.configure(
+            appliedCode: referralService.appliedFriendCode,
+            delegate: self
+        ) { [weak self] in
+            self?.handleApplyFriendCodeTapped()
+        }
+        self.friendCodeInput = cell.input
         return cell
     }
 
     /// Row 3 — small grey caption line. Modeled as a real cell rather than a
     /// section footer so it inherits the card-row styling applied in
     /// `willDisplay`.
-    func makeReferralCaptionCell() -> UITableViewCell {
-        let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
-        cell.backgroundColor = AppColors.bg1
-        cell.selectionStyle = .none
-
-        let label = UILabel()
-        label.text = "За каждого друга — +200 ₽ на ваш баланс"
-        label.font = AppTypography.meta
-        label.textColor = AppColors.fg3
-        label.numberOfLines = 0
-        label.translatesAutoresizingMaskIntoConstraints = false
-        cell.contentView.addSubview(label)
-
-        NSLayoutConstraint.activate([
-            label.leadingAnchor.constraint(
-                equalTo: cell.contentView.leadingAnchor,
-                constant: AppSpacing.lg
-            ),
-            label.trailingAnchor.constraint(
-                equalTo: cell.contentView.trailingAnchor,
-                constant: -AppSpacing.lg
-            ),
-            label.topAnchor.constraint(
-                equalTo: cell.contentView.topAnchor,
-                constant: AppSpacing.md
-            ),
-            label.bottomAnchor.constraint(
-                equalTo: cell.contentView.bottomAnchor,
-                constant: -AppSpacing.md
-            )
-        ])
-
+    func makeReferralCaptionCell(at indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(
+            withIdentifier: ReferralCaptionCell.reuseID,
+            for: indexPath
+        ) as? ReferralCaptionCell else {
+            assertionFailure("dequeueReusableCell returned wrong type for \(ReferralCaptionCell.reuseID)")
+            return UITableViewCell()
+        }
+        cell.configure(text: "За каждого друга — +200 ₽ на ваш баланс")
         return cell
     }
 
@@ -194,7 +87,6 @@ extension SettingsViewController {
         showToast(message: "Скопировано")
     }
 
-    @objc
     func handleApplyFriendCodeTapped() {
         guard let input = friendCodeInput else { return }
         let raw = input.textField.text ?? ""

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController+Sections.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController+Sections.swift
@@ -3,53 +3,40 @@ import UIKit
 // MARK: - Section + cell builders
 //
 // Extracted from `SettingsViewController.swift` (#182) so the host file stays
-// under SwiftLint's `file_length` cap. Each helper owns its row's UIKit
-// composition; behaviour is verbatim — only the physical location moved.
+// under SwiftLint's `file_length` cap. Rewritten in #203 to dequeue reusable
+// `SettingsIconRowCell` instances instead of building nil-reuseIdentifier
+// cells from scratch on every `cellForRowAt:` (which UITableView can never
+// recycle — every `reloadData` accumulated a fresh cell hierarchy).
 
 extension SettingsViewController {
 
     // MARK: Account section
 
-    func makeTransactionHistoryRow() -> UITableViewCell {
-        makeIconRow(
+    func makeTransactionHistoryRow(at indexPath: IndexPath) -> UITableViewCell {
+        let cell = dequeueIconRowCell(at: indexPath)
+        cell.configure(
             systemName: "list.bullet.rectangle",
             iconColor: AppColors.info500,
             title: "История транзакций",
             accessory: .disclosureIndicator
         )
+        return cell
     }
 
-    func makeBalanceRow() -> UITableViewCell {
-        let cell = makeIconRow(
+    func makeBalanceRow(at indexPath: IndexPath) -> UITableViewCell {
+        let cell = dequeueIconRowCell(at: indexPath)
+        // The amount is read fresh on every dequeue, so the row is always
+        // current when it (re-)enters the viewport; live updates while the
+        // row is visible arrive via the balance observer's `reloadRows`.
+        cell.configure(
             systemName: "dollarsign.circle",
             iconColor: AppColors.money500,
             title: "Баланс",
-            accessory: .none
+            trailingText: "₽\(Int(BalanceService.shared.balance))",
+            trailingColor: AppColors.money500,
+            accessory: .none,
+            selectionStyle: .none
         )
-
-        let balanceAmount = UILabel()
-        balanceAmount.text = "₽\(Int(BalanceService.shared.balance))"
-        balanceAmount.font = AppTypography.moneyMd
-        balanceAmount.textColor = AppColors.money500
-        balanceAmount.translatesAutoresizingMaskIntoConstraints = false
-        balanceAmount.setContentHuggingPriority(.required, for: .horizontal)
-        cell.contentView.addSubview(balanceAmount)
-
-        NSLayoutConstraint.activate([
-            balanceAmount.trailingAnchor.constraint(
-                equalTo: cell.contentView.trailingAnchor,
-                constant: -AppSpacing.lg
-            ),
-            balanceAmount.centerYAnchor.constraint(equalTo: cell.contentView.centerYAnchor)
-        ])
-
-        // Track the latest label instance so the balance observer can
-        // refresh it. When the cell is recycled the weak ref nils out
-        // automatically, so the observer becomes a no-op until the row
-        // is rebuilt — at which point this assignment captures the new label.
-        self.balanceAmountLabel = balanceAmount
-
-        cell.selectionStyle = .none
         return cell
     }
 
@@ -57,117 +44,43 @@ extension SettingsViewController {
 
     func makeInfoRow(at indexPath: IndexPath) -> UITableViewCell {
         let title = indexPath.row == 0 ? "Политика конфиденциальности" : "Пользовательское соглашение"
-        return makeIconRow(
+        let cell = dequeueIconRowCell(at: indexPath)
+        cell.configure(
             systemName: "doc.text",
             iconColor: UIColor.systemGray,
             title: title,
             accessory: .disclosureIndicator
         )
+        return cell
     }
 
     // MARK: Contact section
 
-    func makeContactRow() -> UITableViewCell {
-        let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
-        cell.backgroundColor = .secondarySystemBackground
-
-        let icon = makeSettingsIcon(systemName: "envelope", backgroundColor: AppColors.warn500)
-        let titleLabel = UILabel()
-        titleLabel.text = "Связаться с нами"
-        titleLabel.font = AppTypography.bodyLg
-        titleLabel.textColor = AppColors.fg1
-
-        let detailLabel = UILabel()
-        detailLabel.text = "support@alarmcash.app"
-        detailLabel.font = AppTypography.meta
-        detailLabel.textColor = AppColors.fg3
-
-        let textStack = UIStackView(arrangedSubviews: [titleLabel, detailLabel])
-        textStack.axis = .vertical
-        textStack.spacing = 2
-
-        let stack = UIStackView(arrangedSubviews: [icon, textStack])
-        stack.axis = .horizontal
-        stack.spacing = AppSpacing.md
-        stack.alignment = .center
-        stack.translatesAutoresizingMaskIntoConstraints = false
-        cell.contentView.addSubview(stack)
-
-        NSLayoutConstraint.activate([
-            stack.leadingAnchor.constraint(
-                equalTo: cell.contentView.leadingAnchor,
-                constant: AppSpacing.lg
-            ),
-            stack.centerYAnchor.constraint(equalTo: cell.contentView.centerYAnchor),
-            stack.trailingAnchor.constraint(
-                lessThanOrEqualTo: cell.contentView.trailingAnchor,
-                constant: -AppSpacing.lg
-            )
-        ])
-
-        cell.accessoryType = .disclosureIndicator
+    func makeContactRow(at indexPath: IndexPath) -> UITableViewCell {
+        let cell = dequeueIconRowCell(at: indexPath)
+        cell.configure(
+            systemName: "envelope",
+            iconColor: AppColors.warn500,
+            title: "Связаться с нами",
+            subtitle: "support@alarmcash.app",
+            accessory: .disclosureIndicator
+        )
         return cell
     }
 
     // MARK: - Cell factory helpers
 
-    func makeIconRow(
-        systemName: String,
-        iconColor: UIColor,
-        title: String,
-        accessory: UITableViewCell.AccessoryType
-    ) -> UITableViewCell {
-        let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
-        cell.backgroundColor = .secondarySystemBackground
-
-        let icon = makeSettingsIcon(systemName: systemName, backgroundColor: iconColor)
-        let label = UILabel()
-        label.text = title
-        label.font = AppTypography.bodyLg
-        label.textColor = AppColors.fg1
-
-        let stack = UIStackView(arrangedSubviews: [icon, label])
-        stack.axis = .horizontal
-        stack.spacing = AppSpacing.md
-        stack.alignment = .center
-        stack.translatesAutoresizingMaskIntoConstraints = false
-        cell.contentView.addSubview(stack)
-
-        NSLayoutConstraint.activate([
-            stack.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor, constant: AppSpacing.lg),
-            stack.centerYAnchor.constraint(equalTo: cell.contentView.centerYAnchor)
-        ])
-
-        cell.accessoryType = accessory
+    /// Dequeues the shared icon-row cell, falling back to a plain cell (with
+    /// an assertion in debug) if the registration ever drifts out of sync.
+    private func dequeueIconRowCell(at indexPath: IndexPath) -> SettingsIconRowCell {
+        guard let cell = tableView.dequeueReusableCell(
+            withIdentifier: SettingsIconRowCell.reuseID,
+            for: indexPath
+        ) as? SettingsIconRowCell else {
+            assertionFailure("dequeueReusableCell returned wrong type for \(SettingsIconRowCell.reuseID)")
+            return SettingsIconRowCell(style: .default, reuseIdentifier: nil)
+        }
         return cell
-    }
-
-    /// Creates a rounded-rect icon with an SF Symbol, similar to iOS Settings style.
-    func makeSettingsIcon(systemName: String, backgroundColor: UIColor) -> UIView {
-        let size: CGFloat = 30
-        let container = UIView()
-        container.backgroundColor = backgroundColor
-        container.layer.cornerRadius = 7
-        container.layer.masksToBounds = true
-        container.translatesAutoresizingMaskIntoConstraints = false
-
-        let imageView = UIImageView()
-        imageView.image = UIImage(systemName: systemName)?.withConfiguration(
-            UIImage.SymbolConfiguration(pointSize: 15, weight: .medium)
-        )
-        imageView.tintColor = .white
-        imageView.contentMode = .scaleAspectFit
-        imageView.translatesAutoresizingMaskIntoConstraints = false
-        container.addSubview(imageView)
-
-        NSLayoutConstraint.activate([
-            container.widthAnchor.constraint(equalToConstant: size),
-            container.heightAnchor.constraint(equalToConstant: size),
-            imageView.centerXAnchor.constraint(equalTo: container.centerXAnchor),
-            imageView.centerYAnchor.constraint(equalTo: container.centerYAnchor)
-        ])
-
-        return container
     }
 
     // MARK: - Section header builder

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController.swift
@@ -18,12 +18,6 @@ class SettingsViewController: UIViewController {
         return table
     }()
 
-    /// Held weakly so the cell may be recycled (and the label deallocated)
-    /// without leaving the observer with a dangling reference. `internal`
-    /// so the cross-file `+Sections.makeBalanceRow` can capture a fresh
-    /// reference each time the row is dequeued (#182).
-    weak var balanceAmountLabel: UILabel?
-
     // MARK: - Init
 
     init(themeService: ThemeService = .shared) {
@@ -94,15 +88,23 @@ class SettingsViewController: UIViewController {
     /// Subscribe to balance changes so the row updates immediately after a
     /// top-up that happens while Settings is on-screen (e.g. another tab posts
     /// a change). Without this, the balance only refreshes on `viewWillAppear`.
+    ///
+    /// Reloading the row (rather than poking a weak label reference) keeps a
+    /// single source of truth: `makeBalanceRow` reads the fresh balance on
+    /// every dequeue, so live updates and scroll-back-into-view share one
+    /// code path and recycled cells can never show a stale amount (#203).
     private func observeBalanceChanges() {
         balanceObserver = NotificationCenter.default.addObserver(
             forName: BalanceService.balanceChangedNotification,
             object: nil,
             queue: .main
-        ) { [weak self] note in
-            guard let self,
-                  let newBalance = note.userInfo?[BalanceService.balanceUserInfoKey] as? Double else { return }
-            self.balanceAmountLabel?.text = "₽\(Int(newBalance))"
+        ) { [weak self] _ in
+            // Off-screen updates are covered by `viewWillAppear`'s
+            // `reloadData`, so only touch the table while it's in a window —
+            // this also sidesteps reload-before-initial-load edge cases.
+            guard let self, self.tableView.window != nil else { return }
+            let balanceRow = IndexPath(row: 1, section: Section.account.rawValue)
+            self.tableView.reloadRows(at: [balanceRow], with: .none)
         }
     }
 
@@ -112,8 +114,14 @@ class SettingsViewController: UIViewController {
         view.addSubview(tableView)
         tableView.delegate = self
         tableView.dataSource = self
-        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
+        tableView.register(SettingsIconRowCell.self, forCellReuseIdentifier: SettingsIconRowCell.reuseID)
         tableView.register(ThemeSegmentCell.self, forCellReuseIdentifier: ThemeSegmentCell.reuseID)
+        tableView.register(ReferralMyCodeCell.self, forCellReuseIdentifier: ReferralMyCodeCell.reuseID)
+        tableView.register(
+            ReferralFriendInputCell.self,
+            forCellReuseIdentifier: ReferralFriendInputCell.reuseID
+        )
+        tableView.register(ReferralCaptionCell.self, forCellReuseIdentifier: ReferralCaptionCell.reuseID)
 
         NSLayoutConstraint.activate([
             tableView.topAnchor.constraint(equalTo: view.topAnchor),
@@ -202,7 +210,7 @@ extension SettingsViewController: UITableViewDataSource {
         case .referral:   return makeReferralCell(at: indexPath)
         case .appearance: return makeAppearanceCell(tableView, at: indexPath)
         case .info:       return makeInfoRow(at: indexPath)
-        case .contact:    return makeContactRow()
+        case .contact:    return makeContactRow(at: indexPath)
         }
     }
 
@@ -210,7 +218,7 @@ extension SettingsViewController: UITableViewDataSource {
     /// the Balance row (`row == 1`). Split off `cellForRowAt` so the main
     /// switch stays a one-screen overview (#182).
     private func makeAccountCell(at indexPath: IndexPath) -> UITableViewCell {
-        indexPath.row == 0 ? makeTransactionHistoryRow() : makeBalanceRow()
+        indexPath.row == 0 ? makeTransactionHistoryRow(at: indexPath) : makeBalanceRow(at: indexPath)
     }
 
     /// Dequeue + configure for the segmented Theme cell. Pulled out of


### PR DESCRIPTION
Fixes #203

## Что сделано
- Новый `SettingsIconRowCell` (registered/dequeued by reuseID) заменяет фабрику `makeIconRow`, которая создавала `UITableViewCell(style:reuseIdentifier: nil)` на каждый `cellForRowAt:` — такие ячейки никогда не рециклируются, и каждый `reloadData` (каждый `viewWillAppear`) накапливал свежие иерархии. Покрывает rows: история транзакций, баланс, privacy/terms, contact (с subtitle).
- Новые `ReferralMyCodeCell` / `ReferralFriendInputCell` / `ReferralCaptionCell` — referral-секция тоже переведена на register/dequeue; apply-кнопка форвардит тап через closure, который сбрасывается в `prepareForReuse`.
- Баланс: убран хрупкий weak-ref `balanceAmountLabel` (VC-side ссылка на label внутри ячейки). Теперь `makeBalanceRow` читает `BalanceService.shared.balance` на каждом dequeue, а observer `balanceChangedNotification` делает `reloadRows` балансовой строки (только когда таблица в window — off-screen покрыт `reloadData` в `viewWillAppear`). Stale label после рецикла невозможен: dequeue и live-update идут через один code path.
- Удалена мёртвая регистрация `UITableViewCell` под id "cell" (ничем не использовалась).

## Приёмка (из issue)
- [x] All Settings rows use proper reuseIdentifier (account, referral, appearance, info, contact)
- [x] Cell count стабилен: dequeue рециклирует, фабрики больше не создают nil-id ячейки
- [x] Balance label обновляется при возврате строки во viewport (configure читает свежий баланс)

## Verify
- swiftlint: 0 violations в затронутых файлах
- xcodebuild build (scheme SnoozePay, generic/platform=iOS Simulator, CODE_SIGNING_ALLOWED=NO): BUILD SUCCEEDED
- Тесты: новых нет — чистый cell-reuse plumbing, view-model-логика не менялась (`SettingsViewModelTests` не затронуты); полный test suite гоняет orchestrator перед merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)