### PR TITLE
[ui] Design v3 foundation: 07:00 hours, fmtRub narrow ₽ space, new ₽ icon set, chip icon swap (#223)

### DIFF
--- a/SnoozePay/SnoozePay/Models/Transaction.swift
+++ b/SnoozePay/SnoozePay/Models/Transaction.swift
@@ -38,7 +38,7 @@ struct Transaction: Identifiable, Codable {
 
     var formattedAmount: String {
         let prefix = type == .charge ? "-" : "+"
-        return "\(prefix)\(Int(amount)) ₽"
+        return "\(prefix)\(MoneyFormatter.string(amount))"
     }
 
     // MARK: - Typed views (phase 1 of #31)

--- a/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
@@ -396,7 +396,7 @@ final class AlarmScheduler: AlarmScheduling {
         content.body = "Время вставать!"
 
         let penalty = alarm.penalty(forSnoozeCount: snoozeCount + 1)
-        content.subtitle = "+\(alarm.snoozeMinutes) минут · −\(Int(penalty)) ₽"
+        content.subtitle = "+\(alarm.snoozeMinutes) минут · −\(MoneyFormatter.string(penalty))"
 
         // Use critical sound if entitled, otherwise fall back to standard sound.
         // Critical alerts bypass DND and silent mode (requires Apple approval).

--- a/SnoozePay/SnoozePay/Utilities/MoneyFormatter.swift
+++ b/SnoozePay/SnoozePay/Utilities/MoneyFormatter.swift
@@ -1,0 +1,107 @@
+import UIKit
+
+/// Single source of truth for rendering rouble amounts — the Swift port of
+/// the design system's `fmtRub` helper (`docs/design/v2-handoff/components/
+/// SPComponents.jsx` L12-24).
+///
+/// The fmtRub rule (design v3, 2026-06-05 handoff):
+/// - Digits are grouped with the ru-RU thousands separator ("1 234").
+/// - The gap before `₽` is a **narrow** space (~4pt), not a full mono cell.
+///   JetBrains Mono renders every glyph — including U+0020 — at a full
+///   ~0.6em advance, which made "50 ₽" read as "50  ₽". The JSX fixes it by
+///   wrapping the space in a proportional-font span; the UIKit equivalents:
+///   - `string(_:)` uses U+202F NARROW NO-BREAK SPACE for plain-text labels
+///     (proportional fonts render it at roughly half a normal space).
+///   - `attributed(_:digitsFont:)` additionally re-fonts the separator run
+///     with the proportional sans so mono-font money labels get the same
+///     ~4pt gap the design calls for.
+/// - `₽` keeps the digits' size and baseline — no superscript, no shrink.
+enum MoneyFormatter {
+
+    /// U+202F NARROW NO-BREAK SPACE — the gap between the digits and `₽`.
+    /// Exposed so tests (and ad-hoc composers like "−50 ₽ → −100 ₽" tickers)
+    /// can reference the canonical separator instead of copy-pasting the
+    /// invisible character.
+    static let narrowSpace = "\u{202F}"
+
+    // MARK: - Digits
+
+    /// Grouped integer digits without the currency glyph, e.g. `1 234`
+    /// (ru-RU NBSP thousands separator). Truncates the fraction — the app
+    /// transacts whole roubles only.
+    static func digits(_ amount: Decimal) -> String {
+        let number = NSDecimalNumber(decimal: amount)
+        return Self.groupingFormatter.string(from: number) ?? "\(number.intValue)"
+    }
+
+    static func digits(_ amount: Int) -> String {
+        digits(Decimal(amount))
+    }
+
+    // MARK: - Plain string
+
+    /// `"1 234 ₽"` — grouped digits + narrow no-break space + rouble glyph.
+    /// Use for proportional-font labels, accessibility strings and
+    /// notification copy. Mono-font labels should prefer `attributed(_:)`
+    /// so the separator run drops out of the mono advance grid.
+    static func string(_ amount: Decimal) -> String {
+        "\(digits(amount))\(narrowSpace)₽"
+    }
+
+    static func string(_ amount: Int) -> String {
+        string(Decimal(amount))
+    }
+
+    static func string(_ amount: Double) -> String {
+        string(Decimal(amount))
+    }
+
+    // MARK: - Attributed (mono digits + proportional gap)
+
+    /// fmtRub for mono-font money labels: digits and `₽` render in
+    /// `digitsFont` (JetBrains Mono / monospaced system), while the
+    /// separator space is re-fonted with the proportional sans at the same
+    /// point size — that collapses the gap from a full mono cell (~0.6em)
+    /// to the ~4pt the design specifies.
+    ///
+    /// - Parameters:
+    ///   - amount: Whole-rouble amount (fraction truncated).
+    ///   - digitsFont: The label's mono font — kept for digits and `₽`.
+    ///   - prefix: Optional sign/sigil rendered before the digits in the
+    ///     digits font ("+", "−", "Баланс " …).
+    ///   - color: Optional foreground colour applied to the whole run.
+    static func attributed(
+        _ amount: Decimal,
+        digitsFont: UIFont,
+        prefix: String = "",
+        color: UIColor? = nil
+    ) -> NSAttributedString {
+        var digitAttributes: [NSAttributedString.Key: Any] = [.font: digitsFont]
+        var spaceAttributes: [NSAttributedString.Key: Any] = [
+            .font: AppFonts.sans(.regular, digitsFont.pointSize)
+        ]
+        if let color = color {
+            digitAttributes[.foregroundColor] = color
+            spaceAttributes[.foregroundColor] = color
+        }
+        let result = NSMutableAttributedString()
+        result.append(NSAttributedString(string: prefix + digits(amount), attributes: digitAttributes))
+        result.append(NSAttributedString(string: narrowSpace, attributes: spaceAttributes))
+        result.append(NSAttributedString(string: "₽", attributes: digitAttributes))
+        return result
+    }
+
+    // MARK: - Private
+
+    /// Shared grouping formatter — `NumberFormatter` construction costs
+    /// ~0.5ms; money strings rebuild on every balance tick so cache it.
+    /// `NumberFormatter.string(from:)` is documented thread-safe for reads.
+    private static let groupingFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.locale = Locale(identifier: "ru_RU")
+        formatter.maximumFractionDigits = 0
+        formatter.roundingMode = .down
+        return formatter
+    }()
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmCell.swift
@@ -8,7 +8,7 @@ import UIKit
 ///  ┌──────────────────────────────────────────────────────────┐
 ///  │ БУДНИ · ПН–ПТ                              [ ●   ]      │
 ///  │                                                          │
-///  │ 7:00                                                     │
+///  │ 07:00                                                    │
 ///  │                                                          │
 ///  │ ┌──────┐  ┌──────┐  ┌─────────────┐                    │
 ///  │ │ 50 ₽ │  │  ×2  │  │  Soft Dawn  │                    │
@@ -229,12 +229,23 @@ final class AlarmCell: UITableViewCell {
             view.removeFromSuperview()
         }
         // Price pill — warn-tone when enabled, neutral when disabled so a
-        // dimmed row doesn't shout "50 ₽" at the user.
-        let pricePill = SPPill(text: price, tone: enabled ? .warn : .neutral)
+        // dimmed row doesn't shout "50 ₽" at the user. Design v3 leads with
+        // the ₽-coin icon (`IconRubleCoin`, SPScreensV2.jsx L415).
+        let pricePill = SPPill(
+            text: price,
+            tone: enabled ? .warn : .neutral,
+            icon: SPIcons.rubleCoin(size: 12)
+        )
         pillsStack.addArrangedSubview(pricePill)
 
         if let multiplier = multiplier {
-            let mult = SPPill(text: multiplier, tone: enabled ? .pain : .neutral)
+            // Progressive multiplier — trend-up polyline replaced the flame
+            // glyph in design v3 (`IconTrendUp`, SPScreensV2.jsx L416).
+            let mult = SPPill(
+                text: multiplier,
+                tone: enabled ? .pain : .neutral,
+                icon: SPIcons.trendUp(size: 12)
+            )
             pillsStack.addArrangedSubview(mult)
         }
         if let soundName = soundName, !soundName.isEmpty {

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Layout.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Layout.swift
@@ -106,7 +106,11 @@ extension AlarmFiringViewController {
         // `updateBalancePill()` when the tone needs to flip to pain (zero).
         let balance = Int(viewModel.balance.rounded())
         let initialTone: SPPill.Tone = balance == 0 ? .pain : .money
-        let pill = SPPill(text: "Баланс \(balance) ₽", tone: initialTone)
+        let pill = SPPill(
+            text: "Баланс \(MoneyFormatter.string(balance))",
+            tone: initialTone,
+            icon: SPIcons.coin(size: 12)
+        )
         pill.translatesAutoresizingMaskIntoConstraints = false
         balancePill = pill
 

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+NoBalance.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+NoBalance.swift
@@ -139,7 +139,7 @@ extension AlarmFiringViewController {
             variant: .money,
             size: .lg,
             icon: UIImage(systemName: "applelogo"),
-            suffix: "\(Self.noBalanceDisplayAmount) ₽",
+            suffix: MoneyFormatter.string(Self.noBalanceDisplayAmount),
             fullWidth: true
         )
         button.translatesAutoresizingMaskIntoConstraints = false

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Progressive.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Progressive.swift
@@ -92,7 +92,7 @@ extension AlarmFiringViewController {
         // Trailing currency glyph after the last amount only — keeps the
         // arrow chain visually balanced ("−50 → −100 → −200 ₽").
         if let last = parts.last {
-            parts[parts.count - 1] = "\(last) ₽"
+            parts[parts.count - 1] = "\(last)\(MoneyFormatter.narrowSpace)₽"
         }
         ticker.text = "сегодня: \(parts.joined(separator: " → "))"
         ticker.isHidden = false

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
@@ -399,7 +399,7 @@ class AlarmFiringViewController: UIViewController {
         // so caps / custom schedules pick up the right "next" value.
         let next = viewModel.alarm.penalty(forSnoozeCount: viewModel.snoozeCount + 2)
         let nextInt = Int(next.rounded())
-        return "Следующее откладывание: \(nextInt) ₽"
+        return "Следующее откладывание: \(MoneyFormatter.string(nextInt))"
     }
 
     /// Refresh the top-right balance pill so the displayed amount + tone
@@ -409,12 +409,12 @@ class AlarmFiringViewController: UIViewController {
         let balance = Int(viewModel.balance.rounded())
         let tone: SPPill.Tone = balance == 0 ? .pain : .money
         guard let pill = balancePill else { return }
-        pill.setText("Баланс \(balance) ₽")
+        pill.setText("Баланс \(MoneyFormatter.string(balance))")
         // SPPill's `tone` is `let` (constructor-only), so we re-build when
         // the tone needs to flip between money and pain. Cheap — pill is a
         // 26pt-tall capsule with two labels.
         if pill.tone != tone {
-            rebuildBalancePill(tone: tone, text: "Баланс \(balance) ₽")
+            rebuildBalancePill(tone: tone, text: "Баланс \(MoneyFormatter.string(balance))")
         }
     }
 
@@ -423,7 +423,7 @@ class AlarmFiringViewController: UIViewController {
     /// boundary and the chip needs to flip from money → pain or back.
     private func rebuildBalancePill(tone: SPPill.Tone, text: String) {
         guard let old = balancePill else { return }
-        let new = SPPill(text: text, tone: tone)
+        let new = SPPill(text: text, tone: tone, icon: SPIcons.coin(size: 12))
         new.translatesAutoresizingMaskIntoConstraints = false
         if let index = topHeaderRow.arrangedSubviews.firstIndex(of: old) {
             topHeaderRow.removeArrangedSubview(old)

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmThemePickerViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmThemePickerViewController.swift
@@ -62,7 +62,7 @@ final class AlarmThemePickerViewController: UIViewController {
     private let previewClockLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "7:00"
+        label.text = "07:00"
         label.font = AppFonts.mono(.ultralight, 56)
         label.textColor = .white
         label.textAlignment = .center

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/PenaltyCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/PenaltyCell.swift
@@ -112,7 +112,9 @@ final class PenaltyCell: UITableViewCell {
 
     func configure(amount: Double) {
         currentAmount = amount
-        valueLabel.text = "\(Int(amount)) ₽"
+        valueLabel.attributedText = MoneyFormatter.attributed(
+            Decimal(amount), digitsFont: AppTypography.moneyMd
+        )
         refreshAppearance()
     }
 

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/ProgressivePreviewCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/ProgressivePreviewCell.swift
@@ -107,14 +107,22 @@ final class ProgressivePreviewCell: UITableViewCell {
             let isLast = index == amounts.count - 1
             let weight = stopWeights[colorIndex]
             let size = stopSizes[colorIndex]
-            let text = isLast ? "\(amount) ₽" : "\(amount)"
-            composed.append(NSAttributedString(
-                string: text,
-                attributes: [
-                    .font: AppFonts.mono(weight, size),
-                    .foregroundColor: stopColors[colorIndex]
-                ]
-            ))
+            if isLast {
+                // fmtRub: digits + ~4pt proportional gap + ₽ at the same size.
+                composed.append(MoneyFormatter.attributed(
+                    Decimal(amount),
+                    digitsFont: AppFonts.mono(weight, size),
+                    color: stopColors[colorIndex]
+                ))
+            } else {
+                composed.append(NSAttributedString(
+                    string: "\(amount)",
+                    attributes: [
+                        .font: AppFonts.mono(weight, size),
+                        .foregroundColor: stopColors[colorIndex]
+                    ]
+                ))
+            }
             if !isLast {
                 composed.append(arrow)
             }

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/ConfirmDeleteAlarmViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/ConfirmDeleteAlarmViewController.swift
@@ -97,7 +97,7 @@ final class ConfirmDeleteAlarmViewController: UIViewController {
 
     /// - Parameters:
     ///   - body: Subtitle copy. Defaults to the V2 spec text. Pass a tailored
-    ///     line (e.g. "Будни · Пн–Пт · 7:00") when the alarm context is rich.
+    ///     line (e.g. "Будни · Пн–Пт · 07:00") when the alarm context is rich.
     ///   - onConfirm: Closure invoked on the destructive tap. The sheet
     ///     dismisses itself before firing the callback.
     init(

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/FiringTopUpBottomSheetViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/FiringTopUpBottomSheetViewController.swift
@@ -123,7 +123,8 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
         label.font = AppTypography.body
         label.textColor = AppColors.fg2
         label.numberOfLines = 0
-        label.text = "Минимум — 200 ₽ на следующее откладывание. Можно больше, чтобы не возвращаться сюда."
+        label.text = "Минимум — \(MoneyFormatter.string(200)) на следующее откладывание. "
+            + "Можно больше, чтобы не возвращаться сюда."
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
@@ -420,7 +421,7 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
             variant: .money,
             size: .lg,
             icon: UIImage(systemName: "applelogo"),
-            suffix: "\(amount) ₽",
+            suffix: MoneyFormatter.string(amount),
             fullWidth: true
         )
         button.addTarget(self, action: #selector(applePayTapped), for: .touchUpInside)
@@ -532,7 +533,9 @@ extension FiringTopUpBottomSheetViewController {
         successAmount = amount
         purchaseInFlight = false
 
-        successAmountLabel.text = "+\(amount) ₽"
+        successAmountLabel.attributedText = MoneyFormatter.attributed(
+            Decimal(amount), digitsFont: AppTypography.moneyXl, prefix: "+"
+        )
         successContainer.isHidden = false
         UIView.animate(withDuration: SPSupport.durationBase) {
             self.titleCapsLabel.alpha = 0

--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingComponents.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingComponents.swift
@@ -66,7 +66,7 @@ final class OnboardingPenaltyPill: UIView {
 
     private func configureLabel() {
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "−50 ₽"
+        label.text = "−\(MoneyFormatter.string(50))"
         label.font = AppTypography.buttonSm
         label.textColor = AppColors.fgOnWarn
         addSubview(label)
@@ -271,7 +271,9 @@ final class OnboardingDepositOptionView: UIControl {
         descriptionLabel.numberOfLines = 0
 
         amountLabel.translatesAutoresizingMaskIntoConstraints = false
-        amountLabel.text = option.amount.formattedRubles()
+        amountLabel.attributedText = MoneyFormatter.attributed(
+            option.amount, digitsFont: AppTypography.moneyMd
+        )
         amountLabel.font = AppTypography.moneyMd
         amountLabel.textColor = AppColors.fg1
         amountLabel.setContentHuggingPriority(.required, for: .horizontal)

--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController+Pages.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController+Pages.swift
@@ -90,7 +90,7 @@ extension OnboardingViewController {
 
     private func makePage1Clock() -> UILabel {
         let label = UILabel()
-        label.text = "7:00"
+        label.text = "07:00"
         label.font = AppTypography.clockXl
         label.textColor = .white
         label.textAlignment = .center
@@ -160,8 +160,8 @@ extension OnboardingViewController {
         titleLabel.numberOfLines = 0
 
         let rows = [
-            ("1", "Положили 500 ₽", "Это запас, из которого спишутся штрафы."),
-            ("2", "Поспать ещё в 7:00 → −50 ₽", "Каждый раз когда вы тянете, деньги уходят."),
+            ("1", "Положили \(MoneyFormatter.string(500))", "Это запас, из которого спишутся штрафы."),
+            ("2", "Поспать ещё в 07:00 → −\(MoneyFormatter.string(50))", "Каждый раз когда вы тянете, деньги уходят."),
             ("3", "Встали с первого раза → ничего", "Баланс продолжает лежать. Готов к завтрашнему утру.")
         ].map { OnboardingStepRow(number: $0.0, title: $0.1, body: $0.2) }
 

--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController.swift
@@ -4,7 +4,7 @@ import UIKit
 /// (`docs/design/v2-handoff/components/SPMore.jsx` lines 9-149).
 ///
 /// Three full-screen pages on a horizontally-paged `UIScrollView`:
-/// 1. Concept — giant clock "7:00" with a warn "−50 ₽" pill and a hero h1.
+/// 1. Concept — giant clock "07:00" with a warn "−50 ₽" pill and a hero h1.
 /// 2. Mechanics — three numbered steps explaining the snooze-tax loop.
 /// 3. Deposit — caps eyebrow, h1, three option cards (200 / 500 / 1000 ₽)
 ///    with a money-tinted selection, plus a "Положить {value} ₽" CTA and a
@@ -48,7 +48,7 @@ final class OnboardingViewController: UIViewController {
         DepositOption(
             amount: 200,
             title: "Попробовать",
-            description: "≈ 4 откладывания по 50 ₽",
+            description: "≈ 4 откладывания по \(MoneyFormatter.string(50))",
             isPopular: false
         ),
         DepositOption(

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController+Referral.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController+Referral.swift
@@ -153,7 +153,7 @@ extension SettingsViewController {
         cell.selectionStyle = .none
 
         let label = UILabel()
-        label.text = "За каждого друга — +200 ₽ на ваш баланс"
+        label.text = "За каждого друга — +\(MoneyFormatter.string(200)) на ваш баланс"
         label.font = AppTypography.meta
         label.textColor = AppColors.fg3
         label.numberOfLines = 0
@@ -201,7 +201,7 @@ extension SettingsViewController {
         do {
             let credited = try referralService.applyFriendCode(raw)
             input.error = nil
-            input.hint = "Бонус +\(Int(credited)) ₽ зачислен"
+            input.hint = "Бонус +\(MoneyFormatter.string(credited)) зачислен"
             input.textField.isEnabled = false
             input.textField.resignFirstResponder()
             // Friend-input cell needs a re-layout to flip the apply button

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController+Sections.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController+Sections.swift
@@ -28,7 +28,10 @@ extension SettingsViewController {
         )
 
         let balanceAmount = UILabel()
-        balanceAmount.text = "₽\(Int(BalanceService.shared.balance))"
+        balanceAmount.attributedText = MoneyFormatter.attributed(
+            Decimal(BalanceService.shared.balance),
+            digitsFont: AppTypography.moneyMd
+        )
         balanceAmount.font = AppTypography.moneyMd
         balanceAmount.textColor = AppColors.money500
         balanceAmount.translatesAutoresizingMaskIntoConstraints = false

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController+TransactionCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController+TransactionCell.swift
@@ -272,13 +272,14 @@ final class TransactionCell: UITableViewCell {
             subtitleLabel.text = dateString
         }
 
-        // Amount
-        let amount = Int(transaction.amount)
+        // Amount — fmtRub trailing style with an explicit sign; abs() so a
+        // ledger that encodes debits as negative doubles can't render "−-250".
+        let amount = Int(abs(transaction.amount))
         if isCredit {
-            amountLabel.text = "+₽\(amount)"
+            amountLabel.text = "+\(MoneyFormatter.string(amount))"
             amountLabel.textColor = AppColors.money500
         } else {
-            amountLabel.text = "₽\(amount)"
+            amountLabel.text = "−\(MoneyFormatter.string(amount))"
             amountLabel.textColor = AppColors.pain500
         }
     }

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController.swift
@@ -102,7 +102,7 @@ class SettingsViewController: UIViewController {
         ) { [weak self] note in
             guard let self,
                   let newBalance = note.userInfo?[BalanceService.balanceUserInfoKey] as? Double else { return }
-            self.balanceAmountLabel?.text = "₽\(Int(newBalance))"
+            self.balanceAmountLabel?.text = MoneyFormatter.string(newBalance)
         }
     }
 

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/TopUpViewController+State.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/TopUpViewController+State.swift
@@ -103,7 +103,7 @@ extension TopUpViewController {
         successAmount = amount
         purchaseInFlight = false
 
-        successAmountLabel.text = "+\(amount) ₽"
+        successAmountLabel.text = "+\(MoneyFormatter.string(amount))"
         successContainer.isHidden = false
 
         UIView.animate(withDuration: SPSupport.durationBase) {

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/TopUpViewControllerFactory.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/TopUpViewControllerFactory.swift
@@ -66,7 +66,7 @@ enum TopUpViewControllerFactory {
 
     static func applePayButton(amount: Int) -> SPButton {
         let button = SPButton(
-            title: "Пополнить \(amount) ₽",
+            title: "Пополнить \(MoneyFormatter.string(amount))",
             variant: .money,
             size: .lg,
             icon: UIImage(systemName: "applelogo"),

--- a/SnoozePay/SnoozePay/ViewControllers/Statistics/AlarmOffWarningViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Statistics/AlarmOffWarningViewController.swift
@@ -183,7 +183,6 @@ final class AlarmOffWarningViewController: UIViewController {
         body.numberOfLines = 0
         // Inline pain-tinted mono amount via NSAttributedString.
         let prefix = "За эту неделю списано "
-        let amount = "−750 ₽"
         let suffix = ". Возможно, что-то пошло не так. Что хотите сделать?"
         let attr = NSMutableAttributedString(
             string: prefix,
@@ -192,12 +191,11 @@ final class AlarmOffWarningViewController: UIViewController {
                 .foregroundColor: AppColors.fg2
             ]
         )
-        attr.append(NSAttributedString(
-            string: amount,
-            attributes: [
-                .font: AppFonts.mono(.bold, 17),
-                .foregroundColor: AppColors.pain400
-            ]
+        attr.append(MoneyFormatter.attributed(
+            Decimal(750),
+            digitsFont: AppFonts.mono(.bold, 17),
+            prefix: "−",
+            color: AppColors.pain400
         ))
         attr.append(NSAttributedString(
             string: suffix,
@@ -226,14 +224,14 @@ final class AlarmOffWarningViewController: UIViewController {
                 iconTint: AppColors.fg2,
                 iconBackground: AppColors.whiteOverlay06,
                 title: "Перенести будильник",
-                subtitle: "Сегодня поздно лёг — встаём в 8:00"
+                subtitle: "Сегодня поздно лёг — встаём в 08:00"
             ),
             makeSuggestionRow(
                 icon: "creditcard.fill",
                 iconTint: AppColors.warn400,
                 iconBackground: AppColors.warn500.withAlphaComponent(0.14),
                 title: "Снизить цену откладывания",
-                subtitle: "Сейчас 50 ₽ → попробовать 20 ₽"
+                subtitle: "Сейчас \(MoneyFormatter.string(50)) → попробовать \(MoneyFormatter.string(20))"
             ),
             makeSuggestionRow(
                 icon: "xmark",

--- a/SnoozePay/SnoozePay/ViewControllers/Statistics/ReferralViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Statistics/ReferralViewController.swift
@@ -129,7 +129,7 @@ final class ReferralViewController: UIViewController {
         headline.font = AppTypography.h1
         headline.textColor = .white
         headline.numberOfLines = 0
-        headline.text = "+200 ₽ вам\n+200 ₽ другу"
+        headline.text = "+\(MoneyFormatter.string(200)) вам\n+\(MoneyFormatter.string(200)) другу"
         headline.translatesAutoresizingMaskIntoConstraints = false
 
         let body = UILabel()
@@ -269,7 +269,7 @@ final class ReferralViewController: UIViewController {
                 badgeTextColor: AppColors.fgOnMoney,
                 title: "Маша К.",
                 subtitle: "Продержалась 7 дней",
-                trailing: makeAmountLabel(text: "+200 ₽", color: AppColors.money400),
+                trailing: makeAmountLabel(text: "+\(MoneyFormatter.string(200))", color: AppColors.money400),
                 divider: true
             )
         )
@@ -461,7 +461,7 @@ final class ReferralViewController: UIViewController {
 
     @objc private func shareTapped() {
         let text = "Снузь меньше — копи больше. Используй мой код в SnoozePay: "
-            + "\(Self.personalCode) — оба получим +200 ₽ на баланс."
+            + "\(Self.personalCode) — оба получим +\(MoneyFormatter.string(200)) на баланс."
         let activity = UIActivityViewController(activityItems: [text], applicationActivities: nil)
         activity.popoverPresentationController?.sourceView = view
         activity.popoverPresentationController?.sourceRect = view.bounds

--- a/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsViewController.swift
@@ -283,10 +283,10 @@ final class StatisticsViewController: UIViewController {
         let spent = viewModel.totalSpent
         let saved = Double(max(viewModel.streak, 0)) * 50.0   // 50 ₽/day fallback
         let net = saved - spent
-        savedAmountLabel.text = saved > 0 ? "+\(Int(saved)) ₽" : "+0 ₽"
-        spentAmountLabel.text = spent > 0 ? "−\(Int(spent)) ₽" : "0 ₽"
+        savedAmountLabel.text = "+\(MoneyFormatter.string(max(saved, 0)))"
+        spentAmountLabel.text = spent > 0 ? "−\(MoneyFormatter.string(spent))" : MoneyFormatter.string(0)
         let netPrefix = net >= 0 ? "+" : "−"
-        netAmountLabel.text = "\(netPrefix)\(Int(abs(net))) ₽"
+        netAmountLabel.text = "\(netPrefix)\(MoneyFormatter.string(abs(net)))"
 
         // Empty state — VM handles the empty-period detection.
         setEmptyStateVisible(!viewModel.hasData)
@@ -364,7 +364,7 @@ final class StatisticsViewController: UIViewController {
         let dateText = formatter.string(from: cell.date)
         let amountText: String
         if cell.amount > 0 {
-            amountText = "−\(Int(cell.amount)) ₽"
+            amountText = "−\(MoneyFormatter.string(cell.amount))"
         } else {
             amountText = "без штрафов"
         }

--- a/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletTransactionHistoryViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletTransactionHistoryViewController.swift
@@ -236,10 +236,14 @@ final class WalletTransactionHistoryViewController: UIViewController {
         let absAmount = Int(abs(transaction.amount))
         switch transaction.type {
         case .topup, .promotion:
-            label.text = "+\(absAmount) ₽"
+            label.attributedText = MoneyFormatter.attributed(
+                Decimal(absAmount), digitsFont: AppTypography.moneySm, prefix: "+"
+            )
             label.textColor = AppColors.money400
         case .charge:
-            label.text = "−\(absAmount) ₽"
+            label.attributedText = MoneyFormatter.attributed(
+                Decimal(absAmount), digitsFont: AppTypography.moneySm, prefix: "−"
+            )
             label.textColor = AppColors.pain400
         }
         return label

--- a/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
@@ -99,7 +99,7 @@ final class AlarmFiringViewModel {
 
     var snoozeButtonTitle: String {
         if canSnooze {
-            return "+\(alarm.snoozeMinutes) минут · −\(Int(currentPenalty)) ₽"
+            return "+\(alarm.snoozeMinutes) минут · −\(MoneyFormatter.string(currentPenalty))"
         } else {
             return "Баланс пуст"
         }

--- a/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
@@ -207,7 +207,7 @@ final class AlarmsListViewModel {
     // MARK: - Formatted balance
 
     var formattedBalance: String {
-        "\(Int(balance)) ₽"
+        MoneyFormatter.string(balance)
     }
 
     // MARK: - Affordability hint
@@ -346,7 +346,7 @@ final class AlarmsListViewModel {
     /// Penalty line for alarm card (e.g. "▲ ПОСПАТЬ ЕЩЁ: −50 ₽")
     func alarmPenaltyString(at index: Int) -> String {
         guard index < alarms.count else { return "" }
-        return "▲ ПОСПАТЬ ЕЩЁ: −\(Int(alarms[index].penaltyAmount)) ₽"
+        return "▲ ПОСПАТЬ ЕЩЁ: −\(MoneyFormatter.string(alarms[index].penaltyAmount))"
     }
 
     // MARK: - V2 cell helpers

--- a/SnoozePay/SnoozePay/ViewModels/CreateAlarmViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/CreateAlarmViewModel.swift
@@ -153,7 +153,9 @@ final class CreateAlarmViewModel {
     var progressiveScalePreview: String {
         let base = Int(penaltyAmount)
         let values = (0..<4).map { base * Int(pow(2.0, Double($0))) }
-        return values.enumerated().map { "\($0.offset + 1)-е: \($0.element)₽" }.joined(separator: " → ")
+        return values.enumerated()
+            .map { "\($0.offset + 1)-е: \(MoneyFormatter.string($0.element))" }
+            .joined(separator: " → ")
     }
 
     // MARK: - Available sounds (10 sounds matching Figma design)

--- a/SnoozePay/SnoozePay/ViewModels/StatisticsViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/StatisticsViewModel.swift
@@ -107,8 +107,9 @@ final class StatisticsViewModel {
     var totalSpent: Double { charges.reduce(0) { $0 + $1.amount } }
     var snoozeCount: Int { charges.count }
 
+    /// fmtRub suffix style ("250 ₽") — design v3 retired the ₽-prefix format.
     var totalSpentFormatted: String {
-        totalSpent > 0 ? "₽\(Int(totalSpent))" : "₽0"
+        MoneyFormatter.string(max(totalSpent, 0))
     }
     var snoozeCountFormatted: String { "\(snoozeCount)" }
 
@@ -179,7 +180,7 @@ final class StatisticsViewModel {
         guard totalSpent > 0 else { return "Отлично! Вы не откладывали будильник." }
         let coffees = Int(totalSpent / 150)
         if coffees > 0 {
-            return "\(Int(totalSpent))₽ на лень = \(coffees) кофе! ☕"
+            return "\(MoneyFormatter.string(totalSpent)) на лень = \(coffees) кофе! ☕"
         }
         return "Продолжайте в том же духе!"
     }

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPAlarmsListHeader.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPAlarmsListHeader.swift
@@ -53,7 +53,9 @@ final class SPAlarmsListHeader: UIView {
         currentBalance = balance
         let isLow = (NSDecimalNumber(decimal: balance).doubleValue) <= Self.lowBalanceThreshold
         applyTone(isLow: isLow)
-        balanceValueLabel.text = balance.formattedRubles()
+        balanceValueLabel.attributedText = MoneyFormatter.attributed(
+            balance, digitsFont: AppTypography.moneyMd
+        )
         if let hint = hint, !hint.isEmpty {
             balanceHintLabel.text = hint
             balanceHintLabel.isHidden = false

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPAmountPreset.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPAmountPreset.swift
@@ -108,7 +108,9 @@ final class SPAmountPreset: UIControl {
     func update(value: Decimal, label: String?) {
         self.value = value
         self.label = label
-        valueLabel.text = value.formattedRubles()
+        valueLabel.attributedText = MoneyFormatter.attributed(
+            value, digitsFont: AppTypography.moneyMd
+        )
         if let label = label {
             labelView.text = label
             labelView.isHidden = false
@@ -162,10 +164,11 @@ final class SPAmountPreset: UIControl {
 
         NSLayoutConstraint.activate([
             heightAnchor.constraint(greaterThanOrEqualToConstant: 88),
-            stack.topAnchor.constraint(equalTo: topAnchor, constant: 18),
-            stack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -18),
-            stack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
-            stack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
+            // `.sp-preset` padding 16px 16px (design v3; was 18px 12px).
+            stack.topAnchor.constraint(equalTo: topAnchor, constant: 16),
+            stack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -16),
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
 
             popularBadge.centerXAnchor.constraint(equalTo: centerXAnchor),
             popularBadge.centerYAnchor.constraint(equalTo: topAnchor),

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPBalanceCard.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPBalanceCard.swift
@@ -2,7 +2,7 @@ import UIKit
 
 /// Hero balance card — `.sp-balance` in `components.css`.
 ///
-/// Visual: 28pt vertical / 24pt horizontal padding, `bg2` fill with a soft
+/// Visual: 28pt vertical / 20pt horizontal padding, `bg2` fill with a soft
 /// money-tinted radial highlight in the top-right corner. Caps "Баланс"
 /// header sits on top of the big mono number; optional weekly delta
 /// (`↑/↓ amount за неделю`) and hint line stack underneath.
@@ -94,7 +94,13 @@ final class SPBalanceCard: UIView {
         self.balance = balance
         self.delta = delta
         self.hint = hint
-        valueLabel.text = balance.formattedRubles()
+        // fmtRub rule: mono digits, proportional ~4pt gap before ₽ — the
+        // attributed variant re-fonts the separator so it escapes the mono
+        // advance grid (a plain string would render a full-cell space).
+        valueLabel.attributedText = MoneyFormatter.attributed(
+            balance,
+            digitsFont: AppTypography.moneyXl
+        )
         if let delta = delta {
             deltaLabel.isHidden = false
             deltaLabel.attributedText = renderDelta(delta)
@@ -162,10 +168,11 @@ final class SPBalanceCard: UIView {
         addSubview(stack)
 
         NSLayoutConstraint.activate([
+            // `.sp-balance` padding 28px 20px (design v3 tightened 24 → 20).
             stack.topAnchor.constraint(equalTo: topAnchor, constant: 28),
             stack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -28),
-            stack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24),
-            stack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -24)
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20)
         ])
 
         // Add the gradient layer above the label so the mask can clip it.
@@ -193,13 +200,18 @@ final class SPBalanceCard: UIView {
         let renderer = UIGraphicsImageRenderer(size: textBounds.size)
         let mask = renderer.image { ctx in
             ctx.cgContext.setFillColor(UIColor.white.cgColor)
-            (valueLabel.text ?? "").draw(
-                in: textBounds,
-                withAttributes: [
-                    .font: valueLabel.font as Any,
-                    .foregroundColor: UIColor.white
-                ]
+            // The value is an attributed string (mono digits + proportional
+            // separator per fmtRub) — render it verbatim so the mask matches
+            // the on-screen glyph layout, forcing white ink for full alpha.
+            guard let attributed = valueLabel.attributedText?.mutableCopy() as? NSMutableAttributedString else {
+                return
+            }
+            attributed.addAttribute(
+                .foregroundColor,
+                value: UIColor.white,
+                range: NSRange(location: 0, length: attributed.length)
             )
+            attributed.draw(in: textBounds)
         }
         let maskLayer = CALayer()
         maskLayer.frame = textBounds
@@ -274,14 +286,10 @@ extension Decimal {
     /// separator and a trailing `₽` glyph, e.g. `1 234 ₽`. Truncates the
     /// fractional component — the design system never shows kopecks on the
     /// balance card.
+    /// Delegates to `MoneyFormatter` — the single fmtRub implementation —
+    /// so every legacy `formattedRubles()` call site picks up the design-v3
+    /// narrow space before `₽` without churning each caller.
     func formattedRubles() -> String {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        formatter.locale = Locale(identifier: "ru_RU")
-        formatter.maximumFractionDigits = 0
-        formatter.roundingMode = .down
-        let number = NSDecimalNumber(decimal: self)
-        let text = formatter.string(from: number) ?? "\(number.intValue)"
-        return "\(text) ₽"
+        MoneyFormatter.string(self)
     }
 }

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPButton.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPButton.swift
@@ -43,9 +43,11 @@ final class SPButton: UIControl {
         }
 
         var horizontalPadding: CGFloat {
+            // Design v3 tightened `.sp-btn` paddings: 0 24px → 0 20px,
+            // sm 0 14px → 0 12px (`components.css`).
             switch self {
-            case .lg, .md: return AppSpacing.sp6   // 24pt
-            case .sm:      return 14
+            case .lg, .md: return AppSpacing.sp5   // 20pt
+            case .sm:      return AppSpacing.sp3   // 12pt
             }
         }
 

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPIcons.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPIcons.swift
@@ -1,0 +1,157 @@
+import UIKit
+
+/// Code-drawn design-system icons — the Swift port of the `Ico` SVG set in
+/// `docs/design/v2-handoff/components/SPComponents.jsx` (L345+).
+///
+/// Recipe (matches the JSX wrapper): 24×24 viewBox, 1.75 stroke, round caps
+/// and joins, no fill, `currentColor` ink. Here that maps to a stroked
+/// `UIBezierPath` rendered into a template `UIImage`, so `tintColor` plays
+/// the role of `currentColor` — drop the image into any `UIImageView` /
+/// `SPPill` and tint as usual.
+///
+/// Paths are authored in the 24-unit grid straight from the SVG `d`
+/// attributes and scaled at render time; the stroke width scales with the
+/// icon size exactly like an SVG `strokeWidth` would.
+enum SPIcons {
+
+    /// Монета с ₽ — circle + rouble glyph. The unified icon for money /
+    /// balance / price indicators (replaces the abstract coin).
+    /// JSX: `IconCoin` / `IconRubleCoin` (identical paths).
+    static func coin(size: CGFloat) -> UIImage {
+        render(size: size) { path in
+            path.append(circle(center: CGPoint(x: 12, y: 12), radius: 9))
+            path.append(rubleGlyph())
+        }
+    }
+
+    /// Alias for `coin` — the JSX exports both names; chips reference
+    /// `IconRubleCoin`, balance pills reference `IconCoin`.
+    static func rubleCoin(size: CGFloat) -> UIImage {
+        coin(size: size)
+    }
+
+    /// Та же монета, перечёркнутая диагональным слэшем — «нет денег».
+    /// JSX: `IconCoinOff`.
+    static func coinOff(size: CGFloat) -> UIImage {
+        render(size: size) { path in
+            path.append(circle(center: CGPoint(x: 12, y: 12), radius: 9))
+            path.append(rubleGlyph())
+            path.move(to: CGPoint(x: 4.5, y: 4.5))
+            path.addLine(to: CGPoint(x: 19.5, y: 19.5))
+        }
+    }
+
+    /// Тренд вверх — растущая ломаная со стрелкой. Reads as
+    /// «увеличение/множитель» (progressive penalty). JSX: `IconTrendUp`.
+    static func trendUp(size: CGFloat) -> UIImage {
+        render(size: size) { path in
+            path.move(to: CGPoint(x: 3, y: 17))
+            path.addLine(to: CGPoint(x: 9, y: 11))
+            path.addLine(to: CGPoint(x: 13, y: 15))
+            path.addLine(to: CGPoint(x: 21, y: 7))
+            path.move(to: CGPoint(x: 15, y: 7))
+            path.addLine(to: CGPoint(x: 21, y: 7))
+            path.addLine(to: CGPoint(x: 21, y: 13))
+        }
+    }
+
+    /// Купюра с ₽ — rounded rect + rouble glyph. JSX: `IconBanknote`.
+    static func banknote(size: CGFloat) -> UIImage {
+        render(size: size) { path in
+            path.append(UIBezierPath(
+                roundedRect: CGRect(x: 3, y: 7, width: 18, height: 10),
+                cornerRadius: 2
+            ))
+            // Compact ₽: stem, half-circle bowl, crossbar.
+            path.move(to: CGPoint(x: 10, y: 10))
+            path.addLine(to: CGPoint(x: 10, y: 16))
+            path.move(to: CGPoint(x: 10, y: 10))
+            path.addLine(to: CGPoint(x: 12.2, y: 10))
+            path.addArc(
+                withCenter: CGPoint(x: 12.2, y: 11.6),
+                radius: 1.6,
+                startAngle: -.pi / 2,
+                endAngle: .pi / 2,
+                clockwise: true
+            )
+            path.addLine(to: CGPoint(x: 10, y: 13.2))
+            path.move(to: CGPoint(x: 8.6, y: 13.6))
+            path.addLine(to: CGPoint(x: 12, y: 13.6))
+        }
+    }
+
+    /// «Zz» — большая Z + маленькая Z по диагонали. JSX: `IconSnooze`.
+    static func snooze(size: CGFloat) -> UIImage {
+        render(size: size) { path in
+            path.move(to: CGPoint(x: 13, y: 5))
+            path.addLine(to: CGPoint(x: 19, y: 5))
+            path.addLine(to: CGPoint(x: 13, y: 13))
+            path.addLine(to: CGPoint(x: 19, y: 13))
+            path.move(to: CGPoint(x: 5, y: 13))
+            path.addLine(to: CGPoint(x: 9, y: 13))
+            path.addLine(to: CGPoint(x: 5, y: 18))
+            path.addLine(to: CGPoint(x: 9, y: 18))
+        }
+    }
+
+    // MARK: - Shared path fragments
+
+    /// The ₽ glyph used by both the coin and coin-off variants:
+    /// stem `M9 8v9`, bowl `M9 8h3.5a2.5 2.5 0 0 1 0 5H9`,
+    /// crossbar `M7.5 14.5H13`.
+    private static func rubleGlyph() -> UIBezierPath {
+        let path = UIBezierPath()
+        path.move(to: CGPoint(x: 9, y: 8))
+        path.addLine(to: CGPoint(x: 9, y: 17))
+        path.move(to: CGPoint(x: 9, y: 8))
+        path.addLine(to: CGPoint(x: 12.5, y: 8))
+        path.addArc(
+            withCenter: CGPoint(x: 12.5, y: 10.5),
+            radius: 2.5,
+            startAngle: -.pi / 2,
+            endAngle: .pi / 2,
+            clockwise: true
+        )
+        path.addLine(to: CGPoint(x: 9, y: 13))
+        path.move(to: CGPoint(x: 7.5, y: 14.5))
+        path.addLine(to: CGPoint(x: 13, y: 14.5))
+        return path
+    }
+
+    private static func circle(center: CGPoint, radius: CGFloat) -> UIBezierPath {
+        UIBezierPath(
+            arcCenter: center,
+            radius: radius,
+            startAngle: 0,
+            endAngle: 2 * .pi,
+            clockwise: true
+        )
+    }
+
+    // MARK: - Renderer
+
+    /// SVG viewBox edge — all paths are authored on this grid.
+    private static let gridSize: CGFloat = 24
+
+    /// SVG `strokeWidth` in viewBox units; scales with the icon size.
+    private static let strokeWidth: CGFloat = 1.75
+
+    private static func render(size: CGFloat, build: (UIBezierPath) -> Void) -> UIImage {
+        let path = UIBezierPath()
+        build(path)
+
+        let scale = size / gridSize
+        path.apply(CGAffineTransform(scaleX: scale, y: scale))
+        path.lineWidth = strokeWidth * scale
+        path.lineCapStyle = .round
+        path.lineJoinStyle = .round
+
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: size, height: size))
+        let image = renderer.image { _ in
+            UIColor.white.setStroke()
+            path.stroke()
+        }
+        // Template mode — tintColor plays the SVG's `currentColor`.
+        return image.withRenderingMode(.alwaysTemplate)
+    }
+}

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPPill.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPPill.swift
@@ -30,8 +30,8 @@ final class SPPill: UIView {
     ///   - text: Caps-styled label (uppercased automatically per the
     ///     `--sp-t-caps` recipe — bold 12pt + 0.14em tracking).
     ///   - tone: Background + text colour mapping. Defaults to `.neutral`.
-    ///   - icon: Optional 14pt leading icon (rendered as template, tinted
-    ///     to match the label).
+    ///   - icon: Optional 12pt leading icon (rendered as template, tinted
+    ///     to match the label) — JSX chips use `<Icon size={12} />`.
     init(text: String, tone: Tone = .neutral, icon: UIImage? = nil) {
         self.tone = tone
         super.init(frame: .zero)
@@ -80,8 +80,8 @@ final class SPPill: UIView {
             stack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
             stack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
             stack.centerYAnchor.constraint(equalTo: centerYAnchor),
-            iconView.widthAnchor.constraint(equalToConstant: 14),
-            iconView.heightAnchor.constraint(equalToConstant: 14)
+            iconView.widthAnchor.constraint(equalToConstant: 12),
+            iconView.heightAnchor.constraint(equalToConstant: 12)
         ])
 
         applyTone()

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPSnoozePrice.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPSnoozePrice.swift
@@ -117,7 +117,9 @@ final class SPSnoozePrice: UIControl {
                 .foregroundColor: foreground.withAlphaComponent(0.82)
             ]
         )
-        priceLabel.text = "−\(price.formattedRubles())"
+        priceLabel.attributedText = MoneyFormatter.attributed(
+            price, digitsFont: AppTypography.moneyLg, prefix: "−"
+        )
         if let hint = hint {
             hintLabel.text = hint
             hintLabel.isHidden = false
@@ -179,8 +181,9 @@ final class SPSnoozePrice: UIControl {
             heightAnchor.constraint(greaterThanOrEqualToConstant: 80),
             stack.topAnchor.constraint(equalTo: topAnchor, constant: 18),
             stack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -22),
-            stack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24),
-            stack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -24)
+            // `.sp-snooze` padding 18px 20px 22px (design v3 tightened 24 → 20).
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20)
         ])
 
         applyTone()

--- a/SnoozePay/SnoozePayTests/AlarmFiringViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmFiringViewModelTests.swift
@@ -246,8 +246,9 @@ final class AlarmFiringViewModelIOS011Tests: XCTestCase {
         let alarm = makeAlarm(penalty: 50)
         let vm = AlarmFiringViewModel(alarm: alarm, snoozeCount: 0)
 
-        // V2 copy: "+{minutes} минут · −{penalty} ₽" (default snooze = 9 min).
-        XCTAssertEqual(vm.snoozeButtonTitle, "+9 минут \u{00B7} −50 ₽")
+        // V2 copy: "+{minutes} минут · −{penalty} ₽" (default snooze = 9 min,
+        // fmtRub narrow no-break space before ₽).
+        XCTAssertEqual(vm.snoozeButtonTitle, "+9 минут \u{00B7} −50\u{202F}₽")
     }
 
     func testSnoozeButtonTitle_whenCannotSnooze_showsEmpty() {

--- a/SnoozePay/SnoozePayTests/AlarmSchedulerSnoozeTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmSchedulerSnoozeTests.swift
@@ -109,7 +109,7 @@ final class AlarmSchedulerSnoozeTests: XCTestCase {
         // After 1 snooze, the next charge would be the 2nd snooze → 50 * 2 = 100
         let content = scheduler.makeContent(for: alarm, snoozeCount: 1)
 
-        XCTAssertEqual(content.subtitle, "Отложить \u{00B7} 100 ₽",
+        XCTAssertEqual(content.subtitle, "+9 минут \u{00B7} −100\u{202F}₽",
                        "Progressive scale must compound the penalty across snooze re-fires")
     }
 }

--- a/SnoozePay/SnoozePayTests/AlarmSchedulerTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmSchedulerTests.swift
@@ -9,12 +9,41 @@ final class AlarmSchedulerTests: XCTestCase {
 
     // MARK: - Notification content
 
-    func testNotificationContent_hasCriticalInterruptionLevel() {
+    /// The interruption level must follow the resolved permission state:
+    /// `.critical` only when the critical-alert grant succeeded, `.timeSensitive`
+    /// otherwise. The old version asserted `.critical` unconditionally, which
+    /// only passed on simulators where a previous run had already granted the
+    /// permission — on a fresh CI simulator the flag is false and the test
+    /// went red. Driving the flag through `requestPermission` with a stub
+    /// center makes both branches deterministic in any environment.
+    func testNotificationContent_interruptionLevelFollowsCriticalGrant() {
         let alarm = Alarm(penaltyAmount: 50)
-        let content = scheduler.makeContent(for: alarm, snoozeCount: 0)
 
-        XCTAssertEqual(content.interruptionLevel, .critical,
-                       "Alarm notifications must use critical interruption level to bypass DND")
+        // Granted critical-alert permission → .critical (bypasses DND).
+        let granting = PermissionStubCenter(grant: true)
+        let grantedScheduler = AlarmScheduler(notificationCenter: granting)
+        let grantedExp = expectation(description: "granted permission resolves")
+        grantedScheduler.requestPermission { _ in grantedExp.fulfill() }
+        wait(for: [grantedExp], timeout: 2.0)
+        XCTAssertEqual(
+            grantedScheduler.makeContent(for: alarm, snoozeCount: 0).interruptionLevel,
+            .critical,
+            "With critical-alert grant the alarm must bypass DND"
+        )
+
+        // Denied → degrade to .timeSensitive, never silently `.active`.
+        // Running this branch LAST also restores the static flag to false so
+        // no state leaks into other tests.
+        let denying = PermissionStubCenter(grant: false)
+        let deniedScheduler = AlarmScheduler(notificationCenter: denying)
+        let deniedExp = expectation(description: "denied permission resolves")
+        deniedScheduler.requestPermission { _ in deniedExp.fulfill() }
+        wait(for: [deniedExp], timeout: 2.0)
+        XCTAssertEqual(
+            deniedScheduler.makeContent(for: alarm, snoozeCount: 0).interruptionLevel,
+            .timeSensitive,
+            "Without the critical grant the alarm must degrade to time-sensitive"
+        )
     }
 
     func testNotificationContent_includesSoundIDInUserInfo() {
@@ -146,20 +175,19 @@ final class AlarmSchedulerTests: XCTestCase {
 
     // MARK: - Permission / scheduling smoke
     //
-    // NOTE: AlarmScheduler depends on UNUserNotificationCenter.current() which is a
-    // process-wide singleton and cannot be DI'd without a refactor (extracting a
-    // protocol seam). Until that refactor lands, we cannot mock notification-center
-    // failures to assert that errors are logged. The smoke test below verifies that
-    // requesting permission does not crash and invokes its completion handler in a
-    // reasonable time — which at minimum guards against regressions in the
-    // permission dispatch flow added in IOS-033.
+    // Uses the `init(notificationCenter:)` seam with a stub center. The old
+    // version called the REAL UNUserNotificationCenter through
+    // `AlarmScheduler.shared` — on CI simulators the permission daemon never
+    // answers, the completion never fires and the test died on its 5s timeout.
 
     func testRequestPermission_invokesCompletionWithoutCrash() {
+        let scheduler = AlarmScheduler(notificationCenter: PermissionStubCenter(grant: false))
         let expectation = expectation(description: "requestPermission completes")
-        AlarmScheduler.shared.requestPermission { _ in
+        scheduler.requestPermission { granted in
+            XCTAssertFalse(granted, "Stub denies — completion must carry the denial through")
             expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 5.0)
+        wait(for: [expectation], timeout: 2.0)
     }
 
     // MARK: - Cancel covers all trigger variants (regression for IOS-070)
@@ -233,4 +261,43 @@ final class AlarmSchedulerTests: XCTestCase {
         XCTAssertTrue(remainingIDs.isEmpty,
                       "cancel(_:) must remove every notification for the alarm — leaked: \(remainingIDs)")
     }
+}
+
+// MARK: - Test double
+
+/// Minimal `NotificationScheduling` stub for the permission-path tests:
+/// answers `requestAuthorization` synchronously with the configured grant
+/// and treats every other member as a no-op. Keeps the permission tests
+/// deterministic on simulators where the real daemon never answers (CI).
+private final class PermissionStubCenter: NotificationScheduling {
+    private let grant: Bool
+    init(grant: Bool) { self.grant = grant }
+
+    func requestAuthorization(
+        options: UNAuthorizationOptions,
+        completionHandler: @escaping (Bool, Error?) -> Void
+    ) {
+        completionHandler(grant, nil)
+    }
+
+    func add(
+        _ request: UNNotificationRequest,
+        withCompletionHandler completion: ((Error?) -> Void)?
+    ) {
+        completion?(nil)
+    }
+    func getPendingNotificationRequests(
+        completionHandler: @escaping ([UNNotificationRequest]) -> Void
+    ) {
+        completionHandler([])
+    }
+    func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {}
+    func removeDeliveredNotifications(withIdentifiers identifiers: [String]) {}
+    func getDeliveredNotifications(
+        completionHandler: @escaping ([UNNotification]) -> Void
+    ) {
+        completionHandler([])
+    }
+    func setNotificationCategories(_ categories: Set<UNNotificationCategory>) {}
+    func removeAllPendingNotificationRequests() {}
 }

--- a/SnoozePay/SnoozePayTests/AlarmSchedulerTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmSchedulerTests.swift
@@ -80,7 +80,7 @@ final class AlarmSchedulerTests: XCTestCase {
         let content = scheduler.makeContent(for: alarm, snoozeCount: 0)
 
         // snoozeCount=0, so penalty(forSnoozeCount: 1) = 50
-        XCTAssertEqual(content.subtitle, "Отложить \u{00B7} 50 ₽")
+        XCTAssertEqual(content.subtitle, "+9 минут \u{00B7} −50\u{202F}₽")
     }
 
     func testNotificationContent_subtitleWithProgressiveScale() {
@@ -88,7 +88,7 @@ final class AlarmSchedulerTests: XCTestCase {
         let content = scheduler.makeContent(for: alarm, snoozeCount: 2)
 
         // snoozeCount=2, penalty(forSnoozeCount: 3) = 50 * 4 = 200
-        XCTAssertEqual(content.subtitle, "Отложить \u{00B7} 200 ₽")
+        XCTAssertEqual(content.subtitle, "+9 минут \u{00B7} −200\u{202F}₽")
     }
 
     func testNotificationContent_titleIsAlarmName() {

--- a/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
@@ -95,7 +95,7 @@ final class AlarmsListViewModelTests: XCTestCase {
         vm.loadData()
 
         let penalty = vm.alarmPenaltyString(at: 0)
-        XCTAssertEqual(penalty, "▲ ОТЛОЖИТЬ: 50 ₽")
+        XCTAssertEqual(penalty, "▲ ПОСПАТЬ ЕЩЁ: −50\u{202F}₽")
     }
 
     func testAlarmPenaltyString_highPenalty() {
@@ -106,7 +106,7 @@ final class AlarmsListViewModelTests: XCTestCase {
         vm.loadData()
 
         let penalty = vm.alarmPenaltyString(at: 0)
-        XCTAssertEqual(penalty, "▲ ОТЛОЖИТЬ: 1000 ₽")
+        XCTAssertEqual(penalty, "▲ ПОСПАТЬ ЕЩЁ: −1\u{00A0}000\u{202F}₽")
     }
 
     // MARK: - Safe index handling

--- a/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
@@ -547,6 +547,10 @@ final class AlarmsListViewModelTests: XCTestCase {
 
         let vm = makeViewModel()
         vm.loadData()
+        // `repo.save(enabled alarm)` above already scheduled once — that is
+        // by design. Snapshot the count so the assertion below catches only
+        // NEW schedule calls made by the toggle itself.
+        let preToggleScheduleCount = stubScheduler.scheduledIDs.count
         // Pre-arm the stub with a failure — disabling MUST NOT consult it.
         stubScheduler.scheduleResult = .failure(.system(message: "should not fire"))
 
@@ -556,7 +560,8 @@ final class AlarmsListViewModelTests: XCTestCase {
         vm.toggleAlarm(id: alarm.id, enabled: false)
 
         XCTAssertNil(receivedError, "Disabling must skip the scheduler — no failure path")
-        XCTAssertTrue(stubScheduler.scheduledIDs.isEmpty, "schedule() must not run for enabled=false")
+        XCTAssertEqual(stubScheduler.scheduledIDs.count, preToggleScheduleCount,
+                       "schedule() must not run for enabled=false")
         XCTAssertFalse(vm.alarms[0].enabled, "In-memory state must reflect disable")
     }
 }

--- a/SnoozePay/SnoozePayTests/BalanceServiceTests.swift
+++ b/SnoozePay/SnoozePayTests/BalanceServiceTests.swift
@@ -233,11 +233,10 @@ final class BalanceServiceTests: XCTestCase {
     /// wallet doesn't behave as if it owes money.
     func testNegativeStoredBalance_flipsCorruptedFlagAndBroadcasts() {
         let center = NotificationCenter()
-        // Inject the corrupt value directly — the public API would never
-        // produce this state, which is the whole point of the detection.
-        testDefaults.set(-42.5, forKey: "user_balance")
-        let service = BalanceService(defaults: testDefaults, notificationCenter: center)
-
+        // Subscribe BEFORE constructing the service: the corruption probe
+        // runs at init time (#119/#206), so a late observer would miss the
+        // one-shot notification — that cold-start gap is exactly what
+        // `corruptedRawValue` exists for, asserted below.
         let exp = expectation(description: "corruption notification fires")
         var receivedRaw: Double?
         let token = center.addObserver(
@@ -250,10 +249,16 @@ final class BalanceServiceTests: XCTestCase {
         }
         defer { center.removeObserver(token) }
 
-        // Reading triggers detection.
+        // Inject the corrupt value directly — the public API would never
+        // produce this state, which is the whole point of the detection.
+        testDefaults.set(-42.5, forKey: "user_balance")
+        let service = BalanceService(defaults: testDefaults, notificationCenter: center)
+
         XCTAssertEqual(service.balance, 0,
                        "Corrupt negative balance must be reported as 0 to downstream math")
         wait(for: [exp], timeout: 1.0)
+        XCTAssertEqual(service.corruptedRawValue, -42.5,
+                       "Latched raw value must stay queryable for late observers (#206)")
 
         XCTAssertTrue(service.balanceCorrupted, "balanceCorrupted flag must latch on detection")
         XCTAssertEqual(receivedRaw, -42.5, "Notification must carry the raw negative value")
@@ -312,6 +317,10 @@ final class BalanceServiceTests: XCTestCase {
         service.acknowledgeCorruption()
 
         wait(for: [changed], timeout: 1.0)
+        // The post-ack `topUp(50)` below ALSO posts balanceChanged — stop
+        // observing first or the expectation gets a second fulfill (API
+        // violation crash). The defer-removal then becomes a harmless no-op.
+        center.removeObserver(token)
         XCTAssertEqual(receivedAmount, 0)
         XCTAssertFalse(service.balanceCorrupted, "Flag must clear after acknowledgement")
         XCTAssertEqual(service.balance, 0, "Balance must be reset to 0")
@@ -447,15 +456,27 @@ final class AlarmFiringViewModelTests: XCTestCase {
 /// Tests for StatisticsViewModel — streak and period filtering.
 final class StatisticsViewModelTests: XCTestCase {
 
+    /// Both smoke tests below construct the VM on an ISOLATED store — the
+    /// previous `StatisticsViewModel()` default pulled the simulator's real
+    /// `UserDefaults.standard` transactions, so any prior app/test activity
+    /// made "empty data" assertions flake (red on CI, red locally after QA).
+    private func makeIsolatedStatisticsVM() -> StatisticsViewModel {
+        let isolated = UserDefaults(suiteName: "test.statsSmoke.\(UUID().uuidString)")!
+        return StatisticsViewModel(
+            repository: TransactionRepository(defaults: isolated),
+            defaults: isolated
+        )
+    }
+
     func testEmptyDataMotivation() {
-        let vm = StatisticsViewModel()
+        let vm = makeIsolatedStatisticsVM()
         vm.loadData(period: .week)
         // With no transactions, should show positive message
         XCTAssertEqual(vm.motivationalMessage, "Отлично! Вы не откладывали будильник.")
     }
 
     func testTotalSpentZero() {
-        let vm = StatisticsViewModel()
+        let vm = makeIsolatedStatisticsVM()
         vm.loadData(period: .allTime)
         XCTAssertEqual(vm.totalSpent, 0)
         XCTAssertEqual(vm.totalSpentFormatted, "0\u{202F}₽")

--- a/SnoozePay/SnoozePayTests/BalanceServiceTests.swift
+++ b/SnoozePay/SnoozePayTests/BalanceServiceTests.swift
@@ -418,7 +418,7 @@ final class StatisticsViewModelTests: XCTestCase {
         let vm = StatisticsViewModel()
         vm.loadData(period: .allTime)
         XCTAssertEqual(vm.totalSpent, 0)
-        XCTAssertEqual(vm.totalSpentFormatted, "0 ₽")
+        XCTAssertEqual(vm.totalSpentFormatted, "0\u{202F}₽")
     }
 
     func testPeriodTitles() {
@@ -452,12 +452,13 @@ final class CreateAlarmViewModelTests: XCTestCase {
     func testProgressiveScalePreview() {
         let vm = CreateAlarmViewModel()
         vm.penaltyAmount = 50
-        // Expected: "1-е: 50₽ → 2-е: 100₽ → 3-е: 200₽ → 4-е: 400₽"
+        // Expected: "1-е: 50 ₽ → 2-е: 100 ₽ → 3-е: 200 ₽ → 4-е: 400 ₽"
+        // (fmtRub narrow no-break space before ₽)
         let preview = vm.progressiveScalePreview
-        XCTAssertTrue(preview.contains("50₽"))
-        XCTAssertTrue(preview.contains("100₽"))
-        XCTAssertTrue(preview.contains("200₽"))
-        XCTAssertTrue(preview.contains("400₽"))
+        XCTAssertTrue(preview.contains("50\u{202F}₽"))
+        XCTAssertTrue(preview.contains("100\u{202F}₽"))
+        XCTAssertTrue(preview.contains("200\u{202F}₽"))
+        XCTAssertTrue(preview.contains("400\u{202F}₽"))
     }
 
     func testDayToggleAddsAndRemoves() {

--- a/SnoozePay/SnoozePayTests/CreateAlarmViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/CreateAlarmViewModelTests.swift
@@ -126,22 +126,25 @@ final class CreateAlarmViewModelSoundTests: XCTestCase {
         let vm = CreateAlarmViewModel(repository: repo)
         vm.penaltyAmount = 50
         let preview = vm.progressiveScalePreview
-        XCTAssertEqual(preview, "1-е: 50₽ → 2-е: 100₽ → 3-е: 200₽ → 4-е: 400₽")
+        XCTAssertEqual(preview, "1-е: 50\u{202F}₽ → 2-е: 100\u{202F}₽ → 3-е: 200\u{202F}₽ → 4-е: 400\u{202F}₽")
     }
 
     func testProgressiveScalePreview_withHighPenalty() {
         let vm = CreateAlarmViewModel(repository: repo)
         vm.penaltyAmount = 1000
         let preview = vm.progressiveScalePreview
-        XCTAssertEqual(preview, "1-е: 1000₽ → 2-е: 2000₽ → 3-е: 4000₽ → 4-е: 8000₽")
+        XCTAssertEqual(
+            preview,
+            "1-е: 1\u{00A0}000\u{202F}₽ → 2-е: 2\u{00A0}000\u{202F}₽ → 3-е: 4\u{00A0}000\u{202F}₽ → 4-е: 8\u{00A0}000\u{202F}₽"
+        )
     }
 
     func testProgressiveScalePreview_withMinimumPenalty() {
         let vm = CreateAlarmViewModel(repository: repo)
         vm.penaltyAmount = 10
         let preview = vm.progressiveScalePreview
-        XCTAssertTrue(preview.hasPrefix("1-е: 10₽"))
-        XCTAssertTrue(preview.contains("2-е: 20₽"))
+        XCTAssertTrue(preview.hasPrefix("1-е: 10\u{202F}₽"))
+        XCTAssertTrue(preview.contains("2-е: 20\u{202F}₽"))
     }
 
     // MARK: - Progressive scale toggle (regression for #51)
@@ -175,7 +178,7 @@ final class CreateAlarmViewModelSoundTests: XCTestCase {
         let secondPreview = vm.progressiveScalePreview
 
         XCTAssertNotEqual(firstPreview, secondPreview)
-        XCTAssertTrue(secondPreview.hasPrefix("1-е: 200₽"))
+        XCTAssertTrue(secondPreview.hasPrefix("1-е: 200\u{202F}₽"))
     }
 
     // MARK: - Save

--- a/SnoozePay/SnoozePayTests/CreateAlarmViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/CreateAlarmViewModelTests.swift
@@ -159,10 +159,18 @@ final class CreateAlarmViewModelSoundTests: XCTestCase {
 
         vm.progressiveScale = true
         vm.save()
-        XCTAssertTrue(repo.fetchAll().first?.progressiveScale ?? false)
+        let saved = repo.fetchAll().first
+        XCTAssertTrue(saved?.progressiveScale ?? false)
 
-        vm.progressiveScale = false
-        vm.save()
+        // A non-editing VM mints a fresh UUID per save, so a second save()
+        // on the SAME VM would create a second alarm instead of updating the
+        // first. Re-open the persisted alarm in edit mode — that is the flow
+        // the #51 toggle actually runs through on the edit screen.
+        let editVM = CreateAlarmViewModel(alarm: saved, repository: repo)
+        XCTAssertTrue(editVM.progressiveScale, "Edit VM must pick up the persisted toggle state")
+        editVM.progressiveScale = false
+        editVM.save()
+        XCTAssertEqual(repo.fetchAll().count, 1, "Edit-mode save must update, not append")
         XCTAssertFalse(repo.fetchAll().first?.progressiveScale ?? true)
     }
 

--- a/SnoozePay/SnoozePayTests/MoneyFormatterTests.swift
+++ b/SnoozePay/SnoozePayTests/MoneyFormatterTests.swift
@@ -1,0 +1,153 @@
+import XCTest
+@testable import SnoozePay
+
+/// Unit tests for `MoneyFormatter` — the single fmtRub implementation
+/// (design v3): grouped digits, narrow no-break space (U+202F) before `₽`,
+/// and the attributed variant that re-fonts the separator with the
+/// proportional sans so mono money labels get a ~4pt gap.
+final class MoneyFormatterTests: XCTestCase {
+
+    private let narrowSpace = "\u{202F}"
+    private let groupSpace = "\u{00A0}"   // ru-RU thousands separator
+
+    // MARK: - digits(_:)
+
+    func testDigits_smallAmount_noGrouping() {
+        XCTAssertEqual(MoneyFormatter.digits(Decimal(50)), "50")
+    }
+
+    func testDigits_thousands_useNonBreakingGroupSeparator() {
+        XCTAssertEqual(MoneyFormatter.digits(Decimal(1234)), "1\(groupSpace)234")
+        XCTAssertEqual(MoneyFormatter.digits(1_234_567), "1\(groupSpace)234\(groupSpace)567")
+    }
+
+    func testDigits_truncatesFraction() {
+        // The app transacts whole roubles; fmtRub truncates (rounds down).
+        XCTAssertEqual(MoneyFormatter.digits(Decimal(string: "49.99")!), "49")
+    }
+
+    // MARK: - string(_:)
+
+    func testString_usesNarrowNoBreakSpaceBeforeRouble() {
+        XCTAssertEqual(MoneyFormatter.string(Decimal(50)), "50\(narrowSpace)₽")
+    }
+
+    func testString_neverUsesPlainSpaceBeforeRouble() {
+        let formatted = MoneyFormatter.string(Decimal(1000))
+        XCTAssertFalse(
+            formatted.contains(" ₽"),
+            "fmtRub must separate digits from ₽ with U+202F, not a plain space: \(formatted)"
+        )
+        XCTAssertEqual(formatted, "1\(groupSpace)000\(narrowSpace)₽")
+    }
+
+    func testString_intAndDoubleOverloadsAgree() {
+        XCTAssertEqual(MoneyFormatter.string(150), MoneyFormatter.string(Decimal(150)))
+        XCTAssertEqual(MoneyFormatter.string(150.0), MoneyFormatter.string(Decimal(150)))
+    }
+
+    func testString_zero() {
+        XCTAssertEqual(MoneyFormatter.string(0), "0\(narrowSpace)₽")
+    }
+
+    // MARK: - attributed(_:digitsFont:)
+
+    func testAttributed_digitsKeepMonoFontAndRoubleMatchesDigits() {
+        let mono = UIFont.monospacedSystemFont(ofSize: 20, weight: .bold)
+        let attributed = MoneyFormatter.attributed(Decimal(50), digitsFont: mono)
+
+        XCTAssertEqual(attributed.string, "50\(narrowSpace)₽")
+
+        let digitsFont = attributed.attribute(.font, at: 0, effectiveRange: nil) as? UIFont
+        XCTAssertEqual(digitsFont, mono, "Digits must render in the caller's mono font")
+
+        let roubleIndex = attributed.length - 1
+        let roubleFont = attributed.attribute(.font, at: roubleIndex, effectiveRange: nil) as? UIFont
+        XCTAssertEqual(roubleFont, mono, "₽ keeps the digits' font/size/baseline per fmtRub")
+    }
+
+    func testAttributed_separatorIsProportionalFontAtSameSize() {
+        let mono = UIFont.monospacedSystemFont(ofSize: 20, weight: .bold)
+        let attributed = MoneyFormatter.attributed(Decimal(50), digitsFont: mono)
+
+        let spaceIndex = (attributed.string as NSString).range(of: narrowSpace).location
+        XCTAssertNotEqual(spaceIndex, NSNotFound)
+        let spaceFont = attributed.attribute(.font, at: spaceIndex, effectiveRange: nil) as? UIFont
+        XCTAssertNotNil(spaceFont)
+        XCTAssertNotEqual(
+            spaceFont, mono,
+            "Separator must escape the mono advance grid (proportional sans)"
+        )
+        XCTAssertEqual(spaceFont?.pointSize, 20, "Separator keeps the digits' point size")
+    }
+
+    func testAttributed_prefixRendersBeforeDigitsInDigitsFont() {
+        let mono = UIFont.monospacedSystemFont(ofSize: 17, weight: .bold)
+        let attributed = MoneyFormatter.attributed(Decimal(50), digitsFont: mono, prefix: "−")
+
+        XCTAssertEqual(attributed.string, "−50\(narrowSpace)₽")
+        let prefixFont = attributed.attribute(.font, at: 0, effectiveRange: nil) as? UIFont
+        XCTAssertEqual(prefixFont, mono)
+    }
+
+    func testAttributed_colorAppliedToWholeRun() {
+        let mono = UIFont.monospacedSystemFont(ofSize: 17, weight: .bold)
+        let attributed = MoneyFormatter.attributed(Decimal(50), digitsFont: mono, color: .red)
+
+        for index in 0..<attributed.length {
+            let color = attributed.attribute(.foregroundColor, at: index, effectiveRange: nil) as? UIColor
+            XCTAssertEqual(color, .red, "Every run (digits, separator, ₽) must carry the colour")
+        }
+    }
+
+    func testAttributed_withoutColor_carriesNoForegroundColor() {
+        // Labels that recolour via `textColor` (tone flips on SPSnoozePrice,
+        // PenaltyCell) need attribute-free runs — an explicit colour attribute
+        // would override `textColor` and freeze the tone.
+        let mono = UIFont.monospacedSystemFont(ofSize: 17, weight: .bold)
+        let attributed = MoneyFormatter.attributed(Decimal(50), digitsFont: mono)
+
+        for index in 0..<attributed.length {
+            XCTAssertNil(attributed.attribute(.foregroundColor, at: index, effectiveRange: nil))
+        }
+    }
+
+    // MARK: - Legacy bridge
+
+    func testFormattedRubles_delegatesToMoneyFormatter() {
+        XCTAssertEqual(Decimal(1234).formattedRubles(), MoneyFormatter.string(Decimal(1234)))
+        XCTAssertEqual(Decimal(1234).formattedRubles(), "1\(groupSpace)234\(narrowSpace)₽")
+    }
+}
+
+/// Smoke tests for the code-drawn `SPIcons` set — render size, template
+/// mode (so `tintColor` plays SVG's `currentColor`) and non-empty output.
+final class SPIconsTests: XCTestCase {
+
+    func testIcons_renderAtRequestedSizeAsTemplates() {
+        let icons: [UIImage] = [
+            SPIcons.coin(size: 12),
+            SPIcons.rubleCoin(size: 12),
+            SPIcons.coinOff(size: 14),
+            SPIcons.trendUp(size: 12),
+            SPIcons.banknote(size: 16),
+            SPIcons.snooze(size: 16)
+        ]
+        for icon in icons {
+            XCTAssertEqual(icon.renderingMode, .alwaysTemplate)
+            XCTAssertGreaterThan(icon.size.width, 0)
+            XCTAssertEqual(icon.size.width, icon.size.height, "Icons are square")
+        }
+        XCTAssertEqual(SPIcons.coin(size: 12).size.width, 12)
+        XCTAssertEqual(SPIcons.banknote(size: 16).size.width, 16)
+    }
+
+    func testRubleCoin_isSameGlyphAsCoin() {
+        // JSX exports IconCoin and IconRubleCoin with identical paths —
+        // the Swift port must not let them drift apart.
+        let coin = SPIcons.coin(size: 24).pngData()
+        let rubleCoin = SPIcons.rubleCoin(size: 24).pngData()
+        XCTAssertNotNil(coin)
+        XCTAssertEqual(coin, rubleCoin)
+    }
+}

--- a/SnoozePay/SnoozePayTests/StatisticsViewModelPresentationTests.swift
+++ b/SnoozePay/SnoozePayTests/StatisticsViewModelPresentationTests.swift
@@ -120,13 +120,13 @@ final class StatisticsViewModelPresentationTests: XCTestCase {
     func testTotalSpentFormatted_zero_returnsRubleZero() {
         let vm = makeVM()
         vm.loadData(period: .week)
-        XCTAssertEqual(vm.totalSpentFormatted, "₽0")
+        XCTAssertEqual(vm.totalSpentFormatted, "0\u{202F}₽")
     }
 
     func testTotalSpentFormatted_withSpending_includesAmount() {
         addCharge(amount: 250)
         let vm = makeVM()
         vm.loadData(period: .week)
-        XCTAssertEqual(vm.totalSpentFormatted, "₽250")
+        XCTAssertEqual(vm.totalSpentFormatted, "250\u{202F}₽")
     }
 }

--- a/SnoozePay/SnoozePayTests/StatisticsViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/StatisticsViewModelTests.swift
@@ -101,7 +101,7 @@ final class StatisticsViewModelDataTests: XCTestCase {
         vm.loadData(period: .week)
 
         XCTAssertEqual(vm.totalSpent, 225)
-        XCTAssertEqual(vm.totalSpentFormatted, "225 ₽")
+        XCTAssertEqual(vm.totalSpentFormatted, "225\u{202F}₽")
     }
 
     // MARK: - Snooze count
@@ -413,19 +413,19 @@ final class StatisticsViewModelDataTests: XCTestCase {
         let vm = makeVM()
         vm.loadData(period: .week)
 
-        XCTAssertEqual(vm.motivationalMessage, "450₽ на лень = 3 кофе! ☕")
+        XCTAssertEqual(vm.motivationalMessage, "450\u{202F}₽ на лень = 3 кофе! ☕")
     }
 
     // MARK: - Updated formatting properties
 
-    func testTotalSpentFormatted_rublePrefix() {
+    func testTotalSpentFormatted_rubleSuffix() {
         addCharge(amount: 250, daysAgo: 0)
 
         let vm = makeVM()
         vm.loadData(period: .week)
 
-        // New format uses ruble sign as prefix: "₽250"
-        XCTAssertEqual(vm.totalSpentFormatted, "₽250")
+        // fmtRub suffix style with the narrow no-break space: "250 ₽"
+        XCTAssertEqual(vm.totalSpentFormatted, "250\u{202F}₽")
     }
 
     func testSnoozeCountFormatted_justNumber() {

--- a/SnoozePay/SnoozePayTests/StatisticsViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/StatisticsViewModelTests.swift
@@ -116,7 +116,7 @@ final class StatisticsViewModelDataTests: XCTestCase {
         vm.loadData(period: .week)
 
         XCTAssertEqual(vm.snoozeCount, 3)
-        XCTAssertEqual(vm.snoozeCountFormatted, "3 раз")
+        XCTAssertEqual(vm.snoozeCountFormatted, "3", "V2: bare digits — the caption carries the word")
     }
 
     // MARK: - Motivational messages
@@ -134,7 +134,7 @@ final class StatisticsViewModelDataTests: XCTestCase {
         let vm = makeVM()
         vm.loadData(period: .week)
 
-        XCTAssertTrue(vm.motivationalMessage.contains("2 чашек кофе"))
+        XCTAssertTrue(vm.motivationalMessage.contains("2 кофе"), "V2 copy: 'N кофе', got: \(vm.motivationalMessage)")
         XCTAssertTrue(vm.motivationalMessage.contains("☕"))
     }
 
@@ -154,7 +154,7 @@ final class StatisticsViewModelDataTests: XCTestCase {
         let vm = makeVM()
         vm.loadData(period: .week)
 
-        XCTAssertTrue(vm.motivationalMessage.contains("1 чашек кофе"))
+        XCTAssertTrue(vm.motivationalMessage.contains("1 кофе"), "V2 copy: 'N кофе', got: \(vm.motivationalMessage)")
     }
 
     // MARK: - Streak message
@@ -167,7 +167,7 @@ final class StatisticsViewModelDataTests: XCTestCase {
         vm.loadData(period: .week)
 
         if vm.streak > 0 {
-            XCTAssertTrue(vm.streakMessage.contains("без откладывания"))
+            XCTAssertTrue(vm.streakMessage.contains("без откладываний"), "V2 copy plural, got: \(vm.streakMessage)")
             XCTAssertTrue(vm.streakMessage.contains("\(vm.streak)"))
         }
     }


### PR DESCRIPTION
Fixes #223

## Что сделано
- **MoneyFormatter** (`Utilities/MoneyFormatter.swift`) — единый fmtRub helper: сгруппированные цифры (ru-RU), **U+202F narrow no-break space перед ₽**, и attributed-вариант, который перекладывает разделитель на пропорциональный sans — mono-лейблы получают ~4pt-гэп вместо полной mono-ячейки. `Decimal.formattedRubles()` теперь делегирует в него — все легаси-вызовы получили новый формат автоматически.
- Применён во всех местах ручной склейки `"\(n) ₽"`: ViewModels (AlarmsList/Statistics/CreateAlarm/AlarmFiring), Transaction, notification subtitle (AlarmScheduler), Statistics/Referral/Settings/TopUp/Wallet/Onboarding/Firing экраны, SP-компоненты. Стиль `₽250`-префикса в Settings/Statistics заменён на канонический суффиксный.
- **SPIcons** (`Views/DesignSystem/SPIcons.swift`) — кодом нарисованные иконки по SVG-путям из SPComponents.jsx: `coin`/`rubleCoin` (окружность + глиф ₽), `coinOff` (слэш), `trendUp`, `banknote`, `snooze` (zZ). 24-grid, stroke 1.75, round caps, template-режим (tint = currentColor).
- **AlarmCell chips**: ценовой pill → `IconRubleCoin`, прогрессив ×2 → `IconTrendUp`; balance pill на firing-экране → `IconCoin`. SPPill icon slot 14→12pt по JSX.
- **Двузначные часы**: hardcoded `7:00`/`8:00` литералы → `07:00`/`08:00` (ThemePicker, Onboarding, AlarmOffWarning); все форматтеры уже были `HH:mm`.
- **Паддинги design v3** (по диффу components.css): SPButton 24→20 / sm 14→12, SPAmountPreset 18×12→16×16, SPSnoozePrice 24→20, SPBalanceCard 24→20.

## Тесты
- Новые: `MoneyFormatterTests` (digits grouping, narrow space, attributed-раны, легаси-мост) + `SPIconsTests` (размер/template/coin==rubleCoin).
- Обновлены ожидания под новый формат; заодно выровнены устаревшие V2-ожидания в AlarmSchedulerTests/AlarmsListViewModelTests (старая копия "Отложить · N ₽" / "▲ ОТЛОЖИТЬ").

## Verify
- ✅ swiftlint: 0 errors
- ✅ xcodebuild build: succeeded (generic/platform=iOS Simulator)
- ✅ xcodebuild build-for-testing: succeeded (test target компилируется)
- ⏭ test run / screenshots — у orchestrator перед merge (по инструкции волны)

🤖 Generated with [Claude Code](https://claude.com/claude-code)