### PR TITLE
[ui] AlarmsList zero-balance pain state + alarm title wrap rule (#232)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmCell.swift
@@ -38,12 +38,20 @@ final class AlarmCell: UITableViewCell {
         return view
     }()
 
+    /// Title/days caps row. Long alarm names WRAP onto new lines and are
+    /// never truncated or shrunk — the card grows in height and the clock
+    /// + pill rows slide down (`AlarmCardWrapDemo` in SPScreensV2.jsx,
+    /// #232). The ≈26-char single-line capacity is a fact of the layout,
+    /// not an input limit.
     private let capsLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.numberOfLines = 1
-        label.adjustsFontSizeToFitWidth = true
-        label.minimumScaleFactor = 0.85
+        label.numberOfLines = 0
+        label.lineBreakMode = .byWordWrapping
+        // Required vertical resistance so the multi-line height always
+        // wins over the card's compressed fitting pass — without it the
+        // self-sizing cell could clip the second line instead of growing.
+        label.setContentCompressionResistancePriority(.required, for: .vertical)
         return label
     }()
 
@@ -138,15 +146,25 @@ final class AlarmCell: UITableViewCell {
             cardView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -outerH),
             cardView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -outerV),
 
-            // Caps top-leading, switch top-trailing — aligned by centerY.
+            // Caps top-leading, switch top-trailing. The caps label gets a
+            // fully-determined width (equality, not ≤) so UILabel computes
+            // its wrapped multi-line height on its own — long names break
+            // onto new lines instead of truncating (#232).
             capsLabel.topAnchor.constraint(equalTo: cardView.topAnchor, constant: pad),
             capsLabel.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: pad),
             capsLabel.trailingAnchor.constraint(
-                lessThanOrEqualTo: toggleSwitch.leadingAnchor,
+                equalTo: toggleSwitch.leadingAnchor,
                 constant: -AppSpacing.sp3
             ),
 
