### PR TITLE
[ui] Onboarding & Permissions V3 — skip pill, 250 ₽ preset, Пополнить CTA (#238)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController+Pages.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController+Pages.swift
@@ -6,8 +6,8 @@ import UIKit
 // helpers here own:
 //   - per-page content builders (`makePage1` / `makePage2` / `makePage3`),
 //   - the bespoke pill-dot row used in place of `UIPageControl`,
-//   - the action handlers wired from the primary / "Позже" CTAs,
-//   - the CTA-rebuild that swaps "Дальше" → "Положить" on step 3.
+//   - the action handlers wired from the primary / "Позже" / "Пропустить" CTAs,
+//   - the CTA-rebuild that swaps "Дальше" → "Пополнить" on step 3.
 //
 // Single-purpose helper view classes (glow host, penalty pill, numbered step
 // row, page dot, deposit option card) live in `OnboardingComponents.swift`.
@@ -225,26 +225,19 @@ extension OnboardingViewController {
             optionsStack.addArrangedSubview(optionView)
         }
 
-        let footer = UILabel()
-        footer.font = AppTypography.meta
-        footer.text = "Можно поменять в любой момент"
-        footer.textColor = AppColors.fg4
-        footer.textAlignment = .center
-
-        let mainStack = UIStackView(arrangedSubviews: [caps, titleLabel, optionsStack, footer])
+        // V3: no "Можно поменять в любой момент" footer — the deposit column
+        // ends with the option cards; the content block centres vertically
+        // like pages 1/2 (JSX `flex: 1; justify-content: center`).
+        let mainStack = UIStackView(arrangedSubviews: [caps, titleLabel, optionsStack])
         mainStack.translatesAutoresizingMaskIntoConstraints = false
         mainStack.axis = .vertical
         mainStack.alignment = .fill
         mainStack.setCustomSpacing(AppSpacing.sp2, after: caps)
         mainStack.setCustomSpacing(AppSpacing.sp6, after: titleLabel)
-        mainStack.setCustomSpacing(AppSpacing.sp4, after: optionsStack)
 
         container.addSubview(mainStack)
         NSLayoutConstraint.activate([
-            mainStack.topAnchor.constraint(
-                equalTo: container.safeAreaLayoutGuide.topAnchor,
-                constant: AppSpacing.sp9      // 56pt — matches JSX `paddingTop: 54`
-            ),
+            mainStack.centerYAnchor.constraint(equalTo: container.centerYAnchor),
             mainStack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: AppSpacing.sp4),
             mainStack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -AppSpacing.sp4)
         ])
