### PR TITLE
[refactor] Alarm: immutable fields + validating failable init + with(...) mutators (#207)

### DIFF
--- a/SnoozePay/SnoozePay/Models/Alarm.swift
+++ b/SnoozePay/SnoozePay/Models/Alarm.swift
@@ -1,30 +1,100 @@
 import Foundation
 
 /// Domain model for an alarm. Separate from Core Data entity for clean MVVM.
+///
+/// All fields are immutable (#207, interim hardening until #31 phase 2).
+/// Construction goes through one of three boundaries:
+/// - `init(validating:...)` — failable, rejects out-of-range values. Use it
+///   whenever the field values come from outside the app's bounded UI
+///   controls (imports, future deep links, manual copies).
+/// - `init(...)` — the historical default-arg initializer. Delegates to the
+///   validating one and traps on garbage, so in-app call sites (which only
+///   feed slider/toggle-bounded values) keep their non-optional ergonomics.
+/// - `init(from:)` — Codable decode. Sanitizes instead of rejecting, because
+///   throwing here would lock the entire persisted store (#72 / #117).
+///
+/// Legitimate edits produce a new value via `with(...)`.
 struct Alarm: Identifiable, Equatable, Codable {
     let id: UUID
-    var time: Date
-    var repeatDays: [Int] // 0 = Monday, 6 = Sunday
-    var name: String
-    var soundID: String
-    var vibrationEnabled: Bool
-    var snoozeMinutes: Int
-    var penaltyAmount: Double
-    var progressiveScale: Bool
-    var enabled: Bool
+    let time: Date
+    let repeatDays: [Int] // 0 = Monday, 6 = Sunday
+    let name: String
+    let soundID: String
+    let vibrationEnabled: Bool
+    let snoozeMinutes: Int
+    let penaltyAmount: Double
+    let progressiveScale: Bool
+    let enabled: Bool
     /// Per-alarm playback volume in `0.0...1.0`. Default `1.0` keeps the
     /// existing "ring at full volume" behaviour for legacy alarms (#150).
-    var volume: Float
+    let volume: Float
     /// When `true`, AudioService ramps from 0 → `volume` over 30 seconds at
     /// firing time so the user is woken gently. Default `false` preserves the
     /// pre-#150 instant-on behaviour.
-    var volumeFadeIn: Bool
+    let volumeFadeIn: Bool
     /// Visual theme used for the alarm-card background strip and the firing
     /// screen background (#151). Defaults to `.dawn` for both new alarms and
     /// legacy alarms persisted before the theme picker landed — see the
     /// custom `init(from:)` below for the migration path.
-    var theme: AlarmTheme
+    let theme: AlarmTheme
 
+    // MARK: - Validation rules (#207)
+
+    /// Spec range for snooze duration (SPEC.md says 1–30 minutes). The
+    /// create/edit form's slider exposes a narrower 1...15 — that UI bound
+    /// lives in `CreateAlarmViewModel.snoozeMinutesRange`.
+    static let snoozeMinutesRange: ClosedRange<Int> = 1...30
+    /// Legal weekday indices for `repeatDays` (0 = Monday, 6 = Sunday).
+    static let weekdayIndexRange: ClosedRange<Int> = 0...6
+
+    // MARK: - Validating failable init (#207)
+
+    /// Validating construction boundary. Returns `nil` when:
+    /// - any `repeatDays` element falls outside `weekdayIndexRange`
+    /// - `snoozeMinutes` falls outside `snoozeMinutesRange`
+    /// - `penaltyAmount` is negative or non-finite (NaN / infinity)
+    ///
+    /// `volume` is clamped into `0...1` (non-finite → full volume) rather
+    /// than rejected, preserving the historical initializer's behaviour.
+    init?(
+        validating id: UUID,
+        time: Date = Date(),
+        repeatDays: [Int] = [],
+        name: String = "Будильник",
+        soundID: String = "radar",
+        vibrationEnabled: Bool = true,
+        snoozeMinutes: Int = 9,
+        penaltyAmount: Double = 50,
+        progressiveScale: Bool = false,
+        enabled: Bool = true,
+        volume: Float = 1.0,
+        volumeFadeIn: Bool = false,
+        theme: AlarmTheme = .dawn
+    ) {
+        guard repeatDays.allSatisfy(Self.weekdayIndexRange.contains),
+              Self.snoozeMinutesRange.contains(snoozeMinutes),
+              penaltyAmount.isFinite, penaltyAmount >= 0
+        else { return nil }
+
+        self.id = id
+        self.time = time
+        self.repeatDays = repeatDays
+        self.name = name
+        self.soundID = soundID
+        self.vibrationEnabled = vibrationEnabled
+        self.snoozeMinutes = snoozeMinutes
+        self.penaltyAmount = penaltyAmount
+        self.progressiveScale = progressiveScale
+        self.enabled = enabled
+        self.volume = Self.clampedVolume(volume)
+        self.volumeFadeIn = volumeFadeIn
+        self.theme = theme
+    }
+
+    /// Historical default-arg initializer, kept for in-app call sites whose
+    /// inputs are already bounded by UI controls. Delegates to
+    /// `init(validating:...)` and traps if handed garbage — invalid values
+    /// must be rejected at the construction boundary, not stored (#207).
     init(
         id: UUID = UUID(),
         time: Date = Date(),
@@ -40,19 +110,70 @@ struct Alarm: Identifiable, Equatable, Codable {
         volumeFadeIn: Bool = false,
         theme: AlarmTheme = .dawn
     ) {
-        self.id = id
-        self.time = time
-        self.repeatDays = repeatDays
-        self.name = name
-        self.soundID = soundID
-        self.vibrationEnabled = vibrationEnabled
-        self.snoozeMinutes = snoozeMinutes
-        self.penaltyAmount = penaltyAmount
-        self.progressiveScale = progressiveScale
-        self.enabled = enabled
-        self.volume = min(max(volume, 0), 1)
-        self.volumeFadeIn = volumeFadeIn
-        self.theme = theme
+        guard let alarm = Alarm(
+            validating: id,
+            time: time,
+            repeatDays: repeatDays,
+            name: name,
+            soundID: soundID,
+            vibrationEnabled: vibrationEnabled,
+            snoozeMinutes: snoozeMinutes,
+            penaltyAmount: penaltyAmount,
+            progressiveScale: progressiveScale,
+            enabled: enabled,
+            volume: volume,
+            volumeFadeIn: volumeFadeIn,
+            theme: theme
+        ) else {
+            preconditionFailure(
+                """
+                Alarm constructed with invalid fields \
+                (repeatDays=\(repeatDays), snoozeMinutes=\(snoozeMinutes), \
+                penaltyAmount=\(penaltyAmount)). \
+                Use Alarm(validating:...) for unvalidated input.
+                """
+            )
+        }
+        self = alarm
+    }
+
+    // MARK: - with(...) mutators (#207)
+
+    /// Returns a copy with the given fields replaced; `nil` arguments keep
+    /// the current value. Identity (`id`) is intentionally not replaceable.
+    /// Delegates to the trapping initializer, so feeding it unvalidated
+    /// user input for `repeatDays` / `snoozeMinutes` / `penaltyAmount` is a
+    /// programmer error — sanitize first or construct via
+    /// `Alarm(validating:...)`.
+    func with(
+        time: Date? = nil,
+        repeatDays: [Int]? = nil,
+        name: String? = nil,
+        soundID: String? = nil,
+        vibrationEnabled: Bool? = nil,
+        snoozeMinutes: Int? = nil,
+        penaltyAmount: Double? = nil,
+        progressiveScale: Bool? = nil,
+        enabled: Bool? = nil,
+        volume: Float? = nil,
+        volumeFadeIn: Bool? = nil,
+        theme: AlarmTheme? = nil
+    ) -> Alarm {
+        Alarm(
+            id: id,
+            time: time ?? self.time,
+            repeatDays: repeatDays ?? self.repeatDays,
+            name: name ?? self.name,
+            soundID: soundID ?? self.soundID,
+            vibrationEnabled: vibrationEnabled ?? self.vibrationEnabled,
+            snoozeMinutes: snoozeMinutes ?? self.snoozeMinutes,
+            penaltyAmount: penaltyAmount ?? self.penaltyAmount,
+            progressiveScale: progressiveScale ?? self.progressiveScale,
+            enabled: enabled ?? self.enabled,
+            volume: volume ?? self.volume,
+            volumeFadeIn: volumeFadeIn ?? self.volumeFadeIn,
+            theme: theme ?? self.theme
+        )
     }
 
     // MARK: - Codable (backwards-compatible decode)
@@ -65,6 +186,13 @@ struct Alarm: Identifiable, Equatable, Codable {
     // a fatal `decodeFailure` (issue #117 / #72 lock the entire store).
     // Adding a field MUST be backward-compatible — this initializer is the
     // contract that ships safely on top of #143.
+    //
+    // Decode SANITIZES out-of-range legacy values instead of rejecting them
+    // (#207): pre-validation installs may carry snoozeMinutes outside the
+    // spec range, garbage weekday indices, or a negative penalty. Throwing
+    // would lock the whole store; trapping would crash on launch. Clamping /
+    // dropping keeps every legacy alarm readable while guaranteeing decoded
+    // values satisfy the same invariants `init(validating:...)` enforces.
 
     private enum CodingKeys: String, CodingKey {
         case id, time, repeatDays, name, soundID, vibrationEnabled
@@ -76,21 +204,37 @@ struct Alarm: Identifiable, Equatable, Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.id = try container.decode(UUID.self, forKey: .id)
         self.time = try container.decode(Date.self, forKey: .time)
-        self.repeatDays = try container.decode([Int].self, forKey: .repeatDays)
+        // Drop illegal weekday indices from corrupt legacy storage.
+        let rawRepeatDays = try container.decode([Int].self, forKey: .repeatDays)
+        self.repeatDays = rawRepeatDays.filter(Self.weekdayIndexRange.contains)
         self.name = try container.decode(String.self, forKey: .name)
         self.soundID = try container.decode(String.self, forKey: .soundID)
         self.vibrationEnabled = try container.decode(Bool.self, forKey: .vibrationEnabled)
-        self.snoozeMinutes = try container.decode(Int.self, forKey: .snoozeMinutes)
-        self.penaltyAmount = try container.decode(Double.self, forKey: .penaltyAmount)
+        // Clamp into the spec range (pre-#143 alarms could store up to 30;
+        // anything outside 1...30 is corrupt data).
+        let rawSnooze = try container.decode(Int.self, forKey: .snoozeMinutes)
+        self.snoozeMinutes = min(
+            max(rawSnooze, Self.snoozeMinutesRange.lowerBound),
+            Self.snoozeMinutesRange.upperBound
+        )
+        // Negative / non-finite penalties from corrupt storage degrade to 0
+        // (no charge) rather than crashing or locking the store.
+        let rawPenalty = try container.decode(Double.self, forKey: .penaltyAmount)
+        self.penaltyAmount = rawPenalty.isFinite ? max(rawPenalty, 0) : 0
         self.progressiveScale = try container.decode(Bool.self, forKey: .progressiveScale)
         self.enabled = try container.decode(Bool.self, forKey: .enabled)
         // New in #150 — fall back to the "ring at full volume, no fade"
         // pre-#150 behaviour when keys are missing or out of range.
         let rawVolume = try container.decodeIfPresent(Float.self, forKey: .volume) ?? 1.0
-        self.volume = min(max(rawVolume.isFinite ? rawVolume : 1.0, 0), 1)
+        self.volume = Self.clampedVolume(rawVolume)
         self.volumeFadeIn = try container.decodeIfPresent(Bool.self, forKey: .volumeFadeIn) ?? false
         // Migration: pre-#151 alarms have no `theme` field — default to .dawn.
         self.theme = try container.decodeIfPresent(AlarmTheme.self, forKey: .theme) ?? .dawn
+    }
+
+    /// Shared volume sanitization: non-finite → full volume, then clamp 0...1.
+    private static func clampedVolume(_ raw: Float) -> Float {
+        min(max(raw.isFinite ? raw : 1.0, 0), 1)
     }
 
     /// Human-readable repeat days string (e.g. "Пн, Вт, Пт")
@@ -140,14 +284,17 @@ struct Alarm: Identifiable, Equatable, Codable {
         TimeOfDay(from: time)
     }
 
-    /// Typed view over `repeatDays`. Out-of-range integers in legacy storage
-    /// are silently skipped (existing data may contain them).
+    /// Typed view over `repeatDays`. Since #207 the construction boundary
+    /// rejects (init) or drops (decode) out-of-range indices, so this is a
+    /// straight bridge; the legacy-index skip in `Set<Weekday>` is now a
+    /// belt-and-suspenders guard.
     var weekdays: Set<Weekday> {
         Set<Weekday>(legacyMondayFirstIndices: repeatDays)
     }
 
-    /// Typed view of `penaltyAmount`. `nil` if the legacy `Double` is
-    /// negative or non-finite, which a typed setter would have refused.
+    /// Typed view of `penaltyAmount`. Since #207 every construction path
+    /// guarantees a non-negative finite amount, so this never returns `nil`
+    /// in practice; the optional shape stays until phase 2 retypes storage.
     var penaltyMoney: Money? {
         Money(penaltyAmount)
     }

--- a/SnoozePay/SnoozePay/Services/AlarmRepository.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmRepository.swift
@@ -204,7 +204,7 @@ final class AlarmRepository {
                 return nil
             }
             guard let idx = alarms.firstIndex(where: { $0.id == id }) else { return nil }
-            alarms[idx].enabled = enabled
+            alarms[idx] = alarms[idx].with(enabled: enabled)
             guard persist(alarms) else { return nil }
             return alarms[idx]
         }

--- a/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
@@ -126,11 +126,12 @@ final class AlarmsListViewModel {
         // closure first, set `.enabled = !enabled`, then the post-call
         // mutation would clobber the rollback (#129).
         //
-        // Mutate the stored value in place rather than rebuilding `Alarm`
-        // field-by-field — the manual rebuild silently dropped any field it
-        // didn't list (it reset `volume`/`volumeFadeIn`/`theme` from #150/#151
-        // to their defaults) and would do the same for every future field (#205).
-        alarms[index].enabled = enabled
+        // Use `with(enabled:)` rather than rebuilding `Alarm` field-by-field —
+        // the manual rebuild silently dropped any field it didn't list (it
+        // reset `volume`/`volumeFadeIn`/`theme` from #150/#151 to their
+        // defaults) and would do the same for every future field (#205).
+        // `with` copies every other field through unchanged (#207).
+        alarms[index] = alarms[index].with(enabled: enabled)
 
         let didUpdate = alarmRepository.setEnabled(enabled, id: id) { [weak self] result in
             // Scheduling outcome only fires on the successful-persist path.
@@ -145,7 +146,7 @@ final class AlarmsListViewModel {
                     "schedule failed during toggle id=\(id, privacy: .private); rolling back UI + disk"
                 )
                 if let idx = self.alarms.firstIndex(where: { $0.id == id }) {
-                    self.alarms[idx].enabled = !enabled
+                    self.alarms[idx] = self.alarms[idx].with(enabled: !enabled)
                 }
                 // Persist the rollback. We pass `nil` completion so we don't
                 // re-trigger this closure on the rollback's own scheduler call

--- a/SnoozePay/SnoozePay/ViewModels/CreateAlarmViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/CreateAlarmViewModel.swift
@@ -106,15 +106,26 @@ final class CreateAlarmViewModel {
     }
 
     private func makeAlarmFromCurrentState() -> Alarm {
-        Alarm(
+        // Explicit re-construction with validated input (#207). The form's
+        // controls are bounded (sliders/toggles), but `Alarm.init` now traps
+        // on out-of-range values — sanitize here so a future control change
+        // (e.g. a free-text penalty field) degrades gracefully instead of
+        // crashing at the construction boundary.
+        let safeSnooze = min(
+            max(snoozeMinutes, Alarm.snoozeMinutesRange.lowerBound),
+            Alarm.snoozeMinutesRange.upperBound
+        )
+        let safePenalty = penaltyAmount.isFinite ? max(penaltyAmount, 0) : 50
+        let safeRepeatDays = repeatDays.filter(Alarm.weekdayIndexRange.contains)
+        return Alarm(
             id: existingID ?? UUID(),
             time: time,
-            repeatDays: repeatDays,
+            repeatDays: safeRepeatDays,
             name: name.isEmpty ? "Будильник" : name,
             soundID: soundID,
             vibrationEnabled: vibrationEnabled,
-            snoozeMinutes: snoozeMinutes,
-            penaltyAmount: penaltyAmount,
+            snoozeMinutes: safeSnooze,
+            penaltyAmount: safePenalty,
             progressiveScale: progressiveScale,
             enabled: enabled,
             volume: volume,

--- a/SnoozePay/SnoozePayTests/AlarmFiringViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmFiringViewModelTests.swift
@@ -123,9 +123,7 @@ final class AlarmFiringViewModelIOS011Tests: XCTestCase {
 
     func testDismiss_disablesNonRepeatingAlarm() {
         let repo = AlarmRepository(defaults: .standard)
-        var alarm = Alarm(penaltyAmount: 50)
-        alarm.repeatDays = []
-        alarm.enabled = true
+        let alarm = Alarm(repeatDays: [], penaltyAmount: 50, enabled: true)
         repo.save(alarm)
 
         let vm = AlarmFiringViewModel(alarm: alarm, snoozeCount: 0, alarmRepository: repo)
@@ -141,9 +139,7 @@ final class AlarmFiringViewModelIOS011Tests: XCTestCase {
 
     func testDismiss_keepsRepeatingAlarmEnabled() {
         let repo = AlarmRepository(defaults: .standard)
-        var alarm = Alarm(penaltyAmount: 50)
-        alarm.repeatDays = [0, 1, 2, 3, 4] // Weekdays
-        alarm.enabled = true
+        let alarm = Alarm(repeatDays: [0, 1, 2, 3, 4], penaltyAmount: 50, enabled: true) // Weekdays
         repo.save(alarm)
 
         let vm = AlarmFiringViewModel(alarm: alarm, snoozeCount: 0, alarmRepository: repo)
@@ -163,9 +159,7 @@ final class AlarmFiringViewModelIOS011Tests: XCTestCase {
     /// end-state is already achieved.
     func testDismiss_alarmAlreadyRemoved_doesNotCrash() {
         let repo = AlarmRepository(defaults: .standard)
-        var alarm = Alarm(penaltyAmount: 50)
-        alarm.repeatDays = []
-        alarm.enabled = true
+        let alarm = Alarm(repeatDays: [], penaltyAmount: 50, enabled: true)
         // Intentionally do NOT save — simulate "already removed" repo state.
 
         let vm = AlarmFiringViewModel(alarm: alarm, snoozeCount: 0, alarmRepository: repo)

--- a/SnoozePay/SnoozePayTests/AlarmRepositoryTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmRepositoryTests.swift
@@ -45,11 +45,10 @@ final class AlarmRepositoryTests: XCTestCase {
     }
 
     func testSave_updatesExistingAlarm() {
-        var alarm = makeAlarm(name: "Original")
+        let alarm = makeAlarm(name: "Original")
         repo.save(alarm)
 
-        alarm.name = "Updated"
-        repo.save(alarm)
+        repo.save(alarm.with(name: "Updated"))
 
         XCTAssertEqual(repo.fetchAll().count, 1)
         XCTAssertEqual(repo.fetch(id: alarm.id)?.name, "Updated")
@@ -304,11 +303,10 @@ final class AlarmRepositoryTests: XCTestCase {
     /// invariant so a future regression that switched to "always append" would
     /// fail loudly here even if the last-write-wins on the field comparison.
     func testSave_upsertsExistingAlarmInPlace() {
-        var alarm = makeAlarm(name: "v1")
+        let alarm = makeAlarm(name: "v1")
         repo.save(alarm)
         repo.save(alarm) // same id, second time
-        alarm.name = "v2"
-        repo.save(alarm) // mutated, same id
+        repo.save(alarm.with(name: "v2")) // changed copy, same id
 
         let stored = repo.fetchAll()
         XCTAssertEqual(stored.count, 1, "Repeated saves of the same id must NOT duplicate the alarm")
@@ -355,9 +353,7 @@ final class AlarmRepositoryTests: XCTestCase {
             if idx % 2 == 0 {
                 self.repo.setEnabled(true, id: alarm.id)
             } else {
-                var disabled = alarm
-                disabled.enabled = false
-                self.repo.save(disabled)
+                self.repo.save(alarm.with(enabled: false))
             }
         }
 

--- a/SnoozePay/SnoozePayTests/AlarmTransactionTypedViewsTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmTransactionTypedViewsTests.swift
@@ -40,10 +40,13 @@ final class AlarmTransactionTypedViewsTests: XCTestCase {
         XCTAssertTrue(alarm.weekdays.isEmpty)
     }
 
-    func testAlarmWeekdays_dropsOutOfRangeLegacyIntegers() {
-        // Corrupted legacy data (`-1`, `8`, `99`) must not crash; the bridge
-        // silently drops invalid indices, mirroring `repeatDaysDescription`.
-        let alarm = Alarm(repeatDays: [-1, 0, 8, 99, 6])
+    func testAlarmWeekdays_dropsOutOfRangeLegacyIntegers() throws {
+        // Corrupted legacy data (`-1`, `8`, `99`) can no longer be constructed
+        // via the initializer (#207) — it only reaches the model through
+        // decode of pre-validation persisted JSON, which sanitizes the
+        // indices. The typed view then bridges the surviving valid ones.
+        let alarm = try decodeAlarm(repeatDaysJSON: "[-1, 0, 8, 99, 6]")
+        XCTAssertEqual(alarm.repeatDays, [0, 6])
         XCTAssertEqual(alarm.weekdays, [.monday, .sunday])
     }
 
@@ -64,17 +67,39 @@ final class AlarmTransactionTypedViewsTests: XCTestCase {
         XCTAssertEqual(alarm.penaltyMoney, .zero)
     }
 
-    func testAlarmPenaltyMoney_negativeLegacyValueReturnsNil() {
-        // The primitive setter never validated, so corrupt persisted alarms
-        // could carry a negative `penaltyAmount`. The typed view surfaces this
-        // as `nil` so phase-2 callers must explicitly handle it.
-        let alarm = Alarm(penaltyAmount: -50)
-        XCTAssertNil(alarm.penaltyMoney)
+    func testAlarmPenaltyMoney_negativeLegacyValueSanitizedOnDecode() throws {
+        // Pre-#207 stores could carry a negative `penaltyAmount`. Decode now
+        // degrades it to 0 (no charge) instead of letting downstream code see
+        // a negative amount — the typed view then wraps a valid `.zero`.
+        let alarm = try decodeAlarm(penaltyAmountJSON: "-50.0")
+        XCTAssertEqual(alarm.penaltyAmount, 0)
+        XCTAssertEqual(alarm.penaltyMoney, .zero)
     }
 
-    func testAlarmPenaltyMoney_nanReturnsNil() {
-        let alarm = Alarm(penaltyAmount: .nan)
-        XCTAssertNil(alarm.penaltyMoney)
+    // MARK: - Legacy-JSON decode helper (#207)
+
+    /// Decodes a hand-rolled pre-validation alarm JSON with the given raw
+    /// field payloads, mimicking corrupt legacy storage that the initializer
+    /// would reject today.
+    private func decodeAlarm(
+        repeatDaysJSON: String = "[]",
+        penaltyAmountJSON: String = "50.0"
+    ) throws -> Alarm {
+        let json = """
+        {
+            "id":"\(UUID().uuidString)",
+            "time":770000000,
+            "repeatDays":\(repeatDaysJSON),
+            "name":"Legacy",
+            "soundID":"radar",
+            "vibrationEnabled":true,
+            "snoozeMinutes":9,
+            "penaltyAmount":\(penaltyAmountJSON),
+            "progressiveScale":false,
+            "enabled":true
+        }
+        """.data(using: .utf8)!
+        return try JSONDecoder().decode(Alarm.self, from: json)
     }
 
     // MARK: - Transaction.money

--- a/SnoozePay/SnoozePayTests/AlarmValidationTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmValidationTests.swift
@@ -1,0 +1,159 @@
+import XCTest
+@testable import SnoozePay
+
+/// Unit tests for the validating construction boundary added in #207 —
+/// `Alarm(validating:...)` must reject out-of-range field values, the
+/// `with(...)` mutators must preserve identity and untouched fields, and the
+/// Codable decode path must sanitize (not reject) corrupt legacy storage.
+final class AlarmValidationTests: XCTestCase {
+
+    // MARK: - Failable init rejects garbage
+
+    func testValidatingInit_negativePenaltyReturnsNil() {
+        XCTAssertNil(Alarm(validating: UUID(), penaltyAmount: -50))
+    }
+
+    func testValidatingInit_nanPenaltyReturnsNil() {
+        XCTAssertNil(Alarm(validating: UUID(), penaltyAmount: .nan))
+    }
+
+    func testValidatingInit_infinitePenaltyReturnsNil() {
+        XCTAssertNil(Alarm(validating: UUID(), penaltyAmount: .infinity))
+    }
+
+    func testValidatingInit_zeroSnoozeMinutesReturnsNil() {
+        XCTAssertNil(Alarm(validating: UUID(), snoozeMinutes: 0))
+    }
+
+    func testValidatingInit_oversizedSnoozeMinutesReturnsNil() {
+        XCTAssertNil(Alarm(validating: UUID(), snoozeMinutes: 31))
+    }
+
+    func testValidatingInit_negativeWeekdayIndexReturnsNil() {
+        XCTAssertNil(Alarm(validating: UUID(), repeatDays: [-1, 0]))
+    }
+
+    func testValidatingInit_outOfRangeWeekdayIndexReturnsNil() {
+        XCTAssertNil(Alarm(validating: UUID(), repeatDays: [0, 7]))
+    }
+
+    // MARK: - Failable init accepts valid values
+
+    func testValidatingInit_boundaryValuesSucceed() {
+        let alarm = Alarm(
+            validating: UUID(),
+            repeatDays: [0, 6],
+            snoozeMinutes: 30,
+            penaltyAmount: 0
+        )
+        XCTAssertNotNil(alarm)
+        XCTAssertEqual(alarm?.repeatDays, [0, 6])
+        XCTAssertEqual(alarm?.snoozeMinutes, 30)
+        XCTAssertEqual(alarm?.penaltyAmount, 0)
+    }
+
+    func testValidatingInit_defaultsAreValid() {
+        XCTAssertNotNil(Alarm(validating: UUID()))
+    }
+
+    func testValidatingInit_clampsVolumeInsteadOfRejecting() {
+        // Volume keeps the historical clamp-don't-reject semantics.
+        let alarm = Alarm(validating: UUID(), volume: 1.5)
+        XCTAssertEqual(alarm?.volume, 1.0)
+    }
+
+    // MARK: - with(...) mutators
+
+    func testWith_preservesIdentityAndUntouchedFields() {
+        let original = Alarm(
+            repeatDays: [0, 4],
+            name: "Утро",
+            snoozeMinutes: 5,
+            penaltyAmount: 100,
+            enabled: true,
+            volume: 0.5,
+            volumeFadeIn: true,
+            theme: .ocean
+        )
+
+        let toggled = original.with(enabled: false)
+
+        XCTAssertEqual(toggled.id, original.id, "with(...) must keep identity")
+        XCTAssertFalse(toggled.enabled)
+        XCTAssertEqual(toggled.repeatDays, original.repeatDays)
+        XCTAssertEqual(toggled.name, original.name)
+        XCTAssertEqual(toggled.snoozeMinutes, original.snoozeMinutes)
+        XCTAssertEqual(toggled.penaltyAmount, original.penaltyAmount)
+        XCTAssertEqual(toggled.volume, original.volume)
+        XCTAssertEqual(toggled.volumeFadeIn, original.volumeFadeIn)
+        XCTAssertEqual(toggled.theme, original.theme)
+    }
+
+    func testWith_replacesMultipleFields() {
+        let original = Alarm(name: "Старое", penaltyAmount: 50)
+        let edited = original.with(name: "Новое", penaltyAmount: 200)
+
+        XCTAssertEqual(edited.id, original.id)
+        XCTAssertEqual(edited.name, "Новое")
+        XCTAssertEqual(edited.penaltyAmount, 200)
+    }
+
+    // MARK: - Decode sanitizes legacy garbage instead of throwing
+
+    func testDecode_clampsOutOfRangeSnoozeMinutes() throws {
+        let low = try decodeLegacyAlarm(snoozeMinutesJSON: "0")
+        XCTAssertEqual(low.snoozeMinutes, Alarm.snoozeMinutesRange.lowerBound)
+
+        let high = try decodeLegacyAlarm(snoozeMinutesJSON: "999")
+        XCTAssertEqual(high.snoozeMinutes, Alarm.snoozeMinutesRange.upperBound)
+    }
+
+    func testDecode_negativePenaltyDegradesToZero() throws {
+        let alarm = try decodeLegacyAlarm(penaltyAmountJSON: "-50.0")
+        XCTAssertEqual(alarm.penaltyAmount, 0)
+    }
+
+    func testDecode_dropsIllegalWeekdayIndices() throws {
+        let alarm = try decodeLegacyAlarm(repeatDaysJSON: "[-1, 2, 8, 99]")
+        XCTAssertEqual(alarm.repeatDays, [2])
+    }
+
+    func testDecode_validValuesRoundTripUnchanged() throws {
+        let original = Alarm(
+            repeatDays: [0, 1, 2, 3, 4],
+            name: "Будни",
+            snoozeMinutes: 9,
+            penaltyAmount: 150,
+            theme: .mountains
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(Alarm.self, from: data)
+        XCTAssertEqual(decoded, original)
+    }
+
+    // MARK: - Helper
+
+    /// Hand-rolled pre-validation alarm JSON mimicking corrupt legacy storage
+    /// that `Alarm(validating:...)` would reject today.
+    private func decodeLegacyAlarm(
+        repeatDaysJSON: String = "[]",
+        snoozeMinutesJSON: String = "9",
+        penaltyAmountJSON: String = "50.0"
+    ) throws -> Alarm {
+        let json = """
+        {
+            "id":"\(UUID().uuidString)",
+            "time":770000000,
+            "repeatDays":\(repeatDaysJSON),
+            "name":"Legacy",
+            "soundID":"radar",
+            "vibrationEnabled":true,
+            "snoozeMinutes":\(snoozeMinutesJSON),
+            "penaltyAmount":\(penaltyAmountJSON),
+            "progressiveScale":false,
+            "enabled":true
+        }
+        """.data(using: .utf8)!
+        return try JSONDecoder().decode(Alarm.self, from: json)
+    }
+}


### PR DESCRIPTION
Fixes #207

## Что сделано
- **All `Alarm` fields are now `let`** — struct is fully immutable; edits produce a new value via `with(...)` (identity `id` not replaceable).
- **`init?(validating:...)`** — failable construction boundary: rejects `repeatDays` outside 0...6, `snoozeMinutes` outside 1...30 (spec range), negative/non-finite `penaltyAmount`. `volume` keeps the historical clamp-don't-reject semantics.
- **Historical default-arg `init(...)` kept** with the exact same signature; it delegates to the validating init and `preconditionFailure`s on garbage — all existing call sites compile unchanged.
- **Decode sanitizes instead of rejecting** (no store lock per #72/#117, no launch trap): illegal weekday indices dropped, snooze clamped to 1...30, negative penalty degrades to 0.
- Call sites migrated: `AlarmsListViewModel` toggle + rollback and `AlarmRepository.setEnabled` use `with(enabled:)`; `CreateAlarmViewModel.makeAlarmFromCurrentState` sanitizes inputs before explicit re-construction.
- Tests that mutated `var alarm` fields rewritten to `with(...)` / full construction; typed-views "legacy garbage" tests now inject garbage through the only remaining path (decode of hand-rolled legacy JSON).

## Trade-offs vs issue acceptance
- The issue's literal acceptance test `Alarm(penaltyAmount: -50) == nil` is impossible alongside the kept default-arg init (Swift forbids failable/non-failable overloads with identical signatures). Implemented as `Alarm(validating: UUID(), penaltyAmount: -50) == nil` (covered in `AlarmValidationTests`); the unlabeled init traps on the same input, per the issue's "traps on garbage at the construction boundary".
- `testAlarmPenaltyMoney_nanReturnsNil` removed: NaN is no longer constructible and JSON can't carry it; NaN rejection is covered by `testValidatingInit_nanPenaltyReturnsNil`.

## Verify
- ✅ swiftlint: 0 errors on touched files
- ✅ xcodebuild build (generic/platform=iOS Simulator, CODE_SIGNING_ALLOWED=NO): succeeded
- ✅ xcodebuild build-for-testing: test target compiles
- ➖ test run deferred to orchestrator (parallel-wave policy)

## Tests added (`SnoozePayTests/AlarmValidationTests.swift`)
- Rejection: negative/NaN/infinite penalty, snooze 0 / 31, weekday -1 / 7
- Acceptance: boundary values (snooze 30, penalty 0, days [0,6]), defaults, volume clamp
- `with(...)`: identity + untouched-field preservation, multi-field replace
- Decode sanitization: snooze clamp both ends, negative penalty → 0, illegal weekday drop, valid round-trip unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)