### PR TITLE
[test] De-flake AlarmSchedulerErrorPropagationTests — bump 1s waits to 5s

### DIFF
--- a/SnoozePay/SnoozePayTests/AlarmSchedulerErrorPropagationTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmSchedulerErrorPropagationTests.swift
@@ -72,7 +72,7 @@ final class AlarmSchedulerErrorPropagationTests: XCTestCase {
             captured = result
             exp.fulfill()
         }
-        wait(for: [exp], timeout: 1.0)
+        wait(for: [exp], timeout: 5.0)
 
         guard case .failure(let error) = captured else {
             return XCTFail("Expected failure, got \(String(describing: captured))")
@@ -101,7 +101,7 @@ final class AlarmSchedulerErrorPropagationTests: XCTestCase {
             captured = result
             exp.fulfill()
         }
-        wait(for: [exp], timeout: 1.0)
+        wait(for: [exp], timeout: 5.0)
 
         guard case .success = captured else {
             return XCTFail("Expected success, got \(String(describing: captured))")
@@ -119,7 +119,7 @@ final class AlarmSchedulerErrorPropagationTests: XCTestCase {
         scheduler.schedule(alarm) { result in
             if case .success = result { exp.fulfill() }
         }
-        wait(for: [exp], timeout: 1.0)
+        wait(for: [exp], timeout: 5.0)
 
         XCTAssertTrue(mock.addedRequests.isEmpty,
                       "Disabled alarms must not register notifications")
@@ -145,7 +145,7 @@ final class AlarmSchedulerErrorPropagationTests: XCTestCase {
             captured = result
             exp.fulfill()
         }
-        wait(for: [exp], timeout: 1.0)
+        wait(for: [exp], timeout: 5.0)
 
         guard case .failure(let error) = captured else {
             return XCTFail("Expected failure, got \(String(describing: captured))")
@@ -180,7 +180,7 @@ final class AlarmSchedulerErrorPropagationTests: XCTestCase {
             captured = result
             exp.fulfill()
         }
-        wait(for: [exp], timeout: 1.0)
+        wait(for: [exp], timeout: 5.0)
 
         guard case .failure = captured else {
             return XCTFail("Expected failure, got \(String(describing: captured))")


### PR DESCRIPTION
Five `wait(for:timeout: 1.0)` in AlarmSchedulerErrorPropagationTests randomly exceed 1s on loaded CI runners — failed PR #293's run (27409480190) on a change that didn't touch the scheduler. 5s keeps the tests instant on the happy path and kills the flake.

No production code touched.