### PR TITLE
[ui] Confirm-delete copy: balance stays put + alarm context line (#277)

### DIFF
--- a/SnoozePay/SnoozePay/Utilities/AlarmDeletionCopy.swift
+++ b/SnoozePay/SnoozePay/Utilities/AlarmDeletionCopy.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// Copy composer for the confirm-delete bottom sheet (#277).
+///
+/// The pre-#277 default body claimed «Деньги с баланса не вернутся. Это
+/// безвозвратно.» — semantically wrong: deleting an alarm never touches the
+/// balance. The design (`SPMore2.jsx` `ConfirmDelete()`) instead *reassures*
+/// the user:
+///
+///   «Будни · Пн–Пт · 07:00. Баланс 840 ₽ останется на месте — он привязан
+///    к аккаунту, а не к будильнику.»
+///
+/// Two pieces compose that line:
+/// - `contextLine(repeatDays:repeatMode:time:)` — the alarm identity
+///   («Будни · Пн–Пт · 07:00»), mirroring the caps-row phrasing of
+///   `AlarmsListViewModel.weekdayPhrase` (private there, so the weekday
+///   mapping lives here as the shared copy-level source).
+/// - `body(contextLine:balance:)` — the reassurance sentence with the live
+///   balance interpolated via `MoneyFormatter` (single money-string source).
+enum AlarmDeletionCopy {
+
+    // MARK: - Body
+
+    /// Full sheet subtitle. With a context line the result matches the
+    /// artboard: «<context>. Баланс N ₽ останется на месте — …». Without one
+    /// (e.g. generic call sites that have no alarm at hand) the reassurance
+    /// sentence stands alone.
+    static func body(contextLine: String? = nil, balance: Double) -> String {
+        let reassurance = "Баланс \(MoneyFormatter.string(balance)) останется на месте — "
+            + "он привязан к аккаунту, а не к будильнику."
+        guard let contextLine, !contextLine.isEmpty else { return reassurance }
+        return "\(contextLine). \(reassurance)"
+    }
+
+    // MARK: - Context line
+
+    /// «Будни · Пн–Пт · 07:00»-style alarm identity:
+    /// - weekly weekdays  → `Будни · Пн–Пт · 07:00`
+    /// - weekly weekend   → `Выходные · Сб–Вс · 07:00`
+    /// - weekly all days  → `Каждый день · 07:00`
+    /// - weekly subset    → `Вт, Чт · 07:00`
+    /// - one-shot (`.never`) → `Единожды · Пн–Пт · 07:00` (compact day range,
+    ///   no «Будни» expansion — three segments max)
+    /// - no days selected → `Единожды · 07:00`
+    static func contextLine(repeatDays: [Int], repeatMode: AlarmRepeatMode, time: Date) -> String {
+        let timeString = AlarmFiringTimeFormatter.string(from: time)
+        let sorted = sanitizedSortedDays(repeatDays)
+        guard !sorted.isEmpty else { return "Единожды · \(timeString)" }
+        if repeatMode == .never {
+            return "Единожды · \(compactDayPhrase(for: sorted)) · \(timeString)"
+        }
+        return "\(weeklyDayPhrase(for: sorted)) · \(timeString)"
+    }
+
+    // MARK: - Private
+
+    /// Monday-first short weekday names — same table as
+    /// `Alarm.repeatDaysDescription` / `DayPickerCell`.
+    private static let dayNames = ["Пн", "Вт", "Ср", "Чт", "Пт", "Сб", "Вс"]
+    private static let weekdaysSet = [0, 1, 2, 3, 4]
+    private static let weekendSet = [5, 6]
+
+    private static func sanitizedSortedDays(_ days: [Int]) -> [Int] {
+        days.filter { dayNames.indices.contains($0) }.sorted()
+    }
+
+    /// Weekly phrasing per the artboard: named bucket plus the day range.
+    private static func weeklyDayPhrase(for sorted: [Int]) -> String {
+        if sorted == Array(dayNames.indices) { return "Каждый день" }
+        if sorted == weekdaysSet { return "Будни · Пн–Пт" }
+        if sorted == weekendSet { return "Выходные · Сб–Вс" }
+        return joinedDayNames(sorted)
+    }
+
+    /// Range-only phrasing for one-shot alarms, where «Единожды» already
+    /// occupies the leading bucket slot.
+    private static func compactDayPhrase(for sorted: [Int]) -> String {
+        if sorted == Array(dayNames.indices) { return "Пн–Вс" }
+        if sorted == weekdaysSet { return "Пн–Пт" }
+        if sorted == weekendSet { return "Сб–Вс" }
+        return joinedDayNames(sorted)
+    }
+
+    private static func joinedDayNames(_ sorted: [Int]) -> String {
+        sorted.map { dayNames[$0] }.joined(separator: ", ")
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/ConfirmDeleteAlarmViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/ConfirmDeleteAlarmViewController.swift
@@ -25,9 +25,11 @@ final class ConfirmDeleteAlarmViewController: UIViewController {
 
     // MARK: - Body copy
 
-    /// Subtitle line shown below the headline. Defaults to the V2 copy "Деньги
-    /// с баланса не вернутся. Это безвозвратно."; the host can override to
-    /// surface alarm-specific context (name + repeat + time).
+    /// Subtitle line shown below the headline. Defaults to the design's
+    /// reassurance copy «Баланс N ₽ останется на месте — он привязан к
+    /// аккаунту, а не к будильнику» with the live balance interpolated
+    /// (#277); the host should pass `AlarmDeletionCopy.body(contextLine:
+    /// balance:)` to prepend alarm-specific context (repeat + time).
     private let bodyCopy: String
 
     // MARK: - UI
@@ -122,12 +124,13 @@ final class ConfirmDeleteAlarmViewController: UIViewController {
     // MARK: - Init
 
     /// - Parameters:
-    ///   - body: Subtitle copy. Defaults to the V2 spec text. Pass a tailored
-    ///     line (e.g. "Будни · Пн–Пт · 07:00") when the alarm context is rich.
+    ///   - body: Subtitle copy. Defaults to the balance-stays-put reassurance
+    ///     with the live balance (#277). Pass a tailored composition (e.g.
+    ///     "Будни · Пн–Пт · 07:00. Баланс …") when the alarm context is rich.
     ///   - onConfirm: Closure invoked on the destructive tap. The sheet
     ///     dismisses itself before firing the callback.
     init(
-        body: String = "Деньги с баланса не вернутся. Это безвозвратно.",
+        body: String = AlarmDeletionCopy.body(balance: BalanceService.shared.balance),
         onConfirm: (() -> Void)? = nil
     ) {
         self.bodyCopy = body

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController+Pickers.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController+Pickers.swift
@@ -15,8 +15,20 @@ extension CreateAlarmViewController {
     /// rest of the V2 surfaces. The actual `viewModel.delete()` + onDelete
     /// + dismiss chain is unchanged — only the surface that asks "are you
     /// sure?" moved.
+    ///
+    /// Body copy is composed per the `SPMore2.jsx` artboard (#277): the
+    /// alarm's identity line («Будни · Пн–Пт · 07:00») followed by the
+    /// balance-stays-put reassurance with the live balance interpolated.
     func confirmDelete() {
-        let sheet = ConfirmDeleteAlarmViewController { [weak self] in
+        let body = AlarmDeletionCopy.body(
+            contextLine: AlarmDeletionCopy.contextLine(
+                repeatDays: viewModel.repeatDays,
+                repeatMode: viewModel.repeatMode,
+                time: viewModel.time
+            ),
+            balance: BalanceService.shared.balance
+        )
+        let sheet = ConfirmDeleteAlarmViewController(body: body) { [weak self] in
             guard let self else { return }
             // ViewModel.delete forwards to AlarmRepository.delete, which
             // cancels the scheduled UNNotificationRequests via AlarmScheduler.

--- a/SnoozePay/SnoozePayTests/AlarmDeletionCopyTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmDeletionCopyTests.swift
@@ -1,0 +1,132 @@
+import XCTest
+@testable import SnoozePay
+
+/// Unit tests for `AlarmDeletionCopy` (#277) — the confirm-delete sheet copy
+/// composer. The body must reassure that the balance stays put (deleting an
+/// alarm never touches it), with the live amount rendered via
+/// `MoneyFormatter`, and the context line must mirror the design's
+/// «Будни · Пн–Пт · 07:00» phrasing.
+final class AlarmDeletionCopyTests: XCTestCase {
+
+    private let narrowSpace = MoneyFormatter.narrowSpace
+    private let groupSpace = "\u{00A0}"   // ru-RU thousands separator
+
+    /// 07:00 today — the design artboard's example time.
+    private var sevenAM: Date {
+        Calendar.current.date(bySettingHour: 7, minute: 0, second: 0, of: Date())!
+    }
+
+    // MARK: - body(contextLine:balance:)
+
+    func testBody_withoutContext_reassuresBalanceStaysPut() {
+        XCTAssertEqual(
+            AlarmDeletionCopy.body(balance: 840),
+            "Баланс 840\(narrowSpace)₽ останется на месте — "
+                + "он привязан к аккаунту, а не к будильнику."
+        )
+    }
+
+    func testBody_withContext_prependsContextSentence() {
+        let body = AlarmDeletionCopy.body(contextLine: "Будни · Пн–Пт · 07:00", balance: 840)
+        XCTAssertEqual(
+            body,
+            "Будни · Пн–Пт · 07:00. Баланс 840\(narrowSpace)₽ останется на месте — "
+                + "он привязан к аккаунту, а не к будильнику."
+        )
+    }
+
+    func testBody_emptyContext_degradesToReassuranceOnly() {
+        XCTAssertEqual(
+            AlarmDeletionCopy.body(contextLine: "", balance: 100),
+            AlarmDeletionCopy.body(balance: 100)
+        )
+    }
+
+    func testBody_groupsThousandsViaMoneyFormatter() {
+        let body = AlarmDeletionCopy.body(balance: 1234)
+        XCTAssertTrue(
+            body.contains("1\(groupSpace)234\(narrowSpace)₽"),
+            "Balance must render through fmtRub grouping: \(body)"
+        )
+    }
+
+    func testBody_neverClaimsMoneyIsLost() {
+        let body = AlarmDeletionCopy.body(contextLine: "Будни · Пн–Пт · 07:00", balance: 50)
+        XCTAssertFalse(body.contains("не вернутся"), "Pre-#277 false claim must be gone: \(body)")
+        XCTAssertFalse(body.contains("безвозвратно"), "Pre-#277 false claim must be gone: \(body)")
+    }
+
+    // MARK: - contextLine — weekly buckets
+
+    func testContextLine_weeklyWeekdays_matchesDesignExample() {
+        let line = AlarmDeletionCopy.contextLine(
+            repeatDays: [0, 1, 2, 3, 4], repeatMode: .weekly, time: sevenAM
+        )
+        XCTAssertEqual(line, "Будни · Пн–Пт · 07:00")
+    }
+
+    func testContextLine_weeklyWeekend() {
+        let line = AlarmDeletionCopy.contextLine(
+            repeatDays: [5, 6], repeatMode: .weekly, time: sevenAM
+        )
+        XCTAssertEqual(line, "Выходные · Сб–Вс · 07:00")
+    }
+
+    func testContextLine_weeklyEveryDay() {
+        let line = AlarmDeletionCopy.contextLine(
+            repeatDays: Array(0...6), repeatMode: .weekly, time: sevenAM
+        )
+        XCTAssertEqual(line, "Каждый день · 07:00")
+    }
+
+    func testContextLine_weeklySubset_listsDayNamesSorted() {
+        let line = AlarmDeletionCopy.contextLine(
+            repeatDays: [3, 1], repeatMode: .weekly, time: sevenAM
+        )
+        XCTAssertEqual(line, "Вт, Чт · 07:00")
+    }
+
+    // MARK: - contextLine — one-shot
+
+    func testContextLine_noDays_isOneShot() {
+        let line = AlarmDeletionCopy.contextLine(
+            repeatDays: [], repeatMode: .weekly, time: sevenAM
+        )
+        XCTAssertEqual(line, "Единожды · 07:00")
+    }
+
+    func testContextLine_neverMode_weekdays_usesCompactRange() {
+        let line = AlarmDeletionCopy.contextLine(
+            repeatDays: [0, 1, 2, 3, 4], repeatMode: .never, time: sevenAM
+        )
+        XCTAssertEqual(line, "Единожды · Пн–Пт · 07:00")
+    }
+
+    func testContextLine_neverMode_noDays() {
+        let line = AlarmDeletionCopy.contextLine(
+            repeatDays: [], repeatMode: .never, time: sevenAM
+        )
+        XCTAssertEqual(line, "Единожды · 07:00")
+    }
+
+    // MARK: - contextLine — robustness
+
+    func testContextLine_dropsOutOfRangeDayIndices() {
+        // Corrupt storage can carry indices outside 0...6 (#72) — the copy
+        // composer must drop them instead of crashing or rendering garbage.
+        let line = AlarmDeletionCopy.contextLine(
+            repeatDays: [-1, 0, 1, 2, 3, 4, 7], repeatMode: .weekly, time: sevenAM
+        )
+        XCTAssertEqual(line, "Будни · Пн–Пт · 07:00")
+    }
+
+    func testContextLine_rendersTimeAs24Hour() {
+        let evening = Calendar.current.date(
+            bySettingHour: 19, minute: 5, second: 0, of: Date()
+        )!
+        let line = AlarmDeletionCopy.contextLine(
+            repeatDays: [5, 6], repeatMode: .weekly, time: evening
+        )
+        XCTAssertEqual(line, "Выходные · Сб–Вс · 19:05")
+    }
+}


### PR DESCRIPTION
Fixes #277

## What changed

- **`ConfirmDeleteAlarmViewController.swift`** — default body no longer claims «Деньги с баланса не вернутся. Это безвозвратно.» (false: deleting an alarm never touches balance). It now defaults to the design's reassurance copy with the live balance interpolated: «Баланс N ₽ останется на месте — он привязан к аккаунту, а не к будильнику.» (SPMore2.jsx ConfirmDelete artboard; audit alarms P2-3).
- **`Utilities/AlarmDeletionCopy.swift`** (new) — small copy composer:
  - `body(contextLine:balance:)` — reassurance sentence, balance via `MoneyFormatter` only;
  - `contextLine(repeatDays:repeatMode:time:)` — «Будни · Пн–Пт · 07:00»-style alarm identity (weekly weekday/weekend/every-day/subset buckets, one-shot `.never` → «Единожды · Пн–Пт · 07:00», out-of-range day indices dropped).
- **`CreateAlarmViewController+Pickers.swift`** — `confirmDelete()` now composes the full body from the alarm being edited (previously passed nothing).
- Sheet structure untouched: pain badge, «Удалить», «Отмена», scrim/blur presentation unchanged.

## Tests

New `SnoozePayTests/AlarmDeletionCopyTests.swift` — 13 XCTests:
- body with/without context, empty-context degradation, thousands grouping via fmtRub, regression guard that the old false claim is gone;
- context line for weekday / weekend / every-day / subset / one-shot (`.never` with and without days) / no-days alarms;
- robustness: out-of-range day indices, 24-hour time rendering.

## Verify

- swiftlint: 0 violations on touched files
- `xcodebuild build-for-testing` (CODE_SIGNING_ALLOWED=NO): TEST BUILD SUCCEEDED
- CI is the merge gate
