### PR TITLE
[feature] Add Forest + Neon stock alarm themes for v3 lineup (#224)

### DIFF
--- a/SnoozePay/SnoozePay/Models/AlarmTheme.swift
+++ b/SnoozePay/SnoozePay/Models/AlarmTheme.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Visual theme applied to an alarm's card preview and firing screen (#151).
 ///
-/// The five built-in cases are gradient-only so they ship without bundled
+/// The six built-in cases are gradient-only so they ship without bundled
 /// imagery; `.custom` carries an absolute file URL for a user-picked photo
 /// stored in the app's Caches directory by `AlarmThemeImageStore`.
 ///
@@ -15,6 +15,8 @@ enum AlarmTheme: Equatable {
     case dawn
     case mountains
     case ocean
+    case forest
+    case neon
     case abstract
     case custom(imagePath: URL)
 
@@ -27,6 +29,8 @@ enum AlarmTheme: Equatable {
         case .dawn: return "dawn"
         case .mountains: return "mountains"
         case .ocean: return "ocean"
+        case .forest: return "forest"
+        case .neon: return "neon"
         case .abstract: return "abstract"
         case .custom: return "custom"
         }
@@ -41,15 +45,19 @@ enum AlarmTheme: Equatable {
         case .dawn: return "Рассвет"
         case .mountains: return "Горы"
         case .ocean: return "Океан"
-        case .abstract: return "Абстракция"
+        case .forest: return "Лес"
+        case .neon: return "Неон"
+        case .abstract: return "Абстракт"
         case .custom: return "Своё фото"
         }
     }
 
     /// Built-in (non-custom) themes in their canonical picker order. The
     /// `.custom` tile is appended separately by the picker view-controller so
-    /// the "+" affordance always reads as the trailing slot.
-    static let builtInOrder: [AlarmTheme] = [.dawn, .mountains, .ocean, .abstract]
+    /// the "+" affordance always reads as the trailing slot. The sequence
+    /// mirrors the v3 design lineup (`SPMore2.jsx` theme picker / #224):
+    /// dawn, ocean, mountains, forest, neon, abstract.
+    static let builtInOrder: [AlarmTheme] = [.dawn, .ocean, .mountains, .forest, .neon, .abstract]
 }
 
 // MARK: - Codable