-            toggleSwitch.centerYAnchor.constraint(equalTo: capsLabel.centerYAnchor),
+            // The switch stays anchored to the FIRST caps line (its centre
+            // sits where a single-line caps row's centre would be) so a
+            // wrapped title doesn't drag the toggle down the card —
+            // mirrors the demo's `alignItems: flex-start`.
+            toggleSwitch.centerYAnchor.constraint(
+                equalTo: cardView.topAnchor,
+                constant: pad + AppTypography.caps.lineHeight / 2
+            ),
             toggleSwitch.trailingAnchor.constraint(equalTo: cardView.trailingAnchor, constant: -pad),
 
             // Clock below the caps row.

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
@@ -253,7 +253,9 @@ class AlarmsListViewController: UIViewController {
         let balance = Decimal(viewModel.balance)
         header.setBalance(
             balance,
-            hint: viewModel.affordabilityHint,
+            // `balanceHint` swaps in "Откладывать не получится" at 0 ₽
+            // (#232) and falls back to the affordability line otherwise.
+            hint: viewModel.balanceHint,
             delta: viewModel.weeklyDelta
         )
         // Legacy method preserved for source-compat — the V2 pill already

--- a/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
@@ -367,6 +367,30 @@ final class AlarmsListViewModel {
         return "Хватит на ~\(count) \(Self.snoozeWord(for: count))"
     }
 
+    // MARK: - Zero-balance state (#232)
+
+    /// `true` when the user has literally no money. The header pill
+    /// switches into its pain (zero) tone and the hint copy changes —
+    /// distinct from `isLowBalance`, which only warns that the runway
+    /// is short.
+    var isZeroBalance: Bool {
+        balance <= 0
+    }
+
+    /// Copy shown under the 0 ₽ figure. Deliberately "Откладывать не
+    /// получится", NOT "будильники не зазвонят" — the alarm still fires
+    /// at zero balance; the user just can't pay to snooze it (PM call,
+    /// issue #232). Alarms stay visually active for the same reason.
+    static let zeroBalanceHint = "Откладывать не получится"
+
+    /// The single hint string the alarms-list header should render under
+    /// the balance figure: zero-balance copy when the wallet is empty,
+    /// otherwise the regular "Хватит на ~N откладываний" affordability
+    /// line ("~0 откладываний" never ships — the zero branch wins first).
+    var balanceHint: String {
+        isZeroBalance ? Self.zeroBalanceHint : affordabilityHint
+    }
+
     /// Weekly net delta surfaced in the sticky header beneath the balance
     /// (#175). Charge transactions are penalty deductions stored as
     /// positive `Double`s with `type == .charge`, so the user-facing net

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPAlarmsListHeader.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPAlarmsListHeader.swift
@@ -18,6 +18,9 @@ import UIKit
 /// the urgency is now folded directly into the pill: when balance drops below
 /// `SPAlarmsListHeader.lowBalanceThreshold` the pill switches its background
 /// to a soft warn tint + warn-stroke and the hint copy reflects the warning.
+/// At exactly 0 ₽ the pill escalates further into the pain (zero-balance)
+/// variant — red stroke, reddish gradient wash, crossed-out coin tile and a
+/// pain-300 amount (#232); the "Пополнить" CTA stays money-green throughout.
 ///
 /// The 40×40 circular "+" button on the right is the only entry point for
 /// "create new alarm" on this screen — the legacy nav-bar plus button is
@@ -41,8 +44,10 @@ final class SPAlarmsListHeader: UIView {
     /// routes through the same "Пополнить" tap path.
     var onWarnTopUpTap: (() -> Void)?
 
-    /// Update the balance pill in place. The pill auto-switches into its
-    /// warn-tint variant when `balance.doubleValue ≤ lowBalanceThreshold`.
+    /// Update the balance pill in place. The pill auto-switches between
+    /// three tones based on the amount: pain when the balance is 0 ₽
+    /// (zero-balance state, #232), warn-tint when
+    /// `balance.doubleValue ≤ lowBalanceThreshold`, neutral otherwise.
     /// `hint` and `delta` are accepted for source-compat with the legacy
     /// header; `delta` is currently ignored in the V2 pill layout (the
     /// rolling-week change rendered as `↑/↓ amount` migrates onto the
@@ -51,10 +56,14 @@ final class SPAlarmsListHeader: UIView {
     func setBalance(_ balance: Decimal, hint: String?, delta: Decimal? = nil) {
         _ = delta // accepted for API compat; pill omits the delta row.
         currentBalance = balance
-        let isLow = (NSDecimalNumber(decimal: balance).doubleValue) <= Self.lowBalanceThreshold
-        applyTone(isLow: isLow)
+        let tone = Self.tone(for: balance)
+        applyTone(tone)
         balanceValueLabel.attributedText = MoneyFormatter.attributed(
-            balance, digitsFont: AppTypography.moneyMd
+            balance,
+            digitsFont: AppTypography.moneyMd,
+            // 0 ₽ renders in pain-300 per SPScreensV2.jsx L369; the
+            // non-zero tones keep the label's fg1 textColor.
+            color: tone == .zero ? AppColors.pain300 : nil
         )
         if let hint = hint, !hint.isEmpty {
             balanceHintLabel.text = hint
@@ -82,6 +91,24 @@ final class SPAlarmsListHeader: UIView {
     /// the model agree on what "low" means without coupling them through
     /// an import.
     static let lowBalanceThreshold: Double = 100
+
+    /// Visual tone of the balance pill (#232). `zero` (pain chrome +
+    /// IconCoinOff) outranks `low` (warn chrome) — both can't show at
+    /// once and an empty wallet is the more urgent story. The alarms in
+    /// the list stay visually active in every tone: at 0 ₽ they still
+    /// fire, the user just can't pay to snooze them.
+    private enum PillTone {
+        case normal
+        case low
+        case zero
+    }
+
+    private static func tone(for balance: Decimal) -> PillTone {
+        let value = NSDecimalNumber(decimal: balance).doubleValue
+        if value <= 0 { return .zero }
+        if value <= lowBalanceThreshold { return .low }
+        return .normal
+    }
 
     // MARK: - Subviews
 
@@ -145,6 +172,24 @@ final class SPAlarmsListHeader: UIView {
         view.layer.cornerRadius = 14
         view.layer.masksToBounds = true
         view.layer.borderWidth = 1
+        return view
+    }()
+
+    /// Reddish wash behind the pill content in the zero-balance state —
+    /// `linear-gradient(135deg, pain@.10 → pain@.02)` per SPScreensV2.jsx
+    /// L346-347. Hidden in the neutral / warn tones, where the flat
+    /// `backgroundColor` carries the surface instead.
+    private let zeroTintGradient: SPGradientView = {
+        let view = SPGradientView(
+            colors: [
+                AppColors.pain500.withAlphaComponent(0.10).cgColor,
+                AppColors.pain500.withAlphaComponent(0.02).cgColor
+            ],
+            locations: [0.0, 1.0]
+        )
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.isUserInteractionEnabled = false
+        view.isHidden = true
         return view
     }()
 
@@ -251,8 +296,7 @@ final class SPAlarmsListHeader: UIView {
     private func refreshDynamicColors() {
         // CALayer cgColors don't auto-resolve dynamic UIColors.
         bottomHairline.backgroundColor = AppColors.whiteOverlay06
-        let isLow = NSDecimalNumber(decimal: currentBalance).doubleValue <= Self.lowBalanceThreshold
-        applyTone(isLow: isLow)
+        applyTone(Self.tone(for: currentBalance))
     }
 
     // MARK: - Configuration
@@ -267,6 +311,7 @@ final class SPAlarmsListHeader: UIView {
         addButton.addSubview(addIconView)
 
         addSubview(pillButton)
+        pillButton.addSubview(zeroTintGradient)
         pillButton.addSubview(walletIconHost)
         walletIconHost.addSubview(walletIconImageView)
         pillButton.addSubview(balanceCapsLabel)
@@ -311,6 +356,12 @@ final class SPAlarmsListHeader: UIView {
             pillButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: inset),
             pillButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -inset),
             pillButton.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -AppSpacing.sp4),
+
+            // Zero-balance pain wash fills the pill behind the content.
+            zeroTintGradient.topAnchor.constraint(equalTo: pillButton.topAnchor),
+            zeroTintGradient.leadingAnchor.constraint(equalTo: pillButton.leadingAnchor),
+            zeroTintGradient.trailingAnchor.constraint(equalTo: pillButton.trailingAnchor),
+            zeroTintGradient.bottomAnchor.constraint(equalTo: pillButton.bottomAnchor),
 
             // Wallet icon — 40×40 leading.
             walletIconHost.leadingAnchor.constraint(equalTo: pillButton.leadingAnchor, constant: 12),
@@ -364,23 +415,54 @@ final class SPAlarmsListHeader: UIView {
             bottomHairline.heightAnchor.constraint(equalToConstant: 1)
         ])
 
-        applyTone(isLow: false)
+        applyTone(.normal)
     }
 
     /// Switch the pill chrome between the neutral (bg2 + whiteOverlay08
-    /// stroke) and warn (warn500@12% + warn500@45% stroke) variants. The
-    /// hint copy + colour also shift so the low-balance state stays legible
-    /// at a glance without an extra banner row.
-    private func applyTone(isLow: Bool) {
-        if isLow {
+    /// stroke), warn (warn500@12% + warn500@45% stroke) and zero-balance
+    /// pain (pain gradient wash + pain500@30% stroke + IconCoinOff tile,
+    /// #232) variants. The hint colour also shifts so the state stays
+    /// legible at a glance without an extra banner row. The "Пополнить"
+    /// CTA keeps its money variant in every tone — topping up is a
+    /// positive action even when the wallet is empty.
+    private func applyTone(_ tone: PillTone) {
+        zeroTintGradient.isHidden = tone != .zero
+        switch tone {
+        case .zero:
+            // The pain wash gradient carries the surface; flat bg clears.
+            pillButton.backgroundColor = .clear
+            pillButton.layer.borderColor = AppColors.pain500.withAlphaComponent(0.30).cgColor
+            balanceHintLabel.textColor = AppColors.pain300
+            walletIconHost.refresh(
+                colors: SPSupport.painGradientColors,
+                locations: SPSupport.painGradientLocations
+            )
+            // Crossed-out coin on the pain tile, white ink per the JSX.
+            walletIconImageView.image = SPIcons.coinOff(size: 18)
+            walletIconImageView.tintColor = .white
+        case .low:
             pillButton.backgroundColor = AppColors.warn500.withAlphaComponent(0.12)
             pillButton.layer.borderColor = AppColors.warn500.withAlphaComponent(0.45).cgColor
             balanceHintLabel.textColor = AppColors.warn300
-        } else {
+            restoreWalletTile()
+        case .normal:
             pillButton.backgroundColor = AppColors.bg2
             pillButton.layer.borderColor = AppColors.whiteOverlay08.cgColor
             balanceHintLabel.textColor = AppColors.fg3
+            restoreWalletTile()
         }
+    }
+
+    /// Reset the 40×40 leading tile back to its money-gradient wallet
+    /// recipe after a visit to the zero-balance pain variant.
+    private func restoreWalletTile() {
+        walletIconHost.refresh(
+            colors: SPSupport.moneyGradientColors,
+            locations: SPSupport.moneyGradientLocations
+        )
+        let config = UIImage.SymbolConfiguration(pointSize: 18, weight: .semibold)
+        walletIconImageView.image = UIImage(systemName: "creditcard.fill", withConfiguration: config)
+        walletIconImageView.tintColor = AppColors.fgOnMoney
     }
 
     // MARK: - Actions

--- a/SnoozePay/SnoozePayTests/AlarmsListZeroBalanceAndWrapTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmsListZeroBalanceAndWrapTests.swift
@@ -1,0 +1,225 @@
+import XCTest
+@testable import SnoozePay
+
+/// Tests for the alarms-list zero-balance state + alarm-title wrap rule (#232).
+///
+/// Part 1 — `AlarmsListViewModel.balanceHint` must swap the affordability
+/// line for the zero-balance copy "Откладывать не получится" the moment the
+/// wallet hits 0 ₽ (NOT "будильники не зазвонят" — the alarm still fires at
+/// zero balance, the user just can't pay to snooze it).
+///
+/// Part 2 — `AlarmCell` must WRAP long alarm titles onto new lines, never
+/// truncate them: 13/26-char names render on one line, 27-char wraps to 2,
+/// 61-char wraps to 3 (per `AlarmCardWrapDemo` in SPScreensV2.jsx); the card
+/// grows in height each time.
+final class AlarmsListZeroBalanceTests: XCTestCase {
+
+    private var testDefaults: UserDefaults!
+    private var suiteName: String!
+    private var repo: AlarmRepository!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "test.alarmsListZeroBalance.\(UUID().uuidString)"
+        testDefaults = UserDefaults(suiteName: suiteName)!
+        repo = AlarmRepository(
+            defaults: testDefaults,
+            scheduler: AlarmsListViewModelTests.StubScheduler()
+        )
+    }
+
+    override func tearDown() {
+        testDefaults.removePersistentDomain(forName: suiteName)
+        super.tearDown()
+    }
+
+    /// Builds a VM wired to an isolated BalanceService seeded with the
+    /// given balance, so the shared singleton stays untouched.
+    private func makeViewModel(balance: Double) -> AlarmsListViewModel {
+        let center = NotificationCenter()
+        testDefaults.set(balance, forKey: "user_balance")
+        let service = BalanceService(defaults: testDefaults, notificationCenter: center)
+        let viewModel = AlarmsListViewModel(
+            alarmRepository: repo,
+            balanceService: service,
+            transactionRepository: TransactionRepository(defaults: testDefaults),
+            notificationCenter: center
+        )
+        viewModel.loadData()
+        return viewModel
+    }
+
+    func testZeroBalance_hintIsCannotSnoozeCopy() {
+        let viewModel = makeViewModel(balance: 0)
+
+        XCTAssertTrue(viewModel.isZeroBalance)
+        XCTAssertEqual(viewModel.balanceHint, "Откладывать не получится")
+    }
+
+    func testZeroBalance_copyNeverClaimsAlarmsWontRing() {
+        // PM explicitly corrected the copy: the alarm DOES ring at 0 ₽ —
+        // only snoozing is unavailable. Guard against the wrong wording
+        // sneaking back in.
+        XCTAssertFalse(AlarmsListViewModel.zeroBalanceHint.lowercased().contains("не зазвон"))
+        XCTAssertFalse(AlarmsListViewModel.zeroBalanceHint.lowercased().contains("не сработа"))
+    }
+
+    func testPositiveBalance_hintIsAffordabilityLine() {
+        let viewModel = makeViewModel(balance: 150)
+
+        XCTAssertFalse(viewModel.isZeroBalance)
+        // 150 ₽ / default 50 ₽ penalty → 3 snoozes.
+        XCTAssertEqual(viewModel.balanceHint, "Хватит на ~3 откладывания")
+        XCTAssertEqual(viewModel.balanceHint, viewModel.affordabilityHint)
+    }
+
+    func testLowButNonZeroBalance_keepsAffordabilityHint() {
+        // 50 ₽ is at/below the low-balance threshold (100 ₽) but NOT zero —
+        // the pill goes warn-tone, the copy must stay the affordability
+        // line, not the zero-balance escalation.
+        let viewModel = makeViewModel(balance: 50)
+
+        XCTAssertFalse(viewModel.isZeroBalance)
+        XCTAssertTrue(viewModel.isLowBalance)
+        XCTAssertEqual(viewModel.balanceHint, "Хватит на ~1 откладывание")
+    }
+}
+
+// MARK: - AlarmCell title wrap (#232)
+
+final class AlarmCellTitleWrapTests: XCTestCase {
+
+    /// iPhone-class width — gives the caps label ≈258 pt of run room after
+    /// the screen insets, card padding and the switch column.
+    private let cellWidth: CGFloat = 393
+
+    /// The four demo titles from `AlarmCardWrapDemo` (13/26/27/61 chars).
+    private let shortName = "Будни · Пн–Пт".uppercased()
+    private let edgeName = "Понедельник тренировка зал".uppercased()
+    private let twoLineName = "Ранний подъём перед работой каждый день".uppercased()
+    private let longName =
+        "Утренняя тренировка перед работой каждый рабочий день недели".uppercased()
+
+    /// Lays the cell out at `cellWidth` using the same compressed-fitting
+    /// pass UITableView's self-sizing uses, then returns the cell plus the
+    /// caps label rendering `daysCaps`.
+    private func layoutCell(daysCaps: String) -> (cell: AlarmCell, caps: UILabel) {
+        let cell = AlarmCell(style: .default, reuseIdentifier: AlarmCell.reuseID)
+        cell.configure(
+            time: "07:00",
+            daysCaps: daysCaps,
+            priceText: "50 ₽",
+            multiplier: nil,
+            soundName: "Soft Dawn",
+            enabled: true
+        )
+        let fitted = cell.contentView.systemLayoutSizeFitting(
+            CGSize(width: cellWidth, height: UIView.layoutFittingCompressedSize.height),
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        )
+        cell.frame = CGRect(x: 0, y: 0, width: cellWidth, height: ceil(fitted.height))
+        cell.layoutIfNeeded()
+        guard let caps = findLabel(withText: daysCaps, in: cell) else {
+            XCTFail("Caps label rendering \"\(daysCaps)\" not found in AlarmCell")
+            return (cell, UILabel())
+        }
+        return (cell, caps)
+    }
+
+    private func findLabel(withText text: String, in view: UIView) -> UILabel? {
+        if let label = view as? UILabel,
+           label.attributedText?.string == text || label.text == text {
+            return label
+        }
+        for subview in view.subviews {
+            if let found = findLabel(withText: text, in: subview) {
+                return found
+            }
+        }
+        return nil
+    }
+
+    /// Rendered line count — wrapped height divided by the line height of
+    /// the ACTUAL caps font. (`label.font` stays the 17pt default when the
+    /// text is attributed, so read the font off the attributed string.)
+    private func lineCount(of label: UILabel) -> Int {
+        let font = (label.attributedText?.attribute(
+            .font, at: 0, effectiveRange: nil
+        ) as? UIFont) ?? label.font ?? UIFont.systemFont(ofSize: 12)
+        guard font.lineHeight > 0 else { return 0 }
+        return Int((label.bounds.height / font.lineHeight).rounded())
+    }
+
+    /// "Never truncated" — the laid-out label must be tall enough for the
+    /// FULL text at its final width (no vertical clipping → no ellipsis).
+    private func assertNotTruncated(
+        _ label: UILabel,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard let attributed = label.attributedText else {
+            XCTFail("Caps label lost its attributed text", file: file, line: line)
+            return
+        }
+        let required = attributed.boundingRect(
+            with: CGSize(width: label.bounds.width, height: .greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            context: nil
+        ).height
+        XCTAssertGreaterThanOrEqual(
+            label.bounds.height + 0.5, required,
+            "Caps label is shorter than its full text — title is being clipped/truncated",
+            file: file, line: line
+        )
+    }
+
+    func testCapsLabelNeverTruncates() {
+        for name in [shortName, edgeName, twoLineName, longName] {
+            let (_, caps) = layoutCell(daysCaps: name)
+            XCTAssertEqual(caps.numberOfLines, 0, "Caps label must allow unlimited lines")
+            XCTAssertFalse(
+                caps.adjustsFontSizeToFitWidth,
+                "Long titles must wrap, not shrink to fit"
+            )
+            assertNotTruncated(caps)
+        }
+    }
+
+    func testShortNameRendersOnOneLine() {
+        XCTAssertEqual(lineCount(of: layoutCell(daysCaps: shortName).caps), 1)
+    }
+
+    func testEdgeNameStaysCompactAndUnclipped() {
+        // The 26-char demo title sits exactly at the single-line capacity
+        // in the design's CSS metrics. UIFont metrics differ slightly, so
+        // don't pin the boundary to exactly 1 line — assert it stays
+        // compact (≤2 lines) and, critically, is never truncated.
+        let caps = layoutCell(daysCaps: edgeName).caps
+        XCTAssertLessThanOrEqual(lineCount(of: caps), 2)
+        assertNotTruncated(caps)
+    }
+
+    func testLongNamesWrapOntoMultipleLines() {
+        let twoLine = lineCount(of: layoutCell(daysCaps: twoLineName).caps)
+        let threeLine = lineCount(of: layoutCell(daysCaps: longName).caps)
+        XCTAssertGreaterThanOrEqual(twoLine, 2, "≈40-char title must wrap to ≥2 lines")
+        XCTAssertGreaterThanOrEqual(threeLine, 3, "61-char title must wrap to ≥3 lines")
+        XCTAssertGreaterThanOrEqual(threeLine, twoLine, "Longer titles must not collapse lines")
+    }
+
+    func testCardGrowsWithWrappedTitle() {
+        let oneLineHeight = layoutCell(daysCaps: shortName).cell.frame.height
+        let twoLineHeight = layoutCell(daysCaps: twoLineName).cell.frame.height
+        let threeLineHeight = layoutCell(daysCaps: longName).cell.frame.height
+
+        XCTAssertGreaterThan(
+            twoLineHeight, oneLineHeight,
+            "Card must grow when the title wraps to a second line"
+        )
+        XCTAssertGreaterThan(
+            threeLineHeight, twoLineHeight,
+            "Card must keep growing as more lines wrap"
+        )
+    }
+}


### PR DESCRIPTION
Fixes #232

## Что сделано
- **SPAlarmsListHeader** — третий тон balance pill при 0 ₽ (артборд 06a/06b, SPScreensV2.jsx `zeroBalance`): pain-рамка 30%, красноватый градиент-фон (pain @.10→.02, 135°), `IconCoinOff` на pain-градиентном тайле, сумма `0 ₽` в pain-300. Кнопка «Пополнить» остаётся money-green — позитивное действие. Тоны: zero → low (warn) → normal; zero приоритетнее low.
- **AlarmsListViewModel** — `isZeroBalance` + `balanceHint`: при 0 ₽ подпись **«Откладывать не получится»** (НЕ «будильники не зазвонят» — будильник звонит, нельзя только откладывать; PM call), иначе обычная affordability-строка. Будильники визуально активны.
- **AlarmCell** — title wrap rule (`AlarmCardWrapDemo`): caps-заголовок `numberOfLines = 0`, переносится по словам, никогда не обрезается и не ужимается; карточка растёт по высоте (automaticDimension), время/чипы съезжают вниз; свитч закреплён на уровне первой строки.

## Verify
- ✅ swiftlint (touched files): 0 errors
- ✅ `xcodebuild build` (generic/platform=iOS Simulator, CODE_SIGNING_ALLOWED=NO): succeeded
- ✅ `xcodebuild build-for-testing`: succeeded
- 🧪 Тесты: `AlarmsListZeroBalanceTests` (hint copy 0/50/150 ₽, guard от «не зазвонят»-формулировки) + `AlarmCellTitleWrapTests` (13/26/40/61 симв.: no ellipsis, 1/≤2/≥2/≥3 строки, рост карточки) — гоняет CI
- Деньги — через `MoneyFormatter.attributed(color:)`

## Замечания для ревью
- Не трогает AlarmFiring* (там открыт PR #262)
- Граница «26 символов = 1 строка» в тесте смягчена до ≤2 строк: CSS-метрики демо (11px) ≠ UIFont caps (12pt), точная граница флейкала бы