### PR TITLE
[ui] Firing polish pack — gold CTA, ticker pills, glow geometry, sheet header (#288)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Layout.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Layout.swift
@@ -25,16 +25,14 @@ extension AlarmFiringViewController {
         installHeroCenter()
 
         // VM exposes `currentPenalty` as `Double`; wrap in `Decimal` so
-        // `SPSnoozePrice.formattedRubles()` does the locale-aware format.
-        // Tone defaults to warn; progressive alarms cross-fade toward pain
-        // as snoozeCount climbs.
-        let initialTone: SPSnoozePrice.Tone = viewModel.isProgressiveActive
-            ? .progressive(intensity: viewModel.progressiveIntensity)
-            : .warn
+        // `SPSnoozePrice.formattedRubles()` does the locale-aware format. The
+        // CTA stays GOLD (`.warn`) on every step, progressive or not (#288) —
+        // escalation lives in the background tone + indicator pill, not the
+        // button colour.
         let snooze = SPSnoozePrice(
             price: Decimal(viewModel.currentPenalty),
             minutes: viewModel.alarm.snoozeMinutes,
-            tone: initialTone,
+            tone: .warn,
             hint: snoozeHintText()
         )
         snooze.translatesAutoresizingMaskIntoConstraints = false
@@ -43,6 +41,9 @@ extension AlarmFiringViewController {
         snoozeCTA = snooze
 
         dismissButton.translatesAutoresizingMaskIntoConstraints = false
+        // Heavier ghost stroke for the wake CTA: 1.5pt white at .22 alpha
+        // (`SPThemedFiring.jsx:188-203`).
+        dismissButton.ghostBorderOverride = (1.5, UIColor.white.withAlphaComponent(0.22))
         dismissButton.addTarget(self, action: #selector(dismissTapped), for: .touchUpInside)
         view.addSubview(dismissButton)
         view.addSubview(audioWarningBanner)
@@ -51,21 +52,21 @@ extension AlarmFiringViewController {
         let gap: CGFloat = 10                     // 10pt CTA gap — matches SPScreensV2 line 91 ("gap: 12")
 
         // Progressive escalation chrome — only mounted for alarms with the
-        // doubling-penalty toggle. The default flow stays clean. Anchor the
-        // audio-fallback banner to the chrome's top so the banner never
-        // overlaps the indicator when both are on screen.
-        let bannerBottomAnchor: NSLayoutYAxisAnchor
+        // doubling-penalty toggle. The default flow stays clean. The indicator
+        // pill + history ticker live in the CENTRE hero (below the eyebrow
+        // caps) per `SPDawnV3.jsx:114-136 / 216`, not above the CTA.
         if viewModel.isProgressiveActive {
             let stack = installProgressiveStack(inset: inset)
             NSLayoutConstraint.activate([
-                stack.bottomAnchor.constraint(equalTo: snooze.topAnchor, constant: -AppSpacing.sp3)
+                stack.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+                stack.topAnchor.constraint(
+                    equalTo: wakeUpCapsLabel.bottomAnchor,
+                    constant: AppSpacing.sp5
+                )
             ])
-            bannerBottomAnchor = stack.topAnchor
-        } else {
-            bannerBottomAnchor = snooze.topAnchor
         }
 
-        activateMainConstraints(snooze: snooze, bannerBottomAnchor: bannerBottomAnchor, inset: inset, gap: gap)
+        activateMainConstraints(snooze: snooze, bannerBottomAnchor: snooze.topAnchor, inset: inset, gap: gap)
 
         // No-balance stack overlays the same bottom area as the snooze CTA +
         // dismiss group. Initially hidden — `updateUI()` flips visibility
@@ -106,11 +107,9 @@ extension AlarmFiringViewController {
         // `updateBalancePill()` when the tone needs to flip to pain (zero).
         let balance = Int(viewModel.balance.rounded())
         let initialTone: SPPill.Tone = balance == 0 ? .pain : .money
-        let pill = SPPill(
-            text: "Баланс \(MoneyFormatter.string(balance))",
-            tone: initialTone,
-            icon: SPIcons.coin(size: 12)
-        )
+        let pill = SPPill(text: "", tone: initialTone, icon: SPIcons.coin(size: 12))
+        // Two-tier typography — muted «Баланс» label + bold value (#288).
+        pill.setBalance(label: "Баланс", value: MoneyFormatter.string(balance))
         pill.translatesAutoresizingMaskIntoConstraints = false
         balancePill = pill
 

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+NoBalance.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+NoBalance.swift
@@ -213,8 +213,8 @@ extension AlarmFiringViewController {
         noBalanceContainer?.isHidden = !needsNoBalance
         noBalanceCenterBlock?.isHidden = !needsNoBalance
         // Hide the normal-state group when the no-balance stack takes over.
-        // The progressive stack is also hidden (it sits above the snooze
-        // CTA and would orphan above a hidden card otherwise).
+        // The progressive chrome (centre-hero indicator pill + ticker) is also
+        // hidden so it doesn't float over the no-balance layout.
         snoozeCTA?.isHidden = needsNoBalance
         dismissButton.isHidden = needsNoBalance
         progressiveStack?.isHidden = needsNoBalance || !viewModel.isProgressiveActive

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Progressive.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Progressive.swift
@@ -4,26 +4,25 @@ import UIKit
 /// `AlarmFiringViewController` so the main type stays under SwiftLint's
 /// `type_body_length` cap (mirrors the same pattern used by the +Audio file).
 ///
-/// V2 spec (`SPDawnV3.jsx` lines 215–225): when `alarm.progressiveScale ==
-/// true` the firing screen mounts an indicator pill ("Прогрессив · N-е
-/// откладывание") above the snooze CTA, with a pain300 PulseDot to its left,
-/// and a single-line history ticker ("сегодня: −50 → −100 → −200 ₽") below.
-/// The snooze CTA itself cross-fades from warn → pain as the user keeps
-/// snoozing. None of this is touched for default alarms — the +Progressive
-/// installer is a no-op via guard at the call site.
+/// V2 spec (`SPDawnV3.jsx` lines 114-136 + 216-221): the indicator pill
+/// «Прогрессив · {n}-й поспать ещё» (with a pain300 PulseDot) is hidden until
+/// the first snooze, and below it a row of coloured mini-pill tickers
+/// summarises today's charges (amber < 200 ₽ / red ≥ 200 ₽) separated by «·».
+/// The snooze CTA itself stays GOLD on every step (#288). None of this chrome
+/// is mounted for default alarms — the installer is a no-op via the call site.
 extension AlarmFiringViewController {
 
-    /// Build the progressive-snooze indicator pill + history ticker stack
-    /// and pin it horizontally to the screen-inset. Pulse animation on the
-    /// dot is started here once — no need to restart on `updateUI()`.
-    /// Returns the stack so `setupUI` can wire it into the bottom layout.
+    /// Build the progressive-snooze indicator pill + history ticker stack and
+    /// pin it horizontally to the screen-inset. Pulse animation on the dot is
+    /// started here once — no need to restart on `updateUI()`. Returns the
+    /// stack so `setupUI` can wire it into the centre hero layout.
     func installProgressiveStack(inset: CGFloat) -> UIStackView {
-        // Pill: pain-toned per V2 spec line 217–222. Caps text re-titled on
+        // Pill: pain-toned per V2 spec line 217-222. Caps text re-titled on
         // every updateUI. The leading dot is drawn as a sibling 8pt circle
         // view rather than via `SPPill(icon:)` because we need the dot to
         // host its own pulse animation while the pill keeps its background
         // / text styling untouched.
-        let pill = SPPill(text: "Прогрессив · 1-е откладывание", tone: .pain)
+        let pill = SPPill(text: "Прогрессив · 1-й поспать ещё", tone: .pain)
         pill.translatesAutoresizingMaskIntoConstraints = false
         progressivePill = pill
 
@@ -40,30 +39,29 @@ extension AlarmFiringViewController {
         pillRow.axis = .horizontal
         pillRow.spacing = AppSpacing.sp1 + 2   // 6pt — matches SPPill's internal gap recipe
         pillRow.alignment = .center
+        // Hidden until the first snooze (`SPDawnV3.jsx:216`). `updateUI`
+        // un-hides it once `snoozeCount > 0`.
+        pillRow.isHidden = true
+        progressivePillRow = pillRow
 
-        let ticker = UILabel()
-        ticker.translatesAutoresizingMaskIntoConstraints = false
-        ticker.font = AppTypography.meta.monospacedDigit()
-        ticker.textColor = AppColors.fg3
-        ticker.textAlignment = .center
-        ticker.numberOfLines = 1
-        ticker.lineBreakMode = .byTruncatingHead
-        ticker.adjustsFontSizeToFitWidth = true
-        ticker.minimumScaleFactor = 0.7
-        ticker.isHidden = true
-        historyTicker = ticker
+        // Ticker chip row — rebuilt on every updateUI from the VM's history.
+        // Starts empty / hidden; the container reserves the slot in the stack.
+        let tickerContainer = UIStackView()
+        tickerContainer.axis = .vertical
+        tickerContainer.alignment = .center
+        historyTickerContainer = tickerContainer
 
-        let stack = UIStackView(arrangedSubviews: [pillRow, ticker])
+        let stack = UIStackView(arrangedSubviews: [pillRow, tickerContainer])
         stack.translatesAutoresizingMaskIntoConstraints = false
         stack.axis = .vertical
         stack.alignment = .center
-        stack.spacing = AppSpacing.sp2
+        stack.spacing = AppSpacing.sp3
         view.addSubview(stack)
         progressiveStack = stack
 
         NSLayoutConstraint.activate([
-            stack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: inset),
-            stack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -inset),
+            stack.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: inset),
+            stack.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor, constant: -inset),
             dot.widthAnchor.constraint(equalToConstant: 8),
             dot.heightAnchor.constraint(equalToConstant: 8)
         ])
@@ -72,30 +70,45 @@ extension AlarmFiringViewController {
         return stack
     }
 
-    /// Refresh the indicator pill text + the history ticker. Called from
-    /// `updateUI()` so the indicator counts up (`1-й` → `2-й` → ...) and
-    /// the ticker grows as the user keeps snoozing.
-    func updateProgressiveChrome() {
-        let nextIndex = viewModel.snoozeCount + 1
-        progressivePill?.setText("Прогрессив · \(nextIndex)-е откладывание")
+    /// Indicator pill copy «Прогрессив · {n}-й поспать ещё» where
+    /// n = snoozeCount + 1 (`SPDawnV3.jsx:219-221`). Pure function so the copy
+    /// is unit-testable without loading the view hierarchy.
+    static func progressivePillText(snoozeCount: Int) -> String {
+        "Прогрессив · \(snoozeCount + 1)-й поспать ещё"
+    }
 
-        guard let ticker = historyTicker else { return }
-        let past = viewModel.pastPenalties
-        if past.isEmpty {
-            // No history yet — keep the pill, hide the ticker.
-            ticker.isHidden = true
-            ticker.text = nil
+    /// `true` when the indicator pill should be visible — only after the first
+    /// snooze (`SPDawnV3.jsx:216`). Pure for the same testability reason.
+    static func progressivePillVisible(snoozeCount: Int) -> Bool {
+        snoozeCount > 0
+    }
+
+    /// Refresh the indicator pill text + visibility and rebuild the history
+    /// ticker chips. Called from `updateUI()` so the indicator counts up
+    /// (`1-й` → `2-й` → ...) and the chip row grows as the user keeps snoozing.
+    func updateProgressiveChrome() {
+        progressivePill?.setText(Self.progressivePillText(snoozeCount: viewModel.snoozeCount))
+        progressivePillRow?.isHidden = !Self.progressivePillVisible(snoozeCount: viewModel.snoozeCount)
+
+        rebuildTicker()
+    }
+
+    /// Replace the ticker chip row in place with one built from the VM's
+    /// current penalty history. Coloured mini-pills with «·» separators per
+    /// `SPDawnV3.jsx:114-136`.
+    private func rebuildTicker() {
+        guard let container = historyTickerContainer else { return }
+        container.arrangedSubviews.forEach {
+            container.removeArrangedSubview($0)
+            $0.removeFromSuperview()
+        }
+        let entries = SPFiringTicker.entries(from: viewModel.pastPenalties)
+        guard !entries.isEmpty else {
+            container.isHidden = true
             return
         }
-        var parts = past.map { "−\(Self.formatPenalty($0))" }
-        parts.append("−\(Self.formatPenalty(viewModel.currentPenalty))")
-        // Trailing currency glyph after the last amount only — keeps the
-        // arrow chain visually balanced ("−50 → −100 → −200 ₽").
-        if let last = parts.last {
-            parts[parts.count - 1] = "\(last)\(MoneyFormatter.narrowSpace)₽"
-        }
-        ticker.text = "сегодня: \(parts.joined(separator: " → "))"
-        ticker.isHidden = false
+        container.isHidden = false
+        container.addArrangedSubview(SPFiringTicker.makeRow(for: entries))
     }
 
     /// 0.4 → 1.0 opacity autoreverse pulse, 900ms each leg. Driven via
@@ -110,14 +123,5 @@ extension AlarmFiringViewController {
         pulse.autoreverses = true
         pulse.repeatCount = .infinity
         dot.layer.add(pulse, forKey: "progressivePulse")
-    }
-
-    /// Format a penalty amount for the history ticker. The ticker is a
-    /// glanceable single-line summary, so we strip thousand separators and
-    /// the currency glyph (`formattedRubles` adds " ₽" to each value).
-    /// Trailing fraction is dropped — the doubling rule produces integers.
-    private static func formatPenalty(_ amount: Double) -> String {
-        let intValue = Int(amount.rounded())
-        return "\(intValue)"
     }
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+ViewLifecycle.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+ViewLifecycle.swift
@@ -23,17 +23,45 @@ extension AlarmFiringViewController {
         timeLabel.text = AlarmFiringTimeFormatter.string(from: Date())
     }
 
+    // MARK: Clock mount animation
+
+    /// Seed the clock's pre-entrance state: invisible, slightly enlarged (a
+    /// soft "out-of-focus" proxy for the CA blur the design uses), and sunk
+    /// 8pt below its resting position. `SPDawnV3.jsx:48-67` fades + blurs +
+    /// rises the time on mount; CA blur on a live-ticking label is impractical,
+    /// so we approximate it with a subtle scale-down + alpha-up + 8pt rise.
+    func prepareClockMountState() {
+        timeLabel.alpha = 0
+        timeLabel.transform = CGAffineTransform(translationX: 0, y: 8)
+            .scaledBy(x: 1.04, y: 1.04)
+    }
+
+    /// Play the 800ms fade + blur-to-sharp + 8px rise entrance once the screen
+    /// is on-window. Keeps it subtle per the issue's caution.
+    func playClockMountAnimation() {
+        UIView.animate(
+            withDuration: 0.8,
+            delay: 0,
+            options: [.curveEaseOut, .beginFromCurrentState],
+            animations: {
+                self.timeLabel.alpha = 1
+                self.timeLabel.transform = .identity
+            }
+        )
+    }
+
     // MARK: Glow breathing
 
-    /// 4s ease-in-out autoreverse opacity pulse on the Dawn background's sun
-    /// layer. Driven via CABasicAnimation because the sun is a CAGradientLayer
-    /// (not a view). V2 spec retains the "breathing" character from V1 — the
-    /// warm radial just lives inside `SPDawnBackgroundView.sunLayer` now.
+    /// 8s ease-in-out autoreverse opacity pulse on the Dawn background's sun
+    /// layer (`SPDawnV3.jsx:3` — "медленно дышит (8s)"). Driven via
+    /// CABasicAnimation because the sun is a CAGradientLayer (not a view). V2
+    /// spec retains the "breathing" character from V1 — the warm radial just
+    /// lives inside `SPDawnBackgroundView.sunLayer` now.
     func startGlowBreathing() {
         let animation = CABasicAnimation(keyPath: "opacity")
         animation.fromValue = 0.55
         animation.toValue = 1.0
-        animation.duration = 4.0
+        animation.duration = 8.0
         animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
         animation.autoreverses = true
         animation.repeatCount = .infinity

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
@@ -159,11 +159,14 @@ class AlarmFiringViewController: UIViewController {
     /// `internal` so the +NoBalance extension can hide / show this when
     /// swapping between the normal (balance OK) and no-balance layouts.
     /// V2 spec calls for the full "Я встал — выключить" copy, ghost variant,
-    /// lg size, full-width — matches `SPScreensV2.jsx` line 98.
+    /// lg size, full-width, with a leading 18pt checkmark and a heavier 1.5pt
+    /// white .22 stroke — matches `SPThemedFiring.jsx:188-203`. The stroke
+    /// override is applied in `buildFiringLayout`.
     let dismissButton = SPButton(
         title: "Я встал — выключить",
         variant: .ghost,
         size: .lg,
+        icon: UIImage(systemName: "checkmark"),
         fullWidth: true
     )
 
@@ -225,20 +228,24 @@ class AlarmFiringViewController: UIViewController {
     /// entirely — they never enter the layout pass.
     var progressiveStack: UIStackView?
 
-    /// "Прогрессив · N-е откладывание" pill above the snooze CTA. Re-titled
+    /// "Прогрессив · {n}-й поспать ещё" pill in the centre hero. Re-titled
     /// on every `updateUI()` so the label tracks `snoozeCount + 1`. V2 spec
     /// uses pain tone with an inline pulsing dot.
     var progressivePill: SPPill?
+
+    /// Dot + pill wrapper row. Hidden until the first snooze
+    /// (`SPDawnV3.jsx:216`); `updateUI()` un-hides it once `snoozeCount > 0`.
+    var progressivePillRow: UIStackView?
 
     /// Pulsing dot rendered to the left of `progressivePill`. CABasicAnimation
     /// drives a 0.4 → 1.0 opacity autoreverse pulse on 900ms cadence
     /// (`durationAnxious`).
     var progressivePulseDot: UIView?
 
-    /// Single-line ticker rendered between the pill and the snooze CTA.
-    /// `meta` typography, fg-3, mono digits — "сегодня: −50 → −100 → ..."
-    /// Hidden when `snoozeCount == 0` (no history to show yet).
-    var historyTicker: UILabel?
+    /// Container that hosts the history ticker chip row (coloured mini-pills
+    /// with «·» separators — amber < 200 ₽ / red ≥ 200 ₽). Rebuilt in place on
+    /// every `updateUI()`; hidden when `snoozeCount == 0` (no history yet).
+    var historyTickerContainer: UIStackView?
 
     /// Banner shown when AudioService falls back to vibration / silent mode.
     /// Hidden by default; surfaces only on `.silentBecauseConfigFailed` or
@@ -322,6 +329,15 @@ class AlarmFiringViewController: UIViewController {
         // Initial transition may have happened synchronously inside
         // `startAlarmSound` before our observer is wired — sync now.
         applyAudioState(AudioService.shared.state)
+
+        // Seed the clock's pre-mount state (faded, soft, sunk 8pt). The
+        // entrance animation plays in `viewDidAppear`.
+        prepareClockMountState()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        playClockMountAnimation()
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -365,7 +381,7 @@ class AlarmFiringViewController: UIViewController {
 
         // Refresh snooze CTA — VM may have bumped `snoozeCount` (progressive
         // scaling) since the last update, which changes `currentPenalty`.
-        // The hint surfaces "Следующее откладывание: N ₽" when progressive
+        // The hint surfaces «следующее откладывание: N ₽» when progressive
         // is active and not at max, mirroring `SPScreensV2.jsx` line 96.
         if let snooze = snoozeCTA {
             snooze.update(
@@ -374,12 +390,9 @@ class AlarmFiringViewController: UIViewController {
                 hint: snoozeHintText()
             )
             snooze.isEnabled = viewModel.canSnooze
-            if viewModel.isProgressiveActive {
-                // Cross-fade the gradient toward pain as snoozeCount climbs.
-                // SPSnoozePrice.setTone is a no-op when intensity hasn't
-                // moved, so calling it on every updateUI() is cheap.
-                snooze.setTone(.progressive(intensity: viewModel.progressiveIntensity))
-            }
+            // The CTA stays GOLD on every progressive step (#288). Escalation
+            // is carried by the background tone crossfade + the indicator pill,
+            // never by reddening the button — so we no longer re-tone it here.
         }
 
         if viewModel.isProgressiveActive {
@@ -403,8 +416,9 @@ class AlarmFiringViewController: UIViewController {
         viewModel.canSnooze ? "Пора вставать" : "Только встать"
     }
 
-    /// Snooze CTA hint — "Следующее откладывание: N ₽" when progressive is
-    /// active and not at the price ceiling. Mirrors `SPScreensV2.jsx` line 96.
+    /// Snooze CTA hint — «следующее откладывание: N ₽» (lowercase per
+    /// `SPDawnV3.jsx:240`) when progressive is active and not at the price
+    /// ceiling. Mirrors `SPScreensV2.jsx` line 96.
     /// V1 passed nil here; V2 surfaces the escalating cost so the user can
     /// see what they're agreeing to. Once the ladder caps at `base × 8` there
     /// is no higher price to show, so we swap in the max-step copy
@@ -420,7 +434,8 @@ class AlarmFiringViewController: UIViewController {
         }
         let next = viewModel.alarm.penalty(forSnoozeCount: nextCount)
         let nextInt = Int(next.rounded())
-        return "Следующее откладывание: \(MoneyFormatter.string(nextInt))"
+        // Lowercase «следующее откладывание: …» per `SPDawnV3.jsx:240`.
+        return "следующее откладывание: \(MoneyFormatter.string(nextInt))"
     }
 
     /// Refresh the top-right balance pill so the displayed amount + tone
@@ -430,21 +445,23 @@ class AlarmFiringViewController: UIViewController {
         let balance = Int(viewModel.balance.rounded())
         let tone: SPPill.Tone = balance == 0 ? .pain : .money
         guard let pill = balancePill else { return }
-        pill.setText("Баланс \(MoneyFormatter.string(balance))")
+        let value = MoneyFormatter.string(balance)
+        pill.setBalance(label: "Баланс", value: value)
         // SPPill's `tone` is `let` (constructor-only), so we re-build when
         // the tone needs to flip between money and pain. Cheap — pill is a
         // 26pt-tall capsule with two labels.
         if pill.tone != tone {
-            rebuildBalancePill(tone: tone, text: "Баланс \(MoneyFormatter.string(balance))")
+            rebuildBalancePill(tone: tone, value: value)
         }
     }
 
     /// Replace the existing balance pill with a new instance using the
     /// supplied tone. Used when the balance crosses the 0 ↔ positive
     /// boundary and the chip needs to flip from money → pain or back.
-    private func rebuildBalancePill(tone: SPPill.Tone, text: String) {
+    private func rebuildBalancePill(tone: SPPill.Tone, value: String) {
         guard let old = balancePill else { return }
-        let new = SPPill(text: text, tone: tone, icon: SPIcons.coin(size: 12))
+        let new = SPPill(text: "", tone: tone, icon: SPIcons.coin(size: 12))
+        new.setBalance(label: "Баланс", value: value)
         new.translatesAutoresizingMaskIntoConstraints = false
         if let index = topHeaderRow.arrangedSubviews.firstIndex(of: old) {
             topHeaderRow.removeArrangedSubview(old)
@@ -461,7 +478,9 @@ class AlarmFiringViewController: UIViewController {
         let tone: SPDawnBackgroundView.Tone
         if !viewModel.canSnooze {
             tone = .drained
-        } else if viewModel.isProgressiveActive && viewModel.progressiveIntensity >= 0.5 {
+        } else if viewModel.isProgressiveActive && viewModel.currentPenalty >= 200 {
+            // Tense once the live snooze price crosses 200 ₽ (`SPDawnV3.jsx:
+            // 185` — `price >= 200 ? "tense"`), not at the intensity midpoint.
             tone = .tense
         } else {
             tone = .calm

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/FiringTopUpBottomSheetViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/FiringTopUpBottomSheetViewController.swift
@@ -6,11 +6,12 @@ import os
 /// to top up the wallet mid-alarm so they can keep snoozing.
 ///
 /// V2 spec: `docs/design/v2-handoff/components/SPTopUp.jsx`
-/// `FiringTopUpPresets` (lines 103–197). Three preset rows feed a single Apple
-/// Pay primary CTA; each row's amount is the catalogue amount of its mapped SKU
-/// (#275) so display == charge == credit. Visuals match the V2 design
-/// system — bg2 surface, 28pt top corners, caps "ПОПОЛНИТЬ" + close X header,
-/// SPAmountPreset row, money-toned Apple Pay button, footer meta.
+/// `FiringTopUpPresets` (lines 103–197). Three vertical preset rows feed a
+/// single Apple Pay primary CTA; each row's amount is the catalogue amount of
+/// its mapped SKU (#275/#297) so display == charge == credit. Visuals match the
+/// V2 design system — bg1 surface, 28pt top corners, a pulsing warn dot + caps
+/// «Будильник на паузе · MM:SS» + h2 «Пополнить баланс» header, full-width
+/// preset rows, money-toned Apple Pay button, footer meta.
 ///
 /// Side effects beyond pixel layout:
 /// - On `viewWillAppear` the alarm audio + escalation timer are paused via
@@ -36,7 +37,11 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
         /// of `productID` for the current catalogue (or the real product price
         /// once `StoreKitService` has loaded it).
         let amount: Int
+        /// Row title — «+1 откладывание» / «+несколько» / «+неделя»
+        /// (`SPTopUp.jsx:106-108`).
         let label: String
+        /// Row subtitle hint — «ровно на сейчас» etc (`SPTopUp.jsx:106-108`).
+        let hint: String
         let popular: Bool
         /// StoreKit product ID. Falls back to `BalanceService.topUp(amount:)`
         /// when not loaded so debug paths still credit the wallet — with the
@@ -46,21 +51,32 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
         /// Build a preset whose displayed amount is the catalogue amount of the
         /// supplied SKU. Returns nil for an unknown SKU so we never render an
         /// invented number.
-        init?(productID: String, label: String, popular: Bool) {
+        init?(productID: String, label: String, hint: String, popular: Bool) {
             guard let catalogAmount = StoreKitService.catalogAmount(for: productID) else { return nil }
             self.amount = catalogAmount
             self.label = label
+            self.hint = hint
             self.popular = popular
             self.productID = productID
         }
     }
 
     /// Default preset list. Amounts are resolved from the SKU catalogue so each
-    /// tile shows exactly what the App Store charges and the ledger credits.
+    /// row shows exactly what the App Store charges and the ledger credits
+    /// (#297). Labels / hints follow `SPTopUp.jsx:106-108`.
     static let defaultPresets: [Preset] = [
-        Preset(productID: "com.snooze_pay.balance.149", label: "ровно на сейчас", popular: false),
-        Preset(productID: "com.snooze_pay.balance.499", label: "на пару дней", popular: true),
-        Preset(productID: "com.snooze_pay.balance.999", label: "забыть про баланс", popular: false)
+        Preset(
+            productID: "com.snooze_pay.balance.149",
+            label: "+1 откладывание", hint: "ровно на сейчас", popular: false
+        ),
+        Preset(
+            productID: "com.snooze_pay.balance.499",
+            label: "+несколько", hint: "на пару дней", popular: true
+        ),
+        Preset(
+            productID: "com.snooze_pay.balance.999",
+            label: "+неделя", hint: "забыть про баланс", popular: false
+        )
     ].compactMap { $0 }
 
     // MARK: - Configuration
@@ -113,15 +129,26 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
         return view
     }()
 
-    /// Caps "ПОПОЛНИТЬ" header — fg3 colour matches `SPTopUp.jsx` line 137.
-    private let titleCapsLabel: UILabel = {
+    /// h2 «Пополнить баланс» header (`SPTopUp.jsx:138`).
+    private let titleH2Label: UILabel = {
         let label = UILabel()
+        label.font = AppTypography.h2
+        label.textColor = .white
+        label.text = "Пополнить баланс"
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
 
-    /// Optional pause countdown label "Будильник на паузе · 00:54". Rendered
-    /// inline with the title row. Mirrors SPTopUp line 137.
+    /// Pulsing 8pt warn dot to the left of the pause caps (`SPTopUp.jsx:136`).
+    private let pauseDot: UIView = {
+        let view = UIView()
+        view.backgroundColor = AppColors.warn400
+        view.layer.cornerRadius = 4
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    /// Caps pause countdown «Будильник на паузе · 00:54» (`SPTopUp.jsx:137`).
     private let pauseLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -151,13 +178,13 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
         return label
     }()
 
-    /// Horizontal row of `SPAmountPreset` tiles. V2 spec arranges three
-    /// presets edge-to-edge with equal width — `distribution = .fillEqually`.
-    private var presetTiles: [SPAmountPreset] = []
+    /// Vertical column of full-width preset rows (`SPTopUp.jsx:144-175`): each
+    /// row shows the «+1 откладывание» title + hint on the left and the rouble
+    /// amount + a check chip on the right when selected.
+    private var presetRows: [FiringTopUpPresetRow] = []
     private let presetStack: UIStackView = {
         let stack = UIStackView()
-        stack.axis = .horizontal
-        stack.distribution = .fillEqually
+        stack.axis = .vertical
         stack.spacing = AppSpacing.sp2
         stack.translatesAutoresizingMaskIntoConstraints = false
         return stack
@@ -227,11 +254,10 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
 
     init(presets: [Preset] = defaultPresets) {
         self.presets = presets
-        // Default-select the "popular" preset per V2 spec line 107; fall back to
-        // the first preset if none are marked popular, then to 0 (no invented
-        // literal) if the list is empty — see #275.
-        self.selectedAmount = presets.first(where: { $0.popular })?.amount
-            ?? presets.first?.amount ?? 0
+        // Default-select the SMALLEST preset per `SPTopUp.jsx:118` (the sheet
+        // opens pre-selecting the cheapest "ровно на сейчас" tier). Falls back
+        // to 0 (no invented literal) if the list is empty — see #275/#297.
+        self.selectedAmount = presets.map(\.amount).min() ?? 0
         self.remainingSeconds = 60
         super.init(nibName: nil, bundle: nil)
         modalPresentationStyle = .pageSheet
@@ -240,9 +266,11 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
             // preset row + apple pay + footer). Falls back to .medium on
             // older runtimes.
             if #available(iOS 16.0, *) {
+                // ~560pt — header + three full-width preset rows + apple pay +
+                // footer. Taller than the old horizontal-tile comp (#288).
                 let custom = UISheetPresentationController.Detent.custom(
                     identifier: UISheetPresentationController.Detent.Identifier("snoozepay.topup")
-                ) { _ in 440 }
+                ) { _ in 560 }
                 sheet.detents = [custom, .large()]
             } else {
                 sheet.detents = [.medium(), .large()]
@@ -271,7 +299,8 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = AppColors.bg2
+        // Sheet surface bg1 per `SPTopUp.jsx:135-142` (#288).
+        view.backgroundColor = AppColors.bg1
         // Per the spec the firing screen overlay is dark; pin the sheet to
         // dark so SPAmountPreset / SPButton tokens resolve against the same
         // palette as the host VC.
@@ -311,28 +340,27 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
     // MARK: - Setup
 
     private func setupUI() {
-        // Header row: caps title + pause countdown stacked vertically on
-        // the left, close X on the right.
-        titleCapsLabel.attributedText = NSAttributedString(
-            string: "ПОПОЛНИТЬ",
-            attributes: [
-                .font: AppTypography.caps,
-                .kern: AppTypography.capsKerning,
-                .foregroundColor: AppColors.fg3
-            ]
-        )
+        // Header column (`SPTopUp.jsx:135-142`): a pulsing warn dot + caps
+        // pause countdown on top, then the h2 «Пополнить баланс». Close X sits
+        // top-right of the row.
 
         // Seed the subtitle with the real smallest preset amount (catalogue
         // amount of the cheapest SKU) so the "Минимум — N ₽" copy matches what
-        // the App Store actually charges — see #275.
+        // the App Store actually charges — see #275/#297.
         let minimumAmount = presets.map(\.amount).min() ?? 0
         subtitleLabel.text = "Минимум — \(MoneyFormatter.string(minimumAmount)) на следующее откладывание. "
             + "Можно больше, чтобы не возвращаться сюда."
 
-        let headerLeftStack = UIStackView(arrangedSubviews: [titleCapsLabel, pauseLabel])
+        let pauseRow = UIStackView(arrangedSubviews: [pauseDot, pauseLabel])
+        pauseRow.translatesAutoresizingMaskIntoConstraints = false
+        pauseRow.axis = .horizontal
+        pauseRow.spacing = AppSpacing.sp2   // 8pt — matches the JSX `gap: 8`
+        pauseRow.alignment = .center
+
+        let headerLeftStack = UIStackView(arrangedSubviews: [pauseRow, titleH2Label])
         headerLeftStack.translatesAutoresizingMaskIntoConstraints = false
         headerLeftStack.axis = .vertical
-        headerLeftStack.spacing = 2
+        headerLeftStack.spacing = AppSpacing.sp2   // 8pt between caps row and h2
         headerLeftStack.alignment = .leading
 
         let headerRow = UIStackView(arrangedSubviews: [headerLeftStack, closeButton])
@@ -340,6 +368,8 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
         headerRow.axis = .horizontal
         headerRow.alignment = .top
         headerRow.distribution = .equalSpacing
+
+        startPauseDotPulse()
 
         view.addSubview(dragHandle)
         view.addSubview(headerRow)
@@ -377,6 +407,9 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
 
             closeButton.widthAnchor.constraint(equalToConstant: 32),
             closeButton.heightAnchor.constraint(equalToConstant: 32),
+
+            pauseDot.widthAnchor.constraint(equalToConstant: 8),
+            pauseDot.heightAnchor.constraint(equalToConstant: 8),
 
             // Subtitle
             subtitleLabel.topAnchor.constraint(equalTo: headerRow.bottomAnchor, constant: AppSpacing.sp2),
@@ -429,16 +462,16 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
 
     private func setupPresetTiles() {
         for preset in presets {
-            let tile = SPAmountPreset(
-                value: Decimal(preset.amount),
-                label: preset.label,
-                selected: preset.amount == selectedAmount,
-                popular: preset.popular
+            let row = FiringTopUpPresetRow(
+                title: preset.label,
+                hint: preset.hint,
+                amount: preset.amount,
+                selected: preset.amount == selectedAmount
             ) { [weak self] in
                 self?.selectAmount(preset.amount)
             }
-            presetStack.addArrangedSubview(tile)
-            presetTiles.append(tile)
+            presetStack.addArrangedSubview(row)
+            presetRows.append(row)
         }
     }
 
@@ -497,8 +530,8 @@ extension FiringTopUpBottomSheetViewController {
     private func selectAmount(_ amount: Int) {
         guard amount != selectedAmount else { return }
         selectedAmount = amount
-        for (tile, preset) in zip(presetTiles, presets) {
-            tile.isSelected = preset.amount == amount
+        for (row, preset) in zip(presetRows, presets) {
+            row.isSelected = preset.amount == amount
         }
         rebuildApplePayButton()
     }
@@ -568,7 +601,8 @@ extension FiringTopUpBottomSheetViewController {
         )
         successContainer.isHidden = false
         UIView.animate(withDuration: SPSupport.durationBase) {
-            self.titleCapsLabel.alpha = 0
+            self.titleH2Label.alpha = 0
+            self.pauseDot.alpha = 0
             self.pauseLabel.alpha = 0
             self.subtitleLabel.alpha = 0
             self.presetStack.alpha = 0
@@ -630,14 +664,30 @@ extension FiringTopUpBottomSheetViewController {
         }
     }
 
+    /// 0.4 → 1.0 opacity autoreverse pulse on the warn dot, 1.6s each leg —
+    /// matches the `sp-pulse` keyframe the JSX warn dot rides (`SPTopUp.jsx:
+    /// 136`). CABasicAnimation so it keeps running through UIKit interactions.
+    private func startPauseDotPulse() {
+        let pulse = CABasicAnimation(keyPath: "opacity")
+        pulse.fromValue = 0.4
+        pulse.toValue = 1.0
+        pulse.duration = 1.6
+        pulse.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+        pulse.autoreverses = true
+        pulse.repeatCount = .infinity
+        pauseDot.layer.add(pulse, forKey: "pauseDotPulse")
+    }
+
     private func updatePauseLabel() {
         let minutes = remainingSeconds / 60
         let seconds = remainingSeconds % 60
         let countdown = String(format: "%02d:%02d", minutes, seconds)
+        // Caps «Будильник на паузе · MM:SS» per `SPTopUp.jsx:137`.
         let attributed = NSAttributedString(
-            string: "На паузе · \(countdown)",
+            string: "Будильник на паузе · \(countdown)".uppercased(),
             attributes: [
-                .font: AppTypography.meta.monospacedDigit(),
+                .font: AppTypography.caps.monospacedDigit(),
+                .kern: AppTypography.capsKerning,
                 .foregroundColor: AppColors.warn300
             ]
         )

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/FiringTopUpPresetRow.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/FiringTopUpPresetRow.swift
@@ -1,0 +1,132 @@
+import UIKit
+
+/// One full-width top-up preset row in the firing top-up sheet.
+///
+/// Spec — `SPTopUp.jsx:148-170`: a 16×20-padded, 16pt-radius row with the
+/// «+1 откладывание» title (h4) + hint (meta) on the left and the rouble
+/// amount (money-md) + a 22pt warn-gradient check chip on the right. Selected
+/// rows gain a warn400 border + a faint warn .08 wash and tint the amount
+/// warn400; unselected rows use a white08 hairline over a white04 fill.
+///
+/// The displayed amount is passed in by the sheet and is always the SKU's
+/// catalogue amount (#297) — this view never invents a number, it just renders
+/// what it's given.
+final class FiringTopUpPresetRow: UIControl {
+
+    private let titleLabel = UILabel()
+    private let hintLabel = UILabel()
+    private let amountLabel = UILabel()
+    private let checkChip = UIImageView()
+    private let amount: Int
+
+    private let onTap: () -> Void
+
+    override var isSelected: Bool {
+        didSet { refreshSelection() }
+    }
+
+    override var isHighlighted: Bool {
+        didSet { SPSupport.animatePress(self, pressed: isHighlighted) }
+    }
+
+    init(
+        title: String,
+        hint: String,
+        amount: Int,
+        selected: Bool,
+        onTap: @escaping () -> Void
+    ) {
+        self.amount = amount
+        self.onTap = onTap
+        super.init(frame: .zero)
+        translatesAutoresizingMaskIntoConstraints = false
+        configure(title: title, hint: hint)
+        isSelected = selected
+        refreshSelection()
+        addTarget(self, action: #selector(handleTap), for: .touchUpInside)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func configure(title: String, hint: String) {
+        layer.cornerRadius = AppRadius.md      // 16pt
+        layer.borderWidth = 1
+
+        titleLabel.text = title
+        titleLabel.font = AppTypography.h4
+        titleLabel.textColor = .white
+
+        hintLabel.text = hint
+        hintLabel.font = AppTypography.meta
+        hintLabel.textColor = AppColors.fg3
+
+        let leftStack = UIStackView(arrangedSubviews: [titleLabel, hintLabel])
+        leftStack.axis = .vertical
+        leftStack.spacing = 2
+        leftStack.alignment = .leading
+        leftStack.isUserInteractionEnabled = false
+        leftStack.translatesAutoresizingMaskIntoConstraints = false
+
+        amountLabel.font = AppTypography.moneyMd
+        amountLabel.translatesAutoresizingMaskIntoConstraints = false
+        amountLabel.text = MoneyFormatter.string(amount)
+
+        let configuration = UIImage.SymbolConfiguration(pointSize: 13, weight: .bold)
+        checkChip.image = UIImage(systemName: "checkmark", withConfiguration: configuration)?
+            .withRenderingMode(.alwaysTemplate)
+        checkChip.tintColor = AppColors.fgOnWarn
+        checkChip.backgroundColor = AppColors.warn500
+        checkChip.contentMode = .center
+        checkChip.layer.cornerRadius = 11
+        checkChip.layer.masksToBounds = true
+        checkChip.translatesAutoresizingMaskIntoConstraints = false
+
+        let rightStack = UIStackView(arrangedSubviews: [amountLabel, checkChip])
+        rightStack.axis = .horizontal
+        rightStack.spacing = AppSpacing.sp2
+        rightStack.alignment = .center
+        rightStack.isUserInteractionEnabled = false
+        rightStack.translatesAutoresizingMaskIntoConstraints = false
+
+        addSubview(leftStack)
+        addSubview(rightStack)
+
+        NSLayoutConstraint.activate([
+            heightAnchor.constraint(greaterThanOrEqualToConstant: 60),
+            leftStack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: AppSpacing.sp5),
+            leftStack.centerYAnchor.constraint(equalTo: centerYAnchor),
+            leftStack.topAnchor.constraint(greaterThanOrEqualTo: topAnchor, constant: AppSpacing.sp4),
+            leftStack.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor, constant: -AppSpacing.sp4),
+
+            rightStack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -AppSpacing.sp5),
+            rightStack.centerYAnchor.constraint(equalTo: centerYAnchor),
+            rightStack.leadingAnchor.constraint(
+                greaterThanOrEqualTo: leftStack.trailingAnchor,
+                constant: AppSpacing.sp3
+            ),
+
+            checkChip.widthAnchor.constraint(equalToConstant: 22),
+            checkChip.heightAnchor.constraint(equalToConstant: 22)
+        ])
+    }
+
+    private func refreshSelection() {
+        if isSelected {
+            backgroundColor = AppColors.warn500.withAlphaComponent(0.08)
+            layer.borderColor = AppColors.warn400.cgColor
+            amountLabel.textColor = AppColors.warn400
+            checkChip.isHidden = false
+        } else {
+            backgroundColor = AppColors.whiteOverlay04
+            layer.borderColor = AppColors.whiteOverlay08.cgColor
+            amountLabel.textColor = .white
+            checkChip.isHidden = true
+        }
+    }
+
+    @objc private func handleTap() {
+        onTap()
+    }
+}

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPButton.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPButton.swift
@@ -100,6 +100,15 @@ final class SPButton: UIControl {
         didSet { invalidateIntrinsicContentSize() }
     }
 
+    /// Optional heavier stroke for `.ghost` buttons that need to read as a
+    /// stronger affordance than the default hairline (e.g. the firing
+    /// «Я встал — выключить» CTA — 1.5pt white .22 per `SPThemedFiring.jsx:
+    /// 188-203`). Nil keeps the default `1/scale` stroke2 hairline. Applied in
+    /// `applyVariant`, so it survives trait-change re-tints.
+    var ghostBorderOverride: (width: CGFloat, color: UIColor)? {
+        didSet { if variant == .ghost { applyVariant() } }
+    }
+
     // MARK: - Subviews
 
     private let stack = UIStackView()
@@ -278,9 +287,14 @@ final class SPButton: UIControl {
             setForeground(AppColors.fgOnWarn)
         case .ghost:
             backgroundColor = .clear
-            let scale = traitCollection.displayScale > 0 ? traitCollection.displayScale : 1
-            layer.borderWidth = 1.0 / scale
-            layer.borderColor = AppColors.stroke2.resolvedColor(with: traitCollection).cgColor
+            if let override = ghostBorderOverride {
+                layer.borderWidth = override.width
+                layer.borderColor = override.color.resolvedColor(with: traitCollection).cgColor
+            } else {
+                let scale = traitCollection.displayScale > 0 ? traitCollection.displayScale : 1
+                layer.borderWidth = 1.0 / scale
+                layer.borderColor = AppColors.stroke2.resolvedColor(with: traitCollection).cgColor
+            }
             setForeground(AppColors.fg1)
         case .quiet:
             backgroundColor = AppColors.whiteOverlay06

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPDawnBackgroundView.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPDawnBackgroundView.swift
@@ -11,12 +11,13 @@ import UIKit
 /// 2. **Overlay** — radial gradient anchored at the bottom centre (50% 100%),
 ///    blending warn-amber rgba(245,158,11,.22) → pain rgba(244,82,63,.10) →
 ///    transparent at 60%. Sells the "rising heat" cue.
-/// 3. **Sun** — 320×320pt blurred circle anchored 120pt below the bottom edge.
-///    Driven by either the warn or pain radial palette depending on `tone`.
+/// 3. **Sun** — 480×480pt blurred circle anchored 180pt below the bottom edge
+///    (`SPDawnV3.jsx:30-33`). Driven by either the warn or pain radial palette
+///    depending on `tone`.
 ///
 /// The view owns three CAGradientLayers (base, overlay, sun) and reflows them
 /// on every layout pass so rotation / safe-area changes work without per-frame
-/// recompute. The sun layer hosts the 4s opacity breathing animation so
+/// recompute. The sun layer hosts the 8s opacity breathing animation so
 /// `AlarmFiringViewController.startGlowBreathing()` keeps working unchanged.
 final class SPDawnBackgroundView: UIView {
 
@@ -55,14 +56,14 @@ final class SPDawnBackgroundView: UIView {
         return gradient
     }()
 
-    /// 320×320 sun circle, anchored ~120pt below the bottom edge. Public so
-    /// the firing VC can attach the 4s opacity breathing animation.
+    /// 480×480 sun circle, anchored ~180pt below the bottom edge. Public so
+    /// the firing VC can attach the 8s opacity breathing animation.
     let sunLayer: CAGradientLayer = {
         let gradient = CAGradientLayer()
         gradient.type = .radial
         gradient.startPoint = CGPoint(x: 0.5, y: 0.5)
         gradient.endPoint = CGPoint(x: 1.0, y: 1.0)
-        // 320pt circle anchored ~120pt below the bottom edge — the upper
+        // 480pt circle anchored ~180pt below the bottom edge — the upper
         // hemisphere bleeds into the screen as the rising warmth.
         return gradient
     }()
@@ -104,10 +105,11 @@ final class SPDawnBackgroundView: UIView {
         baseLayer.frame = bounds
         overlayLayer.frame = bounds
 
-        // Sun: 320×320pt anchored 120pt below the bottom edge. Centered
-        // horizontally. The upper hemisphere reads as the rising glow.
-        let sunSize: CGFloat = 320
-        let sunY = bounds.height - 120
+        // Sun: 480×480pt whose BOTTOM sits 180pt below the screen edge
+        // (`SPDawnV3.jsx:30` — `bottom: -180px`). Centered horizontally; the
+        // upper hemisphere bleeds in as the rising glow.
+        let sunSize: CGFloat = 480
+        let sunY = bounds.height + 180 - sunSize
         sunLayer.frame = CGRect(
             x: (bounds.width - sunSize) / 2,
             y: sunY,
@@ -140,7 +142,8 @@ final class SPDawnBackgroundView: UIView {
             UIColor(dawnRGB: 0x0E1320).cgColor,
             UIColor(dawnRGB: 0x1A1410).cgColor
         ]
-        baseLayer.locations = [0.0, 0.6, 1.0]
+        // Mid-stop 0.55 per `SPDawnV3.jsx:20` (`#0E1320 55%`).
+        baseLayer.locations = [0.0, 0.55, 1.0]
         // Overlay: warn 22% → pain 10% → transparent
         overlayLayer.colors = [
             UIColor(dawnRGB: 0xF59E0B, alpha: 0.22).cgColor,

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPFiringTicker.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPFiringTicker.swift
@@ -1,0 +1,129 @@
+import UIKit
+
+/// History ticker for the firing screen — the row of coloured mini-pills that
+/// summarise today's snooze charges in the centred hero block.
+///
+/// Spec — `SPDawnV3.jsx:114-136` (`TickerRow`): a caps «СЕГОДНЯ» eyebrow, then
+/// one chip per charged snooze separated by a thin «·». Each chip shows the
+/// rounded rouble amount and tints amber when the charge was under 200 ₽, red
+/// when it was 200 ₽ or more. This replaces the old single-line mono text
+/// summary that lived above the CTA.
+///
+/// The amount → tint mapping is pure logic, so it lives in `SPFiringTickerEntry`
+/// (unit-tested) and the view just renders the entries.
+enum SPFiringTicker {
+
+    /// One charge in today's snooze history.
+    struct Entry: Equatable {
+        /// Rounded rouble amount charged for this snooze.
+        let amount: Int
+
+        /// Tint threshold per `SPDawnV3.jsx:120-121`: amber below 200 ₽, red at
+        /// or above 200 ₽.
+        var isHeavy: Bool { amount >= 200 }
+
+        /// Chip text colour. `pain300` (coral) for heavy charges, `warn300`
+        /// (amber) otherwise.
+        var textColor: UIColor { isHeavy ? AppColors.pain300 : AppColors.warn300 }
+
+        /// Chip background fill — the same hue at ~18% so the pill reads as a
+        /// soft wash, matching `rgba(244,82,63,.18)` / `rgba(245,158,11,.18)`.
+        var fillColor: UIColor {
+            (isHeavy ? AppColors.pain500 : AppColors.warn500).withAlphaComponent(0.18)
+        }
+    }
+
+    /// Map a chronological list of penalty amounts (doubles, as the VM emits
+    /// them) to rounded ticker entries.
+    static func entries(from penalties: [Double]) -> [Entry] {
+        penalties.map { Entry(amount: Int($0.rounded())) }
+    }
+
+    /// Build the chip row view for the supplied entries. Returns a horizontal
+    /// stack: «СЕГОДНЯ» caps eyebrow, then the chips interleaved with thin «·»
+    /// dots. Returns an empty (hidden) stack when there's no history yet.
+    static func makeRow(for entries: [Entry]) -> UIStackView {
+        let row = UIStackView()
+        row.axis = .horizontal
+        row.alignment = .center
+        row.spacing = AppSpacing.sp2 - 2   // 6pt — matches the JSX `gap: 6`
+        row.isHidden = entries.isEmpty
+        guard !entries.isEmpty else { return row }
+
+        let eyebrow = UILabel()
+        eyebrow.attributedText = NSAttributedString(
+            string: "СЕГОДНЯ",
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: 12 * 0.18,
+                .foregroundColor: UIColor.white.withAlphaComponent(0.45)
+            ]
+        )
+        row.addArrangedSubview(eyebrow)
+
+        let chips = UIStackView()
+        chips.axis = .horizontal
+        chips.alignment = .center
+        chips.spacing = AppSpacing.sp1   // 4pt — matches the JSX inner `gap: 4`
+        for (index, entry) in entries.enumerated() {
+            chips.addArrangedSubview(makeChip(entry))
+            if index < entries.count - 1 {
+                chips.addArrangedSubview(makeSeparator())
+            }
+        }
+        row.addArrangedSubview(chips)
+        return row
+    }
+
+    private static func makeChip(_ entry: SPFiringTicker.Entry) -> UIView {
+        let label = SPPaddedLabel(insets: UIEdgeInsets(top: 3, left: 8, bottom: 3, right: 8))
+        label.attributedText = NSAttributedString(
+            string: "−\(entry.amount)",
+            attributes: [
+                .font: AppTypography.moneySm,
+                .foregroundColor: entry.textColor
+            ]
+        )
+        label.backgroundColor = entry.fillColor
+        label.layer.cornerRadius = AppRadius.pill
+        label.layer.masksToBounds = true
+        label.setContentHuggingPriority(.required, for: .horizontal)
+        return label
+    }
+
+    private static func makeSeparator() -> UILabel {
+        let dot = UILabel()
+        dot.text = "·"
+        dot.font = AppFonts.sans(.medium, 10)
+        dot.textColor = UIColor.white.withAlphaComponent(0.25)
+        return dot
+    }
+}
+
+/// Minimal padded-label used for the ticker chips so the pill background hugs
+/// the text with the spec's 3×8 inset. Kept private-ish to the ticker module.
+final class SPPaddedLabel: UILabel {
+    private let insets: UIEdgeInsets
+
+    init(insets: UIEdgeInsets) {
+        self.insets = insets
+        super.init(frame: .zero)
+        translatesAutoresizingMaskIntoConstraints = false
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func drawText(in rect: CGRect) {
+        super.drawText(in: rect.inset(by: insets))
+    }
+
+    override var intrinsicContentSize: CGSize {
+        let size = super.intrinsicContentSize
+        return CGSize(
+            width: size.width + insets.left + insets.right,
+            height: size.height + insets.top + insets.bottom
+        )
+    }
+}

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPPill.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPPill.swift
@@ -104,6 +104,32 @@ final class SPPill: UIView {
         label.attributedText = attributed
     }
 
+    /// Two-tier balance variant — a muted caps label segment («Баланс») next
+    /// to a bold value segment («840 ₽»), per `SPDawnV3.jsx:97-109`
+    /// (`dawn-bal__label` at .55 alpha + bold `dawn-bal__value`). Both segments
+    /// inherit the tone foreground; only the label is dimmed. The value keeps a
+    /// hair of tracking so the mono-ish digits don't crowd the glyph.
+    func setBalance(label labelText: String, value: String) {
+        let ink = label.textColor ?? AppColors.fg2
+        let result = NSMutableAttributedString(
+            string: labelText.uppercased(),
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: 12 * 0.14,
+                .foregroundColor: ink.withAlphaComponent(0.55)
+            ]
+        )
+        result.append(NSAttributedString(
+            string: "  \(value)",
+            attributes: [
+                .font: AppFonts.sans(.bold, 13),
+                .kern: 0.2,
+                .foregroundColor: ink
+            ]
+        ))
+        label.attributedText = result
+    }
+
     /// Override the tone-derived colours with theme-accent values — used by
     /// the V3 themed firing screen (#225) where the balance pill picks up
     /// the alarm theme's accent (`pillBg` / `pillBorder` / `accent` in

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPSnoozePrice.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPSnoozePrice.swift
@@ -3,9 +3,15 @@ import UIKit
 /// Big snooze CTA — `.sp-snooze` in `components.css`.
 ///
 /// Visual hierarchy: the price is the dominant element (32pt mono bold),
-/// with a small caps top label ("Поспать ещё 5 мин") and an optional
-/// hint meta line. Tone selects between the warn (default snooze price)
-/// and pain (progressive / expensive snooze) gradients.
+/// with a small caps top label (a 14pt clock glyph + "Спать ещё 5 мин")
+/// and an optional hint meta line. Tone selects between the warn (default
+/// snooze price) and pain (progressive / expensive snooze) gradients.
+///
+/// Per `SPDawnV3.jsx:82-85` the CTA stays GOLD (`.warn`) on every progressive
+/// step — escalation is signalled by the background tone crossfade + the
+/// indicator pill, never by reddening the button itself. The legacy
+/// `.progressive` tone is kept for back-compat but now resolves to the warn
+/// surface so callers can pass it without re-tinting the button.
 ///
 /// Min height 80pt so the touch target reads as a primary action even on
 /// the smallest device. Press scale 0.97 — unified with SPButton +
@@ -15,11 +21,11 @@ final class SPSnoozePrice: UIControl {
     enum Tone: Equatable {
         case warn   // Default snooze — warm amber gradient
         case pain   // Progressive / expensive — pain coral gradient
-        /// Progressive escalation — interpolates linearly between the warn
-        /// and pain gradients. `intensity` is clamped to `0...1`; 0 renders
-        /// pure warn (snooze #1), 1 renders pure pain (snooze #6+). The
-        /// shadow tint blends the same way so the surrounding glow tracks
-        /// the fill colour as the user keeps snoozing.
+        /// Progressive escalation. Historically interpolated the warn → pain
+        /// gradient by `intensity`; per `SPDawnV3.jsx:153-155` the CTA must
+        /// stay gold across all steps, so this now renders the warn surface
+        /// regardless of `intensity`. The case is retained so the firing flow
+        /// can keep passing it without a call-site rewrite.
         case progressive(intensity: Double)
     }
 
@@ -109,14 +115,7 @@ final class SPSnoozePrice: UIControl {
         self.price = price
         if let minutes = minutes { self.minutes = minutes }
         self.hint = hint
-        capsLabel.attributedText = NSAttributedString(
-            string: "Поспать ещё \(self.minutes) мин".uppercased(),
-            attributes: [
-                .font: AppTypography.caps,
-                .kern: 12 * 0.14,
-                .foregroundColor: foreground.withAlphaComponent(0.82)
-            ]
-        )
+        capsLabel.attributedText = makeCapsText()
         priceLabel.attributedText = MoneyFormatter.attributed(
             price, digitsFont: AppTypography.moneyLg, prefix: "−"
         )
@@ -139,14 +138,34 @@ final class SPSnoozePrice: UIControl {
         hintLabel.textColor = foreground
         // Re-render the caps label so its tinted attributedString picks up
         // the new foreground.
-        capsLabel.attributedText = NSAttributedString(
-            string: "Поспать ещё \(self.minutes) мин".uppercased(),
+        capsLabel.attributedText = makeCapsText()
+    }
+
+    /// Build the caps line — a 14pt leading clock glyph followed by
+    /// «СПАТЬ ЕЩЁ N МИН» (`SPDawnV3.jsx:82-85`). The glyph rides the text
+    /// baseline as an `NSTextAttachment` tinted to the current foreground.
+    private func makeCapsText() -> NSAttributedString {
+        let ink = foreground.withAlphaComponent(0.82)
+        let result = NSMutableAttributedString()
+        if let glyph = UIImage(systemName: "clock")?
+            .withConfiguration(UIImage.SymbolConfiguration(pointSize: 14, weight: .semibold))
+            .withTintColor(ink, renderingMode: .alwaysOriginal) {
+            let attachment = NSTextAttachment(image: glyph)
+            // Nudge the glyph down a touch so it optically centres on the caps
+            // cap-height rather than the ascender.
+            attachment.bounds = CGRect(x: 0, y: -2, width: 14, height: 14)
+            result.append(NSAttributedString(attachment: attachment))
+            result.append(NSAttributedString(string: "  "))
+        }
+        result.append(NSAttributedString(
+            string: "Спать ещё \(minutes) мин".uppercased(),
             attributes: [
                 .font: AppTypography.caps,
                 .kern: 12 * 0.14,
-                .foregroundColor: foreground.withAlphaComponent(0.82)
+                .foregroundColor: ink
             ]
-        )
+        ))
+        return result
     }
 
     // MARK: - Configuration
@@ -193,17 +212,9 @@ final class SPSnoozePrice: UIControl {
         switch tone {
         case .warn: return AppColors.fgOnWarn
         case .pain: return AppColors.fgOnPain
-        case .progressive(let intensity):
-            // Cross-fade the on-fill text colour the same way the gradient
-            // is interpolated. At intensity 0 the surface is pure amber so
-            // we want the warn ink (near-black); at intensity 1 it's coral
-            // and the pain ink (white) gives 4.5:1 contrast.
-            let clamped = max(0.0, min(1.0, intensity))
-            return SPSupport.lerpColor(
-                AppColors.fgOnWarn,
-                AppColors.fgOnPain,
-                progress: clamped
-            )
+        // The CTA stays gold across all progressive steps (`SPDawnV3.jsx:
+        // 153-155`), so the on-fill ink is always the warn ink.
+        case .progressive: return AppColors.fgOnWarn
         }
     }
 
@@ -222,15 +233,12 @@ final class SPSnoozePrice: UIControl {
             gradient.colors = SPSupport.painGradientColors
             gradient.locations = SPSupport.painGradientLocations
             layer.shadowColor = AppColors.pain500.cgColor
-        case .progressive(let intensity):
-            let clamped = max(0.0, min(1.0, intensity))
-            gradient.colors = SPSupport.progressiveGradientColors(intensity: clamped)
+        case .progressive:
+            // Gold CTA on every progressive step — render the warn surface
+            // regardless of intensity (`SPDawnV3.jsx:153-155`).
+            gradient.colors = SPSupport.warnGradientColors
             gradient.locations = SPSupport.warnGradientLocations
-            layer.shadowColor = SPSupport.lerpColor(
-                AppColors.warn500,
-                AppColors.pain500,
-                progress: clamped
-            ).cgColor
+            layer.shadowColor = AppColors.warn500.cgColor
         }
         layer.insertSublayer(gradient, at: 0)
         gradientLayer = gradient

--- a/SnoozePay/SnoozePayTests/AlarmFiringHintTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmFiringHintTests.swift
@@ -28,7 +28,7 @@ final class AlarmFiringHintTests: XCTestCase {
             snoozeCount: 0
         )
         XCTAssertEqual(vc.snoozeHintText(),
-                       "Следующее откладывание: \(MoneyFormatter.string(100))")
+                       "следующее откладывание: \(MoneyFormatter.string(100))")
     }
 
     func testSnoozeHint_showsNextPriceAtThirdRung() {
@@ -38,7 +38,7 @@ final class AlarmFiringHintTests: XCTestCase {
             snoozeCount: 1
         )
         XCTAssertEqual(vc.snoozeHintText(),
-                       "Следующее откладывание: \(MoneyFormatter.string(200))")
+                       "следующее откладывание: \(MoneyFormatter.string(200))")
     }
 
     func testSnoozeHint_showsMaxCopyAtCeiling() {

--- a/SnoozePay/SnoozePayTests/AlarmFiringProgressiveChromeTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmFiringProgressiveChromeTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import SnoozePay
+
+/// Tests for the firing-screen progressive indicator pill copy + visibility
+/// (#288). The pill reads «Прогрессив · {n}-й поспать ещё» and stays hidden
+/// until the first snooze. Both rules are pure functions, so they're exercised
+/// without loading the view hierarchy.
+@MainActor
+final class AlarmFiringProgressiveChromeTests: XCTestCase {
+
+    func testPillCopy_firstStep() {
+        XCTAssertEqual(
+            AlarmFiringViewController.progressivePillText(snoozeCount: 0),
+            "Прогрессив · 1-й поспать ещё"
+        )
+    }
+
+    func testPillCopy_countsUp() {
+        XCTAssertEqual(
+            AlarmFiringViewController.progressivePillText(snoozeCount: 2),
+            "Прогрессив · 3-й поспать ещё"
+        )
+    }
+
+    func testPillHidden_beforeFirstSnooze() {
+        XCTAssertFalse(
+            AlarmFiringViewController.progressivePillVisible(snoozeCount: 0),
+            "Indicator pill is hidden until the first snooze (SPDawnV3.jsx:216)"
+        )
+    }
+
+    func testPillVisible_afterFirstSnooze() {
+        XCTAssertTrue(AlarmFiringViewController.progressivePillVisible(snoozeCount: 1))
+    }
+}

--- a/SnoozePay/SnoozePayTests/SPFiringTickerTests.swift
+++ b/SnoozePay/SnoozePayTests/SPFiringTickerTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import SnoozePay
+
+/// Tests for the firing history ticker model (#288). The ticker renders today's
+/// snooze charges as coloured mini-pills — amber below 200 ₽, red at or above
+/// 200 ₽ — so the amount → tint mapping is pure logic worth pinning.
+final class SPFiringTickerTests: XCTestCase {
+
+    func testEntries_roundPenaltiesToInt() {
+        let entries = SPFiringTicker.entries(from: [50, 100.4, 199.6])
+        XCTAssertEqual(entries.map(\.amount), [50, 100, 200])
+    }
+
+    func testEntries_emptyForNoHistory() {
+        XCTAssertTrue(SPFiringTicker.entries(from: []).isEmpty)
+    }
+
+    func testEntry_isLightBelowTwoHundred() {
+        let entry = SPFiringTicker.Entry(amount: 199)
+        XCTAssertFalse(entry.isHeavy)
+        XCTAssertEqual(entry.textColor, AppColors.warn300,
+                       "Charges under 200 ₽ render amber")
+    }
+
+    func testEntry_isHeavyAtTwoHundred() {
+        let entry = SPFiringTicker.Entry(amount: 200)
+        XCTAssertTrue(entry.isHeavy, "200 ₽ is the heavy threshold (≥ 200)")
+        XCTAssertEqual(entry.textColor, AppColors.pain300,
+                       "Charges at or above 200 ₽ render red")
+    }
+
+    func testEntry_isHeavyAboveTwoHundred() {
+        XCTAssertTrue(SPFiringTicker.Entry(amount: 400).isHeavy)
+    }
+
+    func testMakeRow_hiddenWhenEmpty() {
+        let row = SPFiringTicker.makeRow(for: [])
+        XCTAssertTrue(row.isHidden, "No history → the ticker row stays hidden")
+    }
+
+    func testMakeRow_visibleWithEntries() {
+        let row = SPFiringTicker.makeRow(for: [SPFiringTicker.Entry(amount: 50)])
+        XCTAssertFalse(row.isHidden)
+        XCTAssertFalse(row.arrangedSubviews.isEmpty,
+                       "A non-empty ticker mounts the «СЕГОДНЯ» eyebrow + chips")
+    }
+}

--- a/SnoozePay/SnoozePayTests/TopUpDisplayAmountTests.swift
+++ b/SnoozePay/SnoozePayTests/TopUpDisplayAmountTests.swift
@@ -68,6 +68,7 @@ final class TopUpDisplayAmountTests: XCTestCase {
         let preset = FiringTopUpBottomSheetViewController.Preset(
             productID: "com.snooze_pay.balance.does_not_exist",
             label: "fake",
+            hint: "fake",
             popular: false
         )
         XCTAssertNil(preset, "Preset must not be created for an unknown SKU")


### PR DESCRIPTION
Fixes #288

## Что сделано
Firing polish pack per design (SPDawnV3.jsx / SPThemedFiring.jsx / SPTopUp.jsx):
- **Snooze CTA**: caps «Спать ещё N мин» + 14pt leading clock glyph; CTA stays GOLD on every progressive step (removed warn→pain lerp on the button — escalation now lives only in the background tone + indicator pill).
- **Progressive indicator pill**: hidden until first snooze; copy «Прогрессив · {n}-й поспать ещё»; moved into the centre hero block.
- **History ticker**: colored mini-pills with «·» separators (amber <200 ₽ / red ≥200 ₽) in the centre block — replaces the mono text line above the CTA. Extracted to `SPFiringTicker` (unit-tested).
- **Dawn glow**: 480pt circle, bottom −180, 8s breathing; calm gradient mid-stop 0.55.
- **Tense background threshold**: next price ≥200 ₽ (was intensity ≥0.5).
- **«Я встал — выключить»**: 1.5pt white .22 border + leading checkmark (new `SPButton.ghostBorderOverride`).
- **Balance pill**: two-tier typography — muted «Баланс» label + bold value (new `SPPill.setBalance`).
- **Clock mount animation**: 800ms fade + blur-approximation (scale) + 8px rise.
- **Snooze hint**: lowercase «следующее откладывание: …» (ceiling hint stays lowercase from #298).
- **Top-up sheet**: pulsing warn dot + caps «Будильник на паузе · MM:SS» + h2 «Пополнить баланс»; vertical preset rows «+1 откладывание / +несколько / +неделя» with hints; default selection = smallest preset; surface bg1. Honest amounts (#297) preserved — labels/hints change, numbers stay catalogue-driven.

## Verify
- ✅ swiftlint: 0 errors (changed files)
- ✅ xcodebuild build (iOS Simulator, CODE_SIGNING_ALLOWED=NO): BUILD SUCCEEDED
- ✅ xcodebuild build-for-testing: TEST BUILD SUCCEEDED (all test targets compile)
- Tests: updated AlarmFiringHintTests (lowercase hint) + TopUpDisplayAmountTests (Preset.hint arg); added SPFiringTickerTests (amount→tint mapping) + AlarmFiringProgressiveChromeTests (pill copy/visibility)

Zone respected: only AlarmFiring*, SPSnoozePrice, SPDawnBackgroundView, SPButton, SPPill, FiringTopUp* touched — no Wallet/Statistics files.