### PR TITLE
[ui] Themed firing screen V3 — per-theme background/accent table for 6 stock themes (#225)

### DIFF
--- a/SnoozePay/SnoozePay/Utilities/AlarmFiringThemePalette.swift
+++ b/SnoozePay/SnoozePay/Utilities/AlarmFiringThemePalette.swift
@@ -1,0 +1,212 @@
+import UIKit
+
+/// Per-theme visual recipe for the V3 themed firing screen (#225).
+///
+/// Source of truth — `FIRING_THEMES` in
+/// `docs/design/v2-handoff/components/SPThemedFiring.jsx`. The theme changes
+/// ONLY the atmosphere: full-bleed 160° background, darkening scrim, bottom
+/// accent glow, accent tint (balance pill / eyebrow / bell tile / clock halo).
+/// Layout, copy and CTAs stay identical across all six stock themes.
+///
+/// `.custom` (user photo) intentionally has no palette — the firing screen
+/// keeps the photo + 45% dim treatment from #151, so `palette(for:)` returns
+/// nil and callers fall back to the neutral white chrome.
+struct AlarmFiringThemePalette: Equatable {
+
+    // MARK: - Background
+
+    /// 160°-diagonal linear gradient stops (top-left-ish → bottom-right-ish).
+    /// Also reused by `AlarmThemeRendering` for the picker tile / alarm-cell
+    /// strip so the preview the user picks matches the firing screen.
+    let backgroundColors: [UIColor]
+    /// Stop locations paired with `backgroundColors`.
+    let backgroundLocations: [NSNumber]
+
+    /// Radial vignette over the background — black alpha at the ellipse
+    /// centre (50% x, 70% y) and at its far edge. Keeps the white copy
+    /// legible on the brighter themes (Mountains' near-white horizon).
+    let scrimInnerAlpha: CGFloat
+    let scrimOuterAlpha: CGFloat
+
+    // MARK: - Accents
+
+    /// Theme accent — eyebrow caps, balance-pill text/icon tint.
+    let accent: UIColor
+    /// Low-alpha accent — bell-tile ring + bottom glow fill.
+    let accentSoft: UIColor
+
+    /// Balance pill fill / hairline border (`pillBg` / `pillBorder` in JSX).
+    let pillBackground: UIColor
+    let pillBorder: UIColor
+
+    /// 135°-diagonal gradient for the 72×72 bell tile, stops at 0 / 0.6 / 1.
+    let bellGradientColors: [UIColor]
+
+    /// Soft halo behind the 96pt clock (`timeShadow` in JSX — colour at
+    /// alpha 1 plus the layer `shadowOpacity` that carries the CSS alpha).
+    let timeShadowColor: UIColor
+    let timeShadowOpacity: Float
+
+    // MARK: - Table
+
+    // swiftlint:disable function_body_length
+    /// Resolve the firing palette for a theme. Returns nil for `.custom` —
+    /// photo backgrounds keep the un-themed treatment. Long by design: it's
+    /// the literal six-row `FIRING_THEMES` table, one entry per stock theme.
+    static func palette(for theme: AlarmTheme) -> AlarmFiringThemePalette? {
+        switch theme {
+        case .dawn:
+            return AlarmFiringThemePalette(
+                backgroundColors: [
+                    UIColor(firingRGB: 0x2B1A0E),
+                    UIColor(firingRGB: 0x6B3517),
+                    UIColor(firingRGB: 0xC46A1A)
+                ],
+                backgroundLocations: [0.0, 0.5, 1.0],
+                scrimInnerAlpha: 0.05,
+                scrimOuterAlpha: 0.50,
+                accent: UIColor(firingRGB: 0xFFD479),
+                accentSoft: UIColor(firingRGB: 0xFFD479, alpha: 0.18),
+                pillBackground: UIColor(firingRGB: 0xFFB84D, alpha: 0.16),
+                pillBorder: UIColor(firingRGB: 0xFFD479, alpha: 0.32),
+                bellGradientColors: [
+                    UIColor(firingRGB: 0xFFD479),
+                    UIColor(firingRGB: 0xF59E0B),
+                    UIColor(firingRGB: 0xC97A06)
+                ],
+                timeShadowColor: UIColor(firingRGB: 0xFFB84D),
+                timeShadowOpacity: 0.35
+            )
+        case .ocean:
+            return AlarmFiringThemePalette(
+                backgroundColors: [
+                    UIColor(firingRGB: 0x08182A),
+                    UIColor(firingRGB: 0x134E5E),
+                    UIColor(firingRGB: 0x71B280)
+                ],
+                backgroundLocations: [0.0, 0.5, 1.0],
+                scrimInnerAlpha: 0.05,
+                scrimOuterAlpha: 0.55,
+                accent: UIColor(firingRGB: 0x9EE6CC),
+                accentSoft: UIColor(firingRGB: 0x9EE6CC, alpha: 0.18),
+                pillBackground: UIColor(firingRGB: 0x71B280, alpha: 0.18),
+                pillBorder: UIColor(firingRGB: 0x9EE6CC, alpha: 0.32),
+                bellGradientColors: [
+                    UIColor(firingRGB: 0x9EE6CC),
+                    UIColor(firingRGB: 0x4A9D9C),
+                    UIColor(firingRGB: 0x1F5F66)
+                ],
+                timeShadowColor: UIColor(firingRGB: 0x71B280),
+                timeShadowOpacity: 0.32
+            )
+        case .mountains:
+            return AlarmFiringThemePalette(
+                backgroundColors: [
+                    UIColor(firingRGB: 0x1A1F2E),
+                    UIColor(firingRGB: 0x5A6B8A),
+                    UIColor(firingRGB: 0xE1E5EA)
+                ],
+                backgroundLocations: [0.0, 0.5, 1.0],
+                scrimInnerAlpha: 0.10,
+                scrimOuterAlpha: 0.50,
+                accent: UIColor(firingRGB: 0xE1E5EA),
+                accentSoft: UIColor(firingRGB: 0xE1E5EA, alpha: 0.20),
+                pillBackground: UIColor(firingRGB: 0xB7C0D0, alpha: 0.22),
+                pillBorder: UIColor(firingRGB: 0xE1E5EA, alpha: 0.40),
+                bellGradientColors: [
+                    UIColor(firingRGB: 0xF4F6F9),
+                    UIColor(firingRGB: 0xB7C0D0),
+                    UIColor(firingRGB: 0x5A6B8A)
+                ],
+                timeShadowColor: UIColor(firingRGB: 0xE1E5EA),
+                timeShadowOpacity: 0.30
+            )
+        case .forest:
+            return AlarmFiringThemePalette(
+                backgroundColors: [
+                    UIColor(firingRGB: 0x0A1A0A),
+                    UIColor(firingRGB: 0x1E3823),
+                    UIColor(firingRGB: 0x4A6B3A)
+                ],
+                backgroundLocations: [0.0, 0.5, 1.0],
+                scrimInnerAlpha: 0.05,
+                scrimOuterAlpha: 0.55,
+                accent: UIColor(firingRGB: 0xA8D89A),
+                accentSoft: UIColor(firingRGB: 0xA8D89A, alpha: 0.16),
+                pillBackground: UIColor(firingRGB: 0x4A6B3A, alpha: 0.22),
+                pillBorder: UIColor(firingRGB: 0xA8D89A, alpha: 0.34),
+                bellGradientColors: [
+                    UIColor(firingRGB: 0xC5E8B0),
+                    UIColor(firingRGB: 0x6A9853),
+                    UIColor(firingRGB: 0x2F4D24)
+                ],
+                timeShadowColor: UIColor(firingRGB: 0x4A6B3A),
+                timeShadowOpacity: 0.40
+            )
+        case .neon:
+            return AlarmFiringThemePalette(
+                backgroundColors: [
+                    UIColor(firingRGB: 0x0A0A1F),
+                    UIColor(firingRGB: 0x3D1E63),
+                    UIColor(firingRGB: 0xFF3D8A)
+                ],
+                backgroundLocations: [0.0, 0.5, 1.0],
+                scrimInnerAlpha: 0.10,
+                scrimOuterAlpha: 0.55,
+                accent: UIColor(firingRGB: 0xFF7EC8),
+                accentSoft: UIColor(firingRGB: 0xFF7EC8, alpha: 0.22),
+                pillBackground: UIColor(firingRGB: 0xFF3D8A, alpha: 0.20),
+                pillBorder: UIColor(firingRGB: 0xFF7EC8, alpha: 0.40),
+                bellGradientColors: [
+                    UIColor(firingRGB: 0xFF7EC8),
+                    UIColor(firingRGB: 0xC53578),
+                    UIColor(firingRGB: 0x5C1A4A)
+                ],
+                timeShadowColor: UIColor(firingRGB: 0xFF3D8A),
+                timeShadowOpacity: 0.40
+            )
+        case .abstract:
+            return AlarmFiringThemePalette(
+                backgroundColors: [
+                    UIColor(firingRGB: 0x1E1E1E),
+                    UIColor(firingRGB: 0x2A2A2A)
+                ],
+                backgroundLocations: [0.0, 1.0],
+                scrimInnerAlpha: 0.0,
+                scrimOuterAlpha: 0.30,
+                accent: .white,
+                accentSoft: UIColor(white: 1.0, alpha: 0.12),
+                pillBackground: UIColor(white: 1.0, alpha: 0.10),
+                pillBorder: UIColor(white: 1.0, alpha: 0.22),
+                bellGradientColors: [
+                    UIColor(firingRGB: 0xFFFFFF),
+                    UIColor(firingRGB: 0xBFBFBF),
+                    UIColor(firingRGB: 0x6F6F6F)
+                ],
+                timeShadowColor: .white,
+                timeShadowOpacity: 0.10
+            )
+        case .custom:
+            return nil
+        }
+    }
+    // swiftlint:enable function_body_length
+
+    /// Bell-tile gradient stop locations — the JSX recipe is
+    /// `linear-gradient(135deg, A 0%, B 60%, C 100%)` for every theme.
+    static let bellGradientLocations: [NSNumber] = [0.0, 0.6, 1.0]
+}
+
+// MARK: - Hex helper (file-scoped)
+
+private extension UIColor {
+    /// `0xRRGGBB` literal initializer used by the palette table above.
+    /// File-scoped copy — `private` means file-scope in Swift, so the
+    /// identical helpers in sibling files don't collide.
+    convenience init(firingRGB rgb: UInt32, alpha: CGFloat = 1) {
+        let red = CGFloat((rgb >> 16) & 0xFF) / 255.0
+        let green = CGFloat((rgb >> 8) & 0xFF) / 255.0
+        let blue = CGFloat(rgb & 0xFF) / 255.0
+        self.init(red: red, green: green, blue: blue, alpha: alpha)
+    }
+}

--- a/SnoozePay/SnoozePay/Utilities/AlarmThemeRendering.swift
+++ b/SnoozePay/SnoozePay/Utilities/AlarmThemeRendering.swift
@@ -24,46 +24,12 @@ enum AlarmThemeRendering {
                 UIColor(themeRGB: 0x0A1320).cgColor,
                 UIColor(themeRGB: 0x050912).cgColor
             ]
-        case .mountains:
-            // Placeholder gradient until design ships an alpine image asset
-            // (tracked as a #151 follow-up). The deep mountain blue →
-            // near-black stops still read as "alpine night" until then.
-            return [
-                UIColor(themeRGB: 0x3D5A80).cgColor,
-                UIColor(themeRGB: 0x293241).cgColor
-            ]
-        case .ocean:
-            return [
-                UIColor(themeRGB: 0x1A659E).cgColor,
-                UIColor(themeRGB: 0x003554).cgColor
-            ]
-        case .forest:
-            // FIRING_THEMES.forest stops from the v3 handoff
-            // (`SPThemedFiring.jsx`): deep pine → moss midpoint → sage.
-            return [
-                UIColor(themeRGB: 0x0A1A0A).cgColor,
-                UIColor(themeRGB: 0x1E3823).cgColor,
-                UIColor(themeRGB: 0x4A6B3A).cgColor
-            ]
-        case .neon:
-            // FIRING_THEMES.neon stops from the v3 handoff
-            // (`SPThemedFiring.jsx`): midnight ink → violet midpoint → hot pink.
-            return [
-                UIColor(themeRGB: 0x0A0A1F).cgColor,
-                UIColor(themeRGB: 0x3D1E63).cgColor,
-                UIColor(themeRGB: 0xFF3D8A).cgColor
-            ]
-        case .abstract:
-            // Money-tinted radial vibe — dark green core fading into the
-            // brand near-black ink. Rendered as a vertical gradient here
-            // because both consumers (firing screen, picker tile) use a
-            // CAGradientLayer; the "radial" character is sold by the stop
-            // distribution rather than `.radial` type.
-            return [
-                UIColor(themeRGB: 0x10B981).cgColor,
-                UIColor(themeRGB: 0x064E3B).cgColor,
-                UIColor(themeRGB: 0x050912).cgColor
-            ]
+        case .mountains, .ocean, .forest, .neon, .abstract:
+            // FIRING_THEMES stops from the v3 handoff (`SPThemedFiring.jsx`)
+            // via `AlarmFiringThemePalette` — single table so the picker tile
+            // / alarm-cell strip and the firing background can't drift (#225).
+            return AlarmFiringThemePalette.palette(for: theme)?
+                .backgroundColors.map { $0.cgColor }
         case .custom:
             return nil
         }
