### PR TITLE
[fix] Surface silent-failure long-tail: window-nil, preview no-op, tone init (#210)

### DIFF
--- a/SnoozePay/SnoozePay/SceneDelegate.swift
+++ b/SnoozePay/SnoozePay/SceneDelegate.swift
@@ -3,6 +3,7 @@
 //  SnoozePay
 //
 
+import os
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
@@ -89,7 +90,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     private func transitionToMainApp() {
-        guard let window = window else { return }
+        guard let window = window else {
+            // Permissions flow already flipped its "shown" flag — bailing out
+            // here strands the user on a dead screen with no trace (#210).
+            AppLogger.appDelegate.error("transitionToMainApp: window nil — user stuck on onboarding")
+            return
+        }
         let tabBar = makeTabBarController()
         UIView.transition(with: window, duration: 0.4, options: .transitionCrossDissolve) {
             window.rootViewController = tabBar

--- a/SnoozePay/SnoozePay/Services/AlarmRepository.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmRepository.swift
@@ -77,6 +77,10 @@ final class AlarmRepository {
 
     // MARK: - Read
 
+    /// Lossy read: a decode failure is indistinguishable from "no alarms"
+    /// (#210). Prefer `fetchAllChecked()` in production paths that render
+    /// state to the user — this variant is kept for tests and callers that
+    /// genuinely cannot surface an error.
     func fetchAll() -> [Alarm] {
         queue.sync { (try? readAll()) ?? [] }
     }
@@ -88,6 +92,9 @@ final class AlarmRepository {
         try queue.sync { try readAll() }
     }
 
+    /// Lossy read: a decode failure is indistinguishable from "alarm doesn't
+    /// exist" (#210). Prefer `fetchChecked(id:)` on hot paths — this variant
+    /// is kept for tests and callers that cannot surface an error.
     func fetch(id: UUID) -> Alarm? {
         queue.sync { (try? readAll())?.first { $0.id == id } }
     }

--- a/SnoozePay/SnoozePay/Services/AudioService+Tone.swift
+++ b/SnoozePay/SnoozePay/Services/AudioService+Tone.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 import Foundation
+import os
 
 // MARK: - Synthetic alarm tone generation
 //
@@ -25,7 +26,16 @@ extension AudioService {
         )
 
         let wavData = packWAV(samples: samples, totalSamples: totalSamples)
-        return try? AVAudioPlayer(data: wavData)
+        do {
+            return try AVAudioPlayer(data: wavData)
+        } catch {
+            // Last-resort fallback failed — the alarm fires with vibration
+            // only. Log it so "why no tone" is diagnosable from Console
+            // instead of requiring a source read (#210).
+            let desc = String(describing: error)
+            AppLogger.audio.error("generateAlarmTone: AVAudioPlayer init failed: \(desc, privacy: .public)")
+            return nil
+        }
     }
 
     /// Build interleaved 16-bit PCM samples with the dual-tone amplitude

--- a/SnoozePay/SnoozePay/Services/TransactionRepository.swift
+++ b/SnoozePay/SnoozePay/Services/TransactionRepository.swift
@@ -67,6 +67,10 @@ final class TransactionRepository {
 
     // MARK: - Read
 
+    /// Lossy read: a decode failure is indistinguishable from "no
+    /// transactions" (#210). Prefer `fetchAllChecked()` in production paths
+    /// that render state to the user — callers of this variant should
+    /// consult `lastLoadFailed` before trusting an empty result.
     func fetchAll() -> [Transaction] {
         queue.sync { (try? readAll()) ?? [] }
     }
@@ -78,6 +82,9 @@ final class TransactionRepository {
         try queue.sync { try readAll() }
     }
 
+    /// Lossy read: a decode failure yields `[]` silently (#210). Display-only
+    /// callers (weekly chart) tolerate this; anything that drives money or
+    /// scheduling decisions must use `fetchAllChecked()` and filter.
     func fetchCharges(since date: Date) -> [Transaction] {
         queue.sync {
             let txs = (try? readAll()) ?? []

--- a/SnoozePay/SnoozePay/ViewModels/CreateAlarmViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/CreateAlarmViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AudioToolbox
+import os
 
 /// ViewModel for create/edit alarm screen.
 final class CreateAlarmViewModel {
@@ -187,10 +188,19 @@ final class CreateAlarmViewModel {
         "jazz": 1026
     ]
 
-    /// Play a preview of the given sound using system sounds
-    func previewSound(_ soundID: String) {
-        guard let systemID = Self.systemSoundMap[soundID] else { return }
+    /// Play a preview of the given sound using system sounds.
+    /// - Returns: `false` when `soundID` has no entry in `systemSoundMap` —
+    ///   the tap is a no-op, which previously happened silently (#210). The
+    ///   result is discardable for UI callers but lets tests pin the map
+    ///   against `availableSounds` so they can't drift apart.
+    @discardableResult
+    func previewSound(_ soundID: String) -> Bool {
+        guard let systemID = Self.systemSoundMap[soundID] else {
+            AppLogger.audio.error("previewSound: unknown soundID \(soundID, privacy: .public)")
+            return false
+        }
         AudioServicesPlaySystemSound(systemID)
+        return true
     }
 
     // MARK: - Alarm theme (#151)

--- a/SnoozePay/SnoozePayTests/AudioServiceTests.swift
+++ b/SnoozePay/SnoozePayTests/AudioServiceTests.swift
@@ -4,6 +4,17 @@ import XCTest
 /// Unit tests for AudioService — alarm sound playback state management.
 final class AudioServiceTests: XCTestCase {
 
+    // MARK: - Synthetic tone (#210)
+
+    /// The in-memory WAV fallback must produce a ready AVAudioPlayer — if it
+    /// ever returns nil the alarm fires vibration-only, which previously
+    /// happened without a trace (`try?`). Now the failure path logs, and this
+    /// test pins the happy path so the generated WAV header stays valid.
+    func testGenerateAlarmTone_returnsPlayer() {
+        XCTAssertNotNil(AudioService.generateAlarmTone(),
+                        "Synthetic tone generation must succeed for valid in-memory WAV data")
+    }
+
     // MARK: - Start
 
     func testStartAlarmSound_setsIsPlaying() {

--- a/SnoozePay/SnoozePayTests/CreateAlarmViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/CreateAlarmViewModelTests.swift
@@ -47,17 +47,30 @@ final class CreateAlarmViewModelSoundTests: XCTestCase {
         let vm = CreateAlarmViewModel(repository: repo)
         // Calling previewSound with a valid ID should not crash.
         // AudioServicesPlaySystemSound may be a no-op in test environment.
-        vm.previewSound("dawn")
-        vm.previewSound("radar")
-        vm.previewSound("drops")
+        XCTAssertTrue(vm.previewSound("dawn"))
+        XCTAssertTrue(vm.previewSound("radar"))
+        XCTAssertTrue(vm.previewSound("drops"))
     }
 
     func testPreviewSound_withInvalidID_doesNotCrash() {
         let vm = CreateAlarmViewModel(repository: repo)
-        // Invalid IDs should be silently ignored (guard let returns)
-        vm.previewSound("nonexistent_sound")
-        vm.previewSound("")
-        vm.previewSound("🎵")
+        // Unknown IDs are a no-op — previewSound reports it via the
+        // Bool result (and logs) instead of failing silently (#210).
+        XCTAssertFalse(vm.previewSound("nonexistent_sound"))
+        XCTAssertFalse(vm.previewSound(""))
+        XCTAssertFalse(vm.previewSound("🎵"))
+    }
+
+    /// Drift guard (#210): every sound offered in the picker must have a
+    /// preview mapping, otherwise the preview tap is dead for that row.
+    func testPreviewSound_coversAllAvailableSounds() {
+        let vm = CreateAlarmViewModel(repository: repo)
+        for sound in vm.availableSounds {
+            XCTAssertTrue(
+                vm.previewSound(sound.id),
+                "Sound '\(sound.id)' is listed in availableSounds but has no systemSoundMap entry"
+            )
+        }
     }
 
     // MARK: - Default values


### PR DESCRIPTION
Fixes #210

Targets `design-refresh-2026-04-27` (integration branch). PR #216 fixed part of #210 on `main` only — none of the four items were present on this branch, verified before implementing.

## Что сделано
1. **SceneDelegate.transitionToMainApp** — nil-window bail-out now logs `AppLogger.appDelegate.error("transitionToMainApp: window nil — user stuck on onboarding")` instead of returning silently.
2. **CreateAlarmViewModel.previewSound** — unknown `soundID` now logs `AppLogger.audio.error` and the method returns a `@discardableResult Bool` (UI callers unaffected) so tests can pin `systemSoundMap` against `availableSounds` and catch drift.
3. **AudioService.generateAlarmTone** — `try?` replaced with `do/catch` + `AppLogger.audio.error("generateAlarmTone: AVAudioPlayer init failed: …")`; behaviour (return nil on failure) unchanged.
4. **Unchecked repository fetch variants** — ⚠️ *delete/deprecate is not applicable on this branch*: the audit premise «no production callers» held on `main` at audit time, but V2 UI introduced 7 production call sites of the unchecked variants here (`WalletViewController` ×2, `WalletTransactionHistoryViewController`, `AlarmsListViewModel.fetchCharges`, `TopUpViewController+State.fetchCharges`, `AlarmsListViewController.currentStreak` ×3). Deleting breaks the build; deprecating without migrating adds ~50 warnings (incl. tests) with no behaviour gain. Instead, added explicit «Lossy read — prefer …Checked» doc comments on all unchecked variants. Recommend a follow-up issue to migrate V2 display call sites and then deprecate.

## Tests
- `testPreviewSound_coversAllAvailableSounds` — drift guard: every picker sound must have a preview mapping (would have caught the exact failure mode from the audit).
- `testPreviewSound_withInvalidID_doesNotCrash` — now asserts `false` is returned for unknown IDs.
- `testGenerateAlarmTone_returnsPlayer` — pins the synthetic-tone happy path (valid in-memory WAV).

## Verify
- ✅ swiftlint: 0 issues on all 7 touched files
- ✅ `xcodebuild build-for-testing` (scheme SnoozePay, generic/platform=iOS Simulator, CODE_SIGNING_ALLOWED=NO): **TEST BUILD SUCCEEDED** — app + test targets compile
- ⏭ test run / screenshots skipped per integration-branch verification policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
