### PR TITLE
[fix] Surface cold-start balance corruption to late observers (#206)

### DIFF
--- a/SnoozePay/SnoozePay/Services/BalanceService.swift
+++ b/SnoozePay/SnoozePay/Services/BalanceService.swift
@@ -45,6 +45,19 @@ final class BalanceService {
     private var _balanceCorrupted: Bool = false
     var balanceCorrupted: Bool { queue.sync { _balanceCorrupted } }
 
+    /// The raw invalid value that latched `balanceCorrupted`, kept until the
+    /// user acknowledges via `acknowledgeCorruption()`. `nil` while healthy.
+    ///
+    /// `balanceCorruptedNotification` is posted once per process and
+    /// `NotificationCenter` does not retro-deliver: when corruption is
+    /// detected by the init-time probe (cold start, before any UI exists)
+    /// the event is dropped for late subscribers. This queryable seam lets a
+    /// late-registering observer (e.g. `AlarmsListViewModel.loadData()`) pull
+    /// the pending corruption state after attaching, so the user-facing alert
+    /// still fires (#206).
+    private var _corruptedRawValue: Double?
+    var corruptedRawValue: Double? { queue.sync { _corruptedRawValue } }
+
     /// Production code MUST use `BalanceService.shared` to avoid creating
     /// isolated instances with separate serial queues (which reintroduces the
     /// race this class exists to prevent).
@@ -221,6 +234,7 @@ final class BalanceService {
             guard _balanceCorrupted else { return false }
             defaults.set(0.0, forKey: balanceKey)
             _balanceCorrupted = false
+            _corruptedRawValue = nil
             return true
         }
         if cleared {
@@ -318,6 +332,10 @@ final class BalanceService {
         // acknowledges via `acknowledgeCorruption()`.
         let firstObservation = !_balanceCorrupted
         _balanceCorrupted = true
+        // Keep the offending value queryable for late subscribers — the
+        // one-shot notification below is dropped when corruption latches at
+        // init time before any UI observer is attached (#206).
+        _corruptedRawValue = raw
         if firstObservation {
             os_log(
                 "Corrupted balance observed in storage: %{public}f — gating mutations until acknowledged",

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
@@ -241,6 +241,10 @@ class AlarmsListViewController: UIViewController {
         viewModel.onLoadError = { [weak self] error in
             self?.presentRepositoryError(error)
         }
+
+        viewModel.onBalanceCorrupted = { [weak self] rawValue in
+            self?.presentBalanceCorruptedAlert(rawValue: rawValue)
+        }
     }
 
     /// Push the latest balance / hint state into the sticky header.
@@ -305,6 +309,24 @@ class AlarmsListViewController: UIViewController {
             preferredStyle: .alert
         )
         alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
+    }
+
+    /// Corrupt `user_balance` detected (#119) — possibly at cold start before
+    /// any observer existed (#206). Pop-ups and top-ups are gated until the
+    /// user acknowledges, so the alert offers an immediate reset to 0 ₽.
+    private func presentBalanceCorruptedAlert(rawValue: Double) {
+        guard presentedViewController == nil else { return }
+        let alert = UIAlertController(
+            title: "Баланс повреждён",
+            message: "В хранилище обнаружено некорректное значение баланса (\(rawValue)). "
+                + "Пополнения и списания приостановлены. Сбросить баланс до 0 ₽?",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "Сбросить", style: .destructive) { [weak self] _ in
+            self?.viewModel.acknowledgeBalanceCorruption()
+        })
+        alert.addAction(UIAlertAction(title: "Позже", style: .cancel))
         present(alert, animated: true)
     }
 

--- a/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
@@ -10,6 +10,7 @@ final class AlarmsListViewModel {
     private let alarmRepository: AlarmRepository
     private let balanceService: BalanceService
     private let transactionRepository: TransactionRepository
+    private let notificationCenter: NotificationCenter
 
     // MARK: - State
 
@@ -25,6 +26,14 @@ final class AlarmsListViewModel {
     /// their alarms (issue #72). Carries a `LocalizedError` whose
     /// `errorDescription` is already user-facing Russian copy.
     var onLoadError: ((LocalizedError) -> Void)?
+    /// Fired (once per corruption episode) when the stored balance is
+    /// corrupt — negative / NaN / infinite `user_balance` (#119). Carries the
+    /// raw offending value. The VC presents an alert offering to wipe the
+    /// corrupt value via `acknowledgeBalanceCorruption()`. Covers BOTH the
+    /// live notification AND corruption latched at cold start before this VM
+    /// existed — `loadData()` pulls the latched state from the service, since
+    /// `NotificationCenter` does not retro-deliver to late subscribers (#206).
+    var onBalanceCorrupted: ((Double) -> Void)?
 
     // MARK: - Errors
 
@@ -52,18 +61,33 @@ final class AlarmsListViewModel {
     /// (the ViewController owning it may outlive the VM in edge cases).
     private var balanceObserver: NSObjectProtocol?
 
+    /// Observer token for `balanceCorruptedNotification` — covers corruption
+    /// that latches while this VM is alive. Cold-start corruption (latched in
+    /// `BalanceService.init` before any observer exists) is instead pulled in
+    /// `loadData()` via `surfacePendingBalanceCorruption()` (#206).
+    private var corruptionObserver: NSObjectProtocol?
+
+    /// Dedupe latch so the corruption alert fires once per episode even
+    /// though `loadData()` runs on every `viewWillAppear` (and the live
+    /// notification + the pulled state could otherwise double-fire). Reset
+    /// in `acknowledgeBalanceCorruption()` so a future re-corruption is
+    /// surfaced again.
+    private var hasSurfacedBalanceCorruption = false
+
     // MARK: - Init
 
     init(
         alarmRepository: AlarmRepository = .shared,
         balanceService: BalanceService = .shared,
-        transactionRepository: TransactionRepository = .shared
+        transactionRepository: TransactionRepository = .shared,
+        notificationCenter: NotificationCenter = .default
     ) {
         self.alarmRepository = alarmRepository
         self.balanceService = balanceService
         self.transactionRepository = transactionRepository
+        self.notificationCenter = notificationCenter
 
-        balanceObserver = NotificationCenter.default.addObserver(
+        balanceObserver = notificationCenter.addObserver(
             forName: BalanceService.balanceChangedNotification,
             object: nil,
             queue: .main
@@ -73,11 +97,24 @@ final class AlarmsListViewModel {
             self.balance = newBalance
             self.onBalanceUpdated?(newBalance)
         }
+
+        corruptionObserver = notificationCenter.addObserver(
+            forName: BalanceService.balanceCorruptedNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            guard let self,
+                  let raw = note.userInfo?[BalanceService.balanceCorruptedRawValueKey] as? Double else { return }
+            self.surfaceBalanceCorruption(rawValue: raw)
+        }
     }
 
     deinit {
         if let token = balanceObserver {
-            NotificationCenter.default.removeObserver(token)
+            notificationCenter.removeObserver(token)
+        }
+        if let token = corruptionObserver {
+            notificationCenter.removeObserver(token)
         }
     }
 
@@ -99,6 +136,36 @@ final class AlarmsListViewModel {
         balance = balanceService.balance
         onAlarmsUpdated?()
         onBalanceUpdated?(balance)
+        surfacePendingBalanceCorruption()
+    }
+
+    // MARK: - Balance corruption (#119 / #206)
+
+    /// Pulls corruption state latched BEFORE this VM registered its observer
+    /// (cold start: AppDelegate materializes `BalanceService.shared`, whose
+    /// init-time probe posts `balanceCorruptedNotification` with no listener
+    /// attached — the event is dropped, see #206). Called from `loadData()`,
+    /// which the VC invokes after binding callbacks, so the alert is
+    /// guaranteed a live `onBalanceCorrupted` handler.
+    private func surfacePendingBalanceCorruption() {
+        guard balanceService.balanceCorrupted else { return }
+        surfaceBalanceCorruption(rawValue: balanceService.corruptedRawValue ?? balance)
+    }
+
+    private func surfaceBalanceCorruption(rawValue: Double) {
+        guard !hasSurfacedBalanceCorruption else { return }
+        hasSurfacedBalanceCorruption = true
+        onBalanceCorrupted?(rawValue)
+    }
+
+    /// Wipes the corrupt `user_balance` (resets to 0) after the user
+    /// confirmed in the alert. `BalanceService` broadcasts
+    /// `balanceChangedNotification` on success, which refreshes this VM's
+    /// `balance` via the regular observer. The dedupe latch is reset so a
+    /// future corruption episode surfaces a fresh alert.
+    func acknowledgeBalanceCorruption() {
+        balanceService.acknowledgeCorruption()
+        hasSurfacedBalanceCorruption = false
     }
 
     // MARK: - Toggle

--- a/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
@@ -560,3 +560,123 @@ final class AlarmsListViewModelTests: XCTestCase {
         XCTAssertFalse(vm.alarms[0].enabled, "In-memory state must reflect disable")
     }
 }
+
+// MARK: - Balance corruption surfaced to late observer (#206)
+
+/// Tests that cold-start balance corruption (latched in `BalanceService.init`
+/// before any UI observer exists) still reaches `onBalanceCorrupted` when the
+/// VM registers late — the original notification is dropped, so the VM pulls
+/// the queryable state in `loadData()`.
+final class AlarmsListViewModelCorruptionTests: XCTestCase {
+
+    private var testDefaults: UserDefaults!
+    private var suiteName: String!
+    private var repo: AlarmRepository!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "test.alarmsListCorruption.\(UUID().uuidString)"
+        testDefaults = UserDefaults(suiteName: suiteName)!
+        repo = AlarmRepository(
+            defaults: testDefaults,
+            scheduler: AlarmsListViewModelTests.StubScheduler()
+        )
+    }
+
+    override func tearDown() {
+        testDefaults.removePersistentDomain(forName: suiteName)
+        super.tearDown()
+    }
+
+    /// Builds a VM wired to an isolated BalanceService + NotificationCenter
+    /// so corruption scenarios don't touch the shared singletons.
+    private func makeFixture(rawBalance: Double) -> (vm: AlarmsListViewModel, service: BalanceService) {
+        let center = NotificationCenter()
+        testDefaults.set(rawBalance, forKey: "user_balance")
+        // Service init runs its corruption probe HERE — before the VM (and
+        // its observer) exists. The posted notification is dropped, exactly
+        // like the cold-start AppDelegate access in #206.
+        let service = BalanceService(defaults: testDefaults, notificationCenter: center)
+        let vm = AlarmsListViewModel(
+            alarmRepository: repo,
+            balanceService: service,
+            transactionRepository: TransactionRepository(defaults: testDefaults),
+            notificationCenter: center
+        )
+        return (vm, service)
+    }
+
+    /// Cold-start scenario: corruption latches in `BalanceService.init`
+    /// (notification dropped — no observer yet), the VM registers late, the
+    /// VC binds `onBalanceCorrupted`, then `loadData()` runs. The alert
+    /// callback MUST still fire with the original raw value.
+    func testLoadData_coldStartCorruption_lateObserverStillAlerted() {
+        let (vm, _) = makeFixture(rawBalance: -42.0)
+
+        var receivedRaw: Double?
+        vm.onBalanceCorrupted = { receivedRaw = $0 }
+
+        vm.loadData()
+
+        XCTAssertEqual(receivedRaw, -42.0,
+                       "Late observer must still learn about init-time corruption")
+        XCTAssertEqual(vm.balance, 0,
+                       "Corrupt balance must be reported as 0 to the list UI")
+    }
+
+    /// The alert must fire once per corruption episode — `loadData()` runs on
+    /// every `viewWillAppear`, and the live notification + the pulled state
+    /// must not stack into duplicate alerts.
+    func testLoadData_corruptionAlertFiresOncePerEpisode() {
+        let (vm, _) = makeFixture(rawBalance: -5.0)
+
+        var fireCount = 0
+        vm.onBalanceCorrupted = { _ in fireCount += 1 }
+
+        vm.loadData()
+        vm.loadData()
+        vm.loadData()
+
+        XCTAssertEqual(fireCount, 1, "Corruption alert must be deduped per episode")
+    }
+
+    /// Healthy VM must never fire the corruption callback.
+    func testLoadData_healthyBalance_doesNotFireCorruptionCallback() {
+        let (vm, _) = makeFixture(rawBalance: 150.0)
+
+        var fired = false
+        vm.onBalanceCorrupted = { _ in fired = true }
+
+        vm.loadData()
+
+        XCTAssertFalse(fired, "Healthy balance must not surface a corruption alert")
+        XCTAssertEqual(vm.balance, 150.0)
+    }
+
+    /// `acknowledgeBalanceCorruption()` wipes the corrupt value (service
+    /// resets to 0, flag clears) and re-arms the dedupe latch so a FUTURE
+    /// corruption episode surfaces a fresh alert.
+    func testAcknowledgeBalanceCorruption_resetsServiceAndReArmsAlert() {
+        let (vm, service) = makeFixture(rawBalance: -10.0)
+
+        var fireCount = 0
+        vm.onBalanceCorrupted = { _ in fireCount += 1 }
+
+        vm.loadData()
+        XCTAssertEqual(fireCount, 1)
+
+        vm.acknowledgeBalanceCorruption()
+        XCTAssertFalse(service.balanceCorrupted, "Ack must clear the service flag")
+        XCTAssertEqual(service.balance, 0, "Ack must reset the stored balance to 0")
+
+        // Healthy reload — no new alert.
+        vm.loadData()
+        XCTAssertEqual(fireCount, 1)
+
+        // Second corruption episode (external write) must alert again.
+        testDefaults.set(-99.0, forKey: "user_balance")
+        vm.loadData()
+        XCTAssertEqual(fireCount, 2,
+                       "A fresh corruption episode after ack must re-fire the alert")
+    }
+}

--- a/SnoozePay/SnoozePayTests/BalanceServiceTests.swift
+++ b/SnoozePay/SnoozePayTests/BalanceServiceTests.swift
@@ -335,6 +335,46 @@ final class BalanceServiceTests: XCTestCase {
 
         XCTAssertGreaterThanOrEqual(service.balance, 0)
     }
+
+    // MARK: - Cold-start corruption queryable by late observers (#206)
+
+    /// The init-time probe posts `balanceCorruptedNotification` BEFORE any UI
+    /// observer can exist (cold start: AppDelegate materializes the shared
+    /// instance first). NotificationCenter does not retro-deliver, so the
+    /// corruption state MUST stay queryable — `balanceCorrupted` +
+    /// `corruptedRawValue` — for the late subscriber to pull.
+    func testColdStartCorruption_stateQueryableByLateObserver() {
+        let center = NotificationCenter()
+        testDefaults.set(-77.25, forKey: "user_balance")
+        // Init probe latches corruption and posts with NO observer attached —
+        // the notification is dropped, simulating the cold-start race.
+        let service = BalanceService(defaults: testDefaults, notificationCenter: center)
+
+        // A late observer arrives — no notification will ever replay, but the
+        // queryable seam must expose the full pending corruption state.
+        XCTAssertTrue(service.balanceCorrupted,
+                      "Init-time probe must latch the corruption flag")
+        XCTAssertEqual(service.corruptedRawValue, -77.25,
+                       "Raw corrupt value must stay queryable for late observers")
+    }
+
+    /// `corruptedRawValue` must be `nil` while the store is healthy and must
+    /// clear together with the flag on `acknowledgeCorruption()`.
+    func testCorruptedRawValue_nilWhenHealthyAndClearedAfterAcknowledge() {
+        let center = NotificationCenter()
+        let healthy = makeService(balance: 100, notificationCenter: center)
+        XCTAssertNil(healthy.corruptedRawValue,
+                     "Healthy store must not report a pending corrupt value")
+
+        testDefaults.set(-1.0, forKey: "user_balance")
+        let corrupt = BalanceService(defaults: testDefaults, notificationCenter: center)
+        XCTAssertEqual(corrupt.corruptedRawValue, -1.0)
+
+        corrupt.acknowledgeCorruption()
+        XCTAssertNil(corrupt.corruptedRawValue,
+                     "Acknowledgement must clear the pending corrupt value")
+        XCTAssertFalse(corrupt.balanceCorrupted)
+    }
 }
 
 /// Tests for AlarmFiringViewModel — snooze/balance deduction edge cases.


### PR DESCRIPTION
Fixes #206

## Что сделано
- `BalanceService`: corruption state is now queryable for late subscribers — new `corruptedRawValue` keeps the raw invalid value latched by the init-time probe (`NotificationCenter` does not retro-deliver the one-shot `balanceCorruptedNotification`); cleared on `acknowledgeCorruption()`.
- `AlarmsListViewModel`: new `onBalanceCorrupted` callback. Covers BOTH seams — a live observer for `balanceCorruptedNotification` (corruption that latches while the VM is alive) AND a pull of the latched state in `loadData()` (cold-start corruption latched before the VM existed). Deduped once per corruption episode; `acknowledgeBalanceCorruption()` re-arms the latch and delegates the reset to the service. `NotificationCenter` is now injectable for isolated tests.
- `AlarmsListViewController`: binds `onBalanceCorrupted` to a user-facing alert ("Баланс повреждён") offering to wipe the corrupt value to 0 ₽ via `acknowledgeCorruption()` — previously NO UI observed the corruption notification at all.

## Verify
- ✅ swiftlint: 0 errors / 0 warnings on touched files
- ✅ xcodebuild build-for-testing (scheme SnoozePay, generic iOS Simulator, CODE_SIGNING_ALLOWED=NO): TEST BUILD SUCCEEDED
- ✅ tests written (run deferred to orchestrator per integration-branch mode):
  - `BalanceServiceTests`: cold-start corruption queryable by late observer; `corruptedRawValue` nil-when-healthy / cleared-after-ack
  - `AlarmsListViewModelCorruptionTests`: init-with-corrupt-balance → late observer → alert fires; dedupe per episode; healthy path silent; ack resets service + re-arms alert for a fresh episode

🤖 Generated with [Claude Code](https://claude.com/claude-code)