@@ -76,14 +42,12 @@ enum AlarmThemeRendering {
         switch theme {
         case .dawn:
             return [0.0, 0.4, 0.7, 1.0]
-        case .abstract:
-            return [0.0, 0.55, 1.0]
-        case .forest, .neon:
-            // Midpoint pinned at 50% to match the design's
-            // `linear-gradient(160deg, … 0%, … 50%, … 100%)` recipe.
-            return [0.0, 0.5, 1.0]
-        case .mountains, .ocean:
-            return [0.0, 1.0]
+        case .mountains, .ocean, .forest, .neon, .abstract:
+            // Paired with the `AlarmFiringThemePalette` stop tables above —
+            // midpoint pinned at 50% per the design's
+            // `linear-gradient(160deg, … 0%, … 50%, … 100%)` recipe
+            // (Abstract is the lone two-stop theme).
+            return AlarmFiringThemePalette.palette(for: theme)?.backgroundLocations
         case .custom:
             return nil
         }

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Layout.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Layout.swift
@@ -12,9 +12,9 @@ extension AlarmFiringViewController {
 
     /// Build the firing-screen view stack and pin everything to the screen.
     /// Called once from `viewDidLoad`. Composes:
-    /// 1. Atmospheric `SPDawnBackgroundView` filling the bounds.
+    /// 1. Themed atmospheric background filling the bounds (#225).
     /// 2. Top header — date caps left, balance pill right.
-    /// 3. Centered hero — 96pt mono clock, "Подъём" caps, alarm name.
+    /// 3. Centered hero — bell tile, h3 name, 96pt mono clock, eyebrow caps.
     /// 4. Progressive chrome (only when alarm.progressiveScale).
     /// 5. Audio warning banner, snooze CTA, ghost dismiss.
     /// 6. No-balance stack (hidden by default).
@@ -128,12 +128,15 @@ extension AlarmFiringViewController {
         ])
     }
 