@@ -68,6 +76,8 @@ extension AlarmTheme: Codable {
         case "dawn": self = .dawn
         case "mountains": self = .mountains
         case "ocean": self = .ocean
+        case "forest": self = .forest
+        case "neon": self = .neon
         case "abstract": self = .abstract
         case "custom":
             // Path stored as a string so the JSON stays portable across

--- a/SnoozePay/SnoozePay/Utilities/AlarmThemeRendering.swift
+++ b/SnoozePay/SnoozePay/Utilities/AlarmThemeRendering.swift
@@ -37,6 +37,22 @@ enum AlarmThemeRendering {
                 UIColor(themeRGB: 0x1A659E).cgColor,
                 UIColor(themeRGB: 0x003554).cgColor
             ]
+        case .forest:
+            // FIRING_THEMES.forest stops from the v3 handoff
+            // (`SPThemedFiring.jsx`): deep pine → moss midpoint → sage.
+            return [
+                UIColor(themeRGB: 0x0A1A0A).cgColor,
+                UIColor(themeRGB: 0x1E3823).cgColor,
+                UIColor(themeRGB: 0x4A6B3A).cgColor
+            ]
+        case .neon:
+            // FIRING_THEMES.neon stops from the v3 handoff
+            // (`SPThemedFiring.jsx`): midnight ink → violet midpoint → hot pink.
+            return [
+                UIColor(themeRGB: 0x0A0A1F).cgColor,
+                UIColor(themeRGB: 0x3D1E63).cgColor,
+                UIColor(themeRGB: 0xFF3D8A).cgColor
+            ]
         case .abstract:
             // Money-tinted radial vibe — dark green core fading into the
             // brand near-black ink. Rendered as a vertical gradient here
@@ -62,6 +78,10 @@ enum AlarmThemeRendering {
             return [0.0, 0.4, 0.7, 1.0]
         case .abstract:
             return [0.0, 0.55, 1.0]
+        case .forest, .neon:
+            // Midpoint pinned at 50% to match the design's
+            // `linear-gradient(160deg, … 0%, … 50%, … 100%)` recipe.
+            return [0.0, 0.5, 1.0]
         case .mountains, .ocean:
             return [0.0, 1.0]
         case .custom:

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Theme.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Theme.swift
@@ -47,7 +47,7 @@ extension AlarmFiringViewController {
             themeImageView.isHidden = true
             themeImageDimView.isHidden = true
         } else {
-            // Mountains / Ocean / Abstract — vertical gradient using the
+            // Ocean / Mountains / Forest / Neon / Abstract — vertical gradient using the
             // shared `AlarmThemeRendering` stops. Built on a plain
             // SPGradientView-like CAGradientLayer hosted on a UIView so the
             // +Layout subview ordering still works.

--- a/SnoozePay/SnoozePayTests/AlarmThemeTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmThemeTests.swift
@@ -30,6 +30,32 @@ final class AlarmThemeTests: XCTestCase {
         }
     }
 
+    func testForestAndNeonDecodeFromRawIDs() throws {
+        // The exact raw ids matter — they are the on-disk contract for #224.
+        // A rename would silently degrade every saved forest/neon alarm to
+        // `.dawn` via the unknown-id fallback below.
+        let forest = try JSONDecoder().decode(AlarmTheme.self, from: #"{"id":"forest"}"#.data(using: .utf8)!)
+        let neon = try JSONDecoder().decode(AlarmTheme.self, from: #"{"id":"neon"}"#.data(using: .utf8)!)
+        XCTAssertEqual(forest, .forest)
+        XCTAssertEqual(neon, .neon)
+    }
+
+    func testPreForestNeonThemeIDsStillDecode() throws {
+        // Backwards-compat guard: alarms persisted before #224 keep decoding
+        // to the same cases after the enum grew two members.
+        let legacyIDs: [(String, AlarmTheme)] = [
+            ("dawn", .dawn),
+            ("mountains", .mountains),
+            ("ocean", .ocean),
+            ("abstract", .abstract)
+        ]
+        for (id, expected) in legacyIDs {
+            let json = #"{"id":"\#(id)"}"#.data(using: .utf8)!
+            let decoded = try JSONDecoder().decode(AlarmTheme.self, from: json)
+            XCTAssertEqual(decoded, expected, "Legacy id \(id) no longer decodes to \(expected)")
+        }
+    }
+
     func testUnknownThemeIDDecodesAsDawn() throws {
         let json = #"{"id":"made-up-future-theme"}"#.data(using: .utf8)!
         let decoded = try JSONDecoder().decode(AlarmTheme.self, from: json)
@@ -129,8 +155,20 @@ final class AlarmThemeTests: XCTestCase {
         XCTAssertEqual(AlarmTheme.dawn.displayName, "Рассвет")
         XCTAssertEqual(AlarmTheme.mountains.displayName, "Горы")
         XCTAssertEqual(AlarmTheme.ocean.displayName, "Океан")
-        XCTAssertEqual(AlarmTheme.abstract.displayName, "Абстракция")
+        XCTAssertEqual(AlarmTheme.forest.displayName, "Лес")
+        XCTAssertEqual(AlarmTheme.neon.displayName, "Неон")
+        // Renamed from "Абстракция" in the v3 lineup (#224).
+        XCTAssertEqual(AlarmTheme.abstract.displayName, "Абстракт")
         let custom = AlarmTheme.custom(imagePath: URL(fileURLWithPath: "/x.jpg"))
         XCTAssertEqual(custom.displayName, "Своё фото")
+    }
+
+    func testBuiltInOrderMatchesDesignV3Lineup() {
+        // Picker tile order is part of the v3 design contract (#224):
+        // dawn, ocean, mountains, forest, neon, abstract.
+        XCTAssertEqual(
+            AlarmTheme.builtInOrder,
+            [.dawn, .ocean, .mountains, .forest, .neon, .abstract]
+        )
     }
 }


### PR DESCRIPTION
Fixes #224

## Что сделано
- `AlarmTheme`: добавлены кейсы `.forest` («Лес») и `.neon` («Неон») с raw id `forest`/`neon`; `displayName` «Абстракция» переименован в «Абстракт»; `builtInOrder` приведён к порядку дизайна v3 — dawn, ocean, mountains, forest, neon, abstract.
- `AlarmThemeRendering`: градиенты forest (`#0A1A0A → #1E3823 50% → #4A6B3A`) и neon (`#0A0A1F → #3D1E63 50% → #FF3D8A`) по таблице FIRING_THEMES из `docs/design/v2-handoff/components/SPThemedFiring.jsx`, стопы `[0, 0.5, 1]`. Тайлы пикера, превью и firing-экран используют эти же рецепты (firing — gradient-fallback до тематического firing-issue, не падает).
- Backward compatibility: hand-rolled Codable декодирует старые id (`dawn`/`mountains`/`ocean`/`abstract`) без изменений, неизвестные id по-прежнему деградируют в `.dawn`.
- Тесты: decode новых raw id, регрессия legacy id, round-trip всех built-in тем (через `builtInOrder`), порядок lineup, обновлённые displayName.

## Verify
- ✅ swiftlint: 0 violations в затронутых файлах
- ✅ xcodebuild build (generic/platform=iOS Simulator): succeeded
- ✅ xcodebuild build-for-testing: succeeded (тестовый таргет компилируется; прогон сьюта — на стороне orchestrator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)