### PR TITLE
[ui] AlarmsList chrome — in-header gear, 14px pill, V3 empty state, cell pills (#280)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmCell.swift
@@ -16,9 +16,13 @@ import UIKit
 ///  └──────────────────────────────────────────────────────────┘
 /// ```
 ///
-/// Three tonal states, all 20pt internal padding / 20pt corner radius:
-/// - **enabled**:  `bg2` raised surface, `fg1` clock + `fg3` caps.
-/// - **disabled**: `bg1` surface, `fg3` clock + `fg4` caps.
+/// Three tonal states, all 20pt internal padding / 20pt corner radius. The
+/// card chrome follows the `SPCard` recipe (SPScreensV2.jsx L404/L421) so it
+/// reads as the same primitive as every other surface — `shadow-1`/`shadow-2`
+/// plus the documented light-mode hairline a11y deviation, instead of the old
+/// flat 1pt border with no shadow (#280):
+/// - **enabled**:  `SPCard(tone: .raised)` — `bg2` surface, `fg1` clock + `fg3` caps.
+/// - **disabled**: `SPCard(tone: .surface)` — `bg1` surface, `fg3` clock + `fg4` caps.
 /// - **selected**: handled by `setHighlighted(_:)` press feedback.
 ///
 /// The caps row uses an attributed string with `AppTypography.capsKerning`
@@ -29,12 +33,17 @@ final class AlarmCell: UITableViewCell {
 
     // MARK: - UI Elements
 
+    /// Card surface. Applies the `SPCard` `.raised`/`.surface` recipe inline
+    /// (shadow-2 / shadow-1 + light-mode hairline) rather than embedding an
+    /// `SPCard` — that primitive's tone is immutable at init and the cell flips
+    /// tone per enabled state. `masksToBounds` stays `false` so the shadow can
+    /// render; the rounded corners only clip the background/border on the
+    /// layer, and the cell's subviews never extend past the card edge.
     private let cardView: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.layer.cornerRadius = AppRadius.lg  // 20pt
-        view.layer.masksToBounds = true
-        view.layer.borderWidth = 1
+        view.layer.masksToBounds = false
         return view
     }()
 
@@ -85,6 +94,13 @@ final class AlarmCell: UITableViewCell {
         return stack
     }()
 
+    // MARK: - State
+
+    /// Tracks the last applied enabled tone so theme-flip / layout passes can
+    /// re-resolve the (CALayer cgColor / shadow) recipe without the controller
+    /// re-calling `configure`.
+    private var isEnabledTone = true
+
     // MARK: - Callbacks
 
     /// Invoked when the user flips the toggle. Set by the controller in `cellForRowAt`.
@@ -115,8 +131,9 @@ final class AlarmCell: UITableViewCell {
     }
 
     private func refreshDynamicColors() {
-        // CALayer cgColor doesn't auto-resolve dynamic UIColors.
-        cardView.layer.borderColor = AppColors.whiteOverlay08.cgColor
+        // CALayer cgColor + shadow recipe don't auto-resolve dynamic UIColors,
+        // so re-install the whole card chrome on a theme flip.
+        applyCardChrome(enabled: isEnabledTone)
     }
 
     // MARK: - Setup
@@ -211,7 +228,16 @@ final class AlarmCell: UITableViewCell {
         soundName: String?,
         enabled: Bool
     ) {
-        clockLabel.text = time
+        // −0.04em clock tracking per SPScreensV2.jsx L408 (`letterSpacing:
+        // -.04em`). The colour is applied separately by `applyEnabledTone`, so
+        // omit `.foregroundColor` here and let the label's `textColor` win.
+        clockLabel.attributedText = NSAttributedString(
+            string: time,
+            attributes: [
+                .font: clockLabel.font as Any,
+                .kern: AppTypography.clockLgKerning
+            ]
+        )
         capsLabel.attributedText = NSAttributedString(
             string: daysCaps,
             attributes: [
@@ -246,28 +272,36 @@ final class AlarmCell: UITableViewCell {
             pillsStack.removeArrangedSubview(view)
             view.removeFromSuperview()
         }
-        // Price pill — warn-tone when enabled, neutral when disabled so a
-        // dimmed row doesn't shout "50 ₽" at the user. Design v3 leads with
-        // the ₽-coin icon (`IconRubleCoin`, SPScreensV2.jsx L415).
+        // Enabled cards carry their 12px pill icons; disabled cards drop the
+        // icons entirely so a dimmed row reads quieter (SPScreensV2.jsx
+        // L414-418 vs L431-434, #280).
+        // Price pill — warn-tone when enabled (leading ₽-coin), neutral +
+        // icon-less when disabled.
         let pricePill = SPPill(
             text: price,
             tone: enabled ? .warn : .neutral,
-            icon: SPIcons.rubleCoin(size: 12)
+            icon: enabled ? SPIcons.rubleCoin(size: 12) : nil
         )
         pillsStack.addArrangedSubview(pricePill)
 
         if let multiplier = multiplier {
-            // Progressive multiplier — trend-up polyline replaced the flame
-            // glyph in design v3 (`IconTrendUp`, SPScreensV2.jsx L416).
+            // Progressive multiplier — trend-up polyline (icon only when
+            // enabled).
             let mult = SPPill(
                 text: multiplier,
                 tone: enabled ? .pain : .neutral,
-                icon: SPIcons.trendUp(size: 12)
+                icon: enabled ? SPIcons.trendUp(size: 12) : nil
             )
             pillsStack.addArrangedSubview(mult)
         }
         if let soundName = soundName, !soundName.isEmpty {
-            let sound = SPPill(text: soundName, tone: .neutral)
+            // Sound pill — neutral tone; the 12px speaker glyph appears only
+            // on enabled cards (SPScreensV2.jsx L417, #280).
+            let sound = SPPill(
+                text: soundName,
+                tone: .neutral,
+                icon: enabled ? SPIcons.sound(size: 12) : nil
+            )
             pillsStack.addArrangedSubview(sound)
         }
         // Trailing spacer so pills don't stretch.
@@ -278,9 +312,66 @@ final class AlarmCell: UITableViewCell {
     }
 
     private func applyEnabledTone(_ enabled: Bool) {
-        cardView.backgroundColor = enabled ? AppColors.bg2 : AppColors.bg1
+        isEnabledTone = enabled
         clockLabel.textColor = enabled ? AppColors.fg1 : AppColors.fg3
-        cardView.layer.borderColor = AppColors.whiteOverlay08.cgColor
+        applyCardChrome(enabled: enabled)
+    }
+
+    /// Install the `SPCard` chrome for the given tone: an enabled card uses the
+    /// `.raised` recipe (`bg2` + `shadow-2`), a disabled card the `.surface`
+    /// recipe (`bg1` + `shadow-1`). In light mode both add a 1pt hairline —
+    /// the documented a11y deviation from `SPCard` (near-white surfaces need a
+    /// stroke to read as a card). Dark mode relies on the shadow alone, no
+    /// border, per the design (SPScreensV2.jsx L404/L421).
+    private func applyCardChrome(enabled: Bool) {
+        cardView.backgroundColor = enabled ? AppColors.bg2 : AppColors.bg1
+
+        let trait = traitCollection
+        let isLight = trait.userInterfaceStyle != .dark
+
+        // Shadow recipe.
+        let shadow = enabled ? AppShadow.shadow2(for: trait) : AppShadow.shadow1(for: trait)
+        shadow.apply(to: cardView.layer)
+        // The disabled (`shadow-1`) tone carries a narrow ambient stop on light
+        // surfaces; the enabled (`shadow-2`) tone is a single stop, so clear
+        // any stale ambient layer when switching tones.
+        if enabled {
+            cardView.layer.sublayers?
+                .first { $0.name == AppShadow.ambientShadow1LayerName }?
+                .removeFromSuperlayer()
+        } else {
+            AppShadow.installAmbientShadow1Layer(
+                on: cardView.layer,
+                cornerRadius: AppRadius.lg,
+                trait: trait
+            )
+        }
+
+        // Light-mode hairline a11y deviation.
+        if isLight {
+            let scale = trait.displayScale > 0 ? trait.displayScale : 1
+            cardView.layer.borderWidth = 1.0 / scale
+            cardView.layer.borderColor = AppColors.stroke1.resolvedColor(with: trait).cgColor
+        } else {
+            cardView.layer.borderWidth = 0
+        }
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        // Pre-rasterise the shadow against the rounded path + keep the ambient
+        // layer frame in sync with the card bounds.
+        cardView.layer.shadowPath = UIBezierPath(
+            roundedRect: cardView.bounds,
+            cornerRadius: AppRadius.lg
+        ).cgPath
+        if !isEnabledTone {
+            AppShadow.installAmbientShadow1Layer(
+                on: cardView.layer,
+                cornerRadius: AppRadius.lg,
+                trait: traitCollection
+            )
+        }
     }
 
     @objc private func toggleSwitchChanged() {

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
@@ -75,6 +75,11 @@ class AlarmsListViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        // The V3 header carries its own title + in-row gear, so the system
+        // nav bar is hidden on this tab (#280). It's restored just before a
+        // child screen (Settings/Legal) is pushed so the child keeps its
+        // standard back arrow; returning here re-hides it via this callback.
+        navigationController?.setNavigationBarHidden(true, animated: animated)
         viewModel.loadData()
         tableView.reloadData()
         refreshStreakBanner()
@@ -116,22 +121,16 @@ class AlarmsListViewController: UIViewController {
         navigationItem.title = ""
         navigationController?.navigationBar.prefersLargeTitles = false
 
-        // V1 had a "+" button on the right edge of the nav bar; the V2 header
-        // moves that affordance into the title row so the user always sees
-        // the CTA near the balance. Drop the nav-bar plus to avoid two CTAs.
+        // V1 had a "+" button on the right edge of the nav bar; the V3 header
+        // moves that affordance — and the Settings gear (#280) — into the
+        // title row so the system nav bar can be hidden entirely on this tab
+        // (see `viewWillAppear`). Drop both bar items to avoid duplicates.
         navigationItem.rightBarButtonItem = nil
+        navigationItem.leftBarButtonItem = nil
 
-        // Gear icon — preserved entry point for Settings.
-        let settingsButton = UIBarButtonItem(
-            image: UIImage(systemName: "gearshape"),
-            style: .plain,
-            target: self,
-            action: #selector(openSettings)
-        )
-        navigationItem.leftBarButtonItem = settingsButton
-
-        // DEBUG-only entries — streak modal trigger + onboarding reset.
-        // Required to stay functional after the V2 rewrite.
+        // DEBUG-only entries — streak modal trigger + onboarding reset. The
+        // nav bar is hidden on this tab in release, but these surface when a
+        // developer temporarily un-hides it; keep them wired.
         #if DEBUG
         let streakButton = UIBarButtonItem(
             image: UIImage(systemName: "flame.fill"),
@@ -145,13 +144,17 @@ class AlarmsListViewController: UIViewController {
             target: self,
             action: #selector(debugResetOnboarding)
         )
-        navigationItem.leftBarButtonItems = [settingsButton, streakButton, resetButton]
+        navigationItem.leftBarButtonItems = [streakButton, resetButton]
         #endif
     }
 
     @objc private func openSettings() {
         // Child screen with a back arrow (#237) — pushed onto the tab's
-        // existing navigation stack instead of a standalone modal.
+        // existing navigation stack instead of a standalone modal. The nav
+        // bar is hidden on this root (#280), so restore it before the push
+        // so the Settings screen keeps its standard back arrow + title; this
+        // VC re-hides it in `viewWillAppear` when the user pops back.
+        navigationController?.setNavigationBarHidden(false, animated: true)
         let settingsVC = SettingsViewController()
         navigationController?.pushViewController(settingsVC, animated: true)
     }
@@ -203,6 +206,9 @@ class AlarmsListViewController: UIViewController {
     private func setupCallbacks() {
         header.onAddTap = { [weak self] in
             self?.addAlarmTapped()
+        }
+        header.onSettingsTap = { [weak self] in
+            self?.openSettings()
         }
         header.onBalanceTopUpTap = { [weak self] in
             self?.presentTopUp()

--- a/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletViewController.swift
@@ -71,13 +71,11 @@ final class WalletViewController: UIViewController {
         navigationController?.navigationBar.prefersLargeTitles = false
         navigationItem.largeTitleDisplayMode = .never
 
-        let settingsButton = UIBarButtonItem(
-            image: UIImage(systemName: "gearshape"),
-            style: .plain,
-            target: self,
-            action: #selector(openSettings)
-        )
-        navigationItem.rightBarButtonItem = settingsButton
+        // The design has no Settings entry on the Wallet tab (#280) — the gear
+        // was an invented affordance. Drop the bar item and hide the system
+        // nav bar entirely (mirrors the Alarms tab); the bar is restored just
+        // before child screens are pushed so they keep their back arrow.
+        navigationItem.rightBarButtonItem = nil
 
         setupLayout()
 
@@ -91,6 +89,11 @@ final class WalletViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        // Hide the system nav bar on this tab — the custom page header owns the
+        // title and there's no bar item to show (#280). Restored before a child
+        // push (`openHistory`) so the child keeps its back arrow; popping back
+        // here re-hides it.
+        navigationController?.setNavigationBarHidden(true, animated: animated)
         refresh()
     }
 
@@ -196,14 +199,11 @@ final class WalletViewController: UIViewController {
         present(sheet, animated: true)
     }
 
-    @objc private func openSettings() {
-        // Child screen with a back arrow (#237) — pushed onto the tab's
-        // existing navigation stack instead of a standalone modal.
-        let settings = SettingsViewController()
-        navigationController?.pushViewController(settings, animated: true)
-    }
-
     @objc private func openHistory() {
+        // The nav bar is hidden on this root (#280) — restore it before the
+        // push so the history screen keeps its standard back arrow + title.
+        // `viewWillAppear` re-hides it when the user pops back.
+        navigationController?.setNavigationBarHidden(false, animated: true)
         let history = WalletTransactionHistoryViewController()
         navigationController?.pushViewController(history, animated: true)
     }

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPAlarmsListEmptyState.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPAlarmsListEmptyState.swift
@@ -1,20 +1,21 @@
 import UIKit
 
-/// Empty-state column for the alarms list (V2 design).
+/// Empty-state column for the alarms list (V3 design).
 ///
-/// Reference: `docs/design/v2-handoff/components/SPMore.jsx` L376-407.
+/// Reference: `docs/design/v2-handoff/components/SPMore.jsx` L415-445
+/// (`EmptyAlarms`).
 ///
 /// Visual:
 /// ```
 ///                ┌───────────┐
-///                │   🔔      │   <- 96×96 warm-gradient rounded square
+///                │    🔔     │   <- 84×84 whiteOverlay06 tile, bell fg3
 ///                └───────────┘
-///            ПОКА ПУСТО         <- caps fg3
-///   Создайте первый будильник со
-///   ставкой — он спишет деньги
-///   за каждый снуз                <- body fg2
+///         Ни одного будильника    <- h2
+///   Создайте первый — выставите
+///   время, цену откладывания и
+///   положите баланс.              <- body-lg fg2
 ///
-///        [   ＋ Создать первый   ]
+///        [  ＋ Создать будильник  ]  <- intrinsic-width money lg
 /// ```
 ///
 /// Hosted as an overlay over the table view in
@@ -23,20 +24,21 @@ final class SPAlarmsListEmptyState: UIView {
 
     // MARK: - Public API
 
-    /// Triggered when the user taps "Создать первый".
+    /// Triggered when the user taps "Создать будильник".
     var onAddAlarmTap: (() -> Void)?
 
     // MARK: - Subviews
 
-    /// 96×96 warm-gradient rounded square hosting the alarm icon.
-    private let iconHost: SPGradientView = {
-        let view = SPGradientView(
-            colors: SPSupport.warnGradientColors,
-            locations: SPSupport.warnGradientLocations
-        )
+    /// 84×84 whiteOverlay06 tile (radius 24, whiteOverlay08 hairline) hosting
+    /// the bell glyph — a quiet neutral tile, not the warn-gradient hero the
+    /// V2 layout used (SPMore.jsx L424-430, #280).
+    private let iconHost: UIView = {
+        let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.layer.cornerRadius = AppRadius.xl  // 28pt
+        view.backgroundColor = AppColors.whiteOverlay06
+        view.layer.cornerRadius = AppRadius.xl  // 24pt → matches `borderRadius: 24`
         view.layer.masksToBounds = true
+        view.layer.borderWidth = 1
         return view
     }()
 
@@ -44,45 +46,49 @@ final class SPAlarmsListEmptyState: UIView {
         let view = UIImageView()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.contentMode = .scaleAspectFit
-        view.tintColor = AppColors.fgOnWarn
-        let config = UIImage.SymbolConfiguration(pointSize: 44, weight: .semibold)
-        view.image = UIImage(systemName: "alarm.fill", withConfiguration: config)
+        view.tintColor = AppColors.fg3
+        // Code-drawn outline bell at fg3 — SPMore.jsx L429.
+        view.image = SPIcons.bell(size: 40)
         return view
     }()
 
-    private let capsLabel: UILabel = {
+    private let titleLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
+        // h2 24pt bold with −0.01em tracking per SPMore.jsx L431.
         label.attributedText = NSAttributedString(
-            string: "ПОКА ПУСТО",
+            string: "Ни одного будильника",
             attributes: [
-                .font: AppTypography.caps,
-                .kern: AppTypography.capsKerning,
-                .foregroundColor: AppColors.fg3
+                .font: AppTypography.h2,
+                .kern: AppTypography.h2Kerning,
+                .foregroundColor: AppColors.fg1
             ]
         )
         label.textAlignment = .center
+        label.numberOfLines = 0
         return label
     }()
 
     private let bodyLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "Создайте первый будильник со ставкой — он спишет деньги за каждый снуз."
-        label.font = AppTypography.body
+        // Drops the previously banned «снуз» word — copy per SPMore.jsx L435.
+        label.text = "Создайте первый — выставите время, цену откладывания и положите баланс."
+        label.font = AppTypography.bodyLg
         label.textColor = AppColors.fg2
         label.textAlignment = .center
         label.numberOfLines = 0
         return label
     }()
 
+    /// Intrinsic-width money CTA — NOT full-width (SPMore.jsx L437-439 wraps
+    /// the button in a plain `<div>` so it hugs its label).
     private let addButton: SPButton = {
         let button = SPButton(
-            title: "Создать первый",
+            title: "Создать будильник",
             variant: .money,
             size: .lg,
-            icon: UIImage(systemName: "plus"),
-            fullWidth: true
+            icon: UIImage(systemName: "plus")
         )
         button.translatesAutoresizingMaskIntoConstraints = false
         return button
@@ -93,10 +99,27 @@ final class SPAlarmsListEmptyState: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         configure()
+        if #available(iOS 17.0, *) {
+            registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (view: SPAlarmsListEmptyState, _) in
+                view.refreshDynamicColors()
+            }
+        }
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    @available(iOS, deprecated: 17.0, message: "Replaced by registerForTraitChanges; kept for iOS 15/16.")
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if #available(iOS 17.0, *) { return }
+        refreshDynamicColors()
+    }
+
+    private func refreshDynamicColors() {
+        // CALayer cgColor doesn't auto-resolve dynamic UIColors.
+        iconHost.layer.borderColor = AppColors.whiteOverlay08.cgColor
     }
 
     // MARK: - Configuration
@@ -106,11 +129,13 @@ final class SPAlarmsListEmptyState: UIView {
 
         addSubview(iconHost)
         iconHost.addSubview(iconView)
+        iconHost.layer.borderColor = AppColors.whiteOverlay08.cgColor
 
-        let textStack = UIStackView(arrangedSubviews: [capsLabel, bodyLabel])
+        let textStack = UIStackView(arrangedSubviews: [titleLabel, bodyLabel])
         textStack.axis = .vertical
         textStack.alignment = .center
-        textStack.spacing = AppSpacing.sp2
+        // h2 → body-lg gap of 10pt per SPMore.jsx L434 (`marginTop: 10`).
+        textStack.spacing = 10
         textStack.translatesAutoresizingMaskIntoConstraints = false
         addSubview(textStack)
         addSubview(addButton)
@@ -118,26 +143,28 @@ final class SPAlarmsListEmptyState: UIView {
         addButton.addTarget(self, action: #selector(addTapped), for: .touchUpInside)
 
         NSLayoutConstraint.activate([
-            // Icon centered, 96×96.
+            // Icon centered, 84×84.
             iconHost.centerXAnchor.constraint(equalTo: centerXAnchor),
-            iconHost.bottomAnchor.constraint(equalTo: textStack.topAnchor, constant: -AppSpacing.sp6),
-            iconHost.widthAnchor.constraint(equalToConstant: 96),
-            iconHost.heightAnchor.constraint(equalToConstant: 96),
+            iconHost.bottomAnchor.constraint(equalTo: textStack.topAnchor, constant: -AppSpacing.sp5),
+            iconHost.widthAnchor.constraint(equalToConstant: 84),
+            iconHost.heightAnchor.constraint(equalToConstant: 84),
 
             iconView.centerXAnchor.constraint(equalTo: iconHost.centerXAnchor),
             iconView.centerYAnchor.constraint(equalTo: iconHost.centerYAnchor),
 
-            // Text — centered group above the CTA.
+            // Text — centered group, ~280pt max width (`maxWidth: 280`).
             textStack.centerYAnchor.constraint(equalTo: centerYAnchor),
-            textStack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: AppSpacing.sp7),
-            textStack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -AppSpacing.sp7),
+            textStack.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: AppSpacing.sp7),
+            textStack.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -AppSpacing.sp7),
+            textStack.centerXAnchor.constraint(equalTo: centerXAnchor),
+            textStack.widthAnchor.constraint(lessThanOrEqualToConstant: 280),
 
-            // CTA — full-width below the text, anchored to a flexible gap so
-            // the column reads "balanced" without forcing the button against
-            // the safe-area bottom.
+            // CTA — intrinsic width, centered, 28pt below the text
+            // (`marginTop: 28`).
             addButton.topAnchor.constraint(equalTo: textStack.bottomAnchor, constant: AppSpacing.sp7),
-            addButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: AppSpacing.screenInset),
-            addButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -AppSpacing.screenInset)
+            addButton.centerXAnchor.constraint(equalTo: centerXAnchor),
+            addButton.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: AppSpacing.screenInset),
+            addButton.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -AppSpacing.screenInset)
         ])
     }
 

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPAlarmsListHeader.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPAlarmsListHeader.swift
@@ -39,6 +39,12 @@ final class SPAlarmsListHeader: UIView {
     /// flows (create-alarm vs top-up).
     var onAddTap: (() -> Void)?
 
+    /// Triggered when the user taps the 40×40 gear button. The settings
+    /// affordance now lives inside the header title row (left of the money
+    /// "+"), so the host controller can hide the system nav bar entirely on
+    /// this tab (SPScreensV2.jsx L316-333).
+    var onSettingsTap: (() -> Void)?
+
     /// Kept for binary-compatibility with the legacy header — the V2
     /// pill folds the warning state into itself, so this callback now
     /// routes through the same "Пополнить" tap path.
@@ -60,7 +66,7 @@ final class SPAlarmsListHeader: UIView {
         applyTone(tone)
         balanceValueLabel.attributedText = MoneyFormatter.attributed(
             balance,
-            digitsFont: AppTypography.moneyMd,
+            digitsFont: Self.pillValueFont,
             // 0 ₽ renders in pain-300 per SPScreensV2.jsx L369; the
             // non-zero tones keep the label's fg1 textColor.
             color: tone == .zero ? AppColors.pain300 : nil
@@ -122,11 +128,37 @@ final class SPAlarmsListHeader: UIView {
             string: "Будильники",
             attributes: [
                 .font: AppTypography.h1,
-                .kern: -32 * 0.01, // ~ -0.32 — matches `letterSpacing: -.02em` doubled-down
+                // Full `letterSpacing: -.02em` per SPScreensV2.jsx L315 — the
+                // earlier value was halved (#280). `kern(em:size:)` resolves the
+                // em tracking to points for the 32pt h1.
+                .kern: AppTypography.kern(em: -0.02, size: 32),
                 .foregroundColor: AppColors.fg1
             ]
         )
         return label
+    }()
+
+    /// 40×40 whiteOverlay06 circle hosting the gear glyph — the in-header
+    /// Settings entry point (SPScreensV2.jsx L318-324). Sits left of the
+    /// money "+"; tapping it routes through `onSettingsTap`.
+    private let settingsButton: UIControl = {
+        let view = UIControl()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.layer.cornerRadius = 20
+        view.layer.masksToBounds = true
+        view.backgroundColor = AppColors.whiteOverlay06
+        return view
+    }()
+
+    private let settingsIconView: UIImageView = {
+        let view = UIImageView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.contentMode = .scaleAspectFit
+        view.tintColor = AppColors.fg2
+        let config = UIImage.SymbolConfiguration(pointSize: 18, weight: .regular)
+        view.image = UIImage(systemName: "gearshape", withConfiguration: config)
+        view.isUserInteractionEnabled = false
+        return view
     }()
 
     private let addButton: UIControl = {
@@ -211,8 +243,9 @@ final class SPAlarmsListHeader: UIView {
         view.translatesAutoresizingMaskIntoConstraints = false
         view.contentMode = .scaleAspectFit
         view.tintColor = AppColors.fgOnMoney
-        let config = UIImage.SymbolConfiguration(pointSize: 18, weight: .semibold)
-        view.image = UIImage(systemName: "creditcard.fill", withConfiguration: config)
+        // Code-drawn wallet glyph (SPScreensV2.jsx L359) — replaces the
+        // SF `creditcard.fill` so the pill matches the V3 icon set (#280).
+        view.image = SPIcons.wallet(size: 18)
         return view
     }()
 
@@ -230,11 +263,19 @@ final class SPAlarmsListHeader: UIView {
         return label
     }()
 
+    /// 14pt mono bold balance amount. The design uses `700 14px/18px mono`
+    /// with `letter-spacing: 0` (SPScreensV2.jsx L364-369) — a compact inline
+    /// value, NOT the 20pt `moneyMd` hero number the pill carried before
+    /// (#280). Built in `pillValueFont` so `setBalance` and this declaration
+    /// agree on one source.
+    private static let pillValueFont = AppFonts.mono(.bold, 14)
+
     private let balanceValueLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        // 20pt mono bold — `moneyMd`. Tabular nums via the mono font.
-        label.font = AppTypography.moneyMd
+        // 14pt mono bold — compact inline amount. Tabular nums via the mono
+        // font; tracking stays at 0 per the design.
+        label.font = SPAlarmsListHeader.pillValueFont
         label.textColor = AppColors.fg1
         label.adjustsFontSizeToFitWidth = true
         label.minimumScaleFactor = 0.6
@@ -306,6 +347,8 @@ final class SPAlarmsListHeader: UIView {
         backgroundColor = AppColors.bg0
 
         addSubview(titleLabel)
+        addSubview(settingsButton)
+        settingsButton.addSubview(settingsIconView)
         addSubview(addButton)
         addButton.addSubview(addButtonGradient)
         addButton.addSubview(addIconView)
@@ -324,6 +367,7 @@ final class SPAlarmsListHeader: UIView {
         addSubview(bottomHairline)
 
         addButton.addTarget(self, action: #selector(addTapped), for: .touchUpInside)
+        settingsButton.addTarget(self, action: #selector(settingsTapped), for: .touchUpInside)
         pillButton.addTarget(self, action: #selector(pillTapped), for: .touchUpInside)
         topUpButton.addTarget(self, action: #selector(topUpTapped), for: .touchUpInside)
 
@@ -334,9 +378,19 @@ final class SPAlarmsListHeader: UIView {
             titleLabel.topAnchor.constraint(equalTo: topAnchor, constant: AppSpacing.sp2),
             titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: inset),
             titleLabel.trailingAnchor.constraint(
-                lessThanOrEqualTo: addButton.leadingAnchor,
+                lessThanOrEqualTo: settingsButton.leadingAnchor,
                 constant: -AppSpacing.sp3
             ),
+
+            // Gear — 40×40 circle left of the money "+", 10pt gap between the
+            // two (SPScreensV2.jsx L316).
+            settingsButton.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
+            settingsButton.trailingAnchor.constraint(equalTo: addButton.leadingAnchor, constant: -10),
+            settingsButton.widthAnchor.constraint(equalToConstant: 40),
+            settingsButton.heightAnchor.constraint(equalToConstant: 40),
+
+            settingsIconView.centerXAnchor.constraint(equalTo: settingsButton.centerXAnchor),
+            settingsIconView.centerYAnchor.constraint(equalTo: settingsButton.centerYAnchor),
 
             addButton.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
             addButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -inset),
@@ -460,8 +514,7 @@ final class SPAlarmsListHeader: UIView {
             colors: SPSupport.moneyGradientColors,
             locations: SPSupport.moneyGradientLocations
         )
-        let config = UIImage.SymbolConfiguration(pointSize: 18, weight: .semibold)
-        walletIconImageView.image = UIImage(systemName: "creditcard.fill", withConfiguration: config)
+        walletIconImageView.image = SPIcons.wallet(size: 18)
         walletIconImageView.tintColor = AppColors.fgOnMoney
     }
 
@@ -474,6 +527,15 @@ final class SPAlarmsListHeader: UIView {
             SPSupport.animatePress(self.addButton, pressed: false)
         }
         onAddTap?()
+    }
+
+    @objc private func settingsTapped() {
+        SPSupport.animatePress(settingsButton, pressed: true)
+        DispatchQueue.main.asyncAfter(deadline: .now() + SPSupport.durationQuick) { [weak self] in
+            guard let self else { return }
+            SPSupport.animatePress(self.settingsButton, pressed: false)
+        }
+        onSettingsTap?()
     }
 
     @objc private func pillTapped() {

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPIcons.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPIcons.swift
@@ -116,6 +116,65 @@ enum SPIcons {
         }
     }
 
+    /// Колокольчик — купол + язычок + основание. The empty-state /
+    /// notification glyph. JSX: `IconBell`
+    /// (`M6 19V11a6 6 0 0 1 12 0v8` / `M4 19h16` / `M10 22h4`).
+    static func bell(size: CGFloat) -> UIImage {
+        render(size: size) { path in
+            // Dome: left wall up, arc across the top, right wall down.
+            path.move(to: CGPoint(x: 6, y: 19))
+            path.addLine(to: CGPoint(x: 6, y: 11))
+            path.addArc(
+                withCenter: CGPoint(x: 12, y: 11),
+                radius: 6,
+                startAngle: .pi,
+                endAngle: 0,
+                clockwise: true
+            )
+            path.addLine(to: CGPoint(x: 18, y: 19))
+            // Base line.
+            path.move(to: CGPoint(x: 4, y: 19))
+            path.addLine(to: CGPoint(x: 20, y: 19))
+            // Clapper.
+            path.move(to: CGPoint(x: 10, y: 22))
+            path.addLine(to: CGPoint(x: 14, y: 22))
+        }
+    }
+
+    /// Динамик с волнами — speaker cone + two sound arcs. The alarm-sound
+    /// pill glyph. JSX: `IconSound`
+    /// (`M11 5L6 9H3v6h3l5 4V5z` / `M16 9a4 4 0 0 1 0 6` / `M19 6a8 8 0 0 1 0 12`).
+    static func sound(size: CGFloat) -> UIImage {
+        render(size: size) { path in
+            // Speaker cone.
+            path.move(to: CGPoint(x: 11, y: 5))
+            path.addLine(to: CGPoint(x: 6, y: 9))
+            path.addLine(to: CGPoint(x: 3, y: 9))
+            path.addLine(to: CGPoint(x: 3, y: 15))
+            path.addLine(to: CGPoint(x: 6, y: 15))
+            path.addLine(to: CGPoint(x: 11, y: 19))
+            path.close()
+            // Inner wave: `M16 9a4 4 0 0 1 0 6` — quarter-pair arc on the right.
+            path.move(to: CGPoint(x: 16, y: 9))
+            path.addArc(
+                withCenter: CGPoint(x: 16, y: 12),
+                radius: 3,
+                startAngle: -.pi / 2,
+                endAngle: .pi / 2,
+                clockwise: true
+            )
+            // Outer wave: `M19 6a8 8 0 0 1 0 12`.
+            path.move(to: CGPoint(x: 19, y: 6))
+            path.addArc(
+                withCenter: CGPoint(x: 19, y: 12),
+                radius: 6,
+                startAngle: -.pi / 2,
+                endAngle: .pi / 2,
+                clockwise: true
+            )
+        }
+    }
+
     /// «Zz» — большая Z + маленькая Z по диагонали. JSX: `IconSnooze`.
     static func snooze(size: CGFloat) -> UIImage {
         render(size: size) { path in


### PR DESCRIPTION
Fixes #280

Brings the AlarmsList (and Wallet) chrome in line with the V3 design (audit `docs/AUDIT_DESIGN_GAP_2026-06-12.md` alarms P2-1/P2-2/P3-8/9/11/12/13; `SPScreensV2.jsx:300-450`, `SPMore.jsx:415-445`).

## What changed
- **In-header gear + no system nav bar (Alarms).** Added a 40×40 whiteOverlay06 gear circle inside the title row, left of the money "+" (`onSettingsTap`). The system nav bar is now hidden on the Alarms tab (`viewWillAppear`) and restored just before pushing Settings/child screens so push-navigation keeps its back arrow.
- **Wallet tab.** Removed the invented gear bar item (no Settings entry in the design) and applied the same hide/restore nav-bar handling; history push restores the bar.
- **Balance pill.** Value is now `700 14px` mono (was `moneyMd` 20pt) with `letter-spacing: 0`; wallet glyph (`SPIcons.wallet`) replaces `creditcard.fill`; h1 title kerning is the full −0.02em (was halved).
- **Empty state (V3).** 84×84 whiteOverlay06 tile + whiteOverlay08 hairline, outline bell at `fg3` (not the warn-gradient hero); h2 «Ни одного будильника» (−0.01em); body-lg «Создайте первый — выставите время, цену откладывания и положите баланс.» (drops the banned «снуз» word); intrinsic-width money-lg «Создать будильник».
- **AlarmCell.** Enabled cards keep their 12px pill icons (price ₽-coin, multiplier trend-up, sound speaker glyph); disabled cards drop pill icons entirely. Card chrome follows the SPCard recipe — `.raised` (shadow-2) enabled / `.surface` (shadow-1) disabled — with the documented light-mode hairline a11y deviation, replacing the old flat 1pt border/no-shadow. Clock label gets −0.04em clock tracking.
- **SPIcons.** Added code-drawn `bell` and `sound` glyphs (ports of `IconBell` / `IconSound`).

`AlarmsListViewModel` «ЕДИНОЖДЫ» caps-row logic (#303) is untouched.

## Verify
- swiftlint: 0 errors on changed files
- `xcodebuild build` (generic iOS Simulator, CODE_SIGNING_ALLOWED=NO): **BUILD SUCCEEDED**
- `xcodebuild build-for-testing`: **TEST BUILD SUCCEEDED**
- Tests: no existing test references the changed copy/APIs (pure view-layer change, no logic extracted) — zero test breakage; no new tests warranted.