-    /// Install the centered hero: clock + "Подъём" caps + optional name.
-    /// The caps label is below the clock with 12pt gap per spec line 81.
+    /// Install the centered hero — V3 vertical order per `SPThemedFiring.jsx`
+    /// (#225): bell tile, "Будни · 07:00" h3 name, 96pt clock, eyebrow caps.
+    /// The bell tile is tinted (or hidden, for `.custom`) by the +Theme
+    /// accent pass that ran in `installThemedBackground()`.
     private func installHeroCenter() {
+        view.addSubview(bellTile)
+        view.addSubview(nameLabel)
         view.addSubview(timeLabel)
         view.addSubview(wakeUpCapsLabel)
-        view.addSubview(nameLabel)
     }
 
     /// Pin every always-mounted element. Split out of `buildFiringLayout` so
@@ -145,20 +148,26 @@ extension AlarmFiringViewController {
         gap: CGFloat
     ) {
         NSLayoutConstraint.activate([
-            // Center the clock + caps stack vertically — pull it slightly
-            // above geometric center so the bottom CTAs have generous room.
+            // Center the clock vertically — pull it slightly above geometric
+            // center so the bottom CTAs have generous room. The rest of the
+            // hero hangs off the clock: bell + name above, eyebrow below
+            // (V3 order per `SPThemedFiring.jsx` — 12pt flex gap + 4pt
+            // element margins ≈ sp4 between neighbours).
             timeLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             timeLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: -60),
             timeLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
             timeLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
 
-            wakeUpCapsLabel.topAnchor.constraint(equalTo: timeLabel.bottomAnchor, constant: AppSpacing.sp3),
-            wakeUpCapsLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            bellTile.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            bellTile.bottomAnchor.constraint(equalTo: nameLabel.topAnchor, constant: -AppSpacing.sp4),
 
-            nameLabel.topAnchor.constraint(equalTo: wakeUpCapsLabel.bottomAnchor, constant: AppSpacing.sp2),
+            nameLabel.bottomAnchor.constraint(equalTo: timeLabel.topAnchor, constant: -AppSpacing.sp3),
             nameLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             nameLabel.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: inset),
             nameLabel.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor, constant: -inset),
+
+            wakeUpCapsLabel.topAnchor.constraint(equalTo: timeLabel.bottomAnchor, constant: AppSpacing.sp3),
+            wakeUpCapsLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
 
             audioWarningBanner.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
             audioWarningBanner.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+NoBalance.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+NoBalance.swift
@@ -107,7 +107,9 @@ extension AlarmFiringViewController {
 
         NSLayoutConstraint.activate([
             block.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            block.topAnchor.constraint(equalTo: nameLabel.bottomAnchor, constant: AppSpacing.sp6),
+            // Below the eyebrow caps — V3 moved the name label above the
+            // clock (#225), so the eyebrow is now the hero's bottom edge.
+            block.topAnchor.constraint(equalTo: wakeUpCapsLabel.bottomAnchor, constant: AppSpacing.sp6),
             block.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: inset),
             block.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor, constant: -inset)
         ])

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Theme.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Theme.swift
@@ -1,19 +1,26 @@
 import UIKit
 
-/// Background recipes for the alarm-firing screen, split out by theme.
+/// Background + accent recipes for the alarm-firing screen, split by theme.
 ///
