### PR TITLE
[fix] Tighten snoozeMinutes to design range 1–15 with clamping legacy decode (#286)

### DIFF
--- a/SnoozePay/SnoozePay/Models/Alarm.swift
+++ b/SnoozePay/SnoozePay/Models/Alarm.swift
@@ -44,10 +44,13 @@ struct Alarm: Identifiable, Equatable, Codable {
 
     // MARK: - Validation rules (#207)
 
-    /// Spec range for snooze duration (SPEC.md says 1–30 minutes). The
-    /// create/edit form's slider exposes a narrower 1...15 — that UI bound
-    /// lives in `CreateAlarmViewModel.snoozeMinutesRange`.
-    static let snoozeMinutesRange: ClosedRange<Int> = 1...30
+    /// Canonical range for snooze duration: 1–15 minutes. The design canon
+    /// (chat1.md:996 — per-alarm slider 1–15 min) is the source of truth; the
+    /// older "1–30" SPEC wording was stale and has since been aligned (#302).
+    /// `CreateAlarmViewModel.snoozeMinutesRange` already bounds the create/edit
+    /// slider to this same range. Legacy alarms persisted with snoozeMinutes
+    /// 16–30 are clamped to 15 on decode (see `init(from:)`), never dropped.
+    static let snoozeMinutesRange: ClosedRange<Int> = 1...15
     /// Legal weekday indices for `repeatDays` (0 = Monday, 6 = Sunday).
     static let weekdayIndexRange: ClosedRange<Int> = 0...6
 
@@ -220,8 +223,9 @@ struct Alarm: Identifiable, Equatable, Codable {
         self.name = try container.decode(String.self, forKey: .name)
         self.soundID = try container.decode(String.self, forKey: .soundID)
         self.vibrationEnabled = try container.decode(Bool.self, forKey: .vibrationEnabled)
-        // Clamp into the spec range (pre-#143 alarms could store up to 30;
-        // anything outside 1...30 is corrupt data).
+        // Clamp into the canonical range. Legacy alarms persisted under the
+        // old 1...30 spec (or with corrupt data) carry snoozeMinutes 16–30;
+        // clamp to 15 so the alarm survives rather than being dropped (#286).
         let rawSnooze = try container.decode(Int.self, forKey: .snoozeMinutes)
         self.snoozeMinutes = min(
             max(rawSnooze, Self.snoozeMinutesRange.lowerBound),

--- a/SnoozePay/SnoozePayTests/AlarmValidationTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmValidationTests.swift
@@ -26,7 +26,15 @@ final class AlarmValidationTests: XCTestCase {
     }
 
     func testValidatingInit_oversizedSnoozeMinutesReturnsNil() {
-        XCTAssertNil(Alarm(validating: UUID(), snoozeMinutes: 31))
+        // 16 is the first value above the canonical 1...15 range (#286).
+        XCTAssertNil(Alarm(validating: UUID(), snoozeMinutes: 16))
+        XCTAssertNil(Alarm(validating: UUID(), snoozeMinutes: 30))
+    }
+
+    func testValidatingInit_snoozeBoundariesSucceed() {
+        // Both ends of the canonical 1...15 range construct successfully.
+        XCTAssertEqual(Alarm(validating: UUID(), snoozeMinutes: 1)?.snoozeMinutes, 1)
+        XCTAssertEqual(Alarm(validating: UUID(), snoozeMinutes: 15)?.snoozeMinutes, 15)
     }
 
     func testValidatingInit_negativeWeekdayIndexReturnsNil() {
@@ -43,12 +51,12 @@ final class AlarmValidationTests: XCTestCase {
         let alarm = Alarm(
             validating: UUID(),
             repeatDays: [0, 6],
-            snoozeMinutes: 30,
+            snoozeMinutes: 15,
             penaltyAmount: 0
         )
         XCTAssertNotNil(alarm)
         XCTAssertEqual(alarm?.repeatDays, [0, 6])
-        XCTAssertEqual(alarm?.snoozeMinutes, 30)
+        XCTAssertEqual(alarm?.snoozeMinutes, 15)
         XCTAssertEqual(alarm?.penaltyAmount, 0)
     }
 
@@ -106,6 +114,25 @@ final class AlarmValidationTests: XCTestCase {
 
         let high = try decodeLegacyAlarm(snoozeMinutesJSON: "999")
         XCTAssertEqual(high.snoozeMinutes, Alarm.snoozeMinutesRange.upperBound)
+    }
+
+    /// Legacy alarms persisted under the old 1...30 spec carry snoozeMinutes
+    /// 16–30. They must SURVIVE the tighter 1...15 range — clamped to 15, not
+    /// dropped or trapped (#286).
+    func testDecode_clampsLegacySixteenToFifteen() throws {
+        let alarm = try decodeLegacyAlarm(snoozeMinutesJSON: "16")
+        XCTAssertEqual(alarm.snoozeMinutes, 15)
+    }
+
+    func testDecode_clampsLegacyThirtyToFifteen() throws {
+        let alarm = try decodeLegacyAlarm(snoozeMinutesJSON: "30")
+        XCTAssertEqual(alarm.snoozeMinutes, 15)
+    }
+
+    /// Boundary value 15 round-trips unchanged through decode.
+    func testDecode_preservesInRangeSnoozeMinutes() throws {
+        let alarm = try decodeLegacyAlarm(snoozeMinutesJSON: "15")
+        XCTAssertEqual(alarm.snoozeMinutes, 15)
     }
 
     func testDecode_negativePenaltyDegradesToZero() throws {


### PR DESCRIPTION
Fixes #286

## Что сделано
- `Alarm.snoozeMinutesRange` tightened `1...30` → `1...15` per design canon (chat1.md:996; SPEC aligned in #302) — doc comment now cites the design canon, not the stale SPEC.
- Legacy migration: `init(from decoder:)` already clamps `snoozeMinutes` into `snoozeMinutesRange`, so persisted alarms with 16–30 now clamp to 15 (survive, never dropped/trapped) — same pattern as the volume clamp. Updated the decode comment.
- `init(validating:)` keeps reject-on-invalid for fresh constructions: 0 and 16+ now return nil. The trapping init/`with(...)` inherit this. No call sites needed code changes — CreateAlarmViewModel already clamps the UI slider to 1...15 against `Alarm.snoozeMinutesRange`.

## Tests (AlarmValidationTests)
- `testDecode_clampsLegacySixteenToFifteen` / `testDecode_clampsLegacyThirtyToFifteen` — legacy 16 & 30 clamp to 15, alarm survives.
- `testDecode_preservesInRangeSnoozeMinutes` — boundary 15 round-trips.
- `testValidatingInit_oversizedSnoozeMinutesReturnsNil` — now asserts 16 and 30 reject.
- `testValidatingInit_snoozeBoundariesSucceed` — 1 and 15 construct.
- Updated `testValidatingInit_boundaryValuesSucceed` (30 → 15).

## Verify
- ✅ swiftlint: 0 violations (Alarm.swift + AlarmValidationTests.swift)
- ✅ xcodebuild build + build-for-testing: TEST BUILD SUCCEEDED (iPhone 17 Pro Max, sim 26.5, CODE_SIGNING_ALLOWED=NO)
- Test execution deferred to CI (merge gate)

Scope limited to Alarm.swift + AlarmValidationTests.swift per coordination note.