### PR TITLE
[fix] Onboarding page 1 title collapse — add centerX/width equality constraints (#269)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController+Pages.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController+Pages.swift
@@ -50,6 +50,17 @@ extension OnboardingViewController {
         stack.setCustomSpacing(AppSpacing.sp3 + 2, after: titleLabel)
         container.addSubview(stack)
 
+        // The inequality leading/trailing pins alone don't force a width —
+        // Auto Layout would happily collapse the stack to ~1 glyph and wrap
+        // the title one character per line (#269). Pin centerX and ask for
+        // the full container width at 999 so the required ≤320 cap still
+        // wins on wide screens.
+        let preferredWidth = stack.widthAnchor.constraint(
+            equalTo: container.widthAnchor,
+            constant: -(AppSpacing.sp4 * 2)
+        )
+        preferredWidth.priority = UILayoutPriority(999)
+
         NSLayoutConstraint.activate([
             glowHost.topAnchor.constraint(equalTo: container.topAnchor, constant: 60),
             glowHost.centerXAnchor.constraint(equalTo: container.centerXAnchor),
@@ -57,6 +68,7 @@ extension OnboardingViewController {
             glowHost.heightAnchor.constraint(equalToConstant: 420),
 
             stack.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            stack.centerXAnchor.constraint(equalTo: container.centerXAnchor),
             stack.leadingAnchor.constraint(
                 greaterThanOrEqualTo: container.leadingAnchor,
                 constant: AppSpacing.sp4
@@ -65,6 +77,7 @@ extension OnboardingViewController {
                 lessThanOrEqualTo: container.trailingAnchor,
                 constant: -AppSpacing.sp4
             ),
+            preferredWidth,
             stack.widthAnchor.constraint(lessThanOrEqualToConstant: 320),
             bodyLabel.widthAnchor.constraint(lessThanOrEqualToConstant: 280)
         ])


### PR DESCRIPTION
Fixes #269

## Root cause
`makePage1()` pinned the content stack with inequality-only horizontal constraints (leading >= +16, trailing <= -16, width <= 320) plus centerY — no centerX equality and no equality width. Auto Layout legitimately satisfies all of those by collapsing the stack to ~1 glyph wide, so the title «Будильник со ставкой» and the body wrapped one character per line. Pages 2/3 use equality leading/trailing pins and were unaffected.

## Fix
- Added `stack.centerXAnchor == container.centerXAnchor` (required).
- Added `stack.widthAnchor == container.widthAnchor - 32` at priority 999, keeping the required `width <= 320` cap — so the stack fills the page on phones and the 320pt cap still wins on wide screens.
- No restyling; constants reuse `AppSpacing.sp4` like the existing pins.

## Verify
- swiftlint (touched file): 0 violations
- xcodebuild build (generic/platform=iOS Simulator, CODE_SIGNING_ALLOWED=NO): BUILD SUCCEEDED
- xcodebuild build-for-testing: TEST BUILD SUCCEEDED
- CI on this PR is the merge gate