### PR TITLE
[fix] Top-up tiles and CTAs display the real SKU amount (#275)

### DIFF
--- a/SnoozePay/SnoozePay/Services/StoreKitService.swift
+++ b/SnoozePay/SnoozePay/Services/StoreKitService.swift
@@ -330,6 +330,34 @@ final class StoreKitService {
         return fallbackPrice?.doubleValue ?? 0
     }
 
+    // MARK: - Display / catalogue amounts (#275)
+    //
+    // The amount rendered on a top-up tile or CTA MUST equal the amount the
+    // App Store charges AND the amount credited to the ledger. Historically the
+    // firing-screen tiles hard-coded rounded literals (200 / 500 / 1000 ₽) that
+    // mapped to the 149 / 499 / 999 SKUs — so the user saw 200 ₽ but was charged
+    // and credited 149. These helpers make the displayed number derive from the
+    // catalogue (and, once loaded, the resolved StoreKit product price) so
+    // display == charge == credit for the current catalogue.
+
+    /// The catalogue RUB amount for a SKU (49 / 149 / 299 / 499 / 999), or nil
+    /// for an unknown product ID. This is the same value credited on purchase,
+    /// so it is the honest number to render when the product list hasn't loaded.
+    static func catalogAmount(for productID: String) -> Int? {
+        productAmounts[productID].map { Int($0) }
+    }
+
+    /// The integer RUB amount to DISPLAY for a SKU. Prefers the resolved
+    /// StoreKit product's numeric price (the real charged amount) when the
+    /// catalogue has loaded; otherwise falls back to the catalogue amount.
+    /// Never returns an invented rounded literal.
+    func displayAmount(for productID: String) -> Int? {
+        if let product = products.first(where: { $0.id == productID }) {
+            return NSDecimalNumber(decimal: product.price).intValue
+        }
+        return Self.catalogAmount(for: productID)
+    }
+
     enum StoreError: Error {
         case failedVerification
     }

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+NoBalance.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+NoBalance.swift
@@ -13,8 +13,8 @@ import os
 /// - Bottom CTAs:
 ///   1. Disabled `SPSnoozePrice` (hint "Недостаточно средств") — visual
 ///      continuity so the user sees what they wanted to tap.
-///   2. `SPButton(.money, .lg, fullWidth)` "Apple Pay · 500 ₽" — single-tap
-///      purchase via StoreKitService.
+///   2. `SPButton(.money, .lg, fullWidth)` "Apple Pay · N ₽" (N = catalogue
+///      amount of the resolved SKU) — single-tap purchase via StoreKitService.
 ///   3. `SPButton(.ghost, .lg, fullWidth)` "Я встал — выключить".
 ///
 /// Auto-recovery: `BalanceService.balanceChangedNotification` triggers a
@@ -22,13 +22,17 @@ import os
 /// once the user crosses the affordability threshold.
 extension AlarmFiringViewController {
 
-    /// SKU resolved by the no-balance Apple Pay tap. Hard-coded to the
-    /// 499 ₽ tier rather than a 500 ₽ SKU because the latter doesn't yet
-    /// exist in App Store Connect.
+    /// SKU resolved by the no-balance Apple Pay tap. Targets the 499 ₽ tier;
+    /// the 500 ₽ SKU doesn't exist in App Store Connect (lineup is PM's #240).
     static var noBalanceProductID: String { "com.snooze_pay.balance.499" }
 
-    /// Display amount (₽) for the no-balance Apple Pay button title.
-    static var noBalanceDisplayAmount: Int { 500 }
+    /// Display amount (₽) for the no-balance Apple Pay button title. Derived
+    /// from the catalogue amount of `noBalanceProductID` so the rendered number
+    /// equals what the App Store charges and the ledger credits — see #275. The
+    /// CTA used to show 500 ₽ over the 499 SKU (display != charge != credit).
+    static var noBalanceDisplayAmount: Int {
+        StoreKitService.catalogAmount(for: noBalanceProductID) ?? 0
+    }
 
     // MARK: - Setup
 
@@ -134,8 +138,8 @@ extension AlarmFiringViewController {
 
     private func makeNoBalanceApplePayButton() -> SPButton {
         // V2 spec line 258–266: money variant with apple-logo icon, "Apple Pay"
-        // title, suffix "500 ₽". The suffix uses the mono font so the amount
-        // reads as a money column.
+        // title, suffix = catalogue amount of the resolved SKU (#275). The
+        // suffix uses the mono font so the amount reads as a money column.
         let button = SPButton(
             title: "Apple Pay",
             variant: .money,
@@ -255,7 +259,8 @@ extension AlarmFiringViewController {
 
     // MARK: - Actions
 
-    /// Apple Pay 500 ₽ tap. Resolves the StoreKit product if loaded,
+    /// Apple Pay tap (catalogue amount of the resolved SKU). Resolves the
+    /// StoreKit product if loaded,
     /// otherwise falls back to a direct `BalanceService.topUp` so the
     /// debug / test paths still credit. The re-entrancy guard
     /// (`noBalancePurchaseInFlight`) and `isEnabled = false` flip together

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/FiringTopUpBottomSheetViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/FiringTopUpBottomSheetViewController.swift
@@ -6,8 +6,9 @@ import os
 /// to top up the wallet mid-alarm so they can keep snoozing.
 ///
 /// V2 spec: `docs/design/v2-handoff/components/SPTopUp.jsx`
-/// `FiringTopUpPresets` (lines 103–197). Three preset rows (200 / 500 popular
-/// / 1000 ₽) feed a single Apple Pay primary CTA. Visuals match the V2 design
+/// `FiringTopUpPresets` (lines 103–197). Three preset rows feed a single Apple
+/// Pay primary CTA; each row's amount is the catalogue amount of its mapped SKU
+/// (#275) so display == charge == credit. Visuals match the V2 design
 /// system — bg2 surface, 28pt top corners, caps "ПОПОЛНИТЬ" + close X header,
 /// SPAmountPreset row, money-toned Apple Pay button, footer meta.
 ///
@@ -23,24 +24,44 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
 
     // MARK: - Preset model
 
-    /// One of the three top-up tiles. `productID` points at the closest existing
-    /// IAP SKU in StoreKitService (149 / 499 / 999) — once PM registers exact
-    /// 200 / 500 / 1000 ₽ SKUs in App Store Connect, swap these mappings.
+    /// One of the three top-up tiles. The displayed `amount` is NOT a free
+    /// literal — it is derived from the mapped SKU's catalogue amount (or, once
+    /// loaded, the resolved StoreKit product price) so display == charge ==
+    /// credit. See #275: the tiles used to render rounded literals (200 / 500 /
+    /// 1000 ₽) over the 149 / 499 / 999 SKUs, charging and crediting less than
+    /// shown. The lineup (which SKUs exist) is PM's #240 — this only guarantees
+    /// the rendered number is honest for the current catalogue.
     struct Preset {
+        /// RUB amount to display AND credit. Always equals the catalogue amount
+        /// of `productID` for the current catalogue (or the real product price
+        /// once `StoreKitService` has loaded it).
         let amount: Int
         let label: String
         let popular: Bool
         /// StoreKit product ID. Falls back to `BalanceService.topUp(amount:)`
-        /// when not loaded so debug paths still credit the wallet.
+        /// when not loaded so debug paths still credit the wallet — with the
+        /// SAME `amount` shown, never a rounded literal.
         let productID: String
+
+        /// Build a preset whose displayed amount is the catalogue amount of the
+        /// supplied SKU. Returns nil for an unknown SKU so we never render an
+        /// invented number.
+        init?(productID: String, label: String, popular: Bool) {
+            guard let catalogAmount = StoreKitService.catalogAmount(for: productID) else { return nil }
+            self.amount = catalogAmount
+            self.label = label
+            self.popular = popular
+            self.productID = productID
+        }
     }
 
-    /// Default preset list — see `Preset.productID` for the SKU mapping caveat.
+    /// Default preset list. Amounts are resolved from the SKU catalogue so each
+    /// tile shows exactly what the App Store charges and the ledger credits.
     static let defaultPresets: [Preset] = [
-        Preset(amount: 200, label: "ровно на сейчас", popular: false, productID: "com.snooze_pay.balance.149"),
-        Preset(amount: 500, label: "на пару дней", popular: true, productID: "com.snooze_pay.balance.499"),
-        Preset(amount: 1000, label: "забыть про баланс", popular: false, productID: "com.snooze_pay.balance.999")
-    ]
+        Preset(productID: "com.snooze_pay.balance.149", label: "ровно на сейчас", popular: false),
+        Preset(productID: "com.snooze_pay.balance.499", label: "на пару дней", popular: true),
+        Preset(productID: "com.snooze_pay.balance.999", label: "забыть про баланс", popular: false)
+    ].compactMap { $0 }
 
     // MARK: - Configuration
 
@@ -123,8 +144,9 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
         label.font = AppTypography.body
         label.textColor = AppColors.fg2
         label.numberOfLines = 0
-        label.text = "Минимум — \(MoneyFormatter.string(200)) на следующее откладывание. "
-            + "Можно больше, чтобы не возвращаться сюда."
+        // Text seeded in `setupUI` so the "Минимум — N ₽" amount reflects the
+        // actual smallest preset (catalogue amount), not a hardcoded literal
+        // that diverged from the charged SKU — see #275.
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
@@ -205,10 +227,11 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
 
     init(presets: [Preset] = defaultPresets) {
         self.presets = presets
-        // Default-select the "popular" preset (500 ₽) per V2 spec line 107;
-        // fall back to the first preset if none are marked popular.
+        // Default-select the "popular" preset per V2 spec line 107; fall back to
+        // the first preset if none are marked popular, then to 0 (no invented
+        // literal) if the list is empty — see #275.
         self.selectedAmount = presets.first(where: { $0.popular })?.amount
-            ?? presets.first?.amount ?? 200
+            ?? presets.first?.amount ?? 0
         self.remainingSeconds = 60
         super.init(nibName: nil, bundle: nil)
         modalPresentationStyle = .pageSheet
@@ -298,6 +321,13 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
                 .foregroundColor: AppColors.fg3
             ]
         )
+
+        // Seed the subtitle with the real smallest preset amount (catalogue
+        // amount of the cheapest SKU) so the "Минимум — N ₽" copy matches what
+        // the App Store actually charges — see #275.
+        let minimumAmount = presets.map(\.amount).min() ?? 0
+        subtitleLabel.text = "Минимум — \(MoneyFormatter.string(minimumAmount)) на следующее откладывание. "
+            + "Можно больше, чтобы не возвращаться сюда."
 
         let headerLeftStack = UIStackView(arrangedSubviews: [titleCapsLabel, pauseLabel])
         headerLeftStack.translatesAutoresizingMaskIntoConstraints = false

--- a/SnoozePay/SnoozePayTests/TopUpDisplayAmountTests.swift
+++ b/SnoozePay/SnoozePayTests/TopUpDisplayAmountTests.swift
@@ -1,0 +1,131 @@
+import XCTest
+@testable import SnoozePay
+
+/// #275 — the amount shown on a top-up tile / CTA MUST equal what the App Store
+/// charges (the SKU's catalogue amount) AND what the ledger credits.
+///
+/// Before this fix the firing-screen presets rendered rounded literals
+/// (200 / 500 / 1000 ₽) while resolving the 149 / 499 / 999 SKUs, so the user
+/// saw 200 ₽ but was charged + credited 149. The DEBUG fallback credited the
+/// rounded literal, diverging further. These tests pin display == catalogue ==
+/// credit for every preset and the no-balance CTA, including the debug fallback
+/// path (which credits `Double(preset.amount)`).
+@MainActor
+final class TopUpDisplayAmountTests: XCTestCase {
+
+    // MARK: - Bottom-sheet presets
+
+    /// Every default preset's displayed amount equals the catalogue amount of
+    /// its mapped SKU. This is the core invariant: the rendered number is never
+    /// an invented round literal.
+    func testDefaultPresets_displayedAmount_equalsCatalogueAmount() {
+        let presets = FiringTopUpBottomSheetViewController.defaultPresets
+        XCTAssertFalse(presets.isEmpty, "default presets must resolve for the current catalogue")
+        for preset in presets {
+            let catalogue = StoreKitService.catalogAmount(for: preset.productID)
+            XCTAssertEqual(
+                catalogue,
+                preset.amount,
+                "Preset for \(preset.productID) shows \(preset.amount) but catalogue is \(catalogue ?? -1)"
+            )
+        }
+    }
+
+    /// The debug fallback path credits `Double(preset.amount)`. Assert that the
+    /// credited value equals both the displayed amount and the catalogue amount.
+    func testDefaultPresets_debugFallbackCredit_equalsDisplayedAndCatalogue() {
+        for preset in FiringTopUpBottomSheetViewController.defaultPresets {
+            let creditedByFallback = Double(preset.amount)   // what applePayTapped tops up
+            let catalogue = StoreKitService.productAmounts[preset.productID]
+            XCTAssertEqual(
+                creditedByFallback,
+                catalogue,
+                "Fallback credit for \(preset.productID) is \(creditedByFallback), catalogue is \(catalogue ?? -1)"
+            )
+            XCTAssertEqual(
+                creditedByFallback,
+                Double(preset.amount),
+                "Fallback credit must equal the displayed amount for \(preset.productID)"
+            )
+        }
+    }
+
+    /// The default lineup maps onto real existing SKUs (149 / 499 / 999) — guard
+    /// against a future edit reintroducing a rounded literal that has no SKU.
+    func testDefaultPresets_mapOntoExistingSKUs() {
+        let known = Set(StoreKitService.productIDs)
+        for preset in FiringTopUpBottomSheetViewController.defaultPresets {
+            XCTAssertTrue(
+                known.contains(preset.productID),
+                "Preset SKU \(preset.productID) is not a registered product ID"
+            )
+        }
+    }
+
+    /// `Preset.init?` refuses an unknown SKU rather than inventing an amount —
+    /// this is what prevents a rounded literal from ever being displayed again.
+    func testPresetInit_rejectsUnknownSKU() {
+        let preset = FiringTopUpBottomSheetViewController.Preset(
+            productID: "com.snooze_pay.balance.does_not_exist",
+            label: "fake",
+            popular: false
+        )
+        XCTAssertNil(preset, "Preset must not be created for an unknown SKU")
+    }
+
+    /// The popular default preset resolves to the 499 SKU and shows 499 (not
+    /// the old 500 literal), keeping the most-tapped tile honest.
+    func testPopularPreset_showsCatalogueAmount() {
+        let presets = FiringTopUpBottomSheetViewController.defaultPresets
+        let popular = presets.first(where: { $0.popular })
+        XCTAssertNotNil(popular)
+        XCTAssertEqual(popular?.productID, "com.snooze_pay.balance.499")
+        XCTAssertEqual(popular?.amount, StoreKitService.catalogAmount(for: "com.snooze_pay.balance.499"))
+    }
+
+    // MARK: - No-balance CTA
+
+    /// The no-balance Apple Pay CTA displays the catalogue amount of its SKU
+    /// (499), not the previous 500 literal. Display == charge == credit.
+    func testNoBalanceCTA_displayedAmount_equalsCatalogueAmount() {
+        let displayed = AlarmFiringViewController.noBalanceDisplayAmount
+        let catalogue = StoreKitService.catalogAmount(
+            for: AlarmFiringViewController.noBalanceProductID
+        )
+        XCTAssertEqual(catalogue, displayed)
+        XCTAssertEqual(displayed, 499, "no-balance CTA must show the real 499 SKU amount")
+    }
+
+    /// The no-balance debug fallback credits `Double(noBalanceDisplayAmount)`.
+    /// Assert it equals the catalogue credit for the resolved SKU.
+    func testNoBalanceCTA_debugFallbackCredit_equalsCatalogue() {
+        let creditedByFallback = Double(AlarmFiringViewController.noBalanceDisplayAmount)
+        let catalogue = StoreKitService.productAmounts[
+            AlarmFiringViewController.noBalanceProductID
+        ]
+        XCTAssertEqual(creditedByFallback, catalogue)
+    }
+
+    // MARK: - StoreKitService helpers
+
+    /// `catalogAmount(for:)` returns the credited amount for known SKUs and nil
+    /// for unknown ones (so callers fall back to nothing, never a literal).
+    func testCatalogAmount_matchesCreditedAmountForAllSKUs() {
+        for (productID, amount) in StoreKitService.productAmounts {
+            XCTAssertEqual(StoreKitService.catalogAmount(for: productID), Int(amount))
+        }
+        XCTAssertNil(StoreKitService.catalogAmount(for: "com.snooze_pay.balance.unknown"))
+    }
+
+    /// With no products loaded (test environment), `displayAmount(for:)` falls
+    /// back to the catalogue amount — never nil for a known SKU, never invented.
+    func testDisplayAmount_fallsBackToCatalogueWhenProductNotLoaded() {
+        for (productID, amount) in StoreKitService.productAmounts {
+            XCTAssertEqual(
+                StoreKitService.shared.displayAmount(for: productID),
+                Int(amount),
+                "displayAmount must fall back to the catalogue amount for \(productID)"
+            )
+        }
+    }
+}


### PR DESCRIPTION
Fixes #275

## Что сделано
- Firing top-up presets and the no-balance Apple Pay CTA now render the catalogue amount of their mapped SKU (149 / 499 / 999) instead of hardcoded rounded literals (200 / 500 / 1000). Display == charge == credit for the current catalogue.
- `Preset` is now built from a SKU via a failable initializer that pulls the displayed amount from `StoreKitService.catalogAmount(for:)`; an unknown SKU yields no tile (never an invented number). The DEBUG fallback credit uses the same `preset.amount`, so it no longer diverges.
- No-balance CTA: `noBalanceDisplayAmount` is derived from the catalogue amount of `noBalanceProductID` (499), and the bottom-sheet "Минимум — N ₽" subtitle now reflects the smallest preset.
- Added `StoreKitService.catalogAmount(for:)` (static) and `displayAmount(for:)` (prefers the resolved product price, falls back to catalogue) as the single source of truth.
- Lineup (which SKUs exist) untouched — that stays PM's #240. This only guarantees честность отображения for the current catalogue.

Scope note: touched only `FiringTopUpBottomSheetViewController.swift`, `AlarmFiringViewController+NoBalance.swift` (extension), and `StoreKitService.swift` — the `AlarmFiringViewController.swift` main file was NOT modified.

## Verify
- ✅ swiftlint: 0 errors (pre-existing line-length warnings only)
- ✅ xcodebuild build + build-for-testing: succeeded (CODE_SIGNING_ALLOWED=NO)
- ✅ tests: TopUpDisplayAmountTests 9/9 passed — for every preset/CTA mapping displayed == catalogue == credited (incl. debug fallback path)