-/// V2 spec: the default Dawn flow uses `SPDawnBackgroundView` — a three-layer
-/// atmospheric composition (base + radial overlay + breathing sun). Built-in
-/// themes other than `.dawn` (Mountains, Ocean, Abstract) still ship as
-/// vertical gradient backgrounds — they fall back to a single CAGradientLayer
-/// installed in place of the Dawn view. `.custom(imagePath:)` replaces the
-/// gradient + glow with a full-bleed user photo plus a 45% black dim so the
-/// 96pt clock + warn snooze CTA stay legible against arbitrary imagery.
+/// V3 spec (#225, `SPThemedFiring.jsx`): the alarm's theme drives the firing
+/// atmosphere — full-bleed 160° gradient, radial scrim, bottom accent glow,
+/// and accent tinting on the balance pill / bell tile / eyebrow / clock halo.
+/// Layout, copy and CTAs are identical across all six stock themes.
+///
+/// `.dawn` keeps `SPDawnBackgroundView` for the background (it carries the
+/// calm / tense / drained tone transitions plus the breathing sun, which the
+/// static themed view intentionally doesn't replicate) but picks up the same
+/// accent treatment as the other themes. `.custom(imagePath:)` replaces the
+/// gradient + glow with a full-bleed user photo plus a 45% black dim and no
+/// accent tinting, so the 96pt clock + warn snooze CTA stay legible against
+/// arbitrary imagery.
 extension AlarmFiringViewController {
 
-    /// Install the background appropriate to the alarm's theme. Called once
-    /// from `buildFiringLayout`. Falls back to Dawn if `.custom`'s on-disk
-    /// file is gone (Caches purge) so the firing screen is never blank.
+    /// Install the background appropriate to the alarm's theme and resolve
+    /// `firingPalette` for the accent pass. Called once from
+    /// `buildFiringLayout` BEFORE the header / hero installers so they can
+    /// read the palette. Falls back to Dawn if `.custom`'s on-disk file is
+    /// gone (Caches purge) so the firing screen is never blank.
     func installThemedBackground() {
         let theme = viewModel.alarm.theme
 
@@ -37,65 +44,75 @@ extension AlarmFiringViewController {
 
         if case .custom(let url) = theme, let image = AlarmThemeImageStore.loadImage(at: url) {
             // Custom photo path — hide the Dawn background and surface the
-            // photo + dim. Don't install the dawnBackgroundView at all.
+            // photo + dim. No palette: chrome stays neutral white.
+            firingPalette = nil
             themeImageView.image = image
             themeImageView.isHidden = false
             themeImageDimView.isHidden = false
         } else if case .dawn = theme {
-            // Default Dawn path — install the V2 atmospheric view.
+            // Default Dawn path — tone-reactive atmospheric view + the dawn
+            // accent palette for the pill / bell / eyebrow / clock halo.
+            firingPalette = AlarmFiringThemePalette.palette(for: .dawn)
             installDawnAtmosphericBackground()
             themeImageView.isHidden = true
             themeImageDimView.isHidden = true
-        } else {
-            // Ocean / Mountains / Forest / Neon / Abstract — vertical gradient using the
-            // shared `AlarmThemeRendering` stops. Built on a plain
-            // SPGradientView-like CAGradientLayer hosted on a UIView so the
-            // +Layout subview ordering still works.
-            let gradient = CAGradientLayer()
-            gradient.startPoint = CGPoint(x: 0.5, y: 0.0)
-            gradient.endPoint = CGPoint(x: 0.5, y: 1.0)
-            gradient.colors = AlarmThemeRendering.gradientColors(for: theme)
-                ?? AlarmThemeRendering.gradientColors(for: .dawn)
-            gradient.locations = AlarmThemeRendering.gradientLocations(for: theme)
-                ?? AlarmThemeRendering.gradientLocations(for: .dawn)
-
-            let container = ThemeGradientContainerView(gradient: gradient)
-            container.translatesAutoresizingMaskIntoConstraints = false
-            view.insertSubview(container, at: 0)
+        } else if let palette = AlarmFiringThemePalette.palette(for: theme) {
+            // Ocean / Mountains / Forest / Neon / Abstract — static themed
+            // atmosphere (160° gradient + scrim + bottom glow) per #225.
+            firingPalette = palette
+            let background = SPThemedFiringBackgroundView(palette: palette)
+            view.insertSubview(background, at: 0)
             NSLayoutConstraint.activate([
-                container.topAnchor.constraint(equalTo: view.topAnchor),
-                container.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-                container.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-                container.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+                background.topAnchor.constraint(equalTo: view.topAnchor),
+                background.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                background.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+                background.bottomAnchor.constraint(equalTo: view.bottomAnchor)
             ])
             themeImageView.isHidden = true
             themeImageDimView.isHidden = true
+        } else {
+            // `.custom` whose file is no longer on disk — fall back to the
+            // full Dawn treatment so the screen is never blank.
+            firingPalette = AlarmFiringThemePalette.palette(for: .dawn)
+            installDawnAtmosphericBackground()
+            themeImageView.isHidden = true
+            themeImageDimView.isHidden = true
         }
-    }
-}
 
-// MARK: - Plain gradient host for non-Dawn built-in themes
-//
-// A minimal CALayer host so the +Theme installer can drop in a gradient that
-// fills bounds and reflows on layout. Lives in this file so it's not exposed
-// to other VCs that don't need it.
-
-final class ThemeGradientContainerView: UIView {
-    private let gradientLayer: CAGradientLayer
-
-    init(gradient: CAGradientLayer) {
-        self.gradientLayer = gradient
-        super.init(frame: .zero)
-        layer.addSublayer(gradientLayer)
-        isUserInteractionEnabled = false
+        applyThemeAccents()
     }
 
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+    /// Accent pass — tint the clock halo + bell tile with the resolved
+    /// palette. The balance pill and eyebrow are re-tinted on every
+    /// `updateUI()` (their colour interacts with the zero-balance state), so
+    /// they live in `applyThemeAccentToBalancePill()` /
+    /// `updateAtmosphereTone()` instead.
+    private func applyThemeAccents() {
+        guard let palette = firingPalette else {
+            // `.custom` photo — keep the neutral chrome and skip the bell
+            // tile so the user's image stays clean.
+            bellTile.isHidden = true
+            return
+        }
+        timeLabel.layer.shadowColor = palette.timeShadowColor.cgColor
+        timeLabel.layer.shadowOpacity = palette.timeShadowOpacity
+        bellTile.apply(palette: palette)
+        bellTile.isHidden = false
     }
 
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        gradientLayer.frame = bounds
+    /// Re-tint the balance pill with the theme accent. The themed colours
+    /// only apply while the pill is in its normal `.money` tone — at zero
+    /// balance the stock pain (red) tint is a functional signal and stays
+    /// un-themed in every theme. Called from `updateUI()` after
+    /// `updateBalancePill()` so a tone-flip rebuild gets re-tinted too.
+    func applyThemeAccentToBalancePill() {
+        guard let palette = firingPalette,
+              let pill = balancePill,
+              pill.tone == .money else { return }
+        pill.applyCustomColors(
+            background: palette.pillBackground,
+            border: palette.pillBorder,
+            foreground: palette.accent
+        )
     }
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
@@ -56,6 +56,12 @@ class AlarmFiringViewController: UIViewController {
         return view
     }()
 
+    /// Accent palette resolved from the alarm's theme (#225). Nil only for
+    /// `.custom` photo themes — every stock theme (including Dawn) maps to a
+    /// `FIRING_THEMES` entry. Written once by `installThemedBackground()`;
+    /// read by the accent helpers in +Theme and by `updateAtmosphereTone()`.
+    var firingPalette: AlarmFiringThemePalette?
+
     // MARK: - Top header (V2)
 
     /// Top-bar caps label "Пт · 27 апр" rendered left of the balance pill.
@@ -91,6 +97,11 @@ class AlarmFiringViewController: UIViewController {
 
     // MARK: - Center hero
 
+    /// 72×72 bell tile above the alarm name — V3 themed firing (#225).
+    /// Gradient + ring are tinted from `firingPalette` in the +Theme accent
+    /// pass; hidden for `.custom` photo themes so the image stays clean.
+    let bellTile = SPFiringBellTile()
+
     /// 96pt mono clock — `AppTypography.clockXl` ultralight. `tabular-nums`
     /// equivalent applied via `.monospacedDigit()` so digit columns don't
     /// reflow on each tick. `internal` so the `+Layout` / `+ViewLifecycle`
@@ -112,9 +123,10 @@ class AlarmFiringViewController: UIViewController {
         return label
     }()
 
-    /// Caps "Подъём" subtitle below the clock. Hidden when the alarm name is
-    /// non-empty (the V1 nameLabel handled that case); the V2 layout still
-    /// surfaces the alarm name underneath the caps row when present.
+    /// Caps eyebrow below the clock — "Пора вставать" / "Только встать".
+    /// V3 tints it with the theme accent at 85% (`SPThemedFiring.jsx` line
+    /// 167); the colour is applied in `updateAtmosphereTone()` because it
+    /// flips to pain when the wallet drains.
     let wakeUpCapsLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -123,11 +135,13 @@ class AlarmFiringViewController: UIViewController {
         return label
     }()
 
-    /// `internal` so the `+Layout` extension can pin it next to the clock.
+    /// "Будни · 07:00" h3 title between the bell tile and the clock — V3
+    /// places the alarm identity ABOVE the live time (`SPThemedFiring.jsx`
+    /// line 147). `internal` so the `+Layout` extension can pin it.
     let nameLabel: UILabel = {
         let label = UILabel()
-        label.font = AppTypography.bodyLg
-        label.textColor = UIColor.white.withAlphaComponent(0.55)
+        label.font = AppTypography.h3
+        label.textColor = UIColor.white.withAlphaComponent(0.92)
         label.textAlignment = .center
         label.numberOfLines = 1
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -347,7 +361,7 @@ class AlarmFiringViewController: UIViewController {
     }
 
     func updateUI() {
-        nameLabel.text = viewModel.alarmName
+        nameLabel.text = viewModel.heroTitle
 
         // Refresh snooze CTA — VM may have bumped `snoozeCount` (progressive
         // scaling) since the last update, which changes `currentPenalty`.
@@ -373,6 +387,7 @@ class AlarmFiringViewController: UIViewController {
         }
 
         updateBalancePill()
+        applyThemeAccentToBalancePill()
         updateAtmosphereTone()
 
         // Swap between the normal snooze + dismiss group and the no-balance
@@ -381,11 +396,11 @@ class AlarmFiringViewController: UIViewController {
         refreshNoBalanceVisibility()
     }
 
-    /// Build the "Подъём" / "только встать" caps copy below the clock.
-    /// Mirrors `SPScreensV2.jsx` line 81 (normal) + `SPDawnV3.jsx` line 212
-    /// (no-balance drops to "только встать").
+    /// Build the eyebrow caps copy below the clock. Mirrors `SPDawnV3.jsx`
+    /// line 212 / `SPThemedFiring.jsx` line 172 — "пора вставать" normally,
+    /// dropping to "только встать" when the wallet can't cover a snooze.
     func wakeUpCapsText() -> String {
-        viewModel.canSnooze ? "Подъём" : "Только встать"
+        viewModel.canSnooze ? "Пора вставать" : "Только встать"
     }
 
     /// Snooze CTA hint — "Следующее откладывание: N ₽" when progressive is
@@ -447,16 +462,18 @@ class AlarmFiringViewController: UIViewController {
         }
         dawnBackgroundView.setTone(tone)
 
-        // The "Подъём" caps colour flips with the tone — pain300 when drained
-        // (matches the SPDawnV3 spec line 212).
+        // Eyebrow colour flips with the tone — theme accent at 85% normally
+        // (`SPThemedFiring.jsx` line 167; `.custom` photos keep the neutral
+        // white), pain300 when drained (SPDawnV3 spec line 212). Tracking is
+        // the wider .18em used by the firing eyebrow, not the stock caps .12em.
+        let normalColor = firingPalette?.accent.withAlphaComponent(0.85)
+            ?? UIColor.white.withAlphaComponent(0.5)
         wakeUpCapsLabel.attributedText = NSAttributedString(
             string: wakeUpCapsText().uppercased(),
             attributes: [
                 .font: AppTypography.caps,
-                .kern: AppTypography.capsKerning,
-                .foregroundColor: viewModel.canSnooze
-                    ? UIColor.white.withAlphaComponent(0.5)
-                    : AppColors.pain300
+                .kern: 12 * 0.18,
+                .foregroundColor: viewModel.canSnooze ? normalColor : AppColors.pain300
             ]
         )
     }

--- a/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
@@ -109,6 +109,16 @@ final class AlarmFiringViewModel {
 
     var alarmName: String { alarm.name }
 
+    /// "Будни · 07:00" hero title above the big clock — alarm name plus its
+    /// scheduled time (V3 themed firing, `SPThemedFiring.jsx` line 152).
+    /// A blank / whitespace-only name degrades to just the time so the row
+    /// never renders a dangling "·" separator.
+    var heroTitle: String {
+        let time = AlarmFiringTimeFormatter.string(from: alarm.time)
+        let name = alarm.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return name.isEmpty ? time : "\(name) · \(time)"
+    }
+
     // MARK: - Actions
 
     /// Deduct penalty and reschedule snooze.

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPFiringBellTile.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPFiringBellTile.swift
@@ -1,0 +1,102 @@
+import UIKit
+
+/// 72×72 bell tile rendered above the alarm name on the V3 themed firing
+/// screen (#225).
+///
+/// Spec — `SPThemedFiring.jsx` lines 135–144: rounded square (r22) filled
+/// with the theme's 135° `bellGrad`, a 6pt `accentSoft` ring sold via
+/// `box-shadow: 0 0 0 6px`, a `0 12px 36px rgba(0,0,0,.35)` drop shadow, and
+/// a 32pt stroked bell glyph at 70% black.
+///
+/// The view itself is 84×84 (tile + 6pt ring on every side): the ring is the
+/// view's own rounded background, the gradient tile is inset 6pt inside it.
+final class SPFiringBellTile: UIView {
+
+    // MARK: - Geometry (from the JSX recipe)
+
+    private static let tileSide: CGFloat = 72
+    private static let ringWidth: CGFloat = 6
+    private static let tileCornerRadius: CGFloat = 22
+    static var outerSide: CGFloat { tileSide + ringWidth * 2 }
+
+    // MARK: - Subviews
+
+    private let tileView = UIView()
+    private let gradientLayer: CAGradientLayer = {
+        let gradient = CAGradientLayer()
+        gradient.type = .axial
+        // CSS 135° — top-left → bottom-right diagonal.
+        gradient.startPoint = CGPoint(x: 0, y: 0)
+        gradient.endPoint = CGPoint(x: 1, y: 1)
+        gradient.locations = AlarmFiringThemePalette.bellGradientLocations
+        return gradient
+    }()
+
+    private let iconView: UIImageView = {
+        let view = UIImageView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        let config = UIImage.SymbolConfiguration(pointSize: 32, weight: .medium)
+        view.image = UIImage(systemName: "bell", withConfiguration: config)
+        view.tintColor = UIColor.black.withAlphaComponent(0.7)
+        view.contentMode = .scaleAspectFit
+        return view
+    }()
+
+    // MARK: - Init
+
+    init() {
+        super.init(frame: .zero)
+        translatesAutoresizingMaskIntoConstraints = false
+        isUserInteractionEnabled = false
+
+        // Ring — the view's own rounded fill; radius = tile radius + ring.
+        layer.cornerRadius = Self.tileCornerRadius + Self.ringWidth
+        // Drop shadow lives on the ring layer, so don't mask to bounds.
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOpacity = 0.35
+        layer.shadowRadius = 18      // ≈ CSS blur 36 / 2
+        layer.shadowOffset = CGSize(width: 0, height: 12)
+
+        tileView.translatesAutoresizingMaskIntoConstraints = false
+        tileView.layer.cornerRadius = Self.tileCornerRadius
+        tileView.layer.masksToBounds = true
+        tileView.layer.addSublayer(gradientLayer)
+        addSubview(tileView)
+        tileView.addSubview(iconView)
+
+        NSLayoutConstraint.activate([
+            widthAnchor.constraint(equalToConstant: Self.outerSide),
+            heightAnchor.constraint(equalToConstant: Self.outerSide),
+            tileView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            tileView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            tileView.widthAnchor.constraint(equalToConstant: Self.tileSide),
+            tileView.heightAnchor.constraint(equalToConstant: Self.tileSide),
+            iconView.centerXAnchor.constraint(equalTo: tileView.centerXAnchor),
+            iconView.centerYAnchor.constraint(equalTo: tileView.centerYAnchor)
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Palette
+
+    /// Tint the tile with the theme's bell gradient + soft accent ring.
+    /// Called by `AlarmFiringViewController+Theme` once the alarm's palette
+    /// is resolved; the tile stays hidden for `.custom` photo themes.
+    func apply(palette: AlarmFiringThemePalette) {
+        gradientLayer.colors = palette.bellGradientColors.map { $0.cgColor }
+        backgroundColor = palette.accentSoft
+    }
+
+    // MARK: - Layout
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        gradientLayer.frame = tileView.bounds
+        CATransaction.commit()
+    }
+}

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPPill.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPPill.swift
@@ -104,6 +104,20 @@ final class SPPill: UIView {
         label.attributedText = attributed
     }
 
+    /// Override the tone-derived colours with theme-accent values — used by
+    /// the V3 themed firing screen (#225) where the balance pill picks up
+    /// the alarm theme's accent (`pillBg` / `pillBorder` / `accent` in
+    /// `SPThemedFiring.jsx`) instead of the stock money tint. The hairline
+    /// border only exists in this themed variant, so it's installed here
+    /// rather than in `applyTone()`.
+    func applyCustomColors(background: UIColor, border: UIColor, foreground: UIColor) {
+        backgroundColor = background
+        layer.borderWidth = 1
+        layer.borderColor = border.cgColor
+        label.textColor = foreground
+        iconView.tintColor = foreground
+    }
+
     private func setIcon(_ icon: UIImage?) {
         if let icon = icon {
             iconView.image = icon.withRenderingMode(.alwaysTemplate)

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPThemedFiringBackgroundView.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPThemedFiringBackgroundView.swift
@@ -1,0 +1,115 @@
+import UIKit
+
+/// Atmospheric background for the V3 themed firing screen (#225).
+///
+/// Spec — `FiringTheme` in `docs/design/v2-handoff/components/SPThemedFiring.jsx`.
+/// Three layers, bottom → top:
+/// 1. **Base** — 160° diagonal linear gradient (`FIRING_THEMES[theme].bg`).
+/// 2. **Scrim** — radial vignette anchored at (50%, 70%): nearly clear at the
+///    centre, darkening toward the edges so the white copy stays legible on
+///    bright themes.
+/// 3. **Glow** — a soft 460pt accent circle whose centre sits 160pt below the
+///    bottom edge (`accentSoft → clear at 65%`), selling the "light from
+///    below the horizon" cue without a real Gaussian blur.
+///
+/// The view owns three CAGradientLayers and reflows them on every layout pass
+/// so rotation / safe-area changes work without per-frame recompute. Used for
+/// every stock theme except `.dawn`, which keeps the tone-reactive
+/// `SPDawnBackgroundView` (calm / tense / drained transitions + breathing sun).
+final class SPThemedFiringBackgroundView: UIView {
+
+    // MARK: - Geometry constants
+
+    /// CSS `linear-gradient(160deg, …)` direction. 160° clockwise from north
+    /// in y-down coordinates is `(sin 160°, −cos 160°) ≈ (0.342, 0.940)` —
+    /// mostly downward, drifting right. Half-vector offsets from the centre
+    /// give unit start/end points for CAGradientLayer.
+    private static let axisStart = CGPoint(x: 0.5 - 0.171, y: 0.5 - 0.470)
+    private static let axisEnd = CGPoint(x: 0.5 + 0.171, y: 0.5 + 0.470)
+
+    /// `radial-gradient(circle, accentSoft 0%, transparent 65%)` — 460pt
+    /// circle, horizontally centred, its centre 160pt below the bottom edge.
+    private static let glowDiameter: CGFloat = 460
+    private static let glowBottomOverhang: CGFloat = 160
+
+    // MARK: - Layers
+
+    private let baseLayer: CAGradientLayer = {
+        let gradient = CAGradientLayer()
+        gradient.type = .axial
+        gradient.startPoint = SPThemedFiringBackgroundView.axisStart
+        gradient.endPoint = SPThemedFiringBackgroundView.axisEnd
+        return gradient
+    }()
+
+    /// `radial-gradient(120% 80% at 50% 70%, black(inner) → black(outer))`.
+    /// For `.radial` CAGradientLayer the endPoint deltas define the ellipse
+    /// semi-axes: 120% of the width and 80% of the height.
+    private let scrimLayer: CAGradientLayer = {
+        let gradient = CAGradientLayer()
+        gradient.type = .radial
+        gradient.startPoint = CGPoint(x: 0.5, y: 0.7)
+        gradient.endPoint = CGPoint(x: 0.5 + 1.2, y: 0.7 + 0.8)
+        gradient.locations = [0.0, 1.0]
+        return gradient
+    }()
+
+    private let glowLayer: CAGradientLayer = {
+        let gradient = CAGradientLayer()
+        gradient.type = .radial
+        gradient.startPoint = CGPoint(x: 0.5, y: 0.5)
+        gradient.endPoint = CGPoint(x: 1.0, y: 1.0)
+        gradient.locations = [0.0, 0.65]
+        return gradient
+    }()
+
+    // MARK: - Init
+
+    init(palette: AlarmFiringThemePalette) {
+        super.init(frame: .zero)
+        translatesAutoresizingMaskIntoConstraints = false
+        clipsToBounds = true
+        isUserInteractionEnabled = false
+        layer.addSublayer(baseLayer)
+        layer.addSublayer(scrimLayer)
+        layer.addSublayer(glowLayer)
+        apply(palette: palette)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Palette
+
+    private func apply(palette: AlarmFiringThemePalette) {
+        baseLayer.colors = palette.backgroundColors.map { $0.cgColor }
+        baseLayer.locations = palette.backgroundLocations
+        scrimLayer.colors = [
+            UIColor.black.withAlphaComponent(palette.scrimInnerAlpha).cgColor,
+            UIColor.black.withAlphaComponent(palette.scrimOuterAlpha).cgColor
+        ]
+        glowLayer.colors = [
+            palette.accentSoft.cgColor,
+            palette.accentSoft.withAlphaComponent(0).cgColor
+        ]
+    }
+
+    // MARK: - Layout
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        baseLayer.frame = bounds
+        scrimLayer.frame = bounds
+        let diameter = Self.glowDiameter
+        glowLayer.frame = CGRect(
+            x: bounds.midX - diameter / 2,
+            y: bounds.height + Self.glowBottomOverhang - diameter,
+            width: diameter,
+            height: diameter
+        )
+        CATransaction.commit()
+    }
+}

--- a/SnoozePay/SnoozePayTests/AlarmFiringThemePaletteTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmFiringThemePaletteTests.swift
@@ -1,0 +1,181 @@
+import XCTest
+@testable import SnoozePay
+
+/// Coverage for the V3 themed-firing palette table (#225) — the
+/// `AlarmTheme → AlarmFiringThemePalette` mapping that drives the firing
+/// screen's background, scrim, glow and accent tinting, plus the
+/// `AlarmThemeRendering` delegation that keeps picker tiles in sync, and the
+/// `heroTitle` string the hero name row renders.
+final class AlarmFiringThemePaletteTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Expected accent per stock theme — the `accent` column of
+    /// `FIRING_THEMES` in `SPThemedFiring.jsx`. A drift here means the
+    /// eyebrow / balance pill stop matching the design table.
+    private let expectedAccents: [(AlarmTheme, UInt32)] = [
+        (.dawn, 0xFFD479),
+        (.ocean, 0x9EE6CC),
+        (.mountains, 0xE1E5EA),
+        (.forest, 0xA8D89A),
+        (.neon, 0xFF7EC8),
+        (.abstract, 0xFFFFFF)
+    ]
+
+    private func assertColor(
+        _ color: UIColor,
+        matchesHex hex: UInt32,
+        alpha expectedAlpha: CGFloat = 1.0,
+        _ message: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        let expectedRed = CGFloat((hex >> 16) & 0xFF) / 255.0
+        let expectedGreen = CGFloat((hex >> 8) & 0xFF) / 255.0
+        let expectedBlue = CGFloat(hex & 0xFF) / 255.0
+        XCTAssertEqual(red, expectedRed, accuracy: 0.001, "\(message) (r)", file: file, line: line)
+        XCTAssertEqual(green, expectedGreen, accuracy: 0.001, "\(message) (g)", file: file, line: line)
+        XCTAssertEqual(blue, expectedBlue, accuracy: 0.001, "\(message) (b)", file: file, line: line)
+        XCTAssertEqual(alpha, expectedAlpha, accuracy: 0.001, "\(message) (a)", file: file, line: line)
+    }
+
+    // MARK: - Table coverage
+
+    func testEveryStockThemeHasAPalette() {
+        for theme in AlarmTheme.builtInOrder {
+            XCTAssertNotNil(
+                AlarmFiringThemePalette.palette(for: theme),
+                "Stock theme \(theme.id) must map to a firing palette"
+            )
+        }
+    }
+
+    func testCustomThemeHasNoPalette() {
+        let url = URL(fileURLWithPath: "/tmp/photo.jpg")
+        XCTAssertNil(
+            AlarmFiringThemePalette.palette(for: .custom(imagePath: url)),
+            "Photo themes keep the un-themed firing treatment — no palette"
+        )
+    }
+
+    func testAccentsMatchDesignTable() {
+        for (theme, hex) in expectedAccents {
+            guard let palette = AlarmFiringThemePalette.palette(for: theme) else {
+                XCTFail("Missing palette for \(theme.id)")
+                continue
+            }
+            assertColor(palette.accent, matchesHex: hex, "accent for \(theme.id)")
+        }
+    }
+
+    func testBackgroundStopsPairWithLocations() {
+        for theme in AlarmTheme.builtInOrder {
+            guard let palette = AlarmFiringThemePalette.palette(for: theme) else { continue }
+            XCTAssertEqual(
+                palette.backgroundColors.count,
+                palette.backgroundLocations.count,
+                "Colour/location count mismatch for \(theme.id) would mis-distribute the gradient"
+            )
+            XCTAssertEqual(
+                palette.bellGradientColors.count,
+                AlarmFiringThemePalette.bellGradientLocations.count,
+                "Bell gradient for \(theme.id) must carry the 0 / 0.6 / 1 stop trio"
+            )
+        }
+    }
+
+    func testAbstractIsTheLoneTwoStopTheme() {
+        for theme in AlarmTheme.builtInOrder {
+            guard let palette = AlarmFiringThemePalette.palette(for: theme) else { continue }
+            let expectedStops = theme == .abstract ? 2 : 3
+            XCTAssertEqual(
+                palette.backgroundColors.count,
+                expectedStops,
+                "FIRING_THEMES gives \(theme.id) \(expectedStops) background stops"
+            )
+        }
+    }
+
+    func testScrimAlphasDarkenOutward() {
+        for theme in AlarmTheme.builtInOrder {
+            guard let palette = AlarmFiringThemePalette.palette(for: theme) else { continue }
+            XCTAssertLessThan(
+                palette.scrimInnerAlpha,
+                palette.scrimOuterAlpha,
+                "Scrim for \(theme.id) must be a vignette — darker at the edges than the centre"
+            )
+        }
+    }
+
+    func testNeonScrimAndPillMatchDesignTable() {
+        // Spot-check one non-trivial row end-to-end so a copy/paste slip in
+        // the table doesn't survive (neon has the most distinctive values).
+        guard let neon = AlarmFiringThemePalette.palette(for: .neon) else {
+            return XCTFail("Missing neon palette")
+        }
+        XCTAssertEqual(neon.scrimInnerAlpha, 0.10, accuracy: 0.001)
+        XCTAssertEqual(neon.scrimOuterAlpha, 0.55, accuracy: 0.001)
+        assertColor(neon.pillBackground, matchesHex: 0xFF3D8A, alpha: 0.20, "neon pillBg")
+        assertColor(neon.pillBorder, matchesHex: 0xFF7EC8, alpha: 0.40, "neon pillBorder")
+        assertColor(neon.timeShadowColor, matchesHex: 0xFF3D8A, "neon timeShadow colour")
+        XCTAssertEqual(neon.timeShadowOpacity, 0.40, accuracy: 0.001)
+    }
+
+    // MARK: - AlarmThemeRendering delegation
+
+    func testPickerTileGradientsDelegateToPaletteForNonDawnThemes() {
+        for theme in AlarmTheme.builtInOrder where theme != .dawn {
+            guard let palette = AlarmFiringThemePalette.palette(for: theme) else { continue }
+            XCTAssertEqual(
+                AlarmThemeRendering.gradientColors(for: theme),
+                palette.backgroundColors.map { $0.cgColor },
+                "Picker tile for \(theme.id) must use the same stops as the firing background"
+            )
+            XCTAssertEqual(
+                AlarmThemeRendering.gradientLocations(for: theme),
+                palette.backgroundLocations,
+                "Picker tile locations for \(theme.id) must match the firing background"
+            )
+        }
+    }
+
+    func testDawnPickerTileKeepsHistoricalFourStopRecipe() {
+        // Dawn's firing background is the tone-reactive SPDawnBackgroundView,
+        // not the palette gradient — the tile keeps its pre-#225 night look.
+        XCTAssertEqual(AlarmThemeRendering.gradientColors(for: .dawn)?.count, 4)
+        XCTAssertEqual(AlarmThemeRendering.gradientLocations(for: .dawn), [0.0, 0.4, 0.7, 1.0] as [NSNumber])
+    }
+
+    // MARK: - Hero title
+
+    private func makeViewModel(name: String, hour: Int, minute: Int) -> AlarmFiringViewModel {
+        var components = DateComponents()
+        components.year = 2026
+        components.month = 6
+        components.day = 11
+        components.hour = hour
+        components.minute = minute
+        let time = Calendar.current.date(from: components) ?? Date()
+        let alarm = Alarm(time: time, name: name)
+        return AlarmFiringViewModel(alarm: alarm, snoozeCount: 0)
+    }
+
+    func testHeroTitleJoinsNameAndScheduledTime() {
+        let viewModel = makeViewModel(name: "Будни", hour: 7, minute: 0)
+        XCTAssertEqual(viewModel.heroTitle, "Будни · 07:00")
+    }
+
+    func testHeroTitleDegradesToTimeWhenNameIsBlank() {
+        let viewModel = makeViewModel(name: "   ", hour: 9, minute: 5)
+        XCTAssertEqual(
+            viewModel.heroTitle,
+            "09:05",
+            "Whitespace-only names must not render a dangling separator"
+        )
+    }
+}


### PR DESCRIPTION
Fixes #225

## What's done
- **`AlarmFiringThemePalette`** (new) — the literal `FIRING_THEMES` table from `SPThemedFiring.jsx`: 160° background stops, scrim alphas, accent / accentSoft, pill bg+border, 135° bell gradient, clock-halo colour+opacity for all 6 stock themes; `nil` for `.custom` (photo keeps the un-themed treatment).
- **`SPThemedFiringBackgroundView`** (new) — replaces the vertical CAGradientLayer fallback for Ocean/Mountains/Forest/Neon/Abstract: 160° base gradient + radial vignette scrim at (50%, 70%) + 460pt bottom accent glow. Dawn stays on the tone-reactive `SPDawnBackgroundView` (calm/tense/drained + breathing sun — simpler to maintain, as the issue allows) but picks up the same accent pass.
- **Accent pass** — balance pill tinted with theme accent (pain-red zero-balance signal stays un-themed), eyebrow caps at accent@85% with .18em tracking, per-theme clock halo, new 72×72 `SPFiringBellTile` with accentSoft ring.
- **V3 hero order** — bell tile → "Будни · 07:00" h3 (`heroTitle` on the VM, blank names degrade to bare time) → 96pt clock → eyebrow "пора вставать"/"только встать". No-balance center block re-anchored to the eyebrow.
- **`AlarmThemeRendering`** now delegates non-dawn stock stops to the palette so picker tiles / alarm-cell strips can't drift from the firing background (Ocean/Mountains/Abstract picked up their v3 stops; Forest/Neon values unchanged from #224).
- Audio / coordinator logic untouched; firing stays forced-dark.

## Verify
- swiftlint: 0 errors on touched files (2 pre-existing SPPill warnings exist on base)
- xcodebuild build (generic/platform=iOS Simulator): succeeded
- xcodebuild build-for-testing: succeeded
- Tests: `AlarmFiringThemePaletteTests` (11 tests) — table coverage for all 6 themes, custom→nil, accent hex assertions, scrim vignette invariant, neon row spot-check, AlarmThemeRendering delegation, dawn tile unchanged, heroTitle formatting. Full suite runs on CI.