### PR TITLE
[ui] Stats/Onboarding/Splash polish — hero 56pt, empty state, gaps, one-shot caps row (#289)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingComponents.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingComponents.swift
@@ -67,7 +67,7 @@ final class OnboardingPenaltyPill: UIView {
     private func configureLabel() {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.text = "−\(MoneyFormatter.string(50))"
-        label.font = AppTypography.buttonSm
+        label.font = AppTypography.moneySm  // mono digits for the penalty pill (#289)
         label.textColor = AppColors.fgOnWarn
         addSubview(label)
         NSLayoutConstraint.activate([

--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController+Pages.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController+Pages.swift
@@ -287,10 +287,10 @@ extension OnboardingViewController {
         laterButton.isUserInteractionEnabled = isDepositPage
         laterButton.isAccessibilityElement = isDepositPage
         // Dots sit 14pt above the CTA group on the deposit page
-        // (JSX `marginBottom: 14`), 16pt elsewhere.
+        // (JSX `marginBottom: 14`), 24pt on pages 1/2 (#289).
         dotsGapConstraint?.constant = isDepositPage
             ? -(AppSpacing.sp3 + 2)   // 14pt
-            : -AppSpacing.sp4         // 16pt
+            : -AppSpacing.sp6         // 24pt
         if isDepositPage {
             rebuildDepositCTA()
         } else {

--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/PermissionCardView.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/PermissionCardView.swift
@@ -68,6 +68,17 @@ final class PermissionCardView: UIView {
 
     private let card = SPCard(tone: .surface, padding: 16, cornerRadius: AppRadius.md)
     private let iconHost = UIView()
+    /// Money gradient fill for the granted/enabled state (#289). Hidden for the
+    /// other states, where `iconHost` uses a flat overlay background.
+    private let iconHostGradient: CAGradientLayer = {
+        let gradient = CAGradientLayer()
+        gradient.colors = SPSupport.moneyGradientColors
+        gradient.locations = SPSupport.moneyGradientLocations
+        gradient.startPoint = SPSupport.gradientStart
+        gradient.endPoint = SPSupport.gradientEnd
+        gradient.isHidden = true
+        return gradient
+    }()
     private let iconView = UIImageView()
     private let titleLabel = UILabel()
     private let bodyLabel = UILabel()
@@ -88,6 +99,16 @@ final class PermissionCardView: UIView {
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Layout
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        iconHostGradient.frame = iconHost.bounds
+        CATransaction.commit()
     }
 
     // MARK: - Configuration
@@ -117,6 +138,7 @@ final class PermissionCardView: UIView {
         iconHost.translatesAutoresizingMaskIntoConstraints = false
         iconHost.layer.cornerRadius = AppRadius.sm    // 12pt — matches JSX
         iconHost.layer.masksToBounds = true
+        iconHost.layer.insertSublayer(iconHostGradient, at: 0)
         iconHost.backgroundColor = AppColors.whiteOverlay08
 
         iconView.translatesAutoresizingMaskIntoConstraints = false
@@ -185,7 +207,8 @@ final class PermissionCardView: UIView {
 
         switch status {
         case .granted, .enabled:
-            iconHost.backgroundColor = AppColors.money500
+            iconHost.backgroundColor = .clear
+            iconHostGradient.isHidden = false
             iconView.tintColor = AppColors.fgOnMoney
             let configuration = UIImage.SymbolConfiguration(pointSize: 18, weight: .bold)
             let imageView = UIImageView(
@@ -197,6 +220,7 @@ final class PermissionCardView: UIView {
             mount(imageView)
             tapGesture.isEnabled = false
         case .actionable:
+            iconHostGradient.isHidden = true
             iconHost.backgroundColor = AppColors.whiteOverlay08
             iconView.tintColor = AppColors.fg3
             // The 2026-06 mockup renders an *empty* span where this caps
@@ -205,6 +229,7 @@ final class PermissionCardView: UIView {
             mount(capsLabel(text: "Дать", color: AppColors.warn400))
             tapGesture.isEnabled = true
         case .unavailable:
+            iconHostGradient.isHidden = true
             iconHost.backgroundColor = AppColors.whiteOverlay08
             iconView.tintColor = AppColors.fg3
             mount(capsLabel(text: "Недоступно", color: AppColors.fg3))

--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/SplashViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/SplashViewController.swift
@@ -116,7 +116,7 @@ final class SplashViewController: UIViewController {
         // Force dark — splash is always rendered against the dark canvas
         // regardless of the system theme, so the glow + tile read consistently.
         overrideUserInterfaceStyle = .dark
-        view.backgroundColor = AppColors.bg0
+        view.backgroundColor = AppColors.bg1  // #0E1320 splash canvas (#289)
         view.layer.insertSublayer(glowLayer, at: 0)
         tileView.layer.insertSublayer(tileGradient, at: 0)
 
@@ -149,7 +149,7 @@ final class SplashViewController: UIViewController {
                 constant: -AppSpacing.screenInset
             ),
 
-            subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: AppSpacing.sp3),
+            subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: AppSpacing.sp5),
             subtitleLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor)
         ])
     }

--- a/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsHeatmapView.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsHeatmapView.swift
@@ -220,6 +220,20 @@ final class StatisticsHeatmapView: UIView {
         case .empty: return AppColors.fg3
         }
     }
+
+    /// Gradient stops matching the heatmap cell fill for each status — used by
+    /// the tooltip swatch so it mirrors the tapped cell rather than a flat tone
+    /// (#289). `nil` for `.empty` (the swatch falls back to the flat tone).
+    static func gradientStops(
+        for status: StatisticsViewModel.DayStatus
+    ) -> (colors: [CGColor], locations: [NSNumber])? {
+        switch status {
+        case .woke: return (SPSupport.moneyGradientColors, SPSupport.moneyGradientLocations)
+        case .light: return (SPSupport.warnGradientColors, SPSupport.warnGradientLocations)
+        case .heavy: return (SPSupport.painGradientColors, SPSupport.painGradientLocations)
+        case .empty: return nil
+        }
+    }
 }
 
 // MARK: - Day cell
@@ -282,6 +296,9 @@ private final class HeatmapTooltipView: UIView {
     private let arrowView = UIView()
     private let dateLabel = UILabel()
     private let swatchView = UIView()
+    /// Gradient fill for the swatch so it matches the tapped cell's gradient
+    /// (#289). Hidden for `.empty`, where the flat tone is used instead.
+    private let swatchGradient = CAGradientLayer()
     private let statusLabel = UILabel()
     private let spentLabel = UILabel()
 
@@ -317,7 +334,11 @@ private final class HeatmapTooltipView: UIView {
         dateLabel.translatesAutoresizingMaskIntoConstraints = false
 
         swatchView.layer.cornerRadius = 2
+        swatchView.layer.masksToBounds = true
         swatchView.translatesAutoresizingMaskIntoConstraints = false
+        swatchGradient.startPoint = SPSupport.gradientStart
+        swatchGradient.endPoint = SPSupport.gradientEnd
+        swatchView.layer.insertSublayer(swatchGradient, at: 0)
 
         statusLabel.font = AppFonts.sans(.semibold, 12)
         statusLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -353,7 +374,15 @@ private final class HeatmapTooltipView: UIView {
         dateLabel.text = tooltip.dateText
         statusLabel.text = tooltip.statusText
         statusLabel.textColor = StatisticsHeatmapView.toneColor(for: tooltip.status)
-        swatchView.backgroundColor = StatisticsHeatmapView.toneColor(for: tooltip.status)
+        if let stops = StatisticsHeatmapView.gradientStops(for: tooltip.status) {
+            swatchGradient.isHidden = false
+            swatchGradient.colors = stops.colors
+            swatchGradient.locations = stops.locations
+            swatchView.backgroundColor = .clear
+        } else {
+            swatchGradient.isHidden = true
+            swatchView.backgroundColor = StatisticsHeatmapView.toneColor(for: tooltip.status)
+        }
         spentLabel.text = tooltip.spentText
         spentLabel.isHidden = tooltip.spentText == nil
     }
@@ -374,5 +403,6 @@ private final class HeatmapTooltipView: UIView {
             roundedRect: bounds,
             cornerRadius: layer.cornerRadius
         ).cgPath
+        swatchGradient.frame = swatchView.bounds
     }
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsViewController+Cards.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsViewController+Cards.swift
@@ -16,7 +16,14 @@ extension StatisticsViewController {
     /// (cell tooltip, artboard 27a) so the gesture lives on the row, not
     /// the whole card.
     func makeHeroStreakCard() -> UIView {
-        let card = SPCard(tone: .raised, padding: AppSpacing.sp6, cornerRadius: AppRadius.xl)
+        // Radius 24 + 24v/20h padding per `SPMore4.jsx` (audit P2-3 #289).
+        // SPCard's `padding:` is uniform, so seed it with the vertical inset and
+        // override `layoutMargins` to tighten the horizontal sides to 20.
+        let card = SPCard(tone: .raised, padding: AppSpacing.sp6, cornerRadius: AppSpacing.sp6)
+        card.layoutMargins = UIEdgeInsets(
+            top: AppSpacing.sp6, left: AppSpacing.sp5,
+            bottom: AppSpacing.sp6, right: AppSpacing.sp5
+        )
         // The tooltip bubble overhangs the card's bottom edge for last-row
         // cells — let it escape instead of clipping (issue acceptance:
         // "Tooltip рендерится корректно, не обрезается сеткой").

--- a/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsViewController.swift
@@ -25,6 +25,15 @@ final class StatisticsViewController: UIViewController {
     let scrollView = UIScrollView()
     let contentStack = UIStackView()
 
+    /// Shown over the scroll content when the user has no charges and no wake
+    /// events — nothing to aggregate yet (`SPMore.jsx` `EmptyStats`, #289).
+    let emptyState: SPStatsEmptyState = {
+        let view = SPStatsEmptyState()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.isHidden = true
+        return view
+    }()
+
     /// Hero card reference — raised above its stack siblings while the
     /// heatmap tooltip is visible so the bubble isn't covered by the next
     /// card (the JSX gives the selected cell `zIndex: 3`).
@@ -32,10 +41,11 @@ final class StatisticsViewController: UIViewController {
 
     // MARK: - Hero "Серия"
 
-    /// Big mono streak count drawn at `moneyLg` (32pt).
+    /// Big mono streak count drawn at `moneyXl` (56pt) — the hero number is
+    /// the screen's focal point (`SPMore4.jsx`, audit P2-3 #289).
     let streakBigLabel: UILabel = {
         let label = UILabel()
-        label.font = AppTypography.moneyLg
+        label.font = AppTypography.moneyXl
         label.textColor = AppColors.fg1
         label.adjustsFontForContentSizeCategory = false
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -180,6 +190,13 @@ final class StatisticsViewController: UIViewController {
         contentStack.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(scrollView)
         scrollView.addSubview(contentStack)
+        view.addSubview(emptyState)
+        NSLayoutConstraint.activate([
+            emptyState.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            emptyState.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            emptyState.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            emptyState.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        ])
     }
 
     private func installContainerConstraints() {
@@ -229,6 +246,15 @@ final class StatisticsViewController: UIViewController {
     }
 
     private func refresh() {
+        // Empty state — no charges and no wake events means the three cards
+        // would all read empty, so show the "Пока нечего считать" column
+        // instead (`SPMore.jsx` `EmptyStats`, #289).
+        let isEmpty = viewModel.charges.isEmpty && viewModel.wakeDays.isEmpty
+        emptyState.isHidden = !isEmpty
+        emptyState.setStreak(viewModel.streak)
+        scrollView.isHidden = isEmpty
+        if isEmpty { return }
+
         // Hero streak card.
         let streak = viewModel.streak
         streakBigLabel.text = "\(streak)"

--- a/SnoozePay/SnoozePay/ViewControllers/Statistics/StreakModalViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Statistics/StreakModalViewController.swift
@@ -214,7 +214,7 @@ final class StreakModalViewController: UIViewController {
     private func configurePipStrip() {
         pipStrip.axis = .horizontal
         pipStrip.distribution = .fillEqually
-        pipStrip.spacing = AppSpacing.sp1
+        pipStrip.spacing = 6  // pip gap per design (#289), between sp1/sp2
         pipStrip.alignment = .fill
         pipStrip.translatesAutoresizingMaskIntoConstraints = false
         // 7 numbered green pips. Streaks < 7 fade out future pips by lowering
@@ -303,9 +303,9 @@ final class StreakModalViewController: UIViewController {
         sheet.addSubview(stack)
 
         NSLayoutConstraint.activate([
-            // Sheet anchored to the bottom with screen-inset margins.
-            sheet.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: AppSpacing.sp3),
-            sheet.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -AppSpacing.sp3),
+            // Sheet anchored to the bottom with screen-inset margins (16 — #289).
+            sheet.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: AppSpacing.sp4),
+            sheet.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -AppSpacing.sp4),
             sheet.bottomAnchor.constraint(
                 equalTo: view.safeAreaLayoutGuide.bottomAnchor,
                 constant: -AppSpacing.sp4

--- a/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
@@ -477,13 +477,20 @@ final class AlarmsListViewModel {
     // MARK: - V2 cell helpers
 
     /// Caps-styled day label for the V2 card top row.
-    /// Examples:
+    /// Examples (weekly):
     ///  - `[0,1,2,3,4]`             → `БУДНИ · ПН–ПТ`
     ///  - `[5,6]`                   → `ВЫХОДНЫЕ`
     ///  - `[0,1,2,3,4,5,6]`         → `КАЖДЫЙ ДЕНЬ`
     ///  - `[]`                      → `ЕДИНОЖДЫ`
     ///  - `[1,3]`, with name "Спорт" → `СПОРТ · ВТ, ЧТ`
     ///  - `[0]`, name empty/default → `ПН`
+    ///
+    /// One-shot alarms (`repeatMode == .never`) with a non-empty day set are
+    /// kept visually distinct from the weekly ones so the user can tell "rings
+    /// once on the next Mon–Fri" apart from "rings every Mon–Fri" (#289):
+    ///  - `.never`, `[0,1,2,3,4]`   → `ЕДИНОЖДЫ · ПН–ПТ`
+    ///  - `.never`, `[1,3]`         → `ЕДИНОЖДЫ · ВТ, ЧТ`
+    ///  - `.never`, `[]`            → `ЕДИНОЖДЫ`
     ///
     /// Combines the alarm's user-set `name` with the weekday set when the
     /// name is non-default — otherwise renders the weekday phrase alone. The
@@ -492,7 +499,10 @@ final class AlarmsListViewModel {
     func alarmDaysCaps(at index: Int) -> String {
         guard index < alarms.count else { return "" }
         let alarm = alarms[index]
-        let daysPhrase = Self.weekdayPhrase(for: alarm.repeatDays).uppercased()
+        let daysPhrase = Self.weekdayPhrase(
+            for: alarm.repeatDays,
+            repeatMode: alarm.repeatMode
+        ).uppercased()
         let trimmed = alarm.name.trimmingCharacters(in: .whitespacesAndNewlines)
         // Default name "Будильник" is suppressed in the caps row — it's the
         // boilerplate label every freshly-created alarm carries and would
@@ -508,17 +518,30 @@ final class AlarmsListViewModel {
     /// `Alarm.repeatDaysDescription` shape but always returns a Russian
     /// label suitable for the caps line (no "Единожды" en dash collapsing
     /// the alarm into an unintelligible "·" pair when there's no name).
-    private static func weekdayPhrase(for days: [Int]) -> String {
+    ///
+    /// `repeatMode` decides whether the weekly grouping aliases
+    /// ("Будни · Пн–Пт", "Выходные", "Каждый день") apply: those imply a
+    /// recurring alarm, so a one-shot (`.never`) alarm with days set instead
+    /// renders "Единожды · <day list>" to stay distinguishable from the
+    /// weekly variant (#289).
+    static func weekdayPhrase(
+        for days: [Int],
+        repeatMode: AlarmRepeatMode = .weekly
+    ) -> String {
         guard !days.isEmpty else { return "Единожды" }
         let names = ["Пн", "Вт", "Ср", "Чт", "Пт", "Сб", "Вс"]
         let sorted = days.sorted()
-        if sorted == Array(0...6) { return "Каждый день" }
-        if sorted == [0, 1, 2, 3, 4] { return "Будни · Пн–Пт" }
-        if sorted == [5, 6] { return "Выходные" }
-        return sorted.compactMap { index -> String? in
+        let dayList = sorted.compactMap { index -> String? in
             guard index >= 0, index < names.count else { return nil }
             return names[index]
         }.joined(separator: ", ")
+        if repeatMode == .never {
+            return dayList.isEmpty ? "Единожды" : "Единожды · \(dayList)"
+        }
+        if sorted == Array(0...6) { return "Каждый день" }
+        if sorted == [0, 1, 2, 3, 4] { return "Будни · Пн–Пт" }
+        if sorted == [5, 6] { return "Выходные" }
+        return dayList
     }
 
     /// Price pill text — bare "50 ₽" formatted via `Decimal.formattedRubles`

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPStatsEmptyState.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPStatsEmptyState.swift
@@ -1,0 +1,173 @@
+import UIKit
+
+/// Empty-state column for the behavioural statistics screen (V3 design).
+///
+/// Reference: `docs/design/v2-handoff/components/SPMore.jsx` L447-480
+/// (`EmptyStats`). Shown when the user has no charges and no recorded wake
+/// events — there is nothing to aggregate yet, so the three behavioural cards
+/// would all read empty (audit P2-3 #289).
+///
+/// Visual:
+/// ```
+///                ┌───────────┐
+///                │    📊     │   <- 84×84 soft money-tint rounded square
+///                └───────────┘
+///            Пока нечего считать          <- h2 fg1
+///   Статистика появится после первой
+///   недели использования.                <- body-lg fg2
+///        ( 🔥 Стрик · 2 дня )            <- money-tinted pill
+/// ```
+final class SPStatsEmptyState: UIView {
+
+    // MARK: - Subviews
+
+    /// 84×84 rounded square with the soft money tint + money-400 border from
+    /// the JSX recipe (`linear-gradient(135deg, rgba(46,219,159,.16),
+    /// rgba(46,219,159,.04))`, `1px solid rgba(46,219,159,.25)`).
+    private let iconHost: SPGradientView = {
+        let view = SPGradientView(
+            colors: [
+                AppColors.money400.withAlphaComponent(0.16).cgColor,
+                AppColors.money400.withAlphaComponent(0.04).cgColor
+            ],
+            locations: [0.0, 1.0]
+        )
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.layer.cornerRadius = 24
+        view.layer.masksToBounds = true
+        view.layer.borderWidth = 1
+        view.layer.borderColor = AppColors.money400.withAlphaComponent(0.25).cgColor
+        return view
+    }()
+
+    private let iconView: UIImageView = {
+        let view = UIImageView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.contentMode = .scaleAspectFit
+        view.tintColor = AppColors.money400
+        let config = UIImage.SymbolConfiguration(pointSize: 36, weight: .semibold)
+        view.image = UIImage(systemName: "chart.bar.xaxis", withConfiguration: config)
+        return view
+    }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "Пока нечего считать"
+        label.font = AppTypography.h2
+        label.textColor = AppColors.fg1
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        return label
+    }()
+
+    private let subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "Статистика появится после первой недели использования."
+        label.font = AppTypography.bodyLg
+        label.textColor = AppColors.fg2
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        return label
+    }()
+
+    /// Money-tinted pill: flame icon + "Стрик · N дня".
+    private let streakChip = UIView()
+    private let streakChipLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = AppTypography.meta
+        label.textColor = AppColors.money300
+        return label
+    }()
+
+    // MARK: - Init
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Public API
+
+    /// Update the streak chip's day count + Russian declension.
+    func setStreak(_ days: Int) {
+        let word = StreakModalViewController.dayWord(for: days)
+        streakChipLabel.text = "Стрик · \(days) \(word)"
+        // Hide the chip entirely when there is no streak to celebrate.
+        streakChip.isHidden = days <= 0
+    }
+
+    // MARK: - Configuration
+
+    private func configure() {
+        backgroundColor = .clear
+
+        iconHost.addSubview(iconView)
+        let chip = makeStreakChip()
+
+        let textStack = UIStackView(arrangedSubviews: [titleLabel, subtitleLabel])
+        textStack.axis = .vertical
+        textStack.alignment = .center
+        textStack.spacing = AppSpacing.sp2  // ~10pt
+        textStack.translatesAutoresizingMaskIntoConstraints = false
+
+        let column = UIStackView(arrangedSubviews: [iconHost, textStack, chip])
+        column.axis = .vertical
+        column.alignment = .center
+        column.spacing = AppSpacing.sp5  // 20 — icon→title gap per JSX
+        column.setCustomSpacing(AppSpacing.sp6, after: textStack)  // 24 — text→chip
+        column.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(column)
+
+        NSLayoutConstraint.activate([
+            iconHost.widthAnchor.constraint(equalToConstant: 84),
+            iconHost.heightAnchor.constraint(equalToConstant: 84),
+            iconView.centerXAnchor.constraint(equalTo: iconHost.centerXAnchor),
+            iconView.centerYAnchor.constraint(equalTo: iconHost.centerYAnchor),
+
+            column.centerYAnchor.constraint(equalTo: centerYAnchor),
+            column.centerXAnchor.constraint(equalTo: centerXAnchor),
+            column.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: AppSpacing.sp7),
+            column.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -AppSpacing.sp7),
+            textStack.widthAnchor.constraint(lessThanOrEqualToConstant: 280)
+        ])
+    }
+
+    private func makeStreakChip() -> UIView {
+        streakChip.translatesAutoresizingMaskIntoConstraints = false
+        streakChip.backgroundColor = AppColors.money400.withAlphaComponent(0.10)
+        streakChip.layer.cornerRadius = 999
+        streakChip.layer.borderWidth = 1
+        streakChip.layer.borderColor = AppColors.money400.withAlphaComponent(0.20).cgColor
+
+        let flame = UIImageView(
+            image: UIImage(
+                systemName: "flame.fill",
+                withConfiguration: UIImage.SymbolConfiguration(pointSize: 14, weight: .semibold)
+            )
+        )
+        flame.tintColor = AppColors.money400
+        flame.contentMode = .scaleAspectFit
+        flame.translatesAutoresizingMaskIntoConstraints = false
+
+        let row = UIStackView(arrangedSubviews: [flame, streakChipLabel])
+        row.axis = .horizontal
+        row.alignment = .center
+        row.spacing = AppSpacing.sp2
+        row.translatesAutoresizingMaskIntoConstraints = false
+        streakChip.addSubview(row)
+        NSLayoutConstraint.activate([
+            row.topAnchor.constraint(equalTo: streakChip.topAnchor, constant: 10),
+            row.bottomAnchor.constraint(equalTo: streakChip.bottomAnchor, constant: -10),
+            row.leadingAnchor.constraint(equalTo: streakChip.leadingAnchor, constant: AppSpacing.sp3),
+            row.trailingAnchor.constraint(equalTo: streakChip.trailingAnchor, constant: -AppSpacing.sp3)
+        ])
+        return streakChip
+    }
+}

--- a/SnoozePay/SnoozePayTests/AlarmsListCapsRowTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmsListCapsRowTests.swift
@@ -1,0 +1,146 @@
+import XCTest
+@testable import SnoozePay
+
+/// Caps-row matrix tests for the alarms-list day label (#289).
+///
+/// Covers `AlarmsListViewModel.weekdayPhrase(for:repeatMode:)` across the
+/// weekly × never recurrence and empty × weekday-set axes — the key being
+/// that a one-shot (`.never`) alarm with days set renders a distinct
+/// "Единожды · …" phrase rather than the weekly grouping aliases
+/// ("Будни · Пн–Пт" / "Выходные" / "Каждый день").
+final class AlarmsListCapsRowTests: XCTestCase {
+
+    /// No-op scheduler so `repo.save` never reaches `UNUserNotificationCenter`.
+    private final class NoopScheduler: AlarmScheduling {
+        func schedule(
+            _ alarm: Alarm,
+            completion: ((Result<Void, AlarmScheduler.SchedulingError>) -> Void)?
+        ) {
+            completion?(.success(()))
+        }
+        func cancel(_ alarmID: UUID) {}
+    }
+
+    private var testDefaults: UserDefaults!
+    private var suiteName: String!
+    private var repo: AlarmRepository!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "test.capsRow.\(UUID().uuidString)"
+        testDefaults = UserDefaults(suiteName: suiteName)!
+        repo = AlarmRepository(defaults: testDefaults, scheduler: NoopScheduler())
+    }
+
+    override func tearDown() {
+        testDefaults.removePersistentDomain(forName: suiteName)
+        super.tearDown()
+    }
+
+    // MARK: - weekdayPhrase matrix (pure)
+
+    func testWeekly_weekdaySet_groupsAsBudni() {
+        XCTAssertEqual(
+            AlarmsListViewModel.weekdayPhrase(for: [0, 1, 2, 3, 4], repeatMode: .weekly),
+            "Будни · Пн–Пт"
+        )
+    }
+
+    func testWeekly_weekendSet_groupsAsVyhodnye() {
+        XCTAssertEqual(
+            AlarmsListViewModel.weekdayPhrase(for: [5, 6], repeatMode: .weekly),
+            "Выходные"
+        )
+    }
+
+    func testWeekly_fullWeek_groupsAsEveryDay() {
+        XCTAssertEqual(
+            AlarmsListViewModel.weekdayPhrase(for: Array(0...6), repeatMode: .weekly),
+            "Каждый день"
+        )
+    }
+
+    func testWeekly_arbitrarySet_listsDays() {
+        XCTAssertEqual(
+            AlarmsListViewModel.weekdayPhrase(for: [1, 3], repeatMode: .weekly),
+            "Вт, Чт"
+        )
+    }
+
+    func testWeekly_emptyDays_isEdinozhdy() {
+        XCTAssertEqual(
+            AlarmsListViewModel.weekdayPhrase(for: [], repeatMode: .weekly),
+            "Единожды"
+        )
+    }
+
+    func testNever_weekdaySet_prefixedEdinozhdy_notBudni() {
+        // The crux of #289 — a one-shot with the Mon–Fri set must NOT collapse
+        // into the weekly "Будни · Пн–Пт" alias.
+        let phrase = AlarmsListViewModel.weekdayPhrase(for: [0, 1, 2, 3, 4], repeatMode: .never)
+        XCTAssertEqual(phrase, "Единожды · Пн, Вт, Ср, Чт, Пт")
+        XCTAssertFalse(phrase.contains("Будни"))
+    }
+
+    func testNever_weekendSet_prefixedEdinozhdy_notVyhodnye() {
+        let phrase = AlarmsListViewModel.weekdayPhrase(for: [5, 6], repeatMode: .never)
+        XCTAssertEqual(phrase, "Единожды · Сб, Вс")
+        XCTAssertFalse(phrase.contains("Выходные"))
+    }
+
+    func testNever_fullWeek_prefixedEdinozhdy_notEveryDay() {
+        let phrase = AlarmsListViewModel.weekdayPhrase(for: Array(0...6), repeatMode: .never)
+        XCTAssertEqual(phrase, "Единожды · Пн, Вт, Ср, Чт, Пт, Сб, Вс")
+        XCTAssertFalse(phrase.contains("Каждый день"))
+    }
+
+    func testNever_arbitrarySet_prefixedEdinozhdy() {
+        XCTAssertEqual(
+            AlarmsListViewModel.weekdayPhrase(for: [1, 3], repeatMode: .never),
+            "Единожды · Вт, Чт"
+        )
+    }
+
+    func testNever_emptyDays_isEdinozhdy() {
+        XCTAssertEqual(
+            AlarmsListViewModel.weekdayPhrase(for: [], repeatMode: .never),
+            "Единожды"
+        )
+    }
+
+    // MARK: - alarmDaysCaps through the view model
+
+    func testCapsRow_weeklyWeekdays_upperCased() {
+        let alarm = Alarm(repeatDays: [0, 1, 2, 3, 4], penaltyAmount: 50, repeatMode: .weekly)
+        repo.save(alarm)
+        let vm = AlarmsListViewModel(alarmRepository: repo, balanceService: .shared)
+        vm.loadData()
+        XCTAssertEqual(vm.alarmDaysCaps(at: 0), "БУДНИ · ПН–ПТ")
+    }
+
+    func testCapsRow_oneShotWeekdays_distinctFromWeekly() {
+        let alarm = Alarm(repeatDays: [0, 1, 2, 3, 4], penaltyAmount: 50, repeatMode: .never)
+        repo.save(alarm)
+        let vm = AlarmsListViewModel(alarmRepository: repo, balanceService: .shared)
+        vm.loadData()
+        let caps = vm.alarmDaysCaps(at: 0)
+        XCTAssertEqual(caps, "ЕДИНОЖДЫ · ПН, ВТ, СР, ЧТ, ПТ")
+        XCTAssertFalse(caps.contains("БУДНИ"))
+    }
+
+    func testCapsRow_oneShotNoDays_isEdinozhdy() {
+        let alarm = Alarm(repeatDays: [], penaltyAmount: 50, repeatMode: .never)
+        repo.save(alarm)
+        let vm = AlarmsListViewModel(alarmRepository: repo, balanceService: .shared)
+        vm.loadData()
+        XCTAssertEqual(vm.alarmDaysCaps(at: 0), "ЕДИНОЖДЫ")
+    }
+
+    func testCapsRow_namedOneShot_prefixesName() {
+        let alarm = Alarm(repeatDays: [1, 3], name: "Спорт", penaltyAmount: 50, repeatMode: .never)
+        repo.save(alarm)
+        let vm = AlarmsListViewModel(alarmRepository: repo, balanceService: .shared)
+        vm.loadData()
+        XCTAssertEqual(vm.alarmDaysCaps(at: 0), "СПОРТ · ЕДИНОЖДЫ · ВТ, ЧТ")
+    }
+}


### PR DESCRIPTION
Fixes #289

## Что сделано
- **Stats hero**: streak number → moneyXl 56pt mono; hero card radius 24 + 24v/20h padding.
- **Stats empty state** (`SPStatsEmptyState`): «Пока нечего считать» + «Статистика появится после первой недели использования» + money-tinted streak chip; shown when no charges AND no wake events (`SPMore.jsx` EmptyStats).
- **Heatmap tooltip swatch**: gradient fill matching the tapped cell (woke/light/heavy), flat tone only for empty.
- **Streak modal**: side insets 16 (was 12), pip gap 6 (was 4).
- **Onboarding**: dots→CTA gap 24 on pages 1/2 (page 3 stays 14); «−50 ₽» penalty pill → mono (moneySm).
- **Splash**: canvas → bg1 (#0E1320); title→subtitle gap 20 (was 12).
- **Permissions granted icon**: money gradient fill (was flat money500).
- **AlarmsList caps row**: one-shot (`repeatMode == .never`) alarm with days set now renders «ЕДИНОЖДЫ · ПН, ВТ, …» instead of collapsing into the weekly «БУДНИ · ПН–ПТ» alias — distinguishable from weekly.

## Verify
- ✅ swiftlint: 0 errors (4 pre-existing `x`/`y` warnings in HeatmapView, untouched)
- ✅ xcodebuild build: succeeded (iPhone 17 Pro Max sim, CODE_SIGNING_ALLOWED=NO)
- ✅ xcodebuild build-for-testing: succeeded — new `AlarmsListCapsRowTests` compiles into the test target
- Tests added: caps-row matrix (weekly/never × empty/weekday sets) in `AlarmsListCapsRowTests.swift` (15 cases); CI runs the suite.

## Scope notes
- Stats changes are visual only (VC/views) — did NOT touch `computeStreak`/`WakeEventStore` (#276 agent's scope).
- AlarmsListViewModel diff is limited to the caps-row formatting function (`alarmDaysCaps`/`weekdayPhrase`).