@@ -268,11 +261,23 @@ extension OnboardingViewController {
 
     /// Pager state — toggles glow, the "Позже" secondary, and the primary
     /// button (which transforms into the deposit CTA on step 3).
+    ///
+    /// The "Позже" slot is alpha-faded rather than `isHidden`-collapsed so
+    /// the green primary button bottoms out at the same Y on every page —
+    /// the V3 CTA-anchor rule (`SPMore.jsx` keeps a 20pt spacer under the
+    /// "Дальше" button for the same effect).
     func updatePagerState(forPage page: Int) {
         rebuildDotsRow(activePage: page)
         let isDepositPage = page == pageCount - 1
         setStepGlow(active: isDepositPage)
-        laterButton.isHidden = !isDepositPage
+        laterButton.alpha = isDepositPage ? 1 : 0
+        laterButton.isUserInteractionEnabled = isDepositPage
+        laterButton.isAccessibilityElement = isDepositPage
+        // Dots sit 14pt above the CTA group on the deposit page
+        // (JSX `marginBottom: 14`), 16pt elsewhere.
+        dotsGapConstraint?.constant = isDepositPage
+            ? -(AppSpacing.sp3 + 2)   // 14pt
+            : -AppSpacing.sp4         // 16pt
         if isDepositPage {
             rebuildDepositCTA()
         } else {
@@ -290,18 +295,17 @@ extension OnboardingViewController {
         swapPrimary(with: newButton)
     }
 
-    /// Replace the primary button with the deposit CTA — title "Положить",
-    /// suffix `{value} ₽`, leading shield icon. Re-run on every option-tap
-    /// so the suffix tracks the selection.
+    /// Replace the primary button with the deposit CTA — title "Пополнить",
+    /// suffix `{value} ₽`, leading wallet icon (V3 reads as "put money in",
+    /// matching the Wallet deposit sheet). Re-run on every option-tap so the
+    /// suffix tracks the selection.
     func rebuildDepositCTA() {
         let amount = depositOptions[selectedDepositIndex].amount
-        let configuration = UIImage.SymbolConfiguration(pointSize: 16, weight: .semibold)
-        let shield = UIImage(systemName: "shield.fill", withConfiguration: configuration)
         let newButton = SPButton(
-            title: "Положить",
+            title: "Пополнить",
             variant: .money,
             size: .lg,
-            icon: shield,
+            icon: UIImage(systemName: "wallet.pass"),
             suffix: amount.formattedRubles(),
             fullWidth: true
         )
@@ -348,6 +352,13 @@ extension OnboardingViewController {
         UserDefaults.standard.set(true, forKey: Self.completedKey)
         UserDefaults.standard.set(false, forKey: Self.firstTopUpDoneKey)
         onFinished?()
+    }
+
+    /// Top-right "Пропустить" pill — available on every page; semantically
+    /// identical to "Позже" (finish onboarding without a first top-up).
+    @objc
+    func skipTapped() {
+        laterTapped()
     }
 
     // MARK: - Deposit option taps

--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController.swift
@@ -6,9 +6,16 @@ import UIKit
 /// Three full-screen pages on a horizontally-paged `UIScrollView`:
 /// 1. Concept — giant clock "07:00" with a warn "−50 ₽" pill and a hero h1.
 /// 2. Mechanics — three numbered steps explaining the snooze-tax loop.
-/// 3. Deposit — caps eyebrow, h1, three option cards (200 / 500 / 1000 ₽)
-///    with a money-tinted selection, plus a "Положить {value} ₽" CTA and a
+/// 3. Deposit — caps eyebrow, h1, three option cards (250 / 500 / 1000 ₽)
+///    with a money-tinted selection, plus a "Пополнить {value} ₽" CTA and a
 ///    secondary "Позже — попробовать без баланса" link.
+///
+/// V3 (2026-06 handoff, `docs/design/v2-handoff/components/SPMore.jsx`):
+/// a "Пропустить" pill floats top-right on every page, the deposit page
+/// content centres vertically like pages 1/2, and the green CTA keeps the
+/// same bottom Y on all pages (the secondary "Позже" slot stays in the
+/// layout on pages 1/2 at alpha 0 — the UIKit equivalent of the JSX's
+/// 20pt CTA-anchor spacer).
 ///
 /// Behavioural contract preserved from V1 so SceneDelegate keeps working:
 /// `completedKey`, `isCompleted`, `firstTopUpDoneKey`, and `onFinished` all
@@ -34,7 +41,7 @@ final class OnboardingViewController: UIViewController {
     // MARK: - Page data
 
     /// Deposit presets shown on step 3. The middle preset is the default
-    /// selection so the "Положить" CTA reads "500 ₽" on first appear.
+    /// selection so the "Пополнить" CTA reads "500 ₽" on first appear.
     struct DepositOption {
         let amount: Decimal
         let title: String
@@ -46,9 +53,9 @@ final class OnboardingViewController: UIViewController {
     /// building option cards and the CTA suffix.
     let depositOptions: [DepositOption] = [
         DepositOption(
-            amount: 200,
+            amount: 250,
             title: "Попробовать",
-            description: "≈ 4 откладывания по \(MoneyFormatter.string(50))",
+            description: "≈ 5 откладываний по \(MoneyFormatter.string(50))",
             isPopular: false
         ),
         DepositOption(
@@ -123,10 +130,36 @@ final class OnboardingViewController: UIViewController {
         return stack
     }()
 
+    /// "Пропустить" escape hatch floating top-right on every page
+    /// (`SPMore.jsx OnboardingSkip` — pill 16pt below the status bar, 16pt
+    /// from the trailing edge, `whiteOverlay06` fill + `whiteOverlay08`
+    /// hairline, `fg3` buttonSm label). Completes onboarding exactly like
+    /// the "Позже" secondary.
+    let skipButton: UIButton = {
+        var configuration = UIButton.Configuration.plain()
+        configuration.contentInsets = NSDirectionalEdgeInsets(
+            top: 6, leading: 14, bottom: 6, trailing: 14
+        )
+        configuration.attributedTitle = AttributedString(
+            "Пропустить",
+            attributes: AttributeContainer([
+                .font: AppTypography.buttonSm,
+                .foregroundColor: AppColors.fg3
+            ])
+        )
+        let button = UIButton(configuration: configuration)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.backgroundColor = AppColors.whiteOverlay06
+        button.layer.borderWidth = 1
+        button.layer.borderColor = AppColors.whiteOverlay08.cgColor
+        button.layer.masksToBounds = true
+        return button
+    }()
+
     /// Primary CTA visible on every page. On pages 1 & 2 the title reads
     /// "Дальше"; on page 3 the VC swaps the instance via
-    /// `rebuildDepositCTA()` so the title becomes "Положить" with a money
-    /// suffix and a leading shield icon. `internal` so the `+Pages` extension
+    /// `rebuildDepositCTA()` so the title becomes "Пополнить" with a money
+    /// suffix and a leading wallet icon. `internal` so the `+Pages` extension
     /// can swap the live instance + re-pin the constraints.
     var primaryButton = SPButton(
         title: "Дальше",
@@ -135,9 +168,12 @@ final class OnboardingViewController: UIViewController {
         fullWidth: true
     )
 
-    /// Secondary "Позже — попробовать без баланса" link rendered only on
-    /// step 3. Lives in `secondaryStack` so the layout shifts cleanly when
-    /// the user pages back to steps 1/2.
+    /// Secondary "Позже — попробовать без баланса" link visible only on
+    /// step 3. Always part of `ctaStack`'s layout — on steps 1/2 it fades to
+    /// alpha 0 (interaction off) instead of collapsing, so the green primary
+    /// CTA keeps the exact same bottom Y across all pages (the JSX mockup
+    /// approximates this with a 20pt spacer; the shared-stack layout makes
+    /// the alignment exact).
     let laterButton = SPButton(
         title: "Позже — попробовать без баланса",
         variant: .quiet,
@@ -160,6 +196,11 @@ final class OnboardingViewController: UIViewController {
     /// top-left corner per JSX (rgba(46,219,159,.25) radial). Painted
     /// directly on `view.layer` once and toggled via `setStepGlow(active:)`.
     private var stepGlowLayer: CAGradientLayer?
+
+    /// Bottom gap between the pill-dot row and the CTA stack — 14pt on the
+    /// deposit page (`SPMore.jsx` Onboarding3 `marginBottom: 14`), 16pt on
+    /// pages 1/2. `internal` so `+Pages.updatePagerState` can retune it.
+    var dotsGapConstraint: NSLayoutConstraint?
 
     /// Internal page containers managed by `+Pages.buildPageStack()`.
     var pageViews: [UIView] = []
@@ -208,6 +249,7 @@ final class OnboardingViewController: UIViewController {
             )
         }
         scrollView.contentSize = CGSize(width: width * CGFloat(pageCount), height: height)
+        skipButton.layer.cornerRadius = skipButton.bounds.height / 2   // pill
 
         CATransaction.begin()
         CATransaction.setDisableActions(true)
@@ -224,13 +266,13 @@ final class OnboardingViewController: UIViewController {
         view.addSubview(pageControl)
         view.addSubview(dotsStack)
         view.addSubview(ctaStack)
+        view.addSubview(skipButton)
 
         pageControl.numberOfPages = pageCount
         pageControl.currentPage = 0
 
         ctaStack.addArrangedSubview(primaryButton)
         ctaStack.addArrangedSubview(laterButton)
-        laterButton.isHidden = true
 
         installLayoutConstraints()
         wireActionTargets()
@@ -240,6 +282,11 @@ final class OnboardingViewController: UIViewController {
 
     private func installLayoutConstraints() {
         let inset = AppSpacing.sp4   // 16pt — matches JSX `padding: ... 16px`
+        let dotsGap = dotsStack.bottomAnchor.constraint(
+            equalTo: ctaStack.topAnchor,
+            constant: -AppSpacing.sp4
+        )
+        dotsGapConstraint = dotsGap
         NSLayoutConstraint.activate([
             scrollView.topAnchor.constraint(equalTo: view.topAnchor),
             scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
@@ -254,14 +301,22 @@ final class OnboardingViewController: UIViewController {
             ),
 
             dotsStack.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            dotsStack.bottomAnchor.constraint(
-                equalTo: ctaStack.topAnchor,
-                constant: -AppSpacing.sp4
-            ),
+            dotsGap,
             dotsStack.heightAnchor.constraint(equalToConstant: 6),
 
             pageControl.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            pageControl.bottomAnchor.constraint(equalTo: dotsStack.topAnchor)
+            pageControl.bottomAnchor.constraint(equalTo: dotsStack.topAnchor),
+
+            // "Пропустить" pill — JSX `top: 70; right: 16` on a 54pt-status-bar
+            // frame ⇒ 16pt below the safe-area top, 16pt from the trailing edge.
+            skipButton.topAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.topAnchor,
+                constant: AppSpacing.sp4
+            ),
+            skipButton.trailingAnchor.constraint(
+                equalTo: view.trailingAnchor,
+                constant: -AppSpacing.sp4
+            )
         ])
     }
 
@@ -269,6 +324,7 @@ final class OnboardingViewController: UIViewController {
         scrollView.delegate = self
         primaryButton.addTarget(self, action: #selector(primaryTapped), for: .touchUpInside)
         laterButton.addTarget(self, action: #selector(laterTapped), for: .touchUpInside)
+        skipButton.addTarget(self, action: #selector(skipTapped), for: .touchUpInside)
     }
 
     // MARK: - Step glow

--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/PermissionCardView.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/PermissionCardView.swift
@@ -199,6 +199,9 @@ final class PermissionCardView: UIView {
         case .actionable:
             iconHost.backgroundColor = AppColors.whiteOverlay08
             iconView.tintColor = AppColors.fg3
+            // The 2026-06 mockup renders an *empty* span where this caps
+            // label sits — treated as a mockup bug (#238 p.6): the
+            // ungranted row keeps its explicit "Дать" affordance.
             mount(capsLabel(text: "Дать", color: AppColors.warn400))
             tapGesture.isEnabled = true
         case .unavailable:

--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/PermissionsViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/PermissionsViewController.swift
@@ -1,11 +1,13 @@
 import UIKit
 import UserNotifications
 
-/// Permissions screen — V2 redesign (`docs/design/v2-handoff/components/SPMore2.jsx`
-/// lines 26-65). Shown once after Onboarding finishes, before the main alarms
-/// list. Caps "последний шаг" eyebrow → h1 "Чтобы будильник работал" → body
-/// copy → three permission cards (Notifications, Critical Alerts, Background)
-/// → "Готово" CTA.
+/// Permissions screen — V3 (`docs/design/v2-handoff/components/SPMore2.jsx`
+/// `Permissions`, artboard 05). Shown once after Onboarding finishes, before
+/// the main alarms list. Caps "последний шаг" eyebrow → h1 "Чтобы будильник
+/// работал" → body copy → three permission cards (Notifications, Critical
+/// Alerts, Background) → "Готово" CTA in flow 28pt after the cards (not
+/// pinned to the bottom). Layout padding follows the JSX `70px 16px 52px`
+/// frame: 16pt below the safe-area top, 16pt sides.
 ///
 /// Flow preserves the V1 wiring:
 /// 1. Notifications card → tapping the card calls
@@ -91,7 +93,7 @@ final class PermissionsViewController: UIViewController {
     private let bodyLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "Без этих разрешений iOS не разбудит вас в нужное время — даже если телефон беззвучный."
+        label.text = "Эти разрешения нужны, чтобы будильник прозвенел даже на беззвучном режиме."
         label.font = AppTypography.bodyLg
         label.textColor = AppColors.fg2
         label.numberOfLines = 0
@@ -151,11 +153,13 @@ final class PermissionsViewController: UIViewController {
         view.addSubview(ctaButton)
         ctaButton.translatesAutoresizingMaskIntoConstraints = false
 
-        let inset = AppSpacing.sp4   // 16pt — matches JSX `padding: 54px 16px 32px`
+        let inset = AppSpacing.sp4   // 16pt — matches JSX `padding: 70px 16px 52px`
         NSLayoutConstraint.activate([
+            // JSX top pad 70 on a 54pt-status-bar frame ⇒ 16pt below the
+            // safe-area top.
             capsLabel.topAnchor.constraint(
                 equalTo: view.safeAreaLayoutGuide.topAnchor,
-                constant: AppSpacing.sp6
+                constant: AppSpacing.sp4
             ),
             capsLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
             capsLabel.trailingAnchor.constraint(
@@ -177,9 +181,18 @@ final class PermissionsViewController: UIViewController {
 
             ctaButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
             ctaButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
+            // V3: "Готово" lives in flow 28pt after the cards (JSX
+            // `marginTop: 28`) instead of pinning to the screen bottom —
+            // cards no longer flex-grow into the gap.
+            ctaButton.topAnchor.constraint(
+                equalTo: cardsStack.bottomAnchor,
+                constant: AppSpacing.sp6 + AppSpacing.sp1   // 28pt
+            ),
+            // Safety net for compact heights — never push the CTA below the
+            // JSX's 52px bottom pad (≈ 18pt above the home-indicator inset).
             ctaButton.bottomAnchor.constraint(
-                equalTo: view.safeAreaLayoutGuide.bottomAnchor,
-                constant: -AppSpacing.sp6
+                lessThanOrEqualTo: view.safeAreaLayoutGuide.bottomAnchor,
+                constant: -(AppSpacing.sp4 + 2)   // 18pt
             )
         ])
 

--- a/SnoozePay/SnoozePayTests/OnboardingTests.swift
+++ b/SnoozePay/SnoozePayTests/OnboardingTests.swift
@@ -5,15 +5,18 @@ import XCTest
 final class OnboardingTests: XCTestCase {
 
     private let completedKey = "onboarding_completed"
+    private let firstTopUpDoneKey = "first_top_up_done"
 
     override func setUp() {
         super.setUp()
-        // Reset onboarding flag before each test
+        // Reset onboarding flags before each test
         UserDefaults.standard.removeObject(forKey: completedKey)
+        UserDefaults.standard.removeObject(forKey: firstTopUpDoneKey)
     }
 
     override func tearDown() {
         UserDefaults.standard.removeObject(forKey: completedKey)
+        UserDefaults.standard.removeObject(forKey: firstTopUpDoneKey)
         super.tearDown()
     }
 
@@ -40,5 +43,56 @@ final class OnboardingTests: XCTestCase {
         let pageControl = vc.view.subviews.compactMap { $0 as? UIPageControl }.first
         XCTAssertNotNil(pageControl, "OnboardingViewController should contain a UIPageControl")
         XCTAssertEqual(pageControl?.numberOfPages, 3, "Onboarding should have exactly 3 pages")
+    }
+
+    // MARK: - Deposit presets (V3, #238)
+
+    func testDepositOptions_firstPresetIs250() {
+        let vc = OnboardingViewController()
+
+        let first = vc.depositOptions[0]
+        XCTAssertEqual(first.amount, 250, "V3 entry preset is 250 ₽ (was 200 ₽)")
+        XCTAssertTrue(
+            first.description.contains("5 откладываний"),
+            "250 ₽ preset describes ≈ 5 snoozes at 50 ₽"
+        )
+        XCTAssertTrue(
+            first.description.contains("50\(MoneyFormatter.narrowSpace)₽"),
+            "Preset copy renders money via MoneyFormatter (narrow space before ₽)"
+        )
+    }
+
+    func testDepositOptions_amounts() {
+        let vc = OnboardingViewController()
+
+        XCTAssertEqual(vc.depositOptions.map(\.amount), [250, 500, 1000])
+        XCTAssertEqual(vc.defaultDepositIndex, 1, "500 ₽ stays the default selection")
+    }
+
+    // MARK: - Skip pill (V3, #238)
+
+    func testSkip_marksOnboardingCompleted_andNotifies() {
+        let vc = OnboardingViewController()
+        vc.loadViewIfNeeded()
+        var finished = false
+        vc.onFinished = { finished = true }
+
+        vc.skipTapped()
+
+        XCTAssertTrue(OnboardingViewController.isCompleted, "Skip completes onboarding")
+        XCTAssertFalse(
+            UserDefaults.standard.bool(forKey: firstTopUpDoneKey),
+            "Skip records that the first top-up did not happen"
+        )
+        XCTAssertTrue(finished, "Skip invokes onFinished so SceneDelegate can swap the root")
+    }
+
+    func testSkipButton_isInstalled() {
+        let vc = OnboardingViewController()
+        vc.loadViewIfNeeded()
+
+        XCTAssertNotNil(vc.skipButton.superview, "Skip pill is mounted on the onboarding canvas")
+        let title = vc.skipButton.configuration?.attributedTitle.map { String($0.characters) }
+        XCTAssertEqual(title, "Пропустить")
     }
 }


### PR DESCRIPTION
Fixes #238

## Что сделано
- **«Пропустить» pill** на всех трёх страницах онбординга — top-right (safe-area top + 16, trailing 16), `whiteOverlay06` fill + `whiteOverlay08` hairline, `fg3` buttonSm, pill radius; семантика = «Позже» (завершает онбординг без депозита).
- **CTA-якорь стр. 1/2**: слот «Позже» больше не схлопывается (`isHidden`), а уходит в alpha 0 с выключенным interaction/accessibility — нижний Y зелёной кнопки идентичен на всех трёх страницах (UIKit-эквивалент 20pt спейсера из мокапа, выравнивание точное).
- **Onboarding3 (депозит)**: первый пресет **200 → 250 ₽** (`≈ 5 откладываний по 50 ₽`, копия через MoneyFormatter); контент центрируется по вертикали как на стр. 02/03; дотсы 14pt над CTA (на стр. 1/2 — прежние 16); CTA **«Положить» (shield) → «Пополнить» (wallet.pass, suffix суммы)** — иконка совпадает с Deposit-sheet кошелька; footer «Можно поменять в любой момент» убран; gap «Пополнить»→«Позже» = 8pt (ctaStack spacing, без изменений).
- **Permissions (05)**: интро-копия → «Эти разрешения нужны, чтобы будильник прозвенел даже на беззвучном режиме.»; top pad = safe-area + 16 (JSX 70/16/52); «Готово» теперь в потоке через 28pt после карточек (не прибит к низу) + safety-констрейнт ≤ bottom; карточки не растягиваются.
- **«Дать» сохранён** на негранченных строках — пустой span в мокапе зафиксирован комментарием как баг мокапа (issue п.6), affordance не убран.
- Тесты: пресет 250 ₽ / порядок пресетов / skip завершает онбординг и зовёт `onFinished` / pill смонтирован с титулом «Пропустить».

## Verify
- ✅ swiftlint: 0 errors, 0 warnings в затронутых файлах
- ✅ xcodebuild build (generic/platform=iOS Simulator, CODE_SIGNING_ALLOWED=NO): succeeded
- ✅ xcodebuild build-for-testing: succeeded (app + test bundle компилируются)
- CI (lint + build + full test suite) — merge gate