### PR TITLE
[ui] TxHistory filters + alarm context + unified promo rows (#282)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletTransactionHistoryViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletTransactionHistoryViewController.swift
@@ -28,6 +28,7 @@ final class WalletTransactionHistoryViewController: UIViewController {
     private let stack = UIStackView()
     private var groups: [Group] = []
     private var period: TxHistoryPeriod = .currentMonth()
+    private var typeFilter: TxHistoryTypeFilter = .all
 
     // MARK: - Lifecycle
 
@@ -96,16 +97,28 @@ final class WalletTransactionHistoryViewController: UIViewController {
         }
 
         let all = TransactionRepository.shared.fetchAll()
-        let visible = period.filter(all)
-        groups = Self.group(transactions: visible)
+        // Period narrows by date; the summary card aggregates this whole
+        // period set so its totals stay stable as the user toggles chips.
+        let periodVisible = period.filter(all)
+        // The list then composes the type chip on top of the period set.
+        let listVisible = typeFilter.filter(periodVisible)
+        groups = Self.group(transactions: listVisible)
 
         let chipRow = makePeriodChipRow()
         stack.addArrangedSubview(chipRow)
         stack.setCustomSpacing(AppSpacing.sp4, after: chipRow)
-        stack.addArrangedSubview(makeSummaryCard(summary: TxHistorySummary.compute(from: visible)))
+        stack.addArrangedSubview(makeSummaryCard(summary: TxHistorySummary.compute(from: periodVisible)))
+
+        let filterRow = makeTypeFilterRow()
+        stack.setCustomSpacing(AppSpacing.sp4, after: stack.arrangedSubviews[stack.arrangedSubviews.count - 1])
+        stack.addArrangedSubview(filterRow)
+        stack.setCustomSpacing(AppSpacing.sp3, after: filterRow)
 
         if groups.isEmpty {
-            stack.addArrangedSubview(makeEmptyCard(hasAnyTransactions: !all.isEmpty))
+            stack.addArrangedSubview(makeEmptyCard(
+                hasAnyTransactions: !all.isEmpty,
+                periodHasTransactions: !periodVisible.isEmpty
+            ))
             return
         }
 
@@ -250,13 +263,23 @@ final class WalletTransactionHistoryViewController: UIViewController {
         return column
     }
 
-    private func makeEmptyCard(hasAnyTransactions: Bool = false) -> UIView {
+    private func makeEmptyCard(
+        hasAnyTransactions: Bool = false,
+        periodHasTransactions: Bool = false
+    ) -> UIView {
         let card = SPCard(tone: .surface, padding: AppSpacing.sp6, cornerRadius: AppRadius.lg)
         card.translatesAutoresizingMaskIntoConstraints = false
         let label = UILabel()
-        label.text = hasAnyTransactions
-            ? "За выбранный период операций нет."
-            : "Здесь появятся пополнения, списания и бонусы."
+        let message: String
+        if !hasAnyTransactions {
+            message = "Здесь появятся пополнения, списания и бонусы."
+        } else if periodHasTransactions && typeFilter != .all {
+            // Period has rows but the active type chip filtered them all out.
+            message = "За выбранный период таких операций нет."
+        } else {
+            message = "За выбранный период операций нет."
+        }
+        label.text = message
         label.font = AppTypography.body
         label.textColor = AppColors.fg3
         label.numberOfLines = 0
@@ -307,7 +330,10 @@ final class WalletTransactionHistoryViewController: UIViewController {
 
     private func makeRow(for transaction: Transaction, divider: Bool) -> SPRow {
         let title = Self.title(for: transaction)
-        let subtitle = Self.timeString(for: transaction.createdAt)
+        // Charge rows carry the owning alarm's context as the subtitle —
+        // "Будни · 07:00" — falling back to the bare time when the alarm was
+        // deleted/edited away (issue #282, SPScreensV2.jsx L467).
+        let subtitle = Self.subtitle(for: transaction)
         let leading = Self.makeIcon(for: transaction)
         let trailing = Self.makeAmountLabel(for: transaction)
         return SPRow(
@@ -321,18 +347,49 @@ final class WalletTransactionHistoryViewController: UIViewController {
 
     // MARK: - Cell content helpers
 
-    private static func title(for transaction: Transaction) -> String {
+    static func title(for transaction: Transaction) -> String {
         switch transaction.type {
         case .topup:
             return "Пополнение баланса"
         case .charge:
             return "Поспать ещё"
         case .promotion:
-            // `.promotion` is currently minted only by the referral 7-day
-            // hold reward (`ReferralService`), hence the specific copy
-            // (issue #234 item 4 — "Возврат" → "Бонус").
-            return "Бонус: продержались 7 дней"
+            // `.promotion` is currently minted only by the referral bonus
+            // (`ReferralService`) — there is no 7-day hold today, so the
+            // copy must not claim one (issue #282 — honest, unified copy
+            // shared with the wallet preview).
+            return "Бонус за друга"
         }
+    }
+
+    /// Subtitle for a row: charges append the owning alarm's repeat/time
+    /// context when resolvable; everything else (and orphaned charges) show
+    /// the transaction time only. Static + repository-injectable so the
+    /// composition is unit-tested in `subtitle(for:time:lookup:)`.
+    static func subtitle(for transaction: Transaction) -> String {
+        subtitle(
+            for: transaction,
+            time: timeString(for: transaction.createdAt),
+            lookup: { AlarmRepository.shared.fetch(id: $0) }
+        )
+    }
+
+    static func subtitle(
+        for transaction: Transaction,
+        time: String,
+        calendar: Calendar = .current,
+        lookup: (UUID) -> Alarm?
+    ) -> String {
+        guard transaction.type == .charge else { return time }
+        // Prefer the owning alarm's context ("Будни · 07:00") — it tells the
+        // user *which* alarm this snooze charge came from, which the bare
+        // charge time can't. Rows are already grouped under a day header, so
+        // the per-row time is redundant once context is available. When the
+        // alarm was deleted/edited away the context resolves to nil and we
+        // keep the charge time so the row still says *something* (issue #282).
+        return TransactionAlarmContext.caption(
+            for: transaction.alarmID, calendar: calendar, lookup: lookup
+        ) ?? time
     }
 
     private static func makeIcon(for transaction: Transaction) -> UIView {
@@ -347,9 +404,11 @@ final class WalletTransactionHistoryViewController: UIViewController {
             fill = AppColors.money400.withAlphaComponent(0.14)
             glyph = "plus"
         case .promotion:
+            // Unified with the wallet preview — gift glyph, not a checkmark
+            // (issue #282, single promotion-row rendering).
             tint = AppColors.money400
             fill = AppColors.money400.withAlphaComponent(0.14)
-            glyph = "checkmark"
+            glyph = "gift"
         case .charge:
             tint = AppColors.pain400
             fill = AppColors.pain400.withAlphaComponent(0.14)
@@ -437,5 +496,58 @@ final class WalletTransactionHistoryViewController: UIViewController {
         formatter.locale = Locale(identifier: "ru_RU")
         formatter.dateFormat = "d MMMM"
         return formatter.string(from: date)
+    }
+}
+
+// MARK: - Type filter chips (issue #282, SPMore3.jsx L142-152)
+
+extension WalletTransactionHistoryViewController {
+
+    func makeTypeFilterRow() -> UIView {
+        let row = UIStackView()
+        row.axis = .horizontal
+        row.spacing = AppSpacing.sp2
+        row.alignment = .center
+        for filter in TxHistoryTypeFilter.allCases {
+            row.addArrangedSubview(makeFilterChip(for: filter))
+        }
+        // Trailing spacer so chips left-align (the row otherwise stretches).
+        let spacer = UIView()
+        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        row.addArrangedSubview(spacer)
+        return row
+    }
+
+    private func makeFilterChip(for filter: TxHistoryTypeFilter) -> UIButton {
+        let selected = filter == typeFilter
+        var configuration = UIButton.Configuration.plain()
+        configuration.attributedTitle = AttributedString(
+            filter.title,
+            attributes: AttributeContainer([
+                .font: AppFonts.sans(.semibold, 14),
+                .foregroundColor: selected ? AppColors.bg0 : AppColors.fg2
+            ])
+        )
+        configuration.contentInsets = NSDirectionalEdgeInsets(
+            top: 7, leading: AppSpacing.sp3, bottom: 7, trailing: AppSpacing.sp3
+        )
+        let chip = UIButton(configuration: configuration)
+        chip.backgroundColor = selected ? AppColors.fg1 : AppColors.whiteOverlay06
+        chip.layer.cornerRadius = AppRadius.lg
+        chip.layer.masksToBounds = true
+        chip.accessibilityLabel = filter.title
+        chip.accessibilityTraits = selected ? [.button, .selected] : .button
+        chip.tag = TxHistoryTypeFilter.allCases.firstIndex(of: filter) ?? 0
+        chip.addTarget(self, action: #selector(typeFilterChipTapped(_:)), for: .touchUpInside)
+        return chip
+    }
+
+    @objc fileprivate func typeFilterChipTapped(_ sender: UIButton) {
+        let cases = TxHistoryTypeFilter.allCases
+        guard cases.indices.contains(sender.tag) else { return }
+        let picked = cases[sender.tag]
+        guard picked != typeFilter else { return }
+        typeFilter = picked
+        reload()
     }
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletViewController.swift
@@ -183,7 +183,8 @@ final class WalletViewController: UIViewController {
             sub.removeFromSuperview()
         }
         let items = WalletTransactionPreview.items(
-            from: TransactionRepository.shared.fetchAll()
+            from: TransactionRepository.shared.fetchAll(),
+            alarmLookup: { AlarmRepository.shared.fetch(id: $0) }
         )
         txPreviewHost.addArrangedSubview(makeTxPreviewCard(items: items))
     }

--- a/SnoozePay/SnoozePay/ViewModels/TransactionAlarmContext.swift
+++ b/SnoozePay/SnoozePay/ViewModels/TransactionAlarmContext.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Resolves the alarm-context suffix shown on charge rows — e.g.
+/// "Будни · 07:00" — from a transaction's persisted `alarmID`
+/// (issue #282, `SPScreensV2.jsx` L467).
+///
+/// A charge stores `alarmID` as the alarm's `UUID().uuidString`
+/// (`BalanceService.charge`). The owning alarm may have been edited or
+/// deleted since the charge was minted, so resolution is best-effort: a
+/// missing / malformed id, or an alarm the repository no longer knows,
+/// degrades to `nil` and the caller falls back to the bare "Поспать ещё"
+/// title. Pure value type so the lookup can be stubbed in tests without
+/// touching `AlarmRepository` / `UserDefaults`.
+enum TransactionAlarmContext {
+
+    /// "Будни · 07:00" — repeat-day summary + fire time, joined with the
+    /// app's middot separator. `nil` when the alarm can't be resolved.
+    ///
+    /// - Parameters:
+    ///   - alarmID: the transaction's persisted alarm id (UUID string).
+    ///   - lookup: resolves a `UUID` to an `Alarm`, or `nil` if unknown.
+    ///     Production passes `AlarmRepository.shared.fetch(id:)`.
+    static func caption(
+        for alarmID: String?,
+        calendar: Calendar = .current,
+        lookup: (UUID) -> Alarm?
+    ) -> String? {
+        guard
+            let alarmID,
+            let uuid = UUID(uuidString: alarmID),
+            let alarm = lookup(uuid)
+        else {
+            return nil
+        }
+        return caption(for: alarm, calendar: calendar)
+    }
+
+    /// "Будни · 07:00" for a concrete alarm.
+    static func caption(for alarm: Alarm, calendar: Calendar = .current) -> String {
+        "\(alarm.repeatDaysDescription) · \(timeString(for: alarm.time, calendar: calendar))"
+    }
+
+    private static func timeString(for date: Date, calendar: Calendar) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ru_RU")
+        formatter.calendar = calendar
+        formatter.timeZone = calendar.timeZone
+        formatter.dateFormat = "HH:mm"
+        return formatter.string(from: date)
+    }
+}

--- a/SnoozePay/SnoozePay/ViewModels/TxHistoryPeriod.swift
+++ b/SnoozePay/SnoozePay/ViewModels/TxHistoryPeriod.swift
@@ -53,6 +53,11 @@ struct YearMonth: Equatable, Hashable, Comparable {
     var gridLabel: String {
         Self.shortNames[month - 1].capitalized(with: Locale(identifier: "ru_RU"))
     }
+    /// "Янв 2026" — capitalized compact caption for the (sentence-start)
+    /// header chip when a range is selected.
+    var capitalizedShortCaption: String {
+        "\(Self.shortNames[month - 1].capitalized(with: Locale(identifier: "ru_RU"))) \(year)"
+    }
 }
 
 /// Selected reporting period for the transaction-history screen — either a
@@ -100,9 +105,13 @@ struct TxHistoryPeriod: Equatable {
 
     // MARK: - Captions (artboard 21)
 
-    /// Header chip: "январь 2026" / "ноя 2025 — янв 2026".
+    /// Header chip, capitalized as a sentence start: "Январь 2026" /
+    /// "Ноя 2025 — Янв 2026" (issue #282 — Russian capitalizes month names
+    /// at sentence start, and the chip is a standalone caption).
     var chipCaption: String {
-        isSingleMonth ? start.fullCaption : "\(start.shortCaption) — \(end.shortCaption)"
+        isSingleMonth
+            ? start.capitalizedCaption
+            : "\(start.capitalizedShortCaption) — \(end.capitalizedShortCaption)"
     }
 
     /// Summary-card caption (rendered uppercase by the caps style):
@@ -121,6 +130,46 @@ struct TxHistoryPeriod: Equatable {
 
     /// "3 мес." — month counter next to the picker caption.
     var monthCountText: String { "\(monthCount) мес." }
+}
+
+/// Transaction-type filter for the chip row under the summary card
+/// (issue #282, `SPMore3.jsx` L142-152). Composes *after* the period
+/// filter — period narrows by date, this narrows by direction.
+enum TxHistoryTypeFilter: CaseIterable {
+    /// «Все» — no type restriction.
+    case all
+    /// «Списания» — debits only (`.charge`).
+    case charges
+    /// «Поступления» — credits: paid top-ups *and* bonuses
+    /// (`.topup` + `.promotion`). Both add money to the balance, so the
+    /// user-facing "поступления" bucket groups them.
+    case credits
+
+    /// Chip label.
+    var title: String {
+        switch self {
+        case .all: return "Все"
+        case .charges: return "Списания"
+        case .credits: return "Поступления"
+        }
+    }
+
+    /// Whether a transaction passes this filter.
+    func matches(_ transaction: Transaction) -> Bool {
+        switch self {
+        case .all:
+            return true
+        case .charges:
+            return transaction.type == .charge
+        case .credits:
+            return transaction.type == .topup || transaction.type == .promotion
+        }
+    }
+
+    /// Filtered list, preserving input order.
+    func filter(_ transactions: [Transaction]) -> [Transaction] {
+        transactions.filter(matches)
+    }
 }
 
 /// Three-column aggregate for the summary card — Списано / Пополнения /

--- a/SnoozePay/SnoozePay/ViewModels/WalletTransactionPreview.swift
+++ b/SnoozePay/SnoozePay/ViewModels/WalletTransactionPreview.swift
@@ -28,21 +28,28 @@ enum WalletTransactionPreview {
     /// Newest-first preview rows, capped at `maxItems`. Input order is not
     /// trusted — the repository returns newest-first today, but the preview
     /// re-sorts defensively so a future ordering change can't flip the card.
+    ///
+    /// `alarmLookup` resolves a charge's owning alarm so its context
+    /// ("Будни · 07:00") can prefix the timestamp; production passes
+    /// `AlarmRepository.shared.fetch(id:)`. The default no-op lookup keeps
+    /// existing tests (and any context-free call site) bare.
     static func items(
         from transactions: [Transaction],
         now: Date = Date(),
-        calendar: Calendar = .current
+        calendar: Calendar = .current,
+        alarmLookup: (UUID) -> Alarm? = { _ in nil }
     ) -> [WalletTransactionPreviewItem] {
         transactions
             .sorted { $0.createdAt > $1.createdAt }
             .prefix(maxItems)
-            .map { item(for: $0, now: now, calendar: calendar) }
+            .map { item(for: $0, now: now, calendar: calendar, alarmLookup: alarmLookup) }
     }
 
     static func item(
         for transaction: Transaction,
         now: Date = Date(),
-        calendar: Calendar = .current
+        calendar: Calendar = .current,
+        alarmLookup: (UUID) -> Alarm? = { _ in nil }
     ) -> WalletTransactionPreviewItem {
         let title: String
         let icon: String
@@ -57,15 +64,30 @@ enum WalletTransactionPreview {
             icon = "plus"
             isDebit = false
         case .promotion:
-            title = "Промо-зачисление"
+            // Unified with the history screen — honest copy (the only
+            // promotion source today is the referral bonus) + the same gift
+            // glyph (issue #282).
+            title = "Бонус за друга"
             icon = "gift"
             isDebit = false
         }
         let absolute = Decimal(abs(transaction.amount))
         let sign = isDebit ? "−" : "+"
+        let timestamp = timestampText(for: transaction.createdAt, now: now, calendar: calendar)
+        // Charges prepend the resolvable alarm context, mirroring the
+        // history screen; orphaned/edited-away alarms degrade to bare time.
+        let subtitle: String
+        if transaction.type == .charge,
+           let context = TransactionAlarmContext.caption(
+               for: transaction.alarmID, calendar: calendar, lookup: alarmLookup
+           ) {
+            subtitle = "\(context) · \(timestamp)"
+        } else {
+            subtitle = timestamp
+        }
         return WalletTransactionPreviewItem(
             title: title,
-            timestampText: timestampText(for: transaction.createdAt, now: now, calendar: calendar),
+            timestampText: subtitle,
             amountText: "\(sign)\(absolute.formattedRubles())",
             isDebit: isDebit,
             iconSystemName: icon

--- a/SnoozePay/SnoozePayTests/TransactionAlarmContextTests.swift
+++ b/SnoozePay/SnoozePayTests/TransactionAlarmContextTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+@testable import SnoozePay
+
+/// Tests alarm-context resolution for charge rows (issue #282) — both the
+/// pure `TransactionAlarmContext` resolver and the history screen's
+/// `subtitle(for:time:lookup:)` composition, including the deleted-alarm
+/// fallback.
+final class TransactionAlarmContextTests: XCTestCase {
+
+    private let calendar = Calendar(identifier: .gregorian)
+
+    private func alarm(
+        repeatDays: [Int],
+        hour: Int,
+        minute: Int = 0,
+        name: String = "Поспать ещё"
+    ) -> Alarm {
+        var comps = DateComponents()
+        comps.year = 2026; comps.month = 1; comps.day = 15
+        comps.hour = hour; comps.minute = minute
+        return Alarm(time: calendar.date(from: comps)!, repeatDays: repeatDays, name: name)
+    }
+
+    // MARK: - Resolver
+
+    func testCaption_weekdaysAlarm() {
+        let sample = alarm(repeatDays: [0, 1, 2, 3, 4], hour: 7)
+        XCTAssertEqual(
+            TransactionAlarmContext.caption(for: sample, calendar: calendar),
+            "Будни · 07:00"
+        )
+    }
+
+    func testCaption_weekendAlarm() {
+        let sample = alarm(repeatDays: [5, 6], hour: 9, minute: 30)
+        XCTAssertEqual(
+            TransactionAlarmContext.caption(for: sample, calendar: calendar),
+            "Выходные · 09:30"
+        )
+    }
+
+    func testCaption_resolvesByID() {
+        let sample = alarm(repeatDays: [0, 1, 2, 3, 4], hour: 7)
+        let caption = TransactionAlarmContext.caption(
+            for: sample.id.uuidString, calendar: calendar, lookup: { $0 == sample.id ? sample : nil }
+        )
+        XCTAssertEqual(caption, "Будни · 07:00")
+    }
+
+    func testCaption_deletedAlarm_returnsNil() {
+        let caption = TransactionAlarmContext.caption(
+            for: UUID().uuidString, calendar: calendar, lookup: { _ in nil }
+        )
+        XCTAssertNil(caption)
+    }
+
+    func testCaption_nilID_returnsNil() {
+        XCTAssertNil(
+            TransactionAlarmContext.caption(for: nil, calendar: calendar, lookup: { _ in
+                XCTFail("lookup must not run for nil id")
+                return nil
+            })
+        )
+    }
+
+    func testCaption_malformedID_returnsNil() {
+        XCTAssertNil(
+            TransactionAlarmContext.caption(
+                for: "not-a-uuid", calendar: calendar, lookup: { _ in nil }
+            )
+        )
+    }
+
+    // MARK: - History-screen subtitle composition
+
+    func testSubtitle_chargeWithResolvableAlarm_showsAlarmContext() {
+        let sample = alarm(repeatDays: [0, 1, 2, 3, 4], hour: 7)
+        let tx = Transaction(type: .charge, amount: 50, alarmID: sample.id.uuidString)
+        let subtitle = WalletTransactionHistoryViewController.subtitle(
+            for: tx, time: "08:15", calendar: calendar, lookup: { $0 == sample.id ? sample : nil }
+        )
+        // Day-grouped list → row shows the alarm context, not the charge time.
+        XCTAssertEqual(subtitle, "Будни · 07:00")
+    }
+
+    func testSubtitle_chargeMissingAlarm_fallsBackToBareTime() {
+        let tx = Transaction(type: .charge, amount: 50, alarmID: UUID().uuidString)
+        let subtitle = WalletTransactionHistoryViewController.subtitle(
+            for: tx, time: "08:15", calendar: calendar, lookup: { _ in nil }
+        )
+        XCTAssertEqual(subtitle, "08:15")
+    }
+
+    func testSubtitle_nonChargeNeverGetsContext() {
+        let sample = alarm(repeatDays: [0], hour: 7)
+        let tx = Transaction(type: .topup, amount: 500, alarmID: sample.id.uuidString)
+        let subtitle = WalletTransactionHistoryViewController.subtitle(
+            for: tx, time: "08:15", calendar: calendar, lookup: { _ in sample }
+        )
+        XCTAssertEqual(subtitle, "08:15")
+    }
+
+    // MARK: - Unified promotion copy
+
+    func testPromotionTitle_isHonestUnifiedCopy() {
+        let tx = Transaction(type: .promotion, amount: 200)
+        XCTAssertEqual(WalletTransactionHistoryViewController.title(for: tx), "Бонус за друга")
+    }
+}

--- a/SnoozePay/SnoozePayTests/TxHistoryPeriodTests.swift
+++ b/SnoozePay/SnoozePayTests/TxHistoryPeriodTests.swift
@@ -133,7 +133,7 @@ final class TxHistoryPeriodTests: XCTestCase {
 
     func testCaptions_singleMonth() {
         let period = TxHistoryPeriod(month: YearMonth(year: 2026, month: 1))
-        XCTAssertEqual(period.chipCaption, "январь 2026")
+        XCTAssertEqual(period.chipCaption, "Январь 2026")
         XCTAssertEqual(period.summaryCaption, "январь 2026")
         XCTAssertEqual(period.pickerCaption, "Январь 2026")
         XCTAssertEqual(period.monthCountText, "1 мес.")
@@ -144,7 +144,7 @@ final class TxHistoryPeriodTests: XCTestCase {
             start: YearMonth(year: 2025, month: 11),
             end: YearMonth(year: 2026, month: 1)
         )
-        XCTAssertEqual(period.chipCaption, "ноя 2025 — янв 2026")
+        XCTAssertEqual(period.chipCaption, "Ноя 2025 — Янв 2026")
         XCTAssertEqual(period.summaryCaption, "ноябрь 2025 — январь 2026")
         XCTAssertEqual(period.pickerCaption, "Ноябрь 2025 — Январь 2026")
         XCTAssertEqual(period.monthCountText, "3 мес.")

--- a/SnoozePay/SnoozePayTests/TxHistoryPeriodTests.swift
+++ b/SnoozePay/SnoozePayTests/TxHistoryPeriodTests.swift
@@ -242,4 +242,57 @@ final class TxHistoryPeriodTests: XCTestCase {
             MonthCellRole.none
         )
     }
+
+    // MARK: - Capitalized chip caption (issue #282)
+
+    func testChipCaption_singleMonth_isCapitalized() {
+        let period = TxHistoryPeriod(month: YearMonth(year: 2026, month: 1))
+        XCTAssertEqual(period.chipCaption, "Январь 2026")
+    }
+
+    func testChipCaption_range_capitalizesBothEndpoints() {
+        let period = TxHistoryPeriod(
+            start: YearMonth(year: 2025, month: 11),
+            end: YearMonth(year: 2026, month: 1)
+        )
+        XCTAssertEqual(period.chipCaption, "Ноя 2025 — Янв 2026")
+    }
+
+    // MARK: - Type filter (issue #282)
+
+    private func tx(_ type: TransactionType, month: Int) -> Transaction {
+        Transaction(type: type, amount: 50, createdAt: date(year: 2026, month: month))
+    }
+
+    func testTypeFilter_all_passesEverything() {
+        let list = [tx(.charge, month: 1), tx(.topup, month: 1), tx(.promotion, month: 1)]
+        XCTAssertEqual(TxHistoryTypeFilter.all.filter(list).count, 3)
+    }
+
+    func testTypeFilter_charges_keepsOnlyDebits() {
+        let list = [tx(.charge, month: 1), tx(.topup, month: 1), tx(.promotion, month: 1)]
+        let filtered = TxHistoryTypeFilter.charges.filter(list)
+        XCTAssertEqual(filtered.map(\.type), [.charge])
+    }
+
+    func testTypeFilter_credits_keepsTopupsAndPromotions() {
+        let list = [tx(.charge, month: 1), tx(.topup, month: 1), tx(.promotion, month: 1)]
+        let filtered = TxHistoryTypeFilter.credits.filter(list)
+        XCTAssertEqual(Set(filtered.map(\.type.rawValue)), ["topup", "promotion"])
+    }
+
+    func testTypeFilter_composesWithPeriod() {
+        // Two months of mixed transactions; January period + charges chip
+        // must keep only January charges.
+        let list = [
+            tx(.charge, month: 1), tx(.topup, month: 1),
+            tx(.charge, month: 2), tx(.promotion, month: 2)
+        ]
+        let period = TxHistoryPeriod(month: YearMonth(year: 2026, month: 1))
+        let periodVisible = period.filter(list)
+        let composed = TxHistoryTypeFilter.charges.filter(periodVisible)
+        XCTAssertEqual(composed.count, 1)
+        XCTAssertEqual(composed.first?.type, .charge)
+        XCTAssertTrue(period.contains(composed.first!.createdAt))
+    }
 }

--- a/SnoozePay/SnoozePayTests/WalletTransactionPreviewTests.swift
+++ b/SnoozePay/SnoozePayTests/WalletTransactionPreviewTests.swift
@@ -36,7 +36,7 @@ final class WalletTransactionPreviewTests: XCTestCase {
         let newest = Transaction(type: .topup, amount: 500, createdAt: now)
         let middle = Transaction(type: .promotion, amount: 200, createdAt: date(daysAgo: 1, from: now))
         let items = WalletTransactionPreview.items(from: [oldest, newest, middle], now: now)
-        XCTAssertEqual(items.map(\.title), ["Пополнение баланса", "Промо-зачисление", "Поспать ещё"])
+        XCTAssertEqual(items.map(\.title), ["Пополнение баланса", "Бонус за друга", "Поспать ещё"])
     }
 
     func testItems_emptyInput_returnsEmpty() {
@@ -65,14 +65,64 @@ final class WalletTransactionPreviewTests: XCTestCase {
         XCTAssertEqual(item.amountText, "+500\u{202F}₽")
     }
 
-    func testPromotionItem_isGreenGiftWithPlusAmount() {
+    func testPromotionItem_isGreenGiftWithHonestCopy() {
         let item = WalletTransactionPreview.item(
             for: Transaction(type: .promotion, amount: 200, createdAt: Date())
         )
-        XCTAssertEqual(item.title, "Промо-зачисление")
+        // Honest, unified copy — no nonexistent 7-day hold (issue #282).
+        XCTAssertEqual(item.title, "Бонус за друга")
         XCTAssertFalse(item.isDebit)
         XCTAssertEqual(item.iconSystemName, "gift")
         XCTAssertEqual(item.amountText, "+200\u{202F}₽")
+    }
+
+    // MARK: - Alarm context on charge rows (issue #282)
+
+    func testChargeItem_appendsAlarmContextWhenResolvable() {
+        let calendar = Calendar(identifier: .gregorian)
+        var comps = DateComponents()
+        comps.year = 2026; comps.month = 1; comps.day = 15; comps.hour = 7; comps.minute = 0
+        let alarmTime = calendar.date(from: comps)!
+        let alarm = Alarm(time: alarmTime, repeatDays: [0, 1, 2, 3, 4], name: "Поспать ещё")
+        let tx = Transaction(
+            type: .charge, amount: 50, alarmID: alarm.id.uuidString, createdAt: Date()
+        )
+        let item = WalletTransactionPreview.item(
+            for: tx, alarmLookup: { $0 == alarm.id ? alarm : nil }
+        )
+        XCTAssertTrue(
+            item.timestampText.hasPrefix("Будни · 07:00 · "),
+            "got: \(item.timestampText)"
+        )
+    }
+
+    func testChargeItem_missingAlarm_degradesToBareTimestamp() {
+        let tx = Transaction(
+            type: .charge, amount: 50, alarmID: UUID().uuidString, createdAt: Date()
+        )
+        // Lookup never resolves → no "Будни" prefix, just the timestamp.
+        let item = WalletTransactionPreview.item(for: tx, alarmLookup: { _ in nil })
+        XCTAssertFalse(item.timestampText.contains(" · 07:00 · "))
+        XCTAssertTrue(item.timestampText.hasPrefix("Сегодня · "), "got: \(item.timestampText)")
+    }
+
+    func testChargeItem_nilAlarmID_degradesToBareTimestamp() {
+        let tx = Transaction(type: .charge, amount: 50, alarmID: nil, createdAt: Date())
+        let item = WalletTransactionPreview.item(for: tx, alarmLookup: { _ in
+            XCTFail("lookup must not run for a nil alarmID")
+            return nil
+        })
+        XCTAssertTrue(item.timestampText.hasPrefix("Сегодня · "), "got: \(item.timestampText)")
+    }
+
+    func testTopupItem_ignoresAlarmContext() {
+        let alarm = Alarm(time: Date(), repeatDays: [0], name: "x")
+        let tx = Transaction(
+            type: .topup, amount: 500, alarmID: alarm.id.uuidString, createdAt: Date()
+        )
+        // Non-charge rows never carry alarm context even if an id leaks in.
+        let item = WalletTransactionPreview.item(for: tx, alarmLookup: { _ in alarm })
+        XCTAssertTrue(item.timestampText.hasPrefix("Сегодня · "), "got: \(item.timestampText)")
     }
 
     func testAmountText_usesRussianThousandsSeparator() {


### PR DESCRIPTION
Fixes #282

## Что сделано
- **Type filter chips** «Все / Списания / Поступления» под summary-картой (SPMore3.jsx:142-152). Новый `TxHistoryTypeFilter` композится поверх period-фильтра: period сужает по дате, чип — по направлению. Summary-карта по-прежнему считается по всему period-набору (стабильна при переключении чипов); список фильтруется по period × type.
- **Alarm context в charge-строках** «Будни · 07:00» (SPScreensV2.jsx:467). Новый pure-резолвер `TransactionAlarmContext` разбирает `Transaction.alarmID` (UUID-строка) через `AlarmRepository`. Удалённый/неизвестный будильник → graceful fallback на голое время. Применено и в истории, и в `WalletTransactionPreview` (wallet-превью).
- **Унифицированы promotion-строки** (было 3 варианта). Честная копия без несуществующего 7-дневного холда: «Бонус за друга» (единственный источник промо сегодня — реферальный бонус), одинаковая `gift`-иконка в превью и истории.
- **Period chip с заглавной** «Январь 2026» (TxHistoryPeriod.swift chipCaption + capitalizedShortCaption для диапазонов).

## Файлы
- `ViewModels/TxHistoryPeriod.swift` — `TxHistoryTypeFilter`, capitalized `chipCaption`/`capitalizedShortCaption`
- `ViewModels/TransactionAlarmContext.swift` (new) — pure alarm-context резолвер
- `ViewModels/WalletTransactionPreview.swift` — alarm context + унифицированная промо-копия
- `ViewControllers/Wallet/WalletTransactionHistoryViewController.swift` — чип-ряд, type-фильтрация, alarm-context subtitle, `gift`-glyph для промо
- `ViewControllers/Wallet/WalletViewController.swift` — проброс `alarmLookup` в превью

## Verify
- ✅ swiftlint: 0 errors / 0 warnings (touched files)
- ✅ xcodebuild build: BUILD SUCCEEDED (iPhone 17 Pro Max sim, CODE_SIGNING_ALLOWED=NO)
- ✅ xcodebuild build-for-testing: TEST BUILD SUCCEEDED
- ✅ XCTest написаны: filter (type×period composition), alarm-context resolution incl. deleted/nil/malformed alarm, capitalized chip caption, unified promo copy. Прогон — на CI (merge-гейт).