### PR TITLE
[feature] TxHistory V3 — period chip + month-grid PeriodPickerSheet + period summary (#234)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Wallet/PeriodPickerSheetViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Wallet/PeriodPickerSheetViewController.swift
@@ -1,0 +1,442 @@
+import UIKit
+
+/// Period picker bottom sheet — V3 design `PeriodPickerSheet` in
+/// `docs/design/v2-handoff/components/SPMore3.jsx` (artboards 21a/21b,
+/// issue #234).
+///
+/// Presented over the (dimmed) transaction-history screen as a page sheet.
+/// Layout, top-down: drag handle → "Период" header + "Сбросить" text button
+/// → selected-range summary row → years, each with a 4×3 month grid →
+/// money CTA "Применить".
+///
+/// Selection follows calendar range-selection conventions: tap one month for
+/// a single-month period, tap a second month to extend into a range (the
+/// in-between months get a continuous light fill, the endpoints render as
+/// solid discs with dark text). Months after the current one are disabled.
+/// Tap rules live in `TxHistoryPeriodSelection` so they stay unit-testable.
+final class PeriodPickerSheetViewController: UIViewController {
+
+    // MARK: - State
+
+    private var selection: TxHistoryPeriodSelection
+    private let years: [Int]
+    private let currentMonth: YearMonth
+    /// Called on "Применить". `nil` means the selection was reset — the
+    /// caller falls back to its default period (current month).
+    private let onApply: (TxHistoryPeriod?) -> Void
+
+    private var cells: [YearMonth: MonthCell] = [:]
+
+    // MARK: - Subviews
+
+    private let dragHandle: UIView = {
+        let view = UIView()
+        view.backgroundColor = AppColors.whiteOverlay12
+        view.layer.cornerRadius = 2
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let scrollView: UIScrollView = {
+        let view = UIScrollView()
+        view.alwaysBounceVertical = false
+        view.showsVerticalScrollIndicator = false
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let contentStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.spacing = AppSpacing.sp4
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+
+    private let summaryContainer: UIView = {
+        let view = UIView()
+        view.backgroundColor = AppColors.whiteOverlay06
+        view.layer.cornerRadius = AppRadius.sm
+        return view
+    }()
+
+    private let summaryDot: UIView = {
+        let view = UIView()
+        view.backgroundColor = AppColors.fg1
+        view.layer.cornerRadius = 3
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let summaryLabel: UILabel = {
+        let label = UILabel()
+        label.font = AppFonts.sans(.semibold, 14)
+        label.textColor = AppColors.fg1
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let summaryCountLabel: UILabel = {
+        let label = UILabel()
+        label.font = AppTypography.meta
+        label.textColor = AppColors.fg3
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private lazy var applyButton: SPButton = {
+        let button = SPButton(title: "Применить", variant: .money, size: .lg, fullWidth: true)
+        button.addTarget(self, action: #selector(applyTapped), for: .touchUpInside)
+        return button
+    }()
+
+    // MARK: - Init
+
+    /// - Parameters:
+    ///   - selected: Period currently applied on the history screen.
+    ///   - years: Years to render grids for (ascending, e.g. `[2024, 2025,
+    ///     2026]`) — derived from the oldest recorded transaction.
+    ///   - now: Injectable clock; months after `now`'s month are disabled.
+    ///   - onApply: Receives the chosen period (`nil` after "Сбросить").
+    init(
+        selected: TxHistoryPeriod?,
+        years: [Int],
+        now: Date = Date(),
+        onApply: @escaping (TxHistoryPeriod?) -> Void
+    ) {
+        self.selection = TxHistoryPeriodSelection(period: selected)
+        self.years = years
+        self.currentMonth = YearMonth(date: now)
+        self.onApply = onApply
+        super.init(nibName: nil, bundle: nil)
+        modalPresentationStyle = .pageSheet
+        if let sheet = sheetPresentationController {
+            if #available(iOS 16.0, *) {
+                let custom = UISheetPresentationController.Detent.custom(
+                    identifier: UISheetPresentationController.Detent.Identifier("snoozepay.periodpicker")
+                ) { context in
+                    min(640, context.maximumDetentValue)
+                }
+                sheet.detents = [custom, .large()]
+            } else {
+                sheet.detents = [.medium(), .large()]
+            }
+            sheet.prefersGrabberVisible = false  // we render our own handle
+            sheet.preferredCornerRadius = AppRadius.xl
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = AppColors.bg1
+        setupLayout()
+        refreshSelectionUI()
+    }
+
+    // MARK: - Layout
+
+    private func setupLayout() {
+        view.addSubview(dragHandle)
+        view.addSubview(scrollView)
+        view.addSubview(applyButton)
+        scrollView.addSubview(contentStack)
+
+        contentStack.addArrangedSubview(makeHeaderRow())
+        contentStack.addArrangedSubview(makeSummaryRow())
+        for year in years {
+            contentStack.addArrangedSubview(makeYearBlock(year: year))
+        }
+
+        applyButton.translatesAutoresizingMaskIntoConstraints = false
+
+        let inset = AppSpacing.screenInset
+        NSLayoutConstraint.activate([
+            dragHandle.topAnchor.constraint(equalTo: view.topAnchor, constant: 8),
+            dragHandle.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            dragHandle.widthAnchor.constraint(equalToConstant: 36),
+            dragHandle.heightAnchor.constraint(equalToConstant: 4),
+
+            scrollView.topAnchor.constraint(equalTo: dragHandle.bottomAnchor, constant: AppSpacing.sp4),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: applyButton.topAnchor, constant: -AppSpacing.sp3),
+
+            contentStack.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            contentStack.leadingAnchor.constraint(
+                equalTo: scrollView.contentLayoutGuide.leadingAnchor, constant: inset
+            ),
+            contentStack.trailingAnchor.constraint(
+                equalTo: scrollView.contentLayoutGuide.trailingAnchor, constant: -inset
+            ),
+            contentStack.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
+            contentStack.widthAnchor.constraint(
+                equalTo: scrollView.frameLayoutGuide.widthAnchor, constant: -2 * inset
+            ),
+
+            applyButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
+            applyButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
+            applyButton.bottomAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -AppSpacing.sp3
+            )
+        ])
+    }
+
+    private func makeHeaderRow() -> UIView {
+        let title = UILabel()
+        title.attributedText = NSAttributedString(
+            string: "Период",
+            attributes: [
+                .font: AppTypography.h3,
+                .kern: -20 * 0.01,
+                .foregroundColor: AppColors.fg1
+            ]
+        )
+
+        let reset = UIButton(type: .system)
+        reset.setTitle("Сбросить", for: .normal)
+        reset.titleLabel?.font = AppFonts.sans(.medium, 14)
+        reset.setTitleColor(AppColors.fg3, for: .normal)
+        reset.addTarget(self, action: #selector(resetTapped), for: .touchUpInside)
+
+        let row = UIStackView(arrangedSubviews: [title, UIView(), reset])
+        row.axis = .horizontal
+        row.alignment = .center
+        return row
+    }
+
+    private func makeSummaryRow() -> UIView {
+        summaryContainer.addSubview(summaryDot)
+        summaryContainer.addSubview(summaryLabel)
+        summaryContainer.addSubview(summaryCountLabel)
+        NSLayoutConstraint.activate([
+            summaryContainer.heightAnchor.constraint(greaterThanOrEqualToConstant: 38),
+
+            summaryDot.leadingAnchor.constraint(
+                equalTo: summaryContainer.leadingAnchor, constant: 14
+            ),
+            summaryDot.centerYAnchor.constraint(equalTo: summaryContainer.centerYAnchor),
+            summaryDot.widthAnchor.constraint(equalToConstant: 6),
+            summaryDot.heightAnchor.constraint(equalToConstant: 6),
+
+            summaryLabel.leadingAnchor.constraint(equalTo: summaryDot.trailingAnchor, constant: 10),
+            summaryLabel.topAnchor.constraint(equalTo: summaryContainer.topAnchor, constant: 10),
+            summaryLabel.bottomAnchor.constraint(equalTo: summaryContainer.bottomAnchor, constant: -10),
+
+            summaryCountLabel.leadingAnchor.constraint(
+                greaterThanOrEqualTo: summaryLabel.trailingAnchor, constant: AppSpacing.sp2
+            ),
+            summaryCountLabel.trailingAnchor.constraint(
+                equalTo: summaryContainer.trailingAnchor, constant: -14
+            ),
+            summaryCountLabel.centerYAnchor.constraint(equalTo: summaryContainer.centerYAnchor)
+        ])
+        return summaryContainer
+    }
+
+    private func makeYearBlock(year: Int) -> UIView {
+        let caption = UILabel()
+        caption.attributedText = NSAttributedString(
+            string: "\(year)",
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.fg3
+            ]
+        )
+
+        // 4×3 grid: zero column gap so the range fill reads as one continuous
+        // strip; 6pt row gap (SPMore3.jsx L300-307).
+        let grid = UIStackView()
+        grid.axis = .vertical
+        grid.spacing = 6
+        for rowStart in stride(from: 1, through: 12, by: 4) {
+            let row = UIStackView()
+            row.axis = .horizontal
+            row.distribution = .fillEqually
+            row.spacing = 0
+            for month in rowStart..<(rowStart + 4) {
+                let yearMonth = YearMonth(year: year, month: month)
+                let cell = MonthCell(month: yearMonth, column: (month - 1) % 4) { [weak self] in
+                    self?.monthTapped(yearMonth)
+                }
+                cells[yearMonth] = cell
+                row.addArrangedSubview(cell)
+            }
+            grid.addArrangedSubview(row)
+        }
+
+        let block = UIStackView(arrangedSubviews: [caption, grid])
+        block.axis = .vertical
+        block.spacing = AppSpacing.sp2
+        return block
+    }
+
+    // MARK: - Actions
+
+    private func monthTapped(_ month: YearMonth) {
+        selection.tap(month)
+        refreshSelectionUI()
+    }
+
+    @objc private func resetTapped() {
+        selection.reset()
+        refreshSelectionUI()
+    }
+
+    @objc private func applyTapped() {
+        onApply(selection.period)
+        dismiss(animated: true)
+    }
+
+    // MARK: - Selection rendering
+
+    private func refreshSelectionUI() {
+        let period = selection.period
+        if let period {
+            summaryLabel.text = period.pickerCaption
+            summaryCountLabel.text = period.monthCountText
+        } else {
+            summaryLabel.text = "Выберите месяц"
+            summaryCountLabel.text = nil
+        }
+        for (month, cell) in cells {
+            cell.apply(
+                role: Self.role(of: month, in: period),
+                isFuture: month > currentMonth
+            )
+        }
+    }
+
+    static func role(of month: YearMonth, in period: TxHistoryPeriod?) -> MonthCellRole {
+        guard let period, period.contains(month) else { return .none }
+        if month == period.start && month == period.end { return .single }
+        if month == period.start { return .start }
+        if month == period.end { return .end }
+        return .mid
+    }
+}
+
+// MARK: - Month cell
+
+/// Position of a month inside the selected range — drives the fill shape
+/// (rounded vs. square edges) and the endpoint disc.
+enum MonthCellRole {
+    case none
+    /// Single-month selection — disc only, no range strip.
+    case single
+    case start
+    case mid
+    case end
+}
+
+/// One month in the picker grid. Two layers: a full-width range-fill strip
+/// (light overlay, square edges towards the range interior) and the label
+/// pill on top (solid disc for endpoints).
+private final class MonthCell: UIControl {
+
+    private let month: YearMonth
+    /// 0...3 — position inside the 4-column grid row; outer row edges of a
+    /// range fill get rounded so the strip doesn't bleed past the grid.
+    private let column: Int
+    private let onTap: () -> Void
+
+    private let fillView = UIView()
+    private let pill = UILabel()
+
+    init(month: YearMonth, column: Int, onTap: @escaping () -> Void) {
+        self.month = month
+        self.column = column
+        self.onTap = onTap
+        super.init(frame: .zero)
+
+        translatesAutoresizingMaskIntoConstraints = false
+        heightAnchor.constraint(equalToConstant: 44).isActive = true
+
+        fillView.translatesAutoresizingMaskIntoConstraints = false
+        fillView.backgroundColor = AppColors.whiteOverlay08
+        fillView.isUserInteractionEnabled = false
+        addSubview(fillView)
+
+        pill.translatesAutoresizingMaskIntoConstraints = false
+        pill.text = month.gridLabel
+        pill.textAlignment = .center
+        pill.layer.cornerRadius = 18
+        pill.layer.masksToBounds = true
+        pill.isUserInteractionEnabled = false
+        addSubview(pill)
+
+        NSLayoutConstraint.activate([
+            fillView.topAnchor.constraint(equalTo: topAnchor, constant: 4),
+            fillView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -4),
+            fillView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            fillView.trailingAnchor.constraint(equalTo: trailingAnchor),
+
+            pill.centerXAnchor.constraint(equalTo: centerXAnchor),
+            pill.centerYAnchor.constraint(equalTo: centerYAnchor),
+            pill.widthAnchor.constraint(greaterThanOrEqualToConstant: 48),
+            pill.heightAnchor.constraint(equalToConstant: 36)
+        ])
+
+        isAccessibilityElement = true
+        accessibilityTraits = .button
+        accessibilityLabel = "\(YearMonth.fullNames[month.month - 1]) \(month.year)"
+        addTarget(self, action: #selector(handleTap), for: .touchUpInside)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    @objc private func handleTap() {
+        onTap()
+    }
+
+    func apply(role: MonthCellRole, isFuture: Bool) {
+        isEnabled = !isFuture
+
+        // Range strip: rounded on the outer edge of the range, square towards
+        // its interior so consecutive cells merge into one continuous fill.
+        // The outer edges of each grid row also round (smaller radius) so the
+        // strip wraps cleanly when the range spans multiple rows
+        // (SPMore3.jsx L314-339).
+        switch role {
+        case .none, .single:
+            fillView.isHidden = true
+        case .start, .mid, .end:
+            fillView.isHidden = false
+            var corners: CACornerMask = []
+            if role == .start || column == 0 {
+                corners.insert(.layerMinXMinYCorner)
+                corners.insert(.layerMinXMaxYCorner)
+            }
+            if role == .end || column == 3 {
+                corners.insert(.layerMaxXMinYCorner)
+                corners.insert(.layerMaxXMaxYCorner)
+            }
+            let isEndpointEdge = role == .start || role == .end
+            fillView.layer.cornerRadius = corners.isEmpty ? 0 : (isEndpointEdge ? 18 : 14)
+            fillView.layer.maskedCorners = corners
+        }
+
+        let isEndpoint = role == .single || role == .start || role == .end
+        if isEndpoint {
+            pill.backgroundColor = AppColors.fg1
+            pill.textColor = AppColors.bg0
+            pill.font = AppFonts.sans(.bold, 14)
+        } else {
+            pill.backgroundColor = .clear
+            pill.font = AppFonts.sans(.medium, 14)
+            if isFuture {
+                pill.textColor = AppColors.fg4
+            } else {
+                pill.textColor = role == .mid ? AppColors.fg1 : AppColors.fg2
+            }
+        }
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletTransactionHistoryViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletTransactionHistoryViewController.swift
@@ -1,11 +1,16 @@
 import UIKit
 
-/// Transaction history screen — V2 design `TxHistory` in
-/// `docs/design/v2-handoff/components/SPMore3.jsx` (L6-105).
+/// Transaction history screen — V3 design `TxHistory` in
+/// `docs/design/v2-handoff/components/SPMore3.jsx` (artboards 21/21a/21b,
+/// issue #234).
 ///
-/// Lists every recorded `Transaction` grouped by day. Headers read
-/// "СЕГОДНЯ" / "ВЧЕРА" / "12 АПР" depending on relative date. Tap-through
-/// is not implemented yet — the screen is read-only.
+/// Top-down: centered period chip (current month by default; tap opens
+/// `PeriodPickerSheetViewController` for single-month or month-range
+/// selection) → summary card with Списано / Пополнения / Откладываний
+/// computed over the visible list (bonuses excluded from Пополнения) →
+/// day-grouped transaction list filtered to the selected period. Headers
+/// read "Сегодня" / "Вчера" / "12 января". The whole page scrolls as one
+/// surface — no nested scrolling.
 ///
 /// `Wallet`-prefixed because a legacy `TransactionHistoryViewController`
 /// still lives under `Settings/` for the V1 surface; the two will merge
@@ -22,6 +27,7 @@ final class WalletTransactionHistoryViewController: UIViewController {
     private let scrollView = UIScrollView()
     private let stack = UIStackView()
     private var groups: [Group] = []
+    private var period: TxHistoryPeriod = .currentMonth()
 
     // MARK: - Lifecycle
 
@@ -90,24 +96,167 @@ final class WalletTransactionHistoryViewController: UIViewController {
         }
 
         let all = TransactionRepository.shared.fetchAll()
-        groups = Self.group(transactions: all)
+        let visible = period.filter(all)
+        groups = Self.group(transactions: visible)
+
+        let chipRow = makePeriodChipRow()
+        stack.addArrangedSubview(chipRow)
+        stack.setCustomSpacing(AppSpacing.sp4, after: chipRow)
+        stack.addArrangedSubview(makeSummaryCard(summary: TxHistorySummary.compute(from: visible)))
 
         if groups.isEmpty {
-            stack.addArrangedSubview(makeEmptyCard())
+            stack.addArrangedSubview(makeEmptyCard(hasAnyTransactions: !all.isEmpty))
             return
         }
 
         for group in groups {
-            stack.addArrangedSubview(makeGroupHeader(text: group.title))
+            let header = makeGroupHeader(text: group.title)
+            stack.addArrangedSubview(header)
+            stack.setCustomSpacing(AppSpacing.sp2, after: header)
             stack.addArrangedSubview(makeCard(for: group.entries))
         }
     }
 
-    private func makeEmptyCard() -> UIView {
+    // MARK: - Period chip (artboard 21)
+
+    private func makePeriodChipRow() -> UIView {
+        var configuration = UIButton.Configuration.plain()
+        configuration.attributedTitle = AttributedString(
+            period.chipCaption,
+            attributes: AttributeContainer([
+                .font: AppFonts.sans(.semibold, 15),
+                .foregroundColor: AppColors.fg1
+            ])
+        )
+        configuration.image = UIImage(
+            systemName: "chevron.down",
+            withConfiguration: UIImage.SymbolConfiguration(pointSize: 12, weight: .semibold)
+        )
+        configuration.imagePlacement = .trailing
+        configuration.imagePadding = AppSpacing.sp2
+        configuration.contentInsets = NSDirectionalEdgeInsets(
+            top: 10, leading: AppSpacing.sp4, bottom: 10, trailing: AppSpacing.sp3
+        )
+        configuration.baseForegroundColor = AppColors.fg1
+
+        let chip = UIButton(configuration: configuration)
+        chip.backgroundColor = AppColors.whiteOverlay06
+        chip.layer.cornerRadius = AppRadius.lg
+        chip.layer.masksToBounds = true
+        chip.accessibilityLabel = "Период: \(period.chipCaption)"
+        chip.addTarget(self, action: #selector(periodChipTapped), for: .touchUpInside)
+        chip.translatesAutoresizingMaskIntoConstraints = false
+
+        // Centered inside a full-width row so the stack keeps its margins.
+        let row = UIView()
+        row.addSubview(chip)
+        NSLayoutConstraint.activate([
+            chip.centerXAnchor.constraint(equalTo: row.centerXAnchor),
+            chip.topAnchor.constraint(equalTo: row.topAnchor),
+            chip.bottomAnchor.constraint(equalTo: row.bottomAnchor)
+        ])
+        return row
+    }
+
+    @objc private func periodChipTapped() {
+        let all = TransactionRepository.shared.fetchAll()
+        let currentYear = YearMonth(date: Date()).year
+        let earliestYear = all.map { YearMonth(date: $0.createdAt).year }.min() ?? currentYear
+        let years = Array(min(earliestYear, currentYear)...currentYear)
+        let sheet = PeriodPickerSheetViewController(selected: period, years: years) { [weak self] picked in
+            guard let self else { return }
+            self.period = picked ?? .currentMonth()
+            self.reload()
+        }
+        present(sheet, animated: true)
+    }
+
+    // MARK: - Summary card (artboard 21)
+
+    private func makeSummaryCard(summary: TxHistorySummary) -> UIView {
+        let card = SPCard(tone: .surface, padding: AppSpacing.sp5, cornerRadius: AppRadius.lg)
+
+        let caption = UILabel()
+        caption.attributedText = NSAttributedString(
+            string: "За \(period.summaryCaption)".uppercased(with: Locale(identifier: "ru_RU")),
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.fg3
+            ]
+        )
+
+        let spent = makeSummaryColumn(
+            title: "Списано",
+            value: MoneyFormatter.attributed(
+                summary.spent, digitsFont: AppTypography.moneyMd, prefix: "−", color: AppColors.pain400
+            ),
+            alignment: .left
+        )
+        let topups = makeSummaryColumn(
+            title: "Пополнения",
+            value: MoneyFormatter.attributed(
+                summary.topups, digitsFont: AppTypography.moneyMd, prefix: "+", color: AppColors.money400
+            ),
+            alignment: .left
+        )
+        let snoozes = makeSummaryColumn(
+            title: "Откладываний",
+            value: NSAttributedString(
+                string: "\(summary.snoozeCount)",
+                attributes: [.font: AppTypography.moneyMd, .foregroundColor: AppColors.fg1]
+            ),
+            alignment: .right
+        )
+
+        let columns = UIStackView(arrangedSubviews: [spent, topups, snoozes])
+        columns.axis = .horizontal
+        columns.distribution = .equalSpacing
+        columns.alignment = .lastBaseline
+
+        let content = UIStackView(arrangedSubviews: [caption, columns])
+        content.axis = .vertical
+        content.spacing = AppSpacing.sp2
+        content.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(content)
+        NSLayoutConstraint.activate([
+            content.leadingAnchor.constraint(equalTo: card.layoutMarginsGuide.leadingAnchor),
+            content.trailingAnchor.constraint(equalTo: card.layoutMarginsGuide.trailingAnchor),
+            content.topAnchor.constraint(equalTo: card.layoutMarginsGuide.topAnchor),
+            content.bottomAnchor.constraint(equalTo: card.layoutMarginsGuide.bottomAnchor)
+        ])
+        return card
+    }
+
+    private func makeSummaryColumn(
+        title: String,
+        value: NSAttributedString,
+        alignment: NSTextAlignment
+    ) -> UIView {
+        let titleLabel = UILabel()
+        titleLabel.text = title
+        titleLabel.font = AppTypography.meta
+        titleLabel.textColor = AppColors.fg3
+        titleLabel.textAlignment = alignment
+
+        let valueLabel = UILabel()
+        valueLabel.attributedText = value
+        valueLabel.textAlignment = alignment
+
+        let column = UIStackView(arrangedSubviews: [titleLabel, valueLabel])
+        column.axis = .vertical
+        column.spacing = AppSpacing.sp1
+        column.alignment = alignment == .right ? .trailing : .leading
+        return column
+    }
+
+    private func makeEmptyCard(hasAnyTransactions: Bool = false) -> UIView {
         let card = SPCard(tone: .surface, padding: AppSpacing.sp6, cornerRadius: AppRadius.lg)
         card.translatesAutoresizingMaskIntoConstraints = false
         let label = UILabel()
-        label.text = "Здесь появятся пополнения, списания и возвраты."
+        label.text = hasAnyTransactions
+            ? "За выбранный период операций нет."
+            : "Здесь появятся пополнения, списания и бонусы."
         label.font = AppTypography.body
         label.textColor = AppColors.fg3
         label.numberOfLines = 0
@@ -175,11 +324,14 @@ final class WalletTransactionHistoryViewController: UIViewController {
     private static func title(for transaction: Transaction) -> String {
         switch transaction.type {
         case .topup:
-            return "Пополнение Apple Pay"
+            return "Пополнение баланса"
         case .charge:
             return "Поспать ещё"
         case .promotion:
-            return "Промо-зачисление"
+            // `.promotion` is currently minted only by the referral 7-day
+            // hold reward (`ReferralService`), hence the specific copy
+            // (issue #234 item 4 — "Возврат" → "Бонус").
+            return "Бонус: продержались 7 дней"
         }
     }
 
@@ -197,7 +349,7 @@ final class WalletTransactionHistoryViewController: UIViewController {
         case .promotion:
             tint = AppColors.money400
             fill = AppColors.money400.withAlphaComponent(0.14)
-            glyph = "gift"
+            glyph = "checkmark"
         case .charge:
             tint = AppColors.pain400
             fill = AppColors.pain400.withAlphaComponent(0.14)
@@ -278,11 +430,12 @@ final class WalletTransactionHistoryViewController: UIViewController {
 
     private static func header(for date: Date) -> String {
         let calendar = Calendar.current
-        if calendar.isDateInToday(date) { return "СЕГОДНЯ" }
-        if calendar.isDateInYesterday(date) { return "ВЧЕРА" }
+        if calendar.isDateInToday(date) { return "Сегодня" }
+        if calendar.isDateInYesterday(date) { return "Вчера" }
+        // "12 января" — full genitive month, sentence case (artboard 21b).
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "ru_RU")
-        formatter.dateFormat = "d MMM"
-        return formatter.string(from: date).uppercased(with: Locale(identifier: "ru_RU"))
+        formatter.dateFormat = "d MMMM"
+        return formatter.string(from: date)
     }
 }

--- a/SnoozePay/SnoozePay/ViewModels/TxHistoryPeriod.swift
+++ b/SnoozePay/SnoozePay/ViewModels/TxHistoryPeriod.swift
@@ -1,0 +1,197 @@
+import Foundation
+
+/// One calendar month (`year` + 1-based `month`). The TxHistory period
+/// picker (issue #234, artboards 21/21a/21b) selects whole months, so a
+/// dedicated value type keeps comparisons / range math away from `Date`
+/// pitfalls (DST, time zones, partial days).
+struct YearMonth: Equatable, Hashable, Comparable {
+    let year: Int
+    /// 1...12 (January = 1).
+    let month: Int
+
+    init(year: Int, month: Int) {
+        self.year = year
+        self.month = month
+    }
+
+    init(date: Date, calendar: Calendar = .current) {
+        let components = calendar.dateComponents([.year, .month], from: date)
+        self.year = components.year ?? 1970
+        self.month = components.month ?? 1
+    }
+
+    /// Linear month index — months become comparable / subtractable across
+    /// year boundaries (mirrors `idx()` in `SPMore3.jsx` L214).
+    var linearIndex: Int { year * 12 + (month - 1) }
+
+    static func < (lhs: YearMonth, rhs: YearMonth) -> Bool {
+        lhs.linearIndex < rhs.linearIndex
+    }
+
+    // MARK: - Russian month names
+
+    /// Lowercase nominative names — Russian only capitalizes month names at
+    /// sentence start, so tokens stay lowercase and call sites capitalize.
+    static let fullNames = [
+        "январь", "февраль", "март", "апрель", "май", "июнь",
+        "июль", "август", "сентябрь", "октябрь", "ноябрь", "декабрь"
+    ]
+    static let shortNames = [
+        "янв", "фев", "мар", "апр", "май", "июн",
+        "июл", "авг", "сен", "окт", "ноя", "дек"
+    ]
+
+    /// "январь 2026" — chip / summary caption for a single month.
+    var fullCaption: String { "\(Self.fullNames[month - 1]) \(year)" }
+    /// "янв 2026" — compact range-chip caption.
+    var shortCaption: String { "\(Self.shortNames[month - 1]) \(year)" }
+    /// "Январь 2026" — picker-sheet selected-range row.
+    var capitalizedCaption: String {
+        "\(Self.fullNames[month - 1].capitalized(with: Locale(identifier: "ru_RU"))) \(year)"
+    }
+    /// "Янв" — month-grid cell label.
+    var gridLabel: String {
+        Self.shortNames[month - 1].capitalized(with: Locale(identifier: "ru_RU"))
+    }
+}
+
+/// Selected reporting period for the transaction-history screen — either a
+/// single month or an inclusive month range. Stored normalized
+/// (`start <= end`) regardless of tap order in the picker.
+struct TxHistoryPeriod: Equatable {
+    let start: YearMonth
+    let end: YearMonth
+
+    init(start: YearMonth, end: YearMonth) {
+        if start <= end {
+            self.start = start
+            self.end = end
+        } else {
+            self.start = end
+            self.end = start
+        }
+    }
+
+    init(month: YearMonth) {
+        self.init(start: month, end: month)
+    }
+
+    static func currentMonth(now: Date = Date(), calendar: Calendar = .current) -> TxHistoryPeriod {
+        TxHistoryPeriod(month: YearMonth(date: now, calendar: calendar))
+    }
+
+    var isSingleMonth: Bool { start == end }
+
+    /// Months between `start` and `end` inclusive (≥ 1).
+    var monthCount: Int { end.linearIndex - start.linearIndex + 1 }
+
+    func contains(_ month: YearMonth) -> Bool {
+        (start.linearIndex...end.linearIndex).contains(month.linearIndex)
+    }
+
+    func contains(_ date: Date, calendar: Calendar = .current) -> Bool {
+        contains(YearMonth(date: date, calendar: calendar))
+    }
+
+    /// Transactions inside the period, preserving input order.
+    func filter(_ transactions: [Transaction], calendar: Calendar = .current) -> [Transaction] {
+        transactions.filter { contains($0.createdAt, calendar: calendar) }
+    }
+
+    // MARK: - Captions (artboard 21)
+
+    /// Header chip: "январь 2026" / "ноя 2025 — янв 2026".
+    var chipCaption: String {
+        isSingleMonth ? start.fullCaption : "\(start.shortCaption) — \(end.shortCaption)"
+    }
+
+    /// Summary-card caption (rendered uppercase by the caps style):
+    /// "январь 2026" / "ноябрь 2025 — январь 2026".
+    var summaryCaption: String {
+        isSingleMonth ? start.fullCaption : "\(start.fullCaption) — \(end.fullCaption)"
+    }
+
+    /// Picker-sheet selected-range row: "Январь 2026" /
+    /// "Ноябрь 2025 — Январь 2026".
+    var pickerCaption: String {
+        isSingleMonth
+            ? start.capitalizedCaption
+            : "\(start.capitalizedCaption) — \(end.capitalizedCaption)"
+    }
+
+    /// "3 мес." — month counter next to the picker caption.
+    var monthCountText: String { "\(monthCount) мес." }
+}
+
+/// Three-column aggregate for the summary card — Списано / Пополнения /
+/// Откладываний (issue #234 item 3). Computed over the *visible* list so
+/// the card always reconciles with what the user sees below it.
+struct TxHistorySummary: Equatable {
+    /// Absolute sum of charges, ₽.
+    let spent: Decimal
+    /// Sum of paid top-ups, ₽. Bonuses (`.promotion`) are deliberately
+    /// excluded — they appear in the list but not in this aggregate
+    /// (issue #234 item 4).
+    let topups: Decimal
+    /// Number of snooze charges.
+    let snoozeCount: Int
+
+    static func compute(from transactions: [Transaction]) -> TxHistorySummary {
+        var spent = Decimal(0)
+        var topups = Decimal(0)
+        var snoozes = 0
+        for transaction in transactions {
+            switch transaction.type {
+            case .charge:
+                spent += Decimal(abs(transaction.amount))
+                snoozes += 1
+            case .topup:
+                topups += Decimal(abs(transaction.amount))
+            case .promotion:
+                continue // bonus — list-only, never aggregated
+            }
+        }
+        return TxHistorySummary(spent: spent, topups: topups, snoozeCount: snoozes)
+    }
+}
+
+/// Tap-selection state machine for `PeriodPickerSheetViewController`
+/// (artboards 21a/21b): first tap anchors a single month, a second tap on a
+/// different month extends it into a range, a third tap restarts with a new
+/// anchor. Pure value type so the UX rules are unit-testable without UIKit.
+struct TxHistoryPeriodSelection: Equatable {
+    private(set) var anchor: YearMonth?
+    private(set) var extent: YearMonth?
+
+    init(period: TxHistoryPeriod? = nil) {
+        anchor = period?.start
+        extent = (period?.isSingleMonth == true) ? nil : period?.end
+    }
+
+    /// Current selection as a period; `nil` when nothing is selected
+    /// (after "Сбросить").
+    var period: TxHistoryPeriod? {
+        guard let anchor else { return nil }
+        guard let extent else { return TxHistoryPeriod(month: anchor) }
+        return TxHistoryPeriod(start: anchor, end: extent)
+    }
+
+    mutating func tap(_ month: YearMonth) {
+        switch (anchor, extent) {
+        case (nil, _):
+            anchor = month
+            extent = nil
+        case (let some?, nil):
+            if some == month { return } // re-tap on the anchor keeps single
+            extent = month
+        case (_?, _?):
+            anchor = month
+            extent = nil
+        }
+    }
+
+    mutating func reset() {
+        anchor = nil
+        extent = nil
+    }
+}

--- a/SnoozePay/SnoozePayTests/TxHistoryPeriodTests.swift
+++ b/SnoozePay/SnoozePayTests/TxHistoryPeriodTests.swift
@@ -1,0 +1,245 @@
+import XCTest
+@testable import SnoozePay
+
+/// Tests the TxHistory V3 period logic (issue #234) — month-range
+/// filtering, the Списано / Пополнения / Откладываний aggregates (bonuses
+/// excluded), captions and the picker tap-selection state machine.
+final class TxHistoryPeriodTests: XCTestCase {
+
+    private let calendar = Calendar.current
+
+    // MARK: - Helpers
+
+    private func date(year: Int, month: Int, day: Int = 15, hour: Int = 12) -> Date {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = hour
+        return calendar.date(from: components)!
+    }
+
+    // MARK: - YearMonth
+
+    func testYearMonth_comparesAcrossYearBoundary() {
+        XCTAssertLessThan(YearMonth(year: 2025, month: 12), YearMonth(year: 2026, month: 1))
+        XCTAssertLessThan(YearMonth(year: 2025, month: 3), YearMonth(year: 2025, month: 11))
+    }
+
+    func testYearMonth_fromDate() {
+        let yearMonth = YearMonth(date: date(year: 2026, month: 1, day: 31), calendar: calendar)
+        XCTAssertEqual(yearMonth, YearMonth(year: 2026, month: 1))
+    }
+
+    // MARK: - Period normalization + counting
+
+    func testPeriod_normalizesReversedEndpoints() {
+        let period = TxHistoryPeriod(
+            start: YearMonth(year: 2026, month: 1),
+            end: YearMonth(year: 2025, month: 11)
+        )
+        XCTAssertEqual(period.start, YearMonth(year: 2025, month: 11))
+        XCTAssertEqual(period.end, YearMonth(year: 2026, month: 1))
+    }
+
+    func testPeriod_monthCount_singleAndRange() {
+        XCTAssertEqual(TxHistoryPeriod(month: YearMonth(year: 2026, month: 1)).monthCount, 1)
+        let range = TxHistoryPeriod(
+            start: YearMonth(year: 2025, month: 11),
+            end: YearMonth(year: 2026, month: 1)
+        )
+        XCTAssertEqual(range.monthCount, 3)
+        XCTAssertFalse(range.isSingleMonth)
+    }
+
+    func testCurrentMonth_matchesNow() {
+        let now = date(year: 2026, month: 2, day: 10)
+        let period = TxHistoryPeriod.currentMonth(now: now, calendar: calendar)
+        XCTAssertEqual(period, TxHistoryPeriod(month: YearMonth(year: 2026, month: 2)))
+    }
+
+    // MARK: - Range filtering
+
+    func testFilter_keepsOnlyTransactionsInsideRange() {
+        let period = TxHistoryPeriod(
+            start: YearMonth(year: 2025, month: 11),
+            end: YearMonth(year: 2026, month: 1)
+        )
+        let october = Transaction(type: .charge, amount: 50, createdAt: date(year: 2025, month: 10, day: 31))
+        let november = Transaction(type: .charge, amount: 100, createdAt: date(year: 2025, month: 11, day: 1))
+        let december = Transaction(type: .topup, amount: 500, createdAt: date(year: 2025, month: 12, day: 28))
+        let january = Transaction(type: .charge, amount: 50, createdAt: date(year: 2026, month: 1, day: 12))
+        let february = Transaction(type: .topup, amount: 500, createdAt: date(year: 2026, month: 2, day: 1))
+
+        let visible = period.filter(
+            [october, november, december, january, february], calendar: calendar
+        )
+        XCTAssertEqual(visible.map(\.id), [november, december, january].map(\.id))
+    }
+
+    func testFilter_singleMonth_includesFirstAndLastDay() {
+        let period = TxHistoryPeriod(month: YearMonth(year: 2026, month: 1))
+        let first = Transaction(type: .charge, amount: 50, createdAt: date(year: 2026, month: 1, day: 1, hour: 0))
+        let last = Transaction(type: .charge, amount: 50, createdAt: date(year: 2026, month: 1, day: 31, hour: 23))
+        let next = Transaction(type: .charge, amount: 50, createdAt: date(year: 2026, month: 2, day: 1, hour: 0))
+
+        let visible = period.filter([first, last, next], calendar: calendar)
+        XCTAssertEqual(visible.map(\.id), [first, last].map(\.id))
+    }
+
+    func testFilter_preservesInputOrder() {
+        let period = TxHistoryPeriod(month: YearMonth(year: 2026, month: 1))
+        let newest = Transaction(type: .charge, amount: 50, createdAt: date(year: 2026, month: 1, day: 20))
+        let oldest = Transaction(type: .charge, amount: 50, createdAt: date(year: 2026, month: 1, day: 5))
+        XCTAssertEqual(
+            period.filter([newest, oldest], calendar: calendar).map(\.id),
+            [newest, oldest].map(\.id)
+        )
+    }
+
+    // MARK: - Summary aggregates
+
+    func testSummary_aggregatesSpentTopupsAndSnoozeCount() {
+        let now = Date()
+        let summary = TxHistorySummary.compute(from: [
+            Transaction(type: .charge, amount: 50, createdAt: now),
+            Transaction(type: .charge, amount: 100, createdAt: now),
+            Transaction(type: .charge, amount: 200, createdAt: now),
+            Transaction(type: .topup, amount: 500, createdAt: now),
+            Transaction(type: .topup, amount: 1000, createdAt: now)
+        ])
+        XCTAssertEqual(summary.spent, 350)
+        XCTAssertEqual(summary.topups, 1500)
+        XCTAssertEqual(summary.snoozeCount, 3)
+    }
+
+    func testSummary_excludesBonusesFromTopups() {
+        let now = Date()
+        let summary = TxHistorySummary.compute(from: [
+            Transaction(type: .topup, amount: 500, createdAt: now),
+            Transaction(type: .promotion, amount: 200, createdAt: now)
+        ])
+        XCTAssertEqual(summary.topups, 500, "Bonus credits must not inflate Пополнения")
+        XCTAssertEqual(summary.spent, 0)
+        XCTAssertEqual(summary.snoozeCount, 0)
+    }
+
+    func testSummary_emptyList_allZero() {
+        let summary = TxHistorySummary.compute(from: [])
+        XCTAssertEqual(summary, TxHistorySummary(spent: 0, topups: 0, snoozeCount: 0))
+    }
+
+    // MARK: - Captions
+
+    func testCaptions_singleMonth() {
+        let period = TxHistoryPeriod(month: YearMonth(year: 2026, month: 1))
+        XCTAssertEqual(period.chipCaption, "январь 2026")
+        XCTAssertEqual(period.summaryCaption, "январь 2026")
+        XCTAssertEqual(period.pickerCaption, "Январь 2026")
+        XCTAssertEqual(period.monthCountText, "1 мес.")
+    }
+
+    func testCaptions_range() {
+        let period = TxHistoryPeriod(
+            start: YearMonth(year: 2025, month: 11),
+            end: YearMonth(year: 2026, month: 1)
+        )
+        XCTAssertEqual(period.chipCaption, "ноя 2025 — янв 2026")
+        XCTAssertEqual(period.summaryCaption, "ноябрь 2025 — январь 2026")
+        XCTAssertEqual(period.pickerCaption, "Ноябрь 2025 — Январь 2026")
+        XCTAssertEqual(period.monthCountText, "3 мес.")
+    }
+
+    // MARK: - Picker selection state machine
+
+    func testSelection_firstTap_selectsSingleMonth() {
+        var selection = TxHistoryPeriodSelection()
+        selection.tap(YearMonth(year: 2026, month: 1))
+        XCTAssertEqual(selection.period, TxHistoryPeriod(month: YearMonth(year: 2026, month: 1)))
+    }
+
+    func testSelection_secondTap_extendsIntoRange() {
+        var selection = TxHistoryPeriodSelection()
+        selection.tap(YearMonth(year: 2025, month: 11))
+        selection.tap(YearMonth(year: 2026, month: 1))
+        XCTAssertEqual(
+            selection.period,
+            TxHistoryPeriod(start: YearMonth(year: 2025, month: 11), end: YearMonth(year: 2026, month: 1))
+        )
+    }
+
+    func testSelection_secondTapBeforeAnchor_normalizesOrder() {
+        var selection = TxHistoryPeriodSelection()
+        selection.tap(YearMonth(year: 2026, month: 1))
+        selection.tap(YearMonth(year: 2025, month: 11))
+        XCTAssertEqual(
+            selection.period,
+            TxHistoryPeriod(start: YearMonth(year: 2025, month: 11), end: YearMonth(year: 2026, month: 1))
+        )
+    }
+
+    func testSelection_thirdTap_restartsWithNewAnchor() {
+        var selection = TxHistoryPeriodSelection()
+        selection.tap(YearMonth(year: 2025, month: 11))
+        selection.tap(YearMonth(year: 2026, month: 1))
+        selection.tap(YearMonth(year: 2024, month: 6))
+        XCTAssertEqual(selection.period, TxHistoryPeriod(month: YearMonth(year: 2024, month: 6)))
+    }
+
+    func testSelection_retapAnchor_keepsSingleSelection() {
+        var selection = TxHistoryPeriodSelection()
+        selection.tap(YearMonth(year: 2026, month: 1))
+        selection.tap(YearMonth(year: 2026, month: 1))
+        XCTAssertEqual(selection.period, TxHistoryPeriod(month: YearMonth(year: 2026, month: 1)))
+    }
+
+    func testSelection_reset_clearsPeriod() {
+        var selection = TxHistoryPeriodSelection(
+            period: TxHistoryPeriod(month: YearMonth(year: 2026, month: 1))
+        )
+        selection.reset()
+        XCTAssertNil(selection.period)
+    }
+
+    func testSelection_initFromExistingRange_roundTrips() {
+        let range = TxHistoryPeriod(
+            start: YearMonth(year: 2025, month: 11),
+            end: YearMonth(year: 2026, month: 1)
+        )
+        XCTAssertEqual(TxHistoryPeriodSelection(period: range).period, range)
+    }
+
+    // MARK: - Grid cell roles
+
+    func testCellRole_singleMonthSelection() {
+        let period = TxHistoryPeriod(month: YearMonth(year: 2026, month: 1))
+        XCTAssertEqual(
+            PeriodPickerSheetViewController.role(of: YearMonth(year: 2026, month: 1), in: period),
+            .single
+        )
+        XCTAssertEqual(
+            PeriodPickerSheetViewController.role(of: YearMonth(year: 2025, month: 12), in: period),
+            MonthCellRole.none
+        )
+    }
+
+    func testCellRole_rangeEndpointsAndMiddle() {
+        let period = TxHistoryPeriod(
+            start: YearMonth(year: 2025, month: 11),
+            end: YearMonth(year: 2026, month: 1)
+        )
+        XCTAssertEqual(
+            PeriodPickerSheetViewController.role(of: YearMonth(year: 2025, month: 11), in: period), .start
+        )
+        XCTAssertEqual(
+            PeriodPickerSheetViewController.role(of: YearMonth(year: 2025, month: 12), in: period), .mid
+        )
+        XCTAssertEqual(
+            PeriodPickerSheetViewController.role(of: YearMonth(year: 2026, month: 1), in: period), .end
+        )
+        XCTAssertEqual(
+            PeriodPickerSheetViewController.role(of: YearMonth(year: 2026, month: 2), in: period),
+            MonthCellRole.none
+        )
+    }
+}


### PR DESCRIPTION
Fixes #234

## Что сделано
- **Period chip** под header'ом (по центру): текущий период (`январь 2026` / `ноя 2025 — янв 2026`) + chevron-down; тап открывает PeriodPickerSheet.
- **PeriodPickerSheetViewController** — bottom sheet (page-sheet, custom detent 640 + large): drag handle, header `Период` + `Сбросить`, строка выбранного диапазона (`Ноябрь 2025 — Январь 2026 · 3 мес.`), годы с сетками месяцев 4×3. Выбор: один месяц или диапазон (тап начало + тап конец; промежуточные — непрерывная светлая заливка, края — белые диски с тёмным текстом); будущие месяцы disabled; CTA `Применить` (money lg).
- **Summary-карточка**: Списано / Пополнения / Откладываний по видимому списку (правая колонка вправо); бонусы (`.promotion`) исключены из «Пополнения».
- Категория показа promotion: `Бонус: продержались 7 дней` + checkmark-иконка (бывш. «Промо-зачисление»).
- Range-режим: список фильтруется на весь диапазон, группы по датам по убыванию (`Сегодня`, `Вчера`, `12 января`, `28 декабря`); скроллится страница целиком.
- Логика (период, фильтрация, агрегаты, captions, tap-state-machine выбора) вынесена в `TxHistoryPeriod.swift` — чистые value types без UIKit.

## Verify
- ✅ swiftlint: 0 violations (touched files)
- ✅ xcodebuild build (generic/platform=iOS Simulator): succeeded
- ✅ xcodebuild build-for-testing: succeeded
- 🧪 19 unit tests in `TxHistoryPeriodTests` (агрегаты по периоду, range-фильтрация, исключение бонусов из «Пополнения», captions, selection) — выполняются на CI

Design refs: `docs/design/v2-handoff/components/SPMore3.jsx` (TxHistory L16-196, PeriodPickerSheet L202-390), артборды 21/21a/21b.