### PR TITLE
[fix] Cap progressive penalty at 4 steps (base ×8) + ceiling hint copy (#274)

### DIFF
--- a/SnoozePay/SnoozePay/Models/Alarm.swift
+++ b/SnoozePay/SnoozePay/Models/Alarm.swift
@@ -279,11 +279,24 @@ struct Alarm: Identifiable, Equatable, Codable {
         return time
     }
 
-    /// Penalty for a given snooze count (1-based). Applies progressive doubling if enabled.
+    /// Penalty for a given snooze count (1-based). Applies progressive doubling
+    /// if enabled, capped at a 4-step ladder — `base, ×2, ×4, ×8` (e.g.
+    /// `50 → 100 → 200 → 400 ₽`). The exponent is clamped to `3` so the price
+    /// never escalates past `base × 8`; counts 4, 5, 10, … all return the
+    /// ceiling. Mirrors the design's `idx = min(count, 3)` rule
+    /// (`SPDawnV3.jsx:149-152`, `chat1.md:256`).
     func penalty(forSnoozeCount count: Int) -> Double {
         guard progressiveScale, count > 1 else { return penaltyAmount }
-        let multiplier = pow(2.0, Double(count - 1))
+        let exponent = min(count - 1, 3)
+        let multiplier = pow(2.0, Double(exponent))
         return penaltyAmount * multiplier
+    }
+
+    /// `true` once `penalty(forSnoozeCount:)` has reached the `base × 8`
+    /// ceiling (i.e. `count >= 4`). At the ceiling the firing screen swaps the
+    /// escalating "next price" hint for the max-step copy.
+    func isPenaltyAtCeiling(forSnoozeCount count: Int) -> Bool {
+        progressiveScale && count >= 4
     }
 
     // MARK: - Typed views (phase 1 of #31)

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
@@ -406,13 +406,19 @@ class AlarmFiringViewController: UIViewController {
     /// Snooze CTA hint — "Следующее откладывание: N ₽" when progressive is
     /// active and not at the price ceiling. Mirrors `SPScreensV2.jsx` line 96.
     /// V1 passed nil here; V2 surfaces the escalating cost so the user can
-    /// see what they're agreeing to.
+    /// see what they're agreeing to. Once the ladder caps at `base × 8` there
+    /// is no higher price to show, so we swap in the max-step copy
+    /// «максимум — дальше только встать» (lowercase per `SPDawnV3.jsx:242`).
     func snoozeHintText() -> String? {
         guard viewModel.isProgressiveActive else { return nil }
         // Probe the alarm's penalty schedule one step ahead. The double-snooze
         // rule produces `currentPenalty * 2`, but we route through the model
         // so caps / custom schedules pick up the right "next" value.
-        let next = viewModel.alarm.penalty(forSnoozeCount: viewModel.snoozeCount + 2)
+        let nextCount = viewModel.snoozeCount + 2
+        if viewModel.alarm.isPenaltyAtCeiling(forSnoozeCount: nextCount) {
+            return "максимум — дальше только встать"
+        }
+        let next = viewModel.alarm.penalty(forSnoozeCount: nextCount)
         let nextInt = Int(next.rounded())
         return "Следующее откладывание: \(MoneyFormatter.string(nextInt))"
     }

--- a/SnoozePay/SnoozePayTests/AlarmFiringHintTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmFiringHintTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import SnoozePay
+
+/// Tests for the firing screen's snooze-cost hint copy (#274). Once the
+/// progressive ladder caps at `base × 8` the hint stops quoting a higher
+/// "next price" and shows the max-step copy instead. The hint helper reads
+/// only `viewModel`, which is built in the VC initializer, so we can exercise
+/// it without loading the view hierarchy.
+final class AlarmFiringHintTests: XCTestCase {
+
+    private func makeAlarm(penalty: Double, progressive: Bool) -> Alarm {
+        Alarm(penaltyAmount: penalty, progressiveScale: progressive)
+    }
+
+    func testSnoozeHint_nilWhenNotProgressive() {
+        let vc = AlarmFiringViewController(
+            alarm: makeAlarm(penalty: 50, progressive: false),
+            snoozeCount: 0
+        )
+        XCTAssertNil(vc.snoozeHintText(),
+                     "Flat penalty alarms get no escalating-cost hint")
+    }
+
+    func testSnoozeHint_showsNextPriceBeforeCeiling() {
+        // snoozeCount=0 → probes penalty(forSnoozeCount: 2) = 100.
+        let vc = AlarmFiringViewController(
+            alarm: makeAlarm(penalty: 50, progressive: true),
+            snoozeCount: 0
+        )
+        XCTAssertEqual(vc.snoozeHintText(),
+                       "Следующее откладывание: \(MoneyFormatter.string(100))")
+    }
+
+    func testSnoozeHint_showsNextPriceAtThirdRung() {
+        // snoozeCount=1 → probes penalty(forSnoozeCount: 3) = 200 (still below ceiling).
+        let vc = AlarmFiringViewController(
+            alarm: makeAlarm(penalty: 50, progressive: true),
+            snoozeCount: 1
+        )
+        XCTAssertEqual(vc.snoozeHintText(),
+                       "Следующее откладывание: \(MoneyFormatter.string(200))")
+    }
+
+    func testSnoozeHint_showsMaxCopyAtCeiling() {
+        // snoozeCount=2 → probes penalty(forSnoozeCount: 4), which is the
+        // base × 8 ceiling. No higher price to show → max-step copy.
+        let vc = AlarmFiringViewController(
+            alarm: makeAlarm(penalty: 50, progressive: true),
+            snoozeCount: 2
+        )
+        XCTAssertEqual(vc.snoozeHintText(), "максимум — дальше только встать")
+    }
+
+    func testSnoozeHint_staysMaxCopyBeyondCeiling() {
+        let vc = AlarmFiringViewController(
+            alarm: makeAlarm(penalty: 50, progressive: true),
+            snoozeCount: 8
+        )
+        XCTAssertEqual(vc.snoozeHintText(), "максимум — дальше только встать")
+    }
+}

--- a/SnoozePay/SnoozePayTests/AlarmFiringViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmFiringViewModelTests.swift
@@ -211,10 +211,11 @@ final class AlarmFiringViewModelIOS011Tests: XCTestCase {
         XCTAssertEqual(vm2.currentPenalty, 200, "3rd snooze: 50 * 4 = 200")
 
         let vm3 = AlarmFiringViewModel(alarm: alarm, snoozeCount: 3)
-        XCTAssertEqual(vm3.currentPenalty, 400, "4th snooze: 50 * 8 = 400")
+        XCTAssertEqual(vm3.currentPenalty, 400, "4th snooze: 50 * 8 = 400 (ceiling)")
 
+        // Ladder caps at base × 8 — the 5th snooze stays at 400, not 800 (#274).
         let vm4 = AlarmFiringViewModel(alarm: alarm, snoozeCount: 4)
-        XCTAssertEqual(vm4.currentPenalty, 800, "5th snooze: 50 * 16 = 800")
+        XCTAssertEqual(vm4.currentPenalty, 400, "5th snooze stays at ceiling: 50 * 8 = 400")
     }
 
     func testCurrentPenalty_withoutProgressiveScale_staysFlat() {
@@ -227,12 +228,12 @@ final class AlarmFiringViewModelIOS011Tests: XCTestCase {
         XCTAssertEqual(vm3.currentPenalty, 50, "Without progressive scale, penalty is always base")
     }
 
-    func testCurrentPenalty_progressiveFifthSnoozeWithHighBase() {
-        // Verify overflow scenario: base=1000, 5th snooze = 1000 * 16 = 16000
+    func testCurrentPenalty_progressiveCeilingWithHighBase() {
+        // Ladder caps at base × 8: base=1000 → ceiling 8000, not 16000 (#274).
         let alarm = makeAlarm(penalty: 1000, progressive: true)
         let vm = AlarmFiringViewModel(alarm: alarm, snoozeCount: 4)
-        XCTAssertEqual(vm.currentPenalty, 16000,
-                       "5th snooze with base=1000 should be 16000")
+        XCTAssertEqual(vm.currentPenalty, 8000,
+                       "5th snooze with base=1000 stays at ceiling 8000")
     }
 
     // MARK: - canSnooze

--- a/SnoozePay/SnoozePayTests/AlarmModelTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmModelTests.swift
@@ -14,18 +14,40 @@ final class AlarmModelTests: XCTestCase {
     }
 
     func testProgressivePenaltyDoubles() {
+        // Design: exactly 4 steps — base, ×2, ×4, ×8 (50 → 100 → 200 → 400).
         let alarm = Alarm(penaltyAmount: 50, progressiveScale: true)
-        XCTAssertEqual(alarm.penalty(forSnoozeCount: 1), 50)   // x1
-        XCTAssertEqual(alarm.penalty(forSnoozeCount: 2), 100)  // x2
-        XCTAssertEqual(alarm.penalty(forSnoozeCount: 3), 200)  // x4
-        XCTAssertEqual(alarm.penalty(forSnoozeCount: 4), 400)  // x8
-        XCTAssertEqual(alarm.penalty(forSnoozeCount: 5), 800)  // x16
+        XCTAssertEqual(alarm.penalty(forSnoozeCount: 1), 50)   // ×1 (base)
+        XCTAssertEqual(alarm.penalty(forSnoozeCount: 2), 100)  // ×2
+        XCTAssertEqual(alarm.penalty(forSnoozeCount: 3), 200)  // ×4
+        XCTAssertEqual(alarm.penalty(forSnoozeCount: 4), 400)  // ×8 (ceiling)
     }
 
-    func testProgressivePenaltyFifthSnooze() {
-        // Spec: 5th snooze = base * 16. Verify with base=1000.
+    func testProgressivePenaltyCapsAtBaseTimesEight() {
+        // Once the ladder hits base × 8 it never escalates further: counts
+        // 4, 5, 10 all return the ceiling (#274).
+        let alarm = Alarm(penaltyAmount: 50, progressiveScale: true)
+        XCTAssertEqual(alarm.penalty(forSnoozeCount: 4), 400, "4th snooze = base × 8")
+        XCTAssertEqual(alarm.penalty(forSnoozeCount: 5), 400, "5th snooze stays at ceiling")
+        XCTAssertEqual(alarm.penalty(forSnoozeCount: 10), 400, "10th snooze stays at ceiling")
+    }
+
+    func testProgressivePenaltyCeilingWithLargeBase() {
+        // The cap scales with base: base=1000 → ceiling 8000, not 16000.
         let alarm = Alarm(penaltyAmount: 1000, progressiveScale: true)
-        XCTAssertEqual(alarm.penalty(forSnoozeCount: 5), 16000)
+        XCTAssertEqual(alarm.penalty(forSnoozeCount: 4), 8000)
+        XCTAssertEqual(alarm.penalty(forSnoozeCount: 5), 8000)
+        XCTAssertEqual(alarm.penalty(forSnoozeCount: 10), 8000)
+    }
+
+    func testIsPenaltyAtCeiling() {
+        let progressive = Alarm(penaltyAmount: 50, progressiveScale: true)
+        XCTAssertFalse(progressive.isPenaltyAtCeiling(forSnoozeCount: 3))
+        XCTAssertTrue(progressive.isPenaltyAtCeiling(forSnoozeCount: 4))
+        XCTAssertTrue(progressive.isPenaltyAtCeiling(forSnoozeCount: 9))
+
+        // Non-progressive alarms are never "at the ceiling" — there is no ladder.
+        let flat = Alarm(penaltyAmount: 50, progressiveScale: false)
+        XCTAssertFalse(flat.isPenaltyAtCeiling(forSnoozeCount: 10))
     }
 
     // MARK: - Repeat days description

--- a/SnoozePay/SnoozePayTests/BalanceServiceTests.swift
+++ b/SnoozePay/SnoozePayTests/BalanceServiceTests.swift
@@ -430,11 +430,11 @@ final class AlarmFiringViewModelTests: XCTestCase {
         XCTAssertEqual(vm.currentPenalty, 100)
     }
 
-    func testPenaltyForFifthSnooze() {
+    func testPenaltyForFifthSnoozeCapsAtCeiling() {
         let alarm = alarm(penalty: 50, progressive: true)
         let vm = AlarmFiringViewModel(alarm: alarm, snoozeCount: 4)
-        // snoozeCount=4 → penalty(forSnoozeCount: 5) → 50 * 16 = 800
-        XCTAssertEqual(vm.currentPenalty, 800)
+        // snoozeCount=4 → penalty(forSnoozeCount: 5) caps at base × 8 = 400 (#274)
+        XCTAssertEqual(vm.currentPenalty, 400)
     }
 
     func testSnoozeButtonTitleWhenEmpty() {


### PR DESCRIPTION
Fixes #274

## Что сделано
- `Alarm.penalty(forSnoozeCount:)` теперь капится на `base × 8` — лесенка ровно из 4 шагов (base, ×2, ×4, ×8 → 50→100→200→400). Экспонента clamp'ится через `min(count - 1, 3)`, так что counts 4, 5, 10, … возвращают потолок вместо безграничного удвоения.
- Добавлен хелпер `Alarm.isPenaltyAtCeiling(forSnoozeCount:)` (progressive && count ≥ 4).
- Хинт на firing-экране (`AlarmFiringViewController.snoozeHintText()`): на потолке вместо «Следующее откладывание: N ₽» показывает «максимум — дальше только встать» (lowercase per SPDawnV3.jsx:242).
- `CreateAlarmViewModel.progressiveChain` проверен — он строит 4-шаговую лесенку напрямую (`base << idx`), не через `penalty()`, поэтому не затронут.

## Тесты
- `AlarmModelTests`: обновлены под капинг; добавлены ceiling (counts 4/5/10 → base×8), high-base ceiling, `isPenaltyAtCeiling`.
- `AlarmFiringViewModelTests` / `BalanceServiceTests`: ожидания unbounded-doubling (800/16000) заменены на потолок (400/8000).
- Новый `AlarmFiringHintTests`: next-price до потолка + «максимум — дальше только встать» на потолке и за ним + nil для non-progressive.

## Verify
- ✅ swiftlint: 0 violations (touched files)
- ✅ xcodebuild build-for-testing: TEST BUILD SUCCEEDED (iPhone 17 Pro Max, CODE_SIGNING_ALLOWED=NO)
- ✅ test-without-building: AlarmModelTests / AlarmFiringHintTests / AlarmFiringViewModelTests / BalanceService ceiling — all passed

CAUTION respected: не трогал FiringTopUpBottomSheetViewController / StoreKitService / AlarmFiringViewController+NoBalance.swift.