### PR TITLE
[ui] Tab bar V3 appearance + IconWallet glyph (#279)

### DIFF
--- a/SnoozePay/SnoozePay/SceneDelegate.swift
+++ b/SnoozePay/SnoozePay/SceneDelegate.swift
@@ -133,10 +133,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // (Settings moved behind a gear icon on Alarms / Wallet headers).
         let walletVC = WalletViewController()
         let walletNav = UINavigationController(rootViewController: walletVC)
+        // Design-system wallet glyph (SPComponents.jsx `IconWallet`) — a
+        // template image, so the appearance's icon colors tint it for both
+        // states; no separate "filled" selected variant in the lucide set.
+        let walletIcon = SPIcons.wallet(size: 24)
         walletNav.tabBarItem = UITabBarItem(
             title: "Кошелёк",
-            image: UIImage(systemName: "creditcard"),
-            selectedImage: UIImage(systemName: "creditcard.fill")
+            image: walletIcon,
+            selectedImage: walletIcon
         )
 
         // Statistics tab
@@ -149,7 +153,58 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         )
 
         tabBar.viewControllers = [alarmsNav, walletNav, statsNav]
+        applyTabBarStyle(to: tabBar.tabBar)
         return tabBar
+    }
+
+    /// V3 tab-bar chrome per `components.css` `.sp-tabbar`: bg1 at 85% over
+    /// blur, stroke-1 top hairline, money-400 active tint / fg3 inactive,
+    /// semibold 11pt labels, 28pt rounded top corners.
+    private static func applyTabBarStyle(to tabBar: UITabBar) {
+        let appearance = UITabBarAppearance()
+        appearance.configureWithDefaultBackground()
+        appearance.backgroundEffect = UIBlurEffect(style: .systemUltraThinMaterial)
+        // `bg1` is #0E1320 dark / #FFFFFF light — exactly the design's
+        // rgba(14,19,32,.85) / rgba(255,255,255,.85) over blur(20px).
+        // `withAlphaComponent` keeps the dynamic provider, so both modes stay
+        // correct after trait changes.
+        appearance.backgroundColor = AppColors.bg1.withAlphaComponent(0.85)
+        // Top hairline (`border-top: 1px solid var(--sp-stroke-1)`) — UIKit
+        // models the bar's top edge line as its "shadow".
+        appearance.shadowColor = AppColors.stroke1
+
+        let item = UITabBarItemAppearance()
+        // `.sp-tabbar__label { font: 600 11px }` — semibold 11pt.
+        let labelFont = AppFonts.sans(.semibold, 11)
+        item.normal.iconColor = AppColors.fg3
+        item.normal.titleTextAttributes = [
+            .font: labelFont,
+            .foregroundColor: AppColors.fg3
+        ]
+        item.selected.iconColor = AppColors.money400
+        item.selected.titleTextAttributes = [
+            .font: labelFont,
+            .foregroundColor: AppColors.money400
+        ]
+        appearance.stackedLayoutAppearance = item
+        appearance.inlineLayoutAppearance = item
+        appearance.compactInlineLayoutAppearance = item
+
+        tabBar.standardAppearance = appearance
+        // Same chrome when content scrolls underneath and at rest — the
+        // design's bar is always translucent-over-blur, never transparent.
+        tabBar.scrollEdgeAppearance = appearance
+        tabBar.tintColor = AppColors.money400
+        tabBar.unselectedItemTintColor = AppColors.fg3
+
+        // `border-radius: 28px 28px 0 0`. UITabBar has no native corner API;
+        // masking the bar's own layer is the lightest faithful approach. The
+        // bar's frame already extends through the bottom safe area, so
+        // clipping only the *top* corners doesn't fight the home-indicator
+        // extension or the blur background.
+        tabBar.layer.cornerRadius = AppRadius.xl
+        tabBar.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        tabBar.layer.masksToBounds = true
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPIcons.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPIcons.swift
@@ -80,6 +80,42 @@ enum SPIcons {
         }
     }
 
