### PR TITLE
[feature] Alarm repeat mode — Никогда / Еженедельно one-shot alarms (#229)

### DIFF
--- a/SnoozePay/SnoozePay/Models/Alarm.swift
+++ b/SnoozePay/SnoozePay/Models/Alarm.swift
@@ -37,6 +37,10 @@ struct Alarm: Identifiable, Equatable, Codable {
     /// legacy alarms persisted before the theme picker landed — see the
     /// custom `init(from:)` below for the migration path.
     let theme: AlarmTheme
+    /// Weekly vs one-shot recurrence (#229). Defaults to `.weekly` for both
+    /// new alarms and legacy alarms persisted before the repeat-mode control
+    /// landed — see the custom `init(from:)` below for the migration path.
+    let repeatMode: AlarmRepeatMode
 
     // MARK: - Validation rules (#207)
 
@@ -69,7 +73,8 @@ struct Alarm: Identifiable, Equatable, Codable {
         enabled: Bool = true,
         volume: Float = 1.0,
         volumeFadeIn: Bool = false,
-        theme: AlarmTheme = .dawn
+        theme: AlarmTheme = .dawn,
+        repeatMode: AlarmRepeatMode = .weekly
     ) {
         guard repeatDays.allSatisfy(Self.weekdayIndexRange.contains),
               Self.snoozeMinutesRange.contains(snoozeMinutes),
@@ -89,6 +94,7 @@ struct Alarm: Identifiable, Equatable, Codable {
         self.volume = Self.clampedVolume(volume)
         self.volumeFadeIn = volumeFadeIn
         self.theme = theme
+        self.repeatMode = repeatMode
     }
 
     /// Historical default-arg initializer, kept for in-app call sites whose
@@ -108,7 +114,8 @@ struct Alarm: Identifiable, Equatable, Codable {
         enabled: Bool = true,
         volume: Float = 1.0,
         volumeFadeIn: Bool = false,
-        theme: AlarmTheme = .dawn
+        theme: AlarmTheme = .dawn,
+        repeatMode: AlarmRepeatMode = .weekly
     ) {
         guard let alarm = Alarm(
             validating: id,
@@ -123,7 +130,8 @@ struct Alarm: Identifiable, Equatable, Codable {
             enabled: enabled,
             volume: volume,
             volumeFadeIn: volumeFadeIn,
-            theme: theme
+            theme: theme,
+            repeatMode: repeatMode
         ) else {
             preconditionFailure(
                 """
@@ -157,7 +165,8 @@ struct Alarm: Identifiable, Equatable, Codable {
         enabled: Bool? = nil,
         volume: Float? = nil,
         volumeFadeIn: Bool? = nil,
-        theme: AlarmTheme? = nil
+        theme: AlarmTheme? = nil,
+        repeatMode: AlarmRepeatMode? = nil
     ) -> Alarm {
         Alarm(
             id: id,
@@ -172,7 +181,8 @@ struct Alarm: Identifiable, Equatable, Codable {
             enabled: enabled ?? self.enabled,
             volume: volume ?? self.volume,
             volumeFadeIn: volumeFadeIn ?? self.volumeFadeIn,
-            theme: theme ?? self.theme
+            theme: theme ?? self.theme,
+            repeatMode: repeatMode ?? self.repeatMode
         )
     }
 
@@ -197,7 +207,7 @@ struct Alarm: Identifiable, Equatable, Codable {
     private enum CodingKeys: String, CodingKey {
         case id, time, repeatDays, name, soundID, vibrationEnabled
         case snoozeMinutes, penaltyAmount, progressiveScale, enabled
-        case volume, volumeFadeIn, theme
+        case volume, volumeFadeIn, theme, repeatMode
     }
 
     init(from decoder: Decoder) throws {
@@ -230,6 +240,12 @@ struct Alarm: Identifiable, Equatable, Codable {
         self.volumeFadeIn = try container.decodeIfPresent(Bool.self, forKey: .volumeFadeIn) ?? false
         // Migration: pre-#151 alarms have no `theme` field — default to .dawn.
         self.theme = try container.decodeIfPresent(AlarmTheme.self, forKey: .theme) ?? .dawn
+        // Migration: pre-#229 alarms have no `repeatMode` field — default to
+        // .weekly (the historical behaviour). Decoding the raw string keeps
+        // an unknown value (corrupt storage / rolled-back future mode) from
+        // throwing and locking the whole store — sanitize to .weekly instead.
+        let rawRepeatMode = try container.decodeIfPresent(String.self, forKey: .repeatMode)
+        self.repeatMode = rawRepeatMode.flatMap(AlarmRepeatMode.init(rawValue:)) ?? .weekly
     }
 
     /// Shared volume sanitization: non-finite → full volume, then clamp 0...1.

--- a/SnoozePay/SnoozePay/Models/AlarmRepeatMode.swift
+++ b/SnoozePay/SnoozePay/Models/AlarmRepeatMode.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// How an alarm recurs across weeks (#229).
+///
+/// `weekly` is the historical behaviour — repeating calendar triggers fire
+/// every week on the selected days. `never` makes the alarm one-shot: it
+/// fires once on the next occurrence of the selected days/time and is
+/// auto-disabled after the user dismisses the firing screen
+/// (`AlarmFiringViewModel.dismiss`).
+///
+/// Persisted as a raw string inside the alarm JSON. Decoding is sanitizing,
+/// not throwing: `Alarm.init(from:)` maps a missing key (pre-#229 alarms) or
+/// an unknown raw value (corrupt storage / future mode rolled back) to
+/// `.weekly`, so legacy payloads keep their existing behaviour and the store
+/// never locks (#72 / #117).
+enum AlarmRepeatMode: String, Codable {
+    /// One-shot: ring once on the next occurrence of the selected days, then
+    /// auto-disable after dismiss. Triggers are scheduled non-repeating so
+    /// iOS itself never re-fires the alarm a week later.
+    case never
+    /// Default: repeat every week on the selected days (repeating triggers).
+    case weekly
+}

--- a/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
@@ -444,6 +444,13 @@ final class AlarmScheduler: AlarmScheduling {
             return [TriggerWithLabel(label: "once", trigger: trigger)]
         }
 
+        // One-shot mode (#229): non-repeating triggers fire once at the next
+        // occurrence of each selected weekday and are never re-armed by iOS.
+        // The alarm itself is auto-disabled on dismiss
+        // (`AlarmFiringViewModel.dismiss`), which also cancels the remaining
+        // per-day triggers via `cancel(_:)`.
+        let repeats = alarm.repeatMode == .weekly
+
         // Map our 0=Mon system to iOS weekday (1=Sun, 2=Mon, ..., 7=Sat)
         return alarm.repeatDays.map { day in
             let weekday = ((day + 1) % 7) + 1 // Convert: 0(Mon)->2, 6(Sun)->1
@@ -452,7 +459,7 @@ final class AlarmScheduler: AlarmScheduling {
             components.hour = timeComponents.hour
             components.minute = timeComponents.minute
             components.second = 0
-            let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: true)
+            let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: repeats)
             return TriggerWithLabel(label: "day\(day)", trigger: trigger)
         }
     }

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/RepeatModeCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/RepeatModeCell.swift
@@ -1,0 +1,182 @@
+import UIKit
+
+/// V2 repeat-mode selector under the day chips (#229): caps caption
+/// `ПОВТОР`, a centered two-segment pill **Никогда / Еженедельно**, and a
+/// one-line hint explaining the selected behaviour. Matches the
+/// `RepeatSegmented` component in `SPScreensV2.jsx` — the active segment
+/// uses the money treatment, the inactive one stays transparent on a
+/// `whiteOverlay06` capsule track. Like `DayPickerCell`, the active fill
+/// collapses the JSX money gradient to the dominant `money500` stop because
+/// `UIButton` doesn't render a gradient inline.
+final class RepeatModeCell: UITableViewCell {
+
+    static let reuseID = "RepeatModeCell"
+
+    private static let segmentHeight: CGFloat = 36
+    private static let trackPadding: CGFloat = 4
+
+    /// Ordered segments. Index == button tag.
+    private static let modes: [(mode: AlarmRepeatMode, label: String)] = [
+        (.never, "Никогда"),
+        (.weekly, "Еженедельно")
+    ]
+
+    // MARK: - Callbacks
+
+    /// Notifies the controller that the user picked a mode. The controller
+    /// mutates the view-model and calls `configure(...)` again to repaint
+    /// the segments + hint.
+    var onModeChanged: ((AlarmRepeatMode) -> Void)?
+
+    // MARK: - UI
+
+    private let captionLabel: UILabel = {
+        let label = UILabel()
+        label.attributedText = NSAttributedString(
+            string: "ПОВТОР",
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.fg3
+            ]
+        )
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let track: UIView = {
+        let view = UIView()
+        view.backgroundColor = AppColors.whiteOverlay06
+        view.layer.cornerRadius = (RepeatModeCell.segmentHeight + RepeatModeCell.trackPadding * 2) / 2
+        view.layer.masksToBounds = true
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let segmentStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.distribution = .fillEqually
+        stack.spacing = RepeatModeCell.trackPadding
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+
+    private let hintLabel: UILabel = {
+        let label = UILabel()
+        label.font = AppTypography.meta
+        label.textColor = AppColors.fg3
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private var segmentButtons: [UIButton] = []
+
+    // MARK: - Init
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Setup
+
+    private func setupUI() {
+        selectionStyle = .none
+        backgroundColor = AppColors.bg1
+
+        for (index, option) in Self.modes.enumerated() {
+            var config = UIButton.Configuration.plain()
+            config.contentInsets = NSDirectionalEdgeInsets(
+                top: 0, leading: AppSpacing.sp4 + 2, bottom: 0, trailing: AppSpacing.sp4 + 2
+            )
+            let button = UIButton(configuration: config)
+            button.tag = index
+            button.layer.cornerRadius = Self.segmentHeight / 2
+            button.layer.masksToBounds = true
+            button.accessibilityLabel = option.label
+            button.addTarget(self, action: #selector(segmentTapped(_:)), for: .touchUpInside)
+            button.heightAnchor.constraint(equalToConstant: Self.segmentHeight).isActive = true
+            segmentButtons.append(button)
+            segmentStack.addArrangedSubview(button)
+        }
+
+        track.addSubview(segmentStack)
+        contentView.addSubview(captionLabel)
+        contentView.addSubview(track)
+        contentView.addSubview(hintLabel)
+
+        NSLayoutConstraint.activate([
+            captionLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: AppSpacing.sp2),
+            captionLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.sp4),
+            captionLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.sp4),
+
+            track.topAnchor.constraint(equalTo: captionLabel.bottomAnchor, constant: AppSpacing.sp2),
+            track.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            track.leadingAnchor.constraint(
+                greaterThanOrEqualTo: contentView.leadingAnchor, constant: AppSpacing.sp4
+            ),
+
+            segmentStack.topAnchor.constraint(equalTo: track.topAnchor, constant: Self.trackPadding),
+            segmentStack.bottomAnchor.constraint(equalTo: track.bottomAnchor, constant: -Self.trackPadding),
+            segmentStack.leadingAnchor.constraint(equalTo: track.leadingAnchor, constant: Self.trackPadding),
+            segmentStack.trailingAnchor.constraint(equalTo: track.trailingAnchor, constant: -Self.trackPadding),
+
+            hintLabel.topAnchor.constraint(equalTo: track.bottomAnchor, constant: AppSpacing.sp2),
+            hintLabel.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            hintLabel.widthAnchor.constraint(lessThanOrEqualToConstant: 280),
+            hintLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -AppSpacing.sp3)
+        ])
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        onModeChanged = nil
+    }
+
+    // MARK: - Configure
+
+    func configure(mode: AlarmRepeatMode, hint: String) {
+        for (index, button) in segmentButtons.enumerated() {
+            applyStyle(button, option: Self.modes[index], isSelected: Self.modes[index].mode == mode)
+        }
+        hintLabel.text = hint
+    }
+
+    /// Active → `money500` fill + `fgOnMoney` text; inactive → transparent
+    /// segment on the capsule track + `fg2` text (V2 RepeatSegmented).
+    private func applyStyle(
+        _ button: UIButton,
+        option: (mode: AlarmRepeatMode, label: String),
+        isSelected: Bool
+    ) {
+        button.backgroundColor = isSelected ? AppColors.money500 : .clear
+        var title = AttributedString(option.label)
+        title.font = AppTypography.buttonSm
+        title.foregroundColor = isSelected ? AppColors.fgOnMoney : AppColors.fg2
+        button.configuration?.attributedTitle = title
+        button.accessibilityValue = isSelected ? "выбрано" : "не выбрано"
+    }
+
+    // MARK: - Actions
+
+    @objc private func segmentTapped(_ sender: UIButton) {
+        guard let option = Self.modes[safe: sender.tag] else { return }
+        UISelectionFeedbackGenerator().selectionChanged()
+        onModeChanged?(option.mode)
+    }
+}
+
+// MARK: - Safe array subscript
+private extension Array {
+    subscript(safe index: Int) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController+Sections.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController+Sections.swift
@@ -14,6 +14,7 @@ extension CreateAlarmViewController {
     func registerSectionCells(in tableView: UITableView) {
         tableView.register(TimePickerCell.self, forCellReuseIdentifier: TimePickerCell.reuseID)
         tableView.register(DayPickerCell.self, forCellReuseIdentifier: DayPickerCell.reuseID)
+        tableView.register(RepeatModeCell.self, forCellReuseIdentifier: RepeatModeCell.reuseID)
         tableView.register(NameCell.self, forCellReuseIdentifier: NameCell.reuseID)
         tableView.register(SoundCell.self, forCellReuseIdentifier: SoundCell.reuseID)
         tableView.register(VibrationCell.self, forCellReuseIdentifier: VibrationCell.reuseID)
@@ -51,6 +52,27 @@ extension CreateAlarmViewController {
                 guard let self else { return }
                 self.viewModel.toggleDay(day)
                 cell?.configure(selectedDays: self.viewModel.repeatDays)
+            }
+        }
+        return cell
+    }
+
+    /// Никогда / Еженедельно pill + behaviour hint under the day chips
+    /// (#229). The closure repaints the cell first and only then asks the
+    /// table to re-measure — the never/weekly hints wrap to different line
+    /// counts, so measuring against the stale hint would clip the new one.
+    func makeRepeatModeCell(_ tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: RepeatModeCell.reuseID, for: indexPath)
+        if let cell = cell as? RepeatModeCell {
+            cell.configure(mode: viewModel.repeatMode, hint: viewModel.repeatModeHint)
+            cell.onModeChanged = { [weak self, weak cell] mode in
+                guard let self else { return }
+                self.viewModel.repeatMode = mode
+                cell?.configure(mode: mode, hint: self.viewModel.repeatModeHint)
+                guard self.view.window != nil else { return }
+                // Animate the self-sizing height change without reloading the
+                // cell — a reload would tear down the pill mid-gesture.
+                self.tableView.performBatchUpdates(nil)
             }
         }
         return cell

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
@@ -58,6 +58,13 @@ final class CreateAlarmViewController: UIViewController {
         case vibration
     }
 
+    /// Rows inside `Section.repeatDays` (#229): the Пн-Вс day chips and the
+    /// Никогда / Еженедельно repeat-mode pill below them.
+    enum RepeatRow: Int, CaseIterable {
+        case days = 0
+        case mode
+    }
+
     /// Convenience accessor used by `+Pickers.showThemePicker` so that file
     /// does not have to depend on `Section`/`SettingsRow` raw values directly.
     var themeRowIndexPath: IndexPath {
@@ -315,6 +322,8 @@ extension CreateAlarmViewController: UITableViewDataSource {
         switch sec {
         case .settings:
             return SettingsRow.allCases.count
+        case .repeatDays:
+            return RepeatRow.allCases.count
         default:
             return 1
         }
@@ -323,12 +332,14 @@ extension CreateAlarmViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         guard let sec = Section(rawValue: section) else { return nil }
         switch sec {
-        case .repeatDays: return "ПОВТОР"
         case .penalty: return "ШТРАФ ЗА ОТКЛАДЫВАНИЕ"
         case .snoozeTime: return "ВРЕМЯ ОТКЛАДЫВАНИЯ"
         // Name no longer carries a header — the large in-cell placeholder
         // already reads as the field's purpose (#143). The settings and
         // progressive cards are header-less per the V2 artboard (#231).
+        // The repeat card's `ПОВТОР` caption moved inside `RepeatModeCell`
+        // so it sits between the day chips and the mode pill, matching the
+        // V2 RepeatSegmented layout (#229).
         default: return nil
         }
     }
@@ -359,7 +370,10 @@ extension CreateAlarmViewController: UITableViewDataSource {
         }
         switch section {
         case .timePicker:        return makeTimePickerCell(tableView, at: indexPath)
-        case .repeatDays:        return makeRepeatDaysCell(tableView, at: indexPath)
+        case .repeatDays:
+            return RepeatRow(rawValue: indexPath.row) == .mode
+                ? makeRepeatModeCell(tableView, at: indexPath)
+                : makeRepeatDaysCell(tableView, at: indexPath)
         case .name:              return makeNameCell(tableView, at: indexPath)
         case .settings:          return makeSettingsCell(tableView, at: indexPath)
         case .penalty:           return makePenaltyCell(tableView, at: indexPath)
@@ -377,7 +391,10 @@ extension CreateAlarmViewController: UITableViewDelegate {
         guard let section = Section(rawValue: indexPath.section) else { return 44 }
         switch section {
         case .timePicker: return 200
-        case .repeatDays: return 60
+        // Day-chips row keeps its fixed 60pt; the repeat-mode pill + hint
+        // below self-sizes (the hint wraps to 1–2 lines per mode, #229).
+        case .repeatDays:
+            return RepeatRow(rawValue: indexPath.row) == .days ? 60 : UITableView.automaticDimension
         // V2 penalty row stacks a moneyMd value label above a 40pt chip row
         // — the prior 60pt height clipped the chip ladder, so bump to 96pt.
         case .penalty: return 96

--- a/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
@@ -197,7 +197,11 @@ final class AlarmFiringViewModel {
     }
 
     /// Dismiss the alarm without charge.
-    /// Non-repeating alarms are disabled after dismissal.
+    /// Non-repeating alarms — no selected days, or one-shot `repeatMode ==
+    /// .never` (#229) — are disabled after dismissal. Disabling a one-shot
+    /// alarm also drops its remaining per-day triggers via the
+    /// `scheduler.cancel` call above, so "ring once and switch off" holds
+    /// even when several weekdays were selected.
     ///
     /// `setEnabled` returns `false` when the alarm is no longer in the repository
     /// (e.g. user deleted it from another screen while the firing UI was up).
@@ -207,7 +211,7 @@ final class AlarmFiringViewModel {
     func dismiss() {
         scheduler.cancel(alarm.id)
 
-        if alarm.repeatDays.isEmpty {
+        if alarm.repeatDays.isEmpty || alarm.repeatMode == .never {
             let didUpdate = alarmRepository.setEnabled(false, id: alarm.id)
             if !didUpdate {
                 AppLogger.ui.notice("dismiss: alarm \(self.alarm.id, privacy: .private) already removed from repository")

--- a/SnoozePay/SnoozePay/ViewModels/CreateAlarmViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/CreateAlarmViewModel.swift
@@ -25,6 +25,9 @@ final class CreateAlarmViewModel {
     /// Per-alarm "ramp from 0 → volume over 30 seconds" toggle (#150).
     var volumeFadeIn: Bool
     var theme: AlarmTheme
+    /// Weekly vs one-shot recurrence (#229). Bound to the Никогда /
+    /// Еженедельно pill under the day chips.
+    var repeatMode: AlarmRepeatMode
 
     private let existingID: UUID?
 
@@ -60,6 +63,7 @@ final class CreateAlarmViewModel {
         self.volume = alarm?.volume ?? 1.0
         self.volumeFadeIn = alarm?.volumeFadeIn ?? false
         self.theme = alarm?.theme ?? .dawn
+        self.repeatMode = alarm?.repeatMode ?? .weekly
     }
 
     // MARK: - Save
@@ -134,7 +138,8 @@ final class CreateAlarmViewModel {
             enabled: enabled,
             volume: volume,
             volumeFadeIn: volumeFadeIn,
-            theme: theme
+            theme: theme,
+            repeatMode: repeatMode
         )
     }
 
@@ -150,6 +155,20 @@ final class CreateAlarmViewModel {
     func delete() -> Bool {
         guard let id = existingID else { return false }
         return alarmRepository.delete(id: id)
+    }
+
+    // MARK: - Repeat mode (#229)
+
+    /// One-line explanation of the selected repeat mode, rendered under the
+    /// Никогда / Еженедельно pill so the user understands what changes
+    /// without leaving the screen (`SPScreensV2.jsx` RepeatSegmented).
+    var repeatModeHint: String {
+        switch repeatMode {
+        case .never:
+            return "Будильник сработает в выбранные дни один раз и отключится."
+        case .weekly:
+            return "Будет повторяться каждую неделю по выбранным дням."
+        }
     }
 
     // MARK: - Day toggle helpers

--- a/SnoozePay/SnoozePayTests/AlarmRepeatModeTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmRepeatModeTests.swift
@@ -1,0 +1,228 @@
+import XCTest
+import UserNotifications
+@testable import SnoozePay
+
+/// Unit tests for the weekly / one-shot repeat mode added in #229:
+/// - `Alarm.repeatMode` defaults, `with(...)` mutator, and the
+///   backwards-compatible / sanitizing Codable decode (legacy alarms without
+///   the key, unknown raw values).
+/// - `AlarmScheduler.makeTriggers` planning: `.never` produces non-repeating
+///   per-day triggers, `.weekly` keeps the historical repeating ones.
+/// - `AlarmFiringViewModel.dismiss` auto-disables one-shot alarms and keeps
+///   weekly alarms enabled.
+/// - `CreateAlarmViewModel` seeding + persistence of the new field.
+final class AlarmRepeatModeTests: XCTestCase {
+
+    // MARK: - Model defaults + with(...)
+
+    func testDefaultInit_repeatModeIsWeekly() {
+        XCTAssertEqual(Alarm().repeatMode, .weekly,
+                       "New alarms must default to the historical weekly behaviour")
+    }
+
+    func testValidatingInit_acceptsNeverMode() {
+        let alarm = Alarm(validating: UUID(), repeatDays: [0, 2], repeatMode: .never)
+        XCTAssertEqual(alarm?.repeatMode, .never)
+    }
+
+    func testWith_repeatMode_changesOnlyRepeatMode() {
+        let original = Alarm(repeatDays: [0, 4], name: "Утро", penaltyAmount: 100)
+
+        let oneShot = original.with(repeatMode: .never)
+
+        XCTAssertEqual(oneShot.repeatMode, .never)
+        XCTAssertEqual(oneShot.id, original.id, "with(...) must preserve identity")
+        XCTAssertEqual(oneShot.repeatDays, original.repeatDays)
+        XCTAssertEqual(oneShot.name, original.name)
+        XCTAssertEqual(oneShot.penaltyAmount, original.penaltyAmount)
+    }
+
+    func testWith_otherField_preservesRepeatMode() {
+        let oneShot = Alarm(repeatDays: [1], repeatMode: .never)
+        XCTAssertEqual(oneShot.with(enabled: false).repeatMode, .never)
+    }
+
+    // MARK: - Codable round-trip
+
+    func testEncodeDecode_roundTripsNeverMode() throws {
+        let alarm = Alarm(repeatDays: [0, 3], repeatMode: .never)
+
+        let data = try JSONEncoder().encode(alarm)
+        let decoded = try JSONDecoder().decode(Alarm.self, from: data)
+
+        XCTAssertEqual(decoded.repeatMode, .never)
+        XCTAssertEqual(decoded.id, alarm.id)
+        XCTAssertEqual(decoded.repeatDays, alarm.repeatDays)
+    }
+
+    func testEncodeDecode_roundTripsWeeklyMode() throws {
+        let alarm = Alarm(repeatDays: [5, 6], repeatMode: .weekly)
+
+        let data = try JSONEncoder().encode(alarm)
+        let decoded = try JSONDecoder().decode(Alarm.self, from: data)
+
+        XCTAssertEqual(decoded.repeatMode, .weekly)
+    }
+
+    // MARK: - Legacy decode (pre-#229 payloads)
+
+    /// Strip the `repeatMode` key from an encoded alarm to simulate a
+    /// pre-#229 persisted payload, then decode it back.
+    private func decodeWithoutRepeatModeKey(_ alarm: Alarm) throws -> Alarm {
+        let data = try JSONEncoder().encode(alarm)
+        var json = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        json.removeValue(forKey: "repeatMode")
+        let legacyData = try JSONSerialization.data(withJSONObject: json)
+        return try JSONDecoder().decode(Alarm.self, from: legacyData)
+    }
+
+    func testDecode_missingRepeatModeKey_defaultsToWeekly() throws {
+        let legacy = try decodeWithoutRepeatModeKey(Alarm(repeatDays: [0, 1, 2, 3, 4]))
+        XCTAssertEqual(legacy.repeatMode, .weekly,
+                       "Pre-#229 alarms must keep their historical weekly behaviour")
+    }
+
+    func testDecode_missingRepeatModeKey_preservesOtherFields() throws {
+        let original = Alarm(repeatDays: [2], name: "Зал", penaltyAmount: 75)
+        let legacy = try decodeWithoutRepeatModeKey(original)
+        XCTAssertEqual(legacy.id, original.id)
+        XCTAssertEqual(legacy.repeatDays, original.repeatDays)
+        XCTAssertEqual(legacy.name, original.name)
+        XCTAssertEqual(legacy.penaltyAmount, original.penaltyAmount)
+    }
+
+    func testDecode_unknownRepeatModeRawValue_sanitizesToWeekly() throws {
+        // Corrupt storage / rolled-back future mode must not throw — a throw
+        // would lock the entire persisted store (#72 / #117).
+        let data = try JSONEncoder().encode(Alarm(repeatDays: [0]))
+        var json = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        json["repeatMode"] = "monthly"
+        let corruptData = try JSONSerialization.data(withJSONObject: json)
+
+        let decoded = try JSONDecoder().decode(Alarm.self, from: corruptData)
+
+        XCTAssertEqual(decoded.repeatMode, .weekly)
+    }
+
+    // MARK: - Trigger planning (UNNotificationRequest для never-режима)
+
+    private let scheduler = AlarmScheduler.shared
+
+    private func calendarTrigger(
+        _ trigger: AlarmScheduler.TriggerWithLabel
+    ) -> UNCalendarNotificationTrigger? {
+        trigger.trigger as? UNCalendarNotificationTrigger
+    }
+
+    func testMakeTriggers_neverMode_producesNonRepeatingPerDayTriggers() {
+        let alarm = Alarm(repeatDays: [0, 2], repeatMode: .never)
+
+        let triggers = scheduler.makeTriggers(for: alarm)
+
+        XCTAssertEqual(triggers.count, 2)
+        XCTAssertEqual(triggers.map(\.label).sorted(), ["day0", "day2"],
+                       "Per-day labels must survive so cancel(_:) removes them")
+        for trigger in triggers {
+            let calendar = self.calendarTrigger(trigger)
+            XCTAssertNotNil(calendar)
+            XCTAssertEqual(calendar?.repeats, false,
+                           "One-shot alarm must not re-arm itself a week later")
+            XCTAssertNotNil(calendar?.dateComponents.weekday,
+                            "Each one-shot trigger still pins its weekday")
+        }
+    }
+
+    func testMakeTriggers_weeklyMode_keepsRepeatingTriggers() {
+        let alarm = Alarm(repeatDays: [0, 2], repeatMode: .weekly)
+
+        let triggers = scheduler.makeTriggers(for: alarm)
+
+        XCTAssertEqual(triggers.count, 2)
+        for trigger in triggers {
+            XCTAssertEqual(calendarTrigger(trigger)?.repeats, true,
+                           "Weekly alarms keep the historical repeating triggers")
+        }
+    }
+
+    func testMakeTriggers_neverModeWithoutDays_fallsBackToOnceTrigger() {
+        let alarm = Alarm(repeatDays: [], repeatMode: .never)
+
+        let triggers = scheduler.makeTriggers(for: alarm)
+
+        XCTAssertEqual(triggers.count, 1)
+        XCTAssertEqual(triggers.first?.label, "once")
+        XCTAssertEqual(triggers.first.flatMap(calendarTrigger)?.repeats, false)
+    }
+
+    // MARK: - Dismiss semantics (one-shot auto-disable)
+
+    func testDismiss_oneShotAlarmWithDays_isDisabled() {
+        let repo = AlarmRepository(defaults: .standard)
+        let alarm = Alarm(repeatDays: [0, 1, 2, 3, 4], enabled: true, repeatMode: .never)
+        repo.save(alarm)
+        defer { repo.delete(id: alarm.id) }
+
+        let viewModel = AlarmFiringViewModel(alarm: alarm, snoozeCount: 0, alarmRepository: repo)
+        viewModel.dismiss()
+
+        XCTAssertEqual(repo.fetch(id: alarm.id)?.enabled, false,
+                       "One-shot alarm must auto-disable after dismiss")
+    }
+
+    func testDismiss_weeklyAlarmWithDays_staysEnabled() {
+        let repo = AlarmRepository(defaults: .standard)
+        let alarm = Alarm(repeatDays: [0, 1, 2, 3, 4], enabled: true, repeatMode: .weekly)
+        repo.save(alarm)
+        defer { repo.delete(id: alarm.id) }
+
+        let viewModel = AlarmFiringViewModel(alarm: alarm, snoozeCount: 0, alarmRepository: repo)
+        viewModel.dismiss()
+
+        XCTAssertEqual(repo.fetch(id: alarm.id)?.enabled, true,
+                       "Weekly alarms keep firing every week — dismiss must not disable them")
+    }
+
+    // MARK: - CreateAlarmViewModel seeding + persistence
+
+    func testCreateVM_newAlarm_defaultsToWeekly() {
+        XCTAssertEqual(CreateAlarmViewModel().repeatMode, .weekly)
+    }
+
+    func testCreateVM_editingOneShotAlarm_seedsNever() {
+        let alarm = Alarm(repeatDays: [3], repeatMode: .never)
+        XCTAssertEqual(CreateAlarmViewModel(alarm: alarm).repeatMode, .never)
+    }
+
+    func testCreateVM_save_persistsRepeatMode() {
+        let repo = AlarmRepository(defaults: .standard)
+        let viewModel = CreateAlarmViewModel(repository: repo)
+        viewModel.repeatDays = [0, 2]
+        viewModel.repeatMode = .never
+
+        XCTAssertTrue(viewModel.save())
+
+        let saved = repo.fetchAll().first { $0.repeatDays == [0, 2] && $0.repeatMode == .never }
+        XCTAssertNotNil(saved, "Saved alarm must carry the one-shot mode")
+        if let saved { repo.delete(id: saved.id) }
+    }
+
+    func testCreateVM_hintMatchesMode() {
+        let viewModel = CreateAlarmViewModel()
+
+        viewModel.repeatMode = .never
+        XCTAssertEqual(
+            viewModel.repeatModeHint,
+            "Будильник сработает в выбранные дни один раз и отключится."
+        )
+
+        viewModel.repeatMode = .weekly
+        XCTAssertEqual(
+            viewModel.repeatModeHint,
+            "Будет повторяться каждую неделю по выбранным дням."
+        )
+    }
+}


### PR DESCRIPTION
Fixes #229

## Что сделано
- `Alarm.repeatMode` (`AlarmRepeatMode`: `never` / `weekly`, default `weekly`) — новый `let`-field с поддержкой в `init(validating:)`, trapping init, `with(...)` mutator; sanitizing Codable decode: отсутствующий ключ (legacy alarms) и неизвестный raw value → `.weekly`, store никогда не лочится.
- `AlarmScheduler.makeTriggers`: для `.never` per-day триггеры планируются `repeats: false` (iOS сам не перевзводит их через неделю); labels `dayN` сохранены, так что `cancel(_:)` снимает их как раньше.
- `AlarmFiringViewModel.dismiss`: one-shot будильник (`repeatMode == .never`) после пробуждения автоматически выключается (`enabled = false`), оставшиеся per-day триггеры снимаются существующим `scheduler.cancel`. Weekly-семантика не изменилась.
- UI Create/Edit под day-chips: новый `RepeatModeCell` — caps caption «ПОВТОР», двухсекционный pill **Никогда / Еженедельно** (активный сегмент — money-стиль, как day-chips), hint под контролом меняется по режиму. Caption секции переехал из table header внутрь карточки по V2 `RepeatSegmented` (`SPScreensV2.jsx`).
- `CreateAlarmViewModel.repeatMode` + `repeatModeHint`, прокидка в `makeAlarmFromCurrentState`.

## Тесты
`SnoozePayTests/AlarmRepeatModeTests.swift` — 15 тестов:
- model: default weekly, validating init, `with(repeatMode:)` сохраняет identity/поля
- Codable: round-trip never/weekly, legacy payload без ключа → weekly, неизвестный raw (`"monthly"`) → weekly без throw
- scheduler: never → non-repeating per-day triggers (labels/weekday сохранены), weekly → repeating (regression guard), never без дней → `once`
- dismiss: one-shot с днями выключается, weekly остаётся включён
- CreateAlarmViewModel: seeding, save персистит repeatMode, hint-строки

## Verify
- swiftlint: 0 errors / 0 новых warnings в затронутых файлах
- xcodebuild build (generic/platform=iOS Simulator, CODE_SIGNING_ALLOWED=NO): succeeded
- xcodebuild build-for-testing: succeeded
- CI на этом PR — merge gate