### PR TITLE
[fix] Streak counts real wake days via WakeEventStore (#276)

### DIFF
--- a/SnoozePay/SnoozePay/Services/StreakCalculator.swift
+++ b/SnoozePay/SnoozePay/Services/StreakCalculator.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+/// Computes the «серия» — the run of consecutive days, ending today or
+/// yesterday, on which the user actually exercised the habit (woke without a
+/// charge). Extracted from `TransactionRepository.computeStreak` (#276) once
+/// the definition had to consult `WakeEventStore` as well as the ledger; a
+/// dedicated value type keeps the two inputs injectable and the maths unit
+/// testable without touching either store's serial queue.
+///
+/// ## Semantics (#276, design SPMore4.jsx:113-123 / SPScreensV2.jsx:861-868)
+///
+/// The streak counts «дни без срыва с прорывом привычки» — days the user
+/// genuinely got up. Walking backwards from today:
+///
+///   - **Wake day, no charge** → extends the streak (+1).
+///   - **Charge day** → breaks the streak (stop, regardless of a wake).
+///   - **Neutral day** (no wake *and* no charge — no alarm was scheduled, the
+///     user was travelling, etc.) → SKIP: it neither extends nor breaks the
+///     run. The design counts the habit, not the calendar, so a quiet weekend
+///     shouldn't reset a 30-day streak; but it also can't claim credit for a
+///     day the user never woke to an alarm.
+///   - **Today before its wake is recorded** → neutral, so the number doesn't
+///     optimistically count today until the alarm has actually fired and been
+///     dismissed. (A charge today still breaks immediately.)
+///
+/// The walk starts at today and continues backwards while days remain neutral
+/// or wake-positive; the first charge stops it. Because today and a still-
+/// asleep "tomorrow morning" are neutral, an unbroken run that last logged a
+/// wake *yesterday* still reads as a live streak.
+///
+/// ## Legacy fallback
+///
+/// `WakeEventStore` shipped after the original ledger (#235). Existing users
+/// who built up a streak before wake events were recorded would see it
+/// collapse to 0 the moment this stricter rule lands — every historical day is
+/// "neutral" with no wake data, so nothing extends. To avoid punishing them,
+/// when the wake store is **entirely empty** we fall back to the legacy
+/// transaction-only heuristic (consecutive charge-free days back to the first
+/// transaction). The moment a single real wake event exists we switch to the
+/// accurate definition. New installs have no transactions either, so they
+/// correctly start at 0.
+enum StreakCalculator {
+
+    /// - Parameters:
+    ///   - transactions: the full ledger (charges + topups). Only `.charge`
+    ///     entries break or bound the streak.
+    ///   - wakeDays: `startOfDay` dates the user dismissed an alarm
+    ///     (`WakeEventStore.wakeDays()`).
+    ///   - now: injected for deterministic tests; defaults to the wall clock.
+    ///   - calendar: injected so tests pin a fixed timezone/locale.
+    static func currentStreak(
+        transactions: [Transaction],
+        wakeDays: Set<Date>,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> Int {
+        // No wake history at all → degrade to the pre-#276 behaviour so
+        // long-standing users don't see their streak vanish overnight.
+        guard !wakeDays.isEmpty else {
+            return legacyStreak(transactions: transactions, now: now, calendar: calendar)
+        }
+
+        let chargeDays = Set(
+            transactions
+                .filter { $0.type == .charge }
+                .map { calendar.startOfDay(for: $0.createdAt) }
+        )
+
+        var streak = 0
+        var day = calendar.startOfDay(for: now)
+
+        // Bound the walk so a user with a single ancient wake event doesn't
+        // loop indefinitely over empty history. The wake store retains ~400
+        // days, so anything older can't contribute a wake anyway.
+        let earliest = calendar.date(byAdding: .day, value: -400, to: calendar.startOfDay(for: now))
+            ?? calendar.startOfDay(for: now)
+
+        while day >= earliest {
+            if chargeDays.contains(day) {
+                break              // a slip ends the run immediately.
+            }
+            if wakeDays.contains(day) {
+                streak += 1        // genuine wake without a charge.
+            }
+            // else: neutral day (incl. today before its wake) — skip, don't break.
+            guard let previous = calendar.date(byAdding: .day, value: -1, to: day) else { break }
+            day = previous
+        }
+
+        return streak
+    }
+
+    /// Pre-#276 definition: consecutive charge-free calendar days from today
+    /// back to the first recorded transaction. Retained only as the empty-
+    /// wake-store fallback so historical streaks survive the upgrade.
+    private static func legacyStreak(
+        transactions: [Transaction],
+        now: Date,
+        calendar: Calendar
+    ) -> Int {
+        guard !transactions.isEmpty else { return 0 }
+
+        var streak = 0
+        var checkDate = calendar.startOfDay(for: now)
+        let chargeDates = Set(
+            transactions
+                .filter { $0.type == .charge }
+                .map { calendar.startOfDay(for: $0.createdAt) }
+        )
+        let firstTransactionDate = calendar.startOfDay(
+            for: transactions.map { $0.createdAt }.min() ?? now
+        )
+
+        while !chargeDates.contains(checkDate) && checkDate >= firstTransactionDate {
+            streak += 1
+            guard let previous = calendar.date(byAdding: .day, value: -1, to: checkDate) else { break }
+            checkDate = previous
+        }
+
+        return streak
+    }
+}

--- a/SnoozePay/SnoozePay/Services/TransactionRepository.swift
+++ b/SnoozePay/SnoozePay/Services/TransactionRepository.swift
@@ -36,6 +36,9 @@ final class TransactionRepository {
     static let corruptBackupKey = "stored_transactions_backup_corrupt"
 
     private let defaults: UserDefaults
+    /// Supplies the wake-day signal the streak now requires (#276). Injected
+    /// so tests can pin both inputs; production uses the shared store.
+    private let wakeStore: WakeEventStore
     private let queue = DispatchQueue(label: "com.snoozepay.transactions.serial")
     private static let log = OSLog(
         subsystem: "Ivan-Emelyanov.SnoozePay",
@@ -57,12 +60,13 @@ final class TransactionRepository {
     /// state — that's why this initializer is `internal` rather than `private`.
     /// We deliberately omit the default value so a stray `TransactionRepository()`
     /// call site cannot bypass the singleton.
-    init(defaults: UserDefaults) {
+    init(defaults: UserDefaults, wakeStore: WakeEventStore = .shared) {
         self.defaults = defaults
+        self.wakeStore = wakeStore
     }
 
     private convenience init() {
-        self.init(defaults: .standard)
+        self.init(defaults: .standard, wakeStore: .shared)
     }
 
     // MARK: - Read
@@ -116,10 +120,14 @@ final class TransactionRepository {
 
     // MARK: - Streak calculation
 
-    /// Returns count of consecutive days ending today with no charge transactions.
-    /// Returns 0 if there are no transactions at all (new user) or if the
-    /// store can't be decoded — caller should consult `lastLoadFailed`
-    /// before trusting a zero result.
+    /// Current «серия» — consecutive habit-positive days ending today/yesterday.
+    /// Now consults `WakeEventStore` so the count reflects days the user
+    /// actually woke without a charge, not merely charge-free calendar days
+    /// (#276). See `StreakCalculator` for the full semantics (charge breaks,
+    /// neutral alarm-less days skip, today counts only after its wake, empty
+    /// wake-store legacy fallback). Returns 0 for a brand-new user or a
+    /// corrupt ledger — callers should consult `lastLoadFailed` before
+    /// trusting a zero.
     ///
     /// Production callers that have already paid the cost of a checked read
     /// (StatisticsViewModel) should use `currentStreak(from:)` to avoid a
@@ -127,42 +135,24 @@ final class TransactionRepository {
     /// (issue #117).
     func currentStreak() -> Int {
         let allTransactions = queue.sync { (try? readAll()) ?? [] }
-        return Self.computeStreak(from: allTransactions)
+        return StreakCalculator.currentStreak(
+            transactions: allTransactions,
+            wakeDays: wakeStore.wakeDays()
+        )
     }
 
     /// Streak computation against a caller-supplied transaction list. Used
     /// by callers that already loaded transactions via `fetchAllChecked`,
     /// so a single decode failure surfaces once instead of twice and a
     /// transient zero from a hidden re-read can't contradict the surfaced
-    /// banner (issue #117).
+    /// banner (issue #117). Wake days are still read fresh from the store —
+    /// they live in a separate ledger that the transaction snapshot doesn't
+    /// cover.
     func currentStreak(from transactions: [Transaction]) -> Int {
-        Self.computeStreak(from: transactions)
-    }
-
-    /// Pure function over a transaction list — extracted so `currentStreak()`
-    /// and `currentStreak(from:)` cannot drift apart. Lives as `static` so
-    /// it can't accidentally read instance state and reintroduce the silent
-    /// decode the caller-supplied variant exists to avoid.
-    private static func computeStreak(from transactions: [Transaction]) -> Int {
-        guard !transactions.isEmpty else { return 0 }
-
-        let calendar = Calendar.current
-        var streak = 0
-        var checkDate = calendar.startOfDay(for: Date())
-        let allCharges = transactions.filter { $0.type == .charge }
-        let chargeDates = Set(allCharges.map { calendar.startOfDay(for: $0.createdAt) })
-
-        let firstTransactionDate = calendar.startOfDay(
-            for: transactions.map { $0.createdAt }.min() ?? Date()
+        StreakCalculator.currentStreak(
+            transactions: transactions,
+            wakeDays: wakeStore.wakeDays()
         )
-
-        while !chargeDates.contains(checkDate) && checkDate >= firstTransactionDate {
-            streak += 1
-            guard let previous = calendar.date(byAdding: .day, value: -1, to: checkDate) else { break }
-            checkDate = previous
-        }
-
-        return streak
     }
 
     // MARK: - Recovery

--- a/SnoozePay/SnoozePayTests/StatisticsViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/StatisticsViewModelTests.swift
@@ -23,8 +23,11 @@ final class StatisticsViewModelDataTests: XCTestCase {
         super.setUp()
         suiteName = "test.statistics.\(UUID().uuidString)"
         testDefaults = UserDefaults(suiteName: suiteName)!
-        txRepo = TransactionRepository(defaults: testDefaults)
         wakeStore = WakeEventStore(defaults: testDefaults)
+        // The repository now derives the streak from wake events too (#276),
+        // so it must share the isolated wake store — otherwise it would read
+        // the production singleton and leak real-device history into the test.
+        txRepo = TransactionRepository(defaults: testDefaults, wakeStore: wakeStore)
     }
 
     override func tearDown() {

--- a/SnoozePay/SnoozePayTests/TransactionRepositoryTests.swift
+++ b/SnoozePay/SnoozePayTests/TransactionRepositoryTests.swift
@@ -7,12 +7,23 @@ final class TransactionRepositoryTests: XCTestCase {
     private var testDefaults: UserDefaults!
     private var suiteName: String!
     private var repo: TransactionRepository!
+    private var wakeStore: WakeEventStore!
 
     override func setUp() {
         super.setUp()
         suiteName = "test.txRepo.\(UUID().uuidString)"
         testDefaults = UserDefaults(suiteName: suiteName)!
-        repo = TransactionRepository(defaults: testDefaults)
+        // Isolated wake store so the streak's #276 wake lookup (and its
+        // empty-store legacy fallback) can't read real-device history.
+        wakeStore = WakeEventStore(defaults: testDefaults)
+        repo = TransactionRepository(defaults: testDefaults, wakeStore: wakeStore)
+    }
+
+    /// Records a wake event for the same `daysAgo` offset the charge/topup
+    /// helpers use, so streak tests can opt into the accurate (#276) path.
+    private func recordWake(daysAgo: Int) {
+        let date = Calendar.current.date(byAdding: .day, value: -daysAgo, to: Date())!
+        wakeStore.recordWake(on: date)
     }
 
     override func tearDown() {
@@ -98,7 +109,12 @@ final class TransactionRepositoryTests: XCTestCase {
         XCTAssertTrue(charges.isEmpty)
     }
 
-    // MARK: - Streak calculation
+    // MARK: - Streak: legacy fallback (no wake history)
+    //
+    // None of these record a wake event, so the wake store is empty and the
+    // streak degrades to the pre-#276 transaction-only heuristic. This proves
+    // existing users (who built a streak before WakeEventStore shipped) don't
+    // see it collapse to 0 on upgrade.
 
     func testCurrentStreak_noTransactions_returnsZero() {
         XCTAssertEqual(repo.currentStreak(), 0)
@@ -143,6 +159,98 @@ final class TransactionRepositoryTests: XCTestCase {
         repo.record(topup(amount: 100, daysAgo: 0))
 
         XCTAssertEqual(repo.currentStreak(), 2)
+    }
+
+    // MARK: - Streak: wake-aware path (#276)
+    //
+    // Once any wake event exists the streak uses the accurate definition:
+    // count consecutive wake-without-charge days, neutral (no wake/no charge)
+    // days skip, today counts only after its wake, a charge breaks the run.
+
+    func testCurrentStreak_wakeChain_countsEachWakeDay() {
+        // Woke today, yesterday, two days ago — no charges -> streak = 3.
+        recordWake(daysAgo: 0)
+        recordWake(daysAgo: 1)
+        recordWake(daysAgo: 2)
+
+        XCTAssertEqual(repo.currentStreak(), 3)
+    }
+
+    func testCurrentStreak_chargeBreaksTheChain() {
+        // Woke today & yesterday, charge two days ago -> the charge stops the
+        // walk, so only today + yesterday count -> streak = 2.
+        recordWake(daysAgo: 0)
+        recordWake(daysAgo: 1)
+        recordWake(daysAgo: 2)
+        repo.record(charge(amount: 50, daysAgo: 2))
+
+        XCTAssertEqual(repo.currentStreak(), 2)
+    }
+
+    func testCurrentStreak_chargeToday_breaksImmediately() {
+        // A charge today ends the streak even if a wake was also recorded.
+        recordWake(daysAgo: 0)
+        recordWake(daysAgo: 1)
+        repo.record(charge(amount: 50, daysAgo: 0))
+
+        XCTAssertEqual(repo.currentStreak(), 0)
+    }
+
+    func testCurrentStreak_neutralGapSkips_doesNotBreak() {
+        // Woke today and 3 days ago; days 1 and 2 had no alarm (neutral).
+        // Neutral days skip rather than break -> both wakes count -> streak = 2.
+        recordWake(daysAgo: 0)
+        recordWake(daysAgo: 3)
+
+        XCTAssertEqual(repo.currentStreak(), 2)
+    }
+
+    func testCurrentStreak_preWakeToday_excludesToday() {
+        // No wake recorded today yet, but woke yesterday & the day before.
+        // Today is neutral (skipped, not counted) -> streak = 2 from the two
+        // prior wake days. The number doesn't optimistically claim today.
+        recordWake(daysAgo: 1)
+        recordWake(daysAgo: 2)
+
+        XCTAssertEqual(repo.currentStreak(), 2)
+    }
+
+    func testCurrentStreak_postWakeToday_includesToday() {
+        // Same history, but now today's wake is recorded -> today counts too.
+        recordWake(daysAgo: 0)
+        recordWake(daysAgo: 1)
+        recordWake(daysAgo: 2)
+
+        XCTAssertEqual(repo.currentStreak(), 3)
+    }
+
+    func testCurrentStreak_onlyWakeIsOld_stillCountsViaNeutralSkip() {
+        // A single wake 5 days ago with no charges since: the intervening
+        // neutral days skip, so the streak surfaces that one habit day.
+        recordWake(daysAgo: 5)
+
+        XCTAssertEqual(repo.currentStreak(), 1)
+    }
+
+    func testCurrentStreak_wakeButChargeSameDay_doesNotCountThatDay() {
+        // Woke yesterday but also got charged yesterday: the charge breaks the
+        // walk at yesterday, and today (neutral) contributes nothing -> 0.
+        recordWake(daysAgo: 1)
+        repo.record(charge(amount: 50, daysAgo: 1))
+
+        XCTAssertEqual(repo.currentStreak(), 0)
+    }
+
+    func testCurrentStreakFromTransactions_alsoConsultsWakeStore() {
+        // The caller-supplied variant (#117 hot path) must apply the same
+        // wake-aware definition, not silently fall back to charge-free days.
+        recordWake(daysAgo: 0)
+        recordWake(daysAgo: 1)
+        let snapshot = [
+            Transaction(type: .topup, amount: 100, createdAt: Date())
+        ]
+
+        XCTAssertEqual(repo.currentStreak(from: snapshot), 2)
     }
 
     // MARK: - Edge cases


### PR DESCRIPTION
Fixes #276

## Что сделано
- Новый `StreakCalculator` (Services) — чистая инъектируемая функция над transactions + `WakeEventStore.wakeDays()`. Семантика: серия = подряд идущие дни, где пользователь реально проснулся (wake-событие) без списания; charge рвёт серию; день без будильника и без списания — НЕЙТРАЛЬНЫЙ (skip-neutral: не продлевает и не рвёт); сегодня засчитывается только после записи сегодняшнего wake (до срабатывания будильника — нейтрально).
- Legacy-фолбэк: если `WakeEventStore` полностью пуст (старые пользователи до #235), считаем по прежней транзакционной эвристике, чтобы серия не обнулилась при обновлении. Новые установки без транзакций корректно дают 0.
- `TransactionRepository.currentStreak()` / `currentStreak(from:)` теперь делегируют в `StreakCalculator` и читают `WakeEventStore` (инъекция через init, дефолт `.shared`). Потребители (StatisticsViewModel hero/best-streak, streak-banner и StreakModal trigger в AlarmsList) получают новое значение без изменений сигнатур.

## Тесты (XCTest)
Добавлены в `TransactionRepositoryTests`:
- цепочки wake-дней, charge рвёт цепочку, charge сегодня рвёт сразу;
- нейтральные пропуски не рвут серию;
- сегодня до wake исключается / после wake включается;
- единственный старый wake через нейтральные пропуски;
- wake + charge в один день не засчитывается;
- `currentStreak(from:)` тоже консультирует wake-store.
Существующие streak-тесты переразмечены как legacy-fallback (без wake-событий). `StatisticsViewModelTests` и `TransactionRepositoryTests` инъектируют изолированный `WakeEventStore`, чтобы не читать реальную историю устройства.

## Verify
- ✅ swiftlint: 0 violations (изменённые файлы)
- ✅ xcodebuild build: BUILD SUCCEEDED (generic iOS Simulator, CODE_SIGNING_ALLOWED=NO)
- ✅ xcodebuild build-for-testing: TEST BUILD SUCCEEDED
- тесты не гонял на симуляторе — гейт CI