+    /// Кошелёк — body rect + fold line + card slot + top flap. The tab-bar
+    /// glyph for the «Кошелёк» tab. JSX: `IconWallet`.
+    static func wallet(size: CGFloat) -> UIImage {
+        render(size: size) { path in
+            // Body: `rect x=3 y=6 w=18 h=14 rx=3`.
+            path.append(UIBezierPath(
+                roundedRect: CGRect(x: 3, y: 6, width: 18, height: 14),
+                cornerRadius: 3
+            ))
+            // Fold line + card slot: `M3 10h18` / `M16 14h2`.
+            path.move(to: CGPoint(x: 3, y: 10))
+            path.addLine(to: CGPoint(x: 21, y: 10))
+            path.move(to: CGPoint(x: 16, y: 14))
+            path.addLine(to: CGPoint(x: 18, y: 14))
+            // Top flap: `M18 6V4a2 2 0 0 0-2-2H7a2 2 0 0 0-2 2v2`.
+            path.move(to: CGPoint(x: 18, y: 6))
+            path.addLine(to: CGPoint(x: 18, y: 4))
+            path.addArc(
+                withCenter: CGPoint(x: 16, y: 4),
+                radius: 2,
+                startAngle: 0,
+                endAngle: -.pi / 2,
+                clockwise: false
+            )
+            path.addLine(to: CGPoint(x: 7, y: 2))
+            path.addArc(
+                withCenter: CGPoint(x: 7, y: 4),
+                radius: 2,
+                startAngle: -.pi / 2,
+                endAngle: -.pi,
+                clockwise: false
+            )
+            path.addLine(to: CGPoint(x: 5, y: 6))
+        }
+    }
+
     /// «Zz» — большая Z + маленькая Z по диагонали. JSX: `IconSnooze`.
     static func snooze(size: CGFloat) -> UIImage {
         render(size: size) { path in


### PR DESCRIPTION
Fixes #279

## What's done
- `SceneDelegate.applyTabBarStyle(to:)` — `UITabBarAppearance` per `components.css` `.sp-tabbar` (241-258): background `AppColors.bg1.withAlphaComponent(0.85)` over `systemUltraThinMaterial` blur (dark = rgba(14,19,32,.85), light = rgba(255,255,255,.85) — `bg1` is exactly the design hue in both modes), top hairline via `shadowColor = AppColors.stroke1`, selected tint `money400` (#2EDB9F), unselected `fg3`, labels Manrope semibold 11pt. Applied to both `standardAppearance` and `scrollEdgeAppearance`. Same appearance object for stacked/inline/compact layouts.
- 28pt top corner radius: applied via `tabBar.layer.cornerRadius = AppRadius.xl` + `maskedCorners` (top corners only) + `masksToBounds`. This is the closest faithful approach — the bar's frame already extends through the bottom safe area, so clipping only the top corners doesn't fight the home-indicator extension or the blur background. The straight hairline gets clipped at the corner curves, which matches the CSS border behavior closely enough.
- `SPIcons.wallet(size:)` — port of `IconWallet` SVG path from `SPComponents.jsx:354` (body rect rx3, fold line, card slot, top flap with 2pt-radius arcs) on the same 24-grid / 1.75-stroke recipe as the existing glyphs. Used for the «Кошелёк» tab item (normal + selected; template image, appearance icon colors handle both states).
- Alarm/Stats tabs keep their SF Symbols per issue scope.
- `makeMainTabBar()` signature and the DEBUG `-uitour` hook untouched.

## Verify
- swiftlint: 0 violations in touched files
- `xcodebuild build` (generic iOS Simulator, CODE_SIGNING_ALLOWED=NO): BUILD SUCCEEDED
- `xcodebuild build-for-testing`: TEST BUILD SUCCEEDED
- CI is the merge gate