### PR TITLE
[ui] Sound + Theme pickers V3 — card list, Превью, 3-col grid, 135° gradients (#285)

### DIFF
--- a/SnoozePay/SnoozePay/Models/AlarmThemeSubtitles.swift
+++ b/SnoozePay/SnoozePay/Models/AlarmThemeSubtitles.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Short Russian subtitles for the built-in alarm themes, surfaced beneath the
+/// theme name in the V3 grid tiles (`SPMore2.jsx:394-400`, #285).
+///
+/// Kept as a pure id→subtitle map (no UIKit) so the mapping can be unit-tested
+/// and so the picker tile stays a thin layout layer. The custom-photo slot
+/// gets «Из галереи» to match the design's «Своё фото · Из галереи».
+enum AlarmThemeSubtitles {
+
+    /// Built-in theme subtitles, keyed by `AlarmTheme.id`. Derived from the
+    /// design's per-theme copy (dawn «Тёплый янтарь», ocean «Холодный мятный»…).
+    private static let map: [String: String] = [
+        "dawn": "Тёплый янтарь",
+        "ocean": "Холодный мятный",
+        "mountains": "Молочный свет",
+        "forest": "Хвойный сумрак",
+        "neon": "Городская ночь",
+        "abstract": "Чистый цвет"
+    ]
+
+    /// Subtitle shown on the custom-photo slot tile.
+    static let customSlotSubtitle = "Из галереи"
+
+    /// Subtitle for the given theme. Built-ins resolve from `map`; the custom
+    /// theme returns `customSlotSubtitle`; anything unmapped returns "".
+    static func subtitle(for theme: AlarmTheme) -> String {
+        if case .custom = theme { return customSlotSubtitle }
+        return map[theme.id] ?? ""
+    }
+}

--- a/SnoozePay/SnoozePay/Models/SoundCatalogue.swift
+++ b/SnoozePay/SnoozePay/Models/SoundCatalogue.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Static source of truth for the alarm-sound catalogue surfaced in the V3
+/// sound picker (`SoundPickerViewController`, #285).
+///
+/// The design (`SPMore.jsx:330-409`) renders each sound as a card row with a
+/// descriptive Russian subtitle («Тёплый рассвет с птицами» style) plus a
+/// trailing «Своя мелодия · скоро» slot that is visually present but disabled
+/// until custom-import ships. Keeping this as a plain value type (no UIKit)
+/// lets the subtitle/catalogue mapping be unit-tested without a simulator —
+/// the pure-logic split the issue calls for.
+///
+/// `CreateAlarmViewModel.availableSounds` is derived from `entries`, so the
+/// 10-sound catalogue stays the single source of truth; the picker pulls the
+/// disabled custom slot from `customSlot`.
+enum SoundCatalogue {
+
+    /// One selectable sound. `subtitle` is the V3 descriptive copy.
+    struct Entry: Equatable {
+        let id: String
+        let name: String
+        let subtitle: String
+    }
+
+    /// The 10 system sounds, in catalogue order. IDs and display names match
+    /// the pre-V3 `availableSounds` list (do NOT cut to 6 — design keeps the
+    /// full lineup); only the descriptive subtitles are new.
+    static let entries: [Entry] = [
+        Entry(id: "dawn", name: "Рассвет", subtitle: "Тёплый рассвет с птицами"),
+        Entry(id: "radar", name: "Радар", subtitle: "Нарастающий сигнал тревоги"),
+        Entry(id: "drops", name: "Капли", subtitle: "Мягкие капли воды"),
+        Entry(id: "piano", name: "Пиано", subtitle: "Спокойные клавиши"),
+        Entry(id: "guitar", name: "Гитара", subtitle: "Лёгкий струнный перебор"),
+        Entry(id: "bell", name: "Колокольчик", subtitle: "Чистый звон без музыки"),
+        Entry(id: "waves", name: "Волны", subtitle: "Прибой и морской бриз"),
+        Entry(id: "birds", name: "Птицы", subtitle: "Только щебет, без музыки"),
+        Entry(id: "classic", name: "Классика", subtitle: "Старый добрый писк"),
+        Entry(id: "jazz", name: "Джаз", subtitle: "Бодрое утреннее настроение")
+    ]
+
+    /// Disabled trailing slot rendered after the catalogue. Custom-melody
+    /// import is out of scope here, so the row reads «Своя мелодия · скоро»
+    /// and is non-interactive (matches the design's «Своя мелодия» slot).
+    static let customSlot = Entry(
+        id: "custom",
+        name: "Своя мелодия",
+        subtitle: "Скоро"
+    )
+
+    /// Subtitle for a given sound id, or `nil` when the id isn't catalogued.
+    /// Used by the picker to keep subtitle wiring data-driven.
+    static func subtitle(for soundID: String) -> String? {
+        entries.first(where: { $0.id == soundID })?.subtitle
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmThemePickerViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmThemePickerViewController.swift
@@ -127,7 +127,17 @@ final class AlarmThemePickerViewController: UIViewController {
         )
         titleLabel.accessibilityLabel = "Тема будильника"
         navigationItem.titleView = titleLabel
+
+        // «Готово» quiet-sm — V3 exit affordance (matches SPMore2.jsx:411).
+        let doneButton = SPButton(title: "Готово", variant: .quiet, size: .sm)
+        doneButton.addTarget(self, action: #selector(doneTapped), for: .touchUpInside)
+        navigationItem.rightBarButtonItem = UIBarButtonItem(customView: doneButton)
+
         setupCollectionView()
+    }
+
+    @objc private func doneTapped() {
+        navigationController?.popViewController(animated: true)
     }
 
     // MARK: - Setup
@@ -150,6 +160,11 @@ final class AlarmThemePickerViewController: UIViewController {
         grid.dataSource = self
         grid.delegate = self
         grid.register(AlarmThemeTileCell.self, forCellWithReuseIdentifier: AlarmThemeTileCell.reuseID)
+        grid.register(
+            ThemeSectionHeaderView.self,
+            forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
+            withReuseIdentifier: ThemeSectionHeaderView.reuseID
+        )
         self.view.addSubview(grid)
 
         NSLayoutConstraint.activate([
@@ -204,32 +219,36 @@ final class AlarmThemePickerViewController: UIViewController {
         let gradient = CAGradientLayer()
         gradient.colors = colors
         gradient.locations = AlarmThemeRendering.gradientLocations(for: theme)
-        gradient.startPoint = CGPoint(x: 0.5, y: 0.0)
-        gradient.endPoint = CGPoint(x: 0.5, y: 1.0)
+        // 135° diagonal everywhere (top-left → bottom-right) — matches
+        // ThemeRowCell + the design's `linear-gradient(135deg, …)`.
+        gradient.startPoint = SPSupport.gradientStart
+        gradient.endPoint = SPSupport.gradientEnd
         gradient.frame = previewContainer.bounds
         previewContainer.layer.insertSublayer(gradient, at: 0)
         previewGradient = gradient
     }
 
-    /// Two-column compositional grid. Item ratio is 16:9 — width is whatever
-    /// the column resolves to, height tracks via `.fractionalWidth(9.0/16.0)`
-    /// on the group, dropped to ~`0.625` to leave room for the in-tile name
-    /// label without forcing a separate sectional header layout.
+    /// Three-column compositional grid, tile aspect 1:1.2 (V3 — SPMore2.jsx:
+    /// 430-436). The 10pt inter-column gap is folded into per-item trailing
+    /// insets; the row group height tracks the tile aspect so tiles stay 1:1.2.
+    /// A «Готовые темы» caps header sits above the grid.
     private func makeLayout() -> UICollectionViewLayout {
+        let columns: CGFloat = 3
+        let gap = AppSpacing.sp2 + 2 // ≈10pt
+        // Approximate fraction the gap takes per row so the tile width/height
+        // ratio stays close to 1:1.2 across device widths.
         let item = NSCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(0.5),
+            widthDimension: .fractionalWidth(1.0 / columns),
             heightDimension: .fractionalHeight(1.0)
         ))
-        item.contentInsets = NSDirectionalEdgeInsets(
-            top: 0, leading: 0, bottom: 0, trailing: AppSpacing.sp3
-        )
+        item.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: gap)
 
-        // Group height = (9/16) * group-width. Group width ≈ available width
-        // after content insets; each row contains 2 items.
+        // Tile height ≈ tileWidth * 1.2. tileWidth ≈ (groupWidth / 3). Express
+        // the group height as a fraction of group width: (1/3) * 1.2.
         let group = NSCollectionLayoutGroup.horizontal(
             layoutSize: NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1.0),
-                heightDimension: .fractionalWidth(0.5 * (9.0 / 16.0) + 0.06)
+                heightDimension: .fractionalWidth((1.0 / columns) * 1.2)
             ),
             subitems: [item]
         )
@@ -237,12 +256,22 @@ final class AlarmThemePickerViewController: UIViewController {
 
         let section = NSCollectionLayoutSection(group: group)
         section.contentInsets = NSDirectionalEdgeInsets(
-            top: AppSpacing.sp4,
+            top: AppSpacing.sp3,
             leading: AppSpacing.sp4,
             bottom: AppSpacing.sp4,
-            trailing: AppSpacing.sp4 - AppSpacing.sp3 // trailing inset already on items
+            trailing: AppSpacing.sp4 - gap // trailing gap already on the last item
         )
-        section.interGroupSpacing = AppSpacing.sp3
+        section.interGroupSpacing = gap
+
+        let header = NSCollectionLayoutBoundarySupplementaryItem(
+            layoutSize: NSCollectionLayoutSize(
+                widthDimension: .fractionalWidth(1.0),
+                heightDimension: .absolute(28)
+            ),
+            elementKind: UICollectionView.elementKindSectionHeader,
+            alignment: .top
+        )
+        section.boundarySupplementaryItems = [header]
 
         return UICollectionViewCompositionalLayout(section: section)
     }
@@ -324,6 +353,62 @@ extension AlarmThemePickerViewController: UICollectionViewDataSource, UICollecti
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         collectionView.deselectItem(at: indexPath, animated: true)
         selectItem(at: indexPath)
+    }
+
+    func collectionView(
+        _ collectionView: UICollectionView,
+        viewForSupplementaryElementOfKind kind: String,
+        at indexPath: IndexPath
+    ) -> UICollectionReusableView {
+        guard let header = collectionView.dequeueReusableSupplementaryView(
+            ofKind: kind,
+            withReuseIdentifier: ThemeSectionHeaderView.reuseID,
+            for: indexPath
+        ) as? ThemeSectionHeaderView else {
+            return UICollectionReusableView()
+        }
+        header.setTitle("Готовые темы")
+        return header
+    }
+}
+
+// MARK: - Section header
+
+/// Caps section header «Готовые темы» above the theme grid (#285).
+private final class ThemeSectionHeaderView: UICollectionReusableView {
+
+    static let reuseID = "ThemeSectionHeaderView"
+
+    private let label: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        addSubview(label)
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: AppSpacing.sp4),
+            label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -AppSpacing.sp4),
+            label.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -AppSpacing.sp2)
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func setTitle(_ title: String) {
+        label.attributedText = NSAttributedString(
+            string: title.uppercased(),
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.fg3
+            ]
+        )
     }
 }
 

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/AlarmThemeTileCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/AlarmThemeTileCell.swift
@@ -1,12 +1,12 @@
 import UIKit
 
-/// Single grid tile rendered by `AlarmThemePickerViewController` (#151).
+/// Single grid tile rendered by `AlarmThemePickerViewController` (V3 — #285).
 ///
-/// Top of the tile previews the theme (gradient layer for built-ins, photo
-/// or "+ icon" for `.custom`); the footer band carries the uppercased name
-/// and a checkmark when selected. The tile uses `SPCard(tone: .surface,
-/// padding: 0, cornerRadius: AppRadius.md)` so it shares the design system's
-/// shadow + stroke recipe with the rest of the create-form surfaces.
+/// Per `SPMore2.jsx:434-456`: the whole tile is the theme preview (135° gradient
+/// for built-ins, photo / "+" for `.custom`). The name + subtitle are overlaid
+/// bottom-left with a text shadow (no opaque footer band); a 22pt money-gradient
+/// checkmark badge sits top-right when selected, and the selected tile gets a
+/// money outline with a 2pt offset.
 final class AlarmThemeTileCell: UICollectionViewCell {
 
     static let reuseID = "AlarmThemeTileCell"
@@ -36,13 +36,12 @@ final class AlarmThemeTileCell: UICollectionViewCell {
         return view
     }()
 
-    /// Centered "+" symbol for the empty `.custom` slot. Hidden the moment a
-    /// custom image is picked so the user gets a thumbnail preview.
+    /// Centered "+" symbol for the empty `.custom` slot.
     private let plusIcon: UIImageView = {
         let icon = UIImageView(image: UIImage(systemName: "plus")?
             .withConfiguration(UIImage.SymbolConfiguration(pointSize: 28, weight: .semibold)))
         icon.translatesAutoresizingMaskIntoConstraints = false
-        icon.tintColor = AppColors.fg2
+        icon.tintColor = AppColors.fg3
         icon.contentMode = .center
         icon.isHidden = true
         return icon
@@ -51,27 +50,48 @@ final class AlarmThemeTileCell: UICollectionViewCell {
     private let nameLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.textAlignment = .center
-        label.attributedText = nil
-        label.textColor = AppColors.fg1
+        label.font = AppTypography.buttonSm
+        label.textColor = .white
+        label.numberOfLines = 1
         return label
     }()
 
-    /// `bg2` chrome at the bottom of the tile holds the name + checkmark so
-    /// the type stays legible against any underlying gradient or photo.
-    private let footerView: UIView = {
+    private let subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = AppFonts.sans(.medium, 10)
+        label.textColor = UIColor.white.withAlphaComponent(0.75)
+        label.numberOfLines = 1
+        return label
+    }()
+
+    private let textStack: UIStackView = {
+        let stack = UIStackView()
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .vertical
+        stack.spacing = 1
+        stack.alignment = .leading
+        return stack
+    }()
+
+    /// 22pt money-gradient checkmark badge, top-right when selected.
+    private let checkmarkBadge: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = AppColors.bg2.withAlphaComponent(0.92)
+        view.layer.cornerRadius = 11
+        view.layer.masksToBounds = true
+        view.isHidden = true
         return view
     }()
 
-    private let checkmark: UIImageView = {
-        let view = UIImageView(image: UIImage(systemName: "checkmark.circle.fill")?
-            .withConfiguration(UIImage.SymbolConfiguration(pointSize: 22, weight: .bold)))
+    private let checkmarkGradient = CAGradientLayer()
+
+    private let checkmarkIcon: UIImageView = {
+        let view = UIImageView(image: UIImage(systemName: "checkmark")?
+            .withConfiguration(UIImage.SymbolConfiguration(pointSize: 12, weight: .bold)))
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.tintColor = AppColors.money500
-        view.isHidden = true
+        view.tintColor = AppColors.fgOnMoney
+        view.contentMode = .center
         return view
     }()
 
@@ -94,9 +114,20 @@ final class AlarmThemeTileCell: UICollectionViewCell {
         card.addSubview(gradientView)
         card.addSubview(imageView)
         card.addSubview(plusIcon)
-        card.addSubview(footerView)
-        footerView.addSubview(nameLabel)
-        footerView.addSubview(checkmark)
+
+        textStack.addArrangedSubview(nameLabel)
+        textStack.addArrangedSubview(subtitleLabel)
+        applyTextShadow(to: nameLabel)
+        applyTextShadow(to: subtitleLabel)
+        card.addSubview(textStack)
+
+        checkmarkGradient.startPoint = SPSupport.gradientStart
+        checkmarkGradient.endPoint = SPSupport.gradientEnd
+        checkmarkGradient.colors = SPSupport.moneyGradientColors
+        checkmarkGradient.locations = SPSupport.moneyGradientLocations
+        checkmarkBadge.layer.insertSublayer(checkmarkGradient, at: 0)
+        checkmarkBadge.addSubview(checkmarkIcon)
+        card.addSubview(checkmarkBadge)
 
         NSLayoutConstraint.activate([
             card.topAnchor.constraint(equalTo: contentView.topAnchor),
@@ -115,91 +146,92 @@ final class AlarmThemeTileCell: UICollectionViewCell {
             imageView.bottomAnchor.constraint(equalTo: card.bottomAnchor),
 
             plusIcon.centerXAnchor.constraint(equalTo: card.centerXAnchor),
-            plusIcon.centerYAnchor.constraint(equalTo: card.centerYAnchor, constant: -10),
+            plusIcon.centerYAnchor.constraint(equalTo: card.centerYAnchor, constant: -8),
 
-            footerView.leadingAnchor.constraint(equalTo: card.leadingAnchor),
-            footerView.trailingAnchor.constraint(equalTo: card.trailingAnchor),
-            footerView.bottomAnchor.constraint(equalTo: card.bottomAnchor),
-            footerView.heightAnchor.constraint(equalToConstant: 28),
+            textStack.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: AppSpacing.sp2),
+            textStack.trailingAnchor.constraint(lessThanOrEqualTo: card.trailingAnchor, constant: -AppSpacing.sp2),
+            textStack.bottomAnchor.constraint(equalTo: card.bottomAnchor, constant: -AppSpacing.sp2),
 
-            nameLabel.centerYAnchor.constraint(equalTo: footerView.centerYAnchor),
-            nameLabel.leadingAnchor.constraint(equalTo: footerView.leadingAnchor, constant: AppSpacing.sp3),
-            nameLabel.trailingAnchor.constraint(lessThanOrEqualTo: checkmark.leadingAnchor, constant: -AppSpacing.sp2),
+            checkmarkBadge.topAnchor.constraint(equalTo: card.topAnchor, constant: 6),
+            checkmarkBadge.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -6),
+            checkmarkBadge.widthAnchor.constraint(equalToConstant: 22),
+            checkmarkBadge.heightAnchor.constraint(equalToConstant: 22),
 
-            checkmark.centerYAnchor.constraint(equalTo: footerView.centerYAnchor),
-            checkmark.trailingAnchor.constraint(equalTo: footerView.trailingAnchor, constant: -AppSpacing.sp2),
-            checkmark.widthAnchor.constraint(equalToConstant: 24),
-            checkmark.heightAnchor.constraint(equalToConstant: 24)
+            checkmarkIcon.centerXAnchor.constraint(equalTo: checkmarkBadge.centerXAnchor),
+            checkmarkIcon.centerYAnchor.constraint(equalTo: checkmarkBadge.centerYAnchor)
         ])
+    }
+
+    private func applyTextShadow(to label: UILabel) {
+        label.layer.shadowColor = UIColor.black.cgColor
+        label.layer.shadowOpacity = 0.6
+        label.layer.shadowOffset = CGSize(width: 0, height: 1)
+        label.layer.shadowRadius = 4
+        label.layer.masksToBounds = false
     }
 
     override func layoutSubviews() {
         super.layoutSubviews()
         gradientLayer?.frame = gradientView.bounds
+        checkmarkGradient.frame = checkmarkBadge.bounds
     }
 
     // MARK: - Configure
 
     /// - Parameters:
-    ///   - theme: built-in theme to render the gradient/name from. Ignored
-    ///     for the custom slot (pass `.dawn` as a placeholder).
+    ///   - theme: built-in theme to render the gradient/name/subtitle from.
+    ///     Ignored for the custom slot (pass `.dawn` as a placeholder).
     ///   - isCustomSlot: when true, render the `+` affordance plus a dimmed
-    ///     placeholder gradient. When the user has already picked a photo,
-    ///     pass `customImage` to surface the thumbnail instead.
-    ///   - isSelected: highlights the tile (money-tinted border + checkmark).
-    ///   - customImage: thumbnail for the `.custom` slot when a photo has
-    ///     been picked previously. nil → "+ Своё фото" placeholder.
+    ///     placeholder gradient (or the picked photo thumbnail).
+    ///   - isSelected: money outline + offset + checkmark badge.
+    ///   - customImage: thumbnail for the `.custom` slot when a photo exists.
     func configure(theme: AlarmTheme, isCustomSlot: Bool, isSelected: Bool, customImage: UIImage?) {
-        // Reset prior state so recycled cells don't keep the previous tile's
-        // gradient / image.
         gradientLayer?.removeFromSuperlayer()
         gradientLayer = nil
         imageView.image = nil
         imageView.isHidden = true
         plusIcon.isHidden = true
 
-        let displayName: String
+        let displayTheme: AlarmTheme
         if isCustomSlot {
-            displayName = AlarmTheme.custom(imagePath: URL(fileURLWithPath: "/")).displayName
+            displayTheme = AlarmTheme.custom(imagePath: URL(fileURLWithPath: "/"))
             if let image = customImage {
                 imageView.image = image
                 imageView.isHidden = false
+                gradientView.alpha = 0
             } else {
                 installGradient(for: .dawn)
-                gradientView.alpha = 0.4 // dim the placeholder so "+" pops
+                gradientView.alpha = 0.4 // dim placeholder so "+" pops
                 plusIcon.isHidden = false
             }
         } else if case .custom(let url) = theme {
-            displayName = theme.displayName
+            displayTheme = theme
             if let image = AlarmThemeImageStore.loadImage(at: url) {
                 imageView.image = image
                 imageView.isHidden = false
+                gradientView.alpha = 0
             } else {
                 installGradient(for: .dawn)
+                gradientView.alpha = 1.0
             }
         } else {
-            displayName = theme.displayName
+            displayTheme = theme
             installGradient(for: theme)
             gradientView.alpha = 1.0
         }
 
-        nameLabel.attributedText = NSAttributedString(
-            string: displayName.uppercased(),
-            attributes: [
-                .font: AppTypography.caps,
-                .kern: AppTypography.capsKerning,
-                .foregroundColor: AppColors.fg1
-            ]
-        )
+        nameLabel.text = displayTheme.displayName
+        subtitleLabel.text = AlarmThemeSubtitles.subtitle(for: displayTheme)
 
-        checkmark.isHidden = !isSelected
-        // Outline the selected tile with a money-tinted border for an extra
-        // affordance beyond the checkmark.
+        checkmarkBadge.isHidden = !isSelected
+        // Money outline + 2pt offset on the selected tile (SPMore2.jsx:438-439).
         if isSelected {
             card.layer.borderColor = AppColors.money500.cgColor
             card.layer.borderWidth = 2
         } else {
-            card.layer.borderWidth = 0
+            let scale = traitCollection.displayScale > 0 ? traitCollection.displayScale : 1
+            card.layer.borderColor = AppColors.stroke1.cgColor
+            card.layer.borderWidth = 1.0 / scale
         }
     }
 
@@ -208,8 +240,10 @@ final class AlarmThemeTileCell: UICollectionViewCell {
         let layer = CAGradientLayer()
         layer.colors = colors
         layer.locations = AlarmThemeRendering.gradientLocations(for: theme)
-        layer.startPoint = CGPoint(x: 0.5, y: 0.0)
-        layer.endPoint = CGPoint(x: 0.5, y: 1.0)
+        // 135° diagonal (top-left → bottom-right) — matches ThemeRowCell and the
+        // design's `linear-gradient(135deg, …)`.
+        layer.startPoint = SPSupport.gradientStart
+        layer.endPoint = SPSupport.gradientEnd
         layer.frame = gradientView.bounds
         gradientView.layer.insertSublayer(layer, at: 0)
         gradientLayer = layer

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/SoundPickerRowCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/SoundPickerRowCell.swift
@@ -1,33 +1,45 @@
 import UIKit
 
-/// Single-sound row used by `SoundPickerViewController` (#150 design refresh).
+/// Single-sound row used by `SoundPickerViewController` (V3 — #285).
 ///
-/// Layout: leading `SPButton(.quiet, .sm)` toggling between play / pause →
-/// title (bodyLg) + duration (meta) text stack → trailing checkmark on the
-/// selected row. The whole content is wrapped in a hand-rolled card surface
-/// — `SPCard` itself doesn't expose a "selected" state, so we render the
-/// money-tinted border + `whiteOverlay06` fill directly on a plain `UIView`
-/// container so the picker can animate selection without re-instantiating
-/// the card every reload.
+/// Layout per `SPMore.jsx:354-382`: a 36×36 leading icon tile (money-gradient
+/// when the row is selected, faint overlay otherwise) → title (h4) + subtitle
+/// (meta) stack → trailing 20pt money checkmark on the selected row. Rows sit
+/// inside a single shared `SPCard` owned by the view-controller, so each cell
+/// only draws a hairline bottom divider (suppressed on the last row) rather
+/// than its own card chrome. Preview playback lives in a separate bottom
+/// «Превью» player card, NOT on the row — so there's no per-row play button.
+///
+/// A disabled variant renders the «Своя мелодия · скоро» slot dimmed and
+/// non-interactive.
 final class SoundPickerRowCell: UITableViewCell {
 
     static let reuseID = "SoundPickerRowCell"
 
-    var onPlayTapped: (() -> Void)?
-
     // MARK: - UI
 
-    private let cardContainer = UIView()
-    private var playButton = SPButton(
-        title: "",
-        variant: .quiet,
-        size: .sm,
-        icon: UIImage(systemName: "play.fill")
-    )
+    /// 36×36 rounded icon tile. Fill flips to the money gradient when selected.
+    private let iconTile: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.layer.cornerRadius = 10
+        view.layer.masksToBounds = true
+        return view
+    }()
+
+    private let iconTileGradient = CAGradientLayer()
+
+    private let iconView: UIImageView = {
+        let view = UIImageView(image: UIImage(systemName: "music.note")?
+            .withConfiguration(UIImage.SymbolConfiguration(pointSize: 16, weight: .semibold)))
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.contentMode = .center
+        return view
+    }()
 
     private let titleLabel: UILabel = {
         let label = UILabel()
-        label.font = AppTypography.bodyLg
+        label.font = AppTypography.h4
         label.textColor = AppColors.fg1
         label.numberOfLines = 1
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -46,10 +58,17 @@ final class SoundPickerRowCell: UITableViewCell {
     private let checkmark: UIImageView = {
         let view = UIImageView()
         view.image = UIImage(systemName: "checkmark")?.withConfiguration(
-            UIImage.SymbolConfiguration(pointSize: 16, weight: .semibold)
+            UIImage.SymbolConfiguration(pointSize: 18, weight: .semibold)
         )
         view.tintColor = AppColors.money500
         view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let divider: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = AppColors.whiteOverlay08
         return view
     }()
 
@@ -64,18 +83,16 @@ final class SoundPickerRowCell: UITableViewCell {
     }()
 
     private var lastIsSelected = false
+    private var dividerHeightConstraint: NSLayoutConstraint?
 
     // MARK: - Init
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setupUI()
-        // iOS 17 deprecated `traitCollectionDidChange(_:)` — register a
-        // closure-based observer when available; the legacy override below
-        // remains as a fallback for older runtimes.
         if #available(iOS 17.0, *) {
             registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (view: SoundPickerRowCell, _) in
-                view.refreshChromeColors()
+                view.refreshIconTile()
             }
         }
     }
@@ -92,137 +109,117 @@ final class SoundPickerRowCell: UITableViewCell {
         contentView.backgroundColor = .clear
         selectionStyle = .none
 
-        cardContainer.translatesAutoresizingMaskIntoConstraints = false
-        cardContainer.layer.cornerRadius = AppRadius.sm
-        cardContainer.layer.masksToBounds = false
-        contentView.addSubview(cardContainer)
+        iconTileGradient.startPoint = SPSupport.gradientStart
+        iconTileGradient.endPoint = SPSupport.gradientEnd
+        iconTile.layer.insertSublayer(iconTileGradient, at: 0)
+        iconTile.addSubview(iconView)
 
         textStack.addArrangedSubview(titleLabel)
         textStack.addArrangedSubview(subtitleLabel)
 
-        playButton.translatesAutoresizingMaskIntoConstraints = false
-        playButton.addTarget(self, action: #selector(playTapped), for: .touchUpInside)
+        contentView.addSubview(iconTile)
+        contentView.addSubview(textStack)
+        contentView.addSubview(checkmark)
+        contentView.addSubview(divider)
 
-        cardContainer.addSubview(playButton)
-        cardContainer.addSubview(textStack)
-        cardContainer.addSubview(checkmark)
-
-        let cardInset = AppSpacing.sp3
-        let verticalPadding = AppSpacing.sp3
+        // 14×16 inset per JSX (padding "14px 16px").
+        let hInset = AppSpacing.sp4
         NSLayoutConstraint.activate([
-            cardContainer.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 4),
-            cardContainer.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -4),
-            cardContainer.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-            cardContainer.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            iconTile.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: hInset),
+            iconTile.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            iconTile.widthAnchor.constraint(equalToConstant: 36),
+            iconTile.heightAnchor.constraint(equalToConstant: 36),
 
-            playButton.leadingAnchor.constraint(equalTo: cardContainer.leadingAnchor, constant: cardInset),
-            playButton.centerYAnchor.constraint(equalTo: cardContainer.centerYAnchor),
-            playButton.widthAnchor.constraint(equalToConstant: 44),
+            iconView.centerXAnchor.constraint(equalTo: iconTile.centerXAnchor),
+            iconView.centerYAnchor.constraint(equalTo: iconTile.centerYAnchor),
 
-            textStack.leadingAnchor.constraint(equalTo: playButton.trailingAnchor, constant: AppSpacing.sp3),
-            textStack.centerYAnchor.constraint(equalTo: cardContainer.centerYAnchor),
-            textStack.topAnchor.constraint(
-                greaterThanOrEqualTo: cardContainer.topAnchor, constant: verticalPadding
-            ),
-            textStack.bottomAnchor.constraint(
-                lessThanOrEqualTo: cardContainer.bottomAnchor, constant: -verticalPadding
-            ),
+            textStack.leadingAnchor.constraint(equalTo: iconTile.trailingAnchor, constant: AppSpacing.sp3),
+            textStack.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            textStack.topAnchor.constraint(greaterThanOrEqualTo: contentView.topAnchor, constant: 14),
+            textStack.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor, constant: -14),
 
-            checkmark.trailingAnchor.constraint(equalTo: cardContainer.trailingAnchor, constant: -cardInset),
-            checkmark.centerYAnchor.constraint(equalTo: cardContainer.centerYAnchor),
+            checkmark.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -hInset),
+            checkmark.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
             checkmark.widthAnchor.constraint(equalToConstant: 20),
+            checkmark.heightAnchor.constraint(equalToConstant: 20),
 
             textStack.trailingAnchor.constraint(
                 lessThanOrEqualTo: checkmark.leadingAnchor, constant: -AppSpacing.sp3
             ),
-            cardContainer.heightAnchor.constraint(greaterThanOrEqualToConstant: 56)
+
+            divider.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: hInset),
+            divider.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -hInset),
+            divider.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+
+            contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: 64)
         ])
+
+        let dividerHeight = divider.heightAnchor.constraint(equalToConstant: 0.5)
+        dividerHeight.isActive = true
+        dividerHeightConstraint = dividerHeight
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        iconTileGradient.frame = iconTile.bounds
+        let scale = traitCollection.displayScale > 0 ? traitCollection.displayScale : 1
+        dividerHeightConstraint?.constant = 1.0 / scale
     }
 
     @available(iOS, deprecated: 17.0, message: "Replaced by registerForTraitChanges; kept for iOS 15/16.")
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        // iOS 17+ runtimes get the refresh through the registered observer
-        // (see init); skip here so we don't refresh twice.
         if #available(iOS 17.0, *) { return }
-        // CALayer cgColor doesn't auto-resolve dynamic UIColors — refresh
-        // border / shadow on system theme flips.
-        refreshChromeColors()
+        refreshIconTile()
     }
 
-    private func refreshChromeColors() {
-        let scale = max(traitCollection.displayScale, 1)
+    private func refreshIconTile() {
         if lastIsSelected {
-            cardContainer.backgroundColor = AppColors.whiteOverlay06
-            cardContainer.layer.borderWidth = 1.0 / scale
-            cardContainer.layer.borderColor = AppColors.strokeMoney
-                .resolvedColor(with: traitCollection).cgColor
-            cardContainer.layer.shadowColor = AppColors.money500.cgColor
-            cardContainer.layer.shadowOpacity = traitCollection.userInterfaceStyle == .light ? 0.15 : 0.2
-            cardContainer.layer.shadowRadius = 8
-            cardContainer.layer.shadowOffset = CGSize(width: 0, height: 4)
+            iconTileGradient.colors = SPSupport.moneyGradientColors
+            iconTileGradient.locations = SPSupport.moneyGradientLocations
+            iconTileGradient.isHidden = false
+            iconTile.backgroundColor = .clear
+            iconView.tintColor = AppColors.fgOnMoney
         } else {
-            cardContainer.backgroundColor = AppColors.bg1
-            cardContainer.layer.borderWidth = 1.0 / scale
-            cardContainer.layer.borderColor = AppColors.stroke1
-                .resolvedColor(with: traitCollection).cgColor
-            cardContainer.layer.shadowOpacity = 0
+            iconTileGradient.isHidden = true
+            iconTile.backgroundColor = AppColors.whiteOverlay06
+            iconView.tintColor = AppColors.fg3
         }
     }
 
     // MARK: - Configure
 
-    func configure(name: String, duration: String, isSelected: Bool, isPlaying: Bool) {
+    /// - Parameters:
+    ///   - name: sound display name.
+    ///   - subtitle: descriptive copy («Тёплый рассвет с птицами»).
+    ///   - isSelected: money-gradient icon tile + trailing checkmark.
+    ///   - isLast: suppress the hairline divider on the final row.
+    ///   - isEnabled: `false` for the «Своя мелодия · скоро» slot — dims the
+    ///     row and lets the controller skip selection.
+    func configure(
+        name: String,
+        subtitle: String,
+        isSelected: Bool,
+        isLast: Bool,
+        isEnabled: Bool
+    ) {
         titleLabel.text = name
-        subtitleLabel.text = duration
-        checkmark.isHidden = !isSelected
-        lastIsSelected = isSelected
-        refreshChromeColors()
+        subtitleLabel.text = subtitle
+        lastIsSelected = isSelected && isEnabled
+        checkmark.isHidden = !(isSelected && isEnabled)
+        divider.isHidden = isLast
+        refreshIconTile()
 
-        // Replace the SPButton's icon by rebuilding it — `SPButton` doesn't
-        // expose a setter for the leading icon and we want the play / pause
-        // toggle to read with the system "play.fill" / "pause.fill" SF
-        // symbols at consistent weight. Cheaper than animating into a
-        // CAShapeLayer.
-        playButton.removeFromSuperview()
-        playButton.removeTarget(self, action: nil, for: .allEvents)
-        let newIcon = UIImage(systemName: isPlaying ? "pause.fill" : "play.fill")
-        let replacement = SPButton(
-            title: "",
-            variant: .quiet,
-            size: .sm,
-            icon: newIcon
-        )
-        replacement.translatesAutoresizingMaskIntoConstraints = false
-        replacement.addTarget(self, action: #selector(playTapped), for: .touchUpInside)
-        cardContainer.addSubview(replacement)
-        NSLayoutConstraint.activate([
-            replacement.leadingAnchor.constraint(equalTo: cardContainer.leadingAnchor, constant: AppSpacing.sp3),
-            replacement.centerYAnchor.constraint(equalTo: cardContainer.centerYAnchor),
-            replacement.widthAnchor.constraint(equalToConstant: 44)
-        ])
-        playButton = replacement
-
-        // Re-pin the text stack leading anchor because we just swapped the
-        // play button view it depends on. AutoLayout keeps the old (deleted)
-        // constraint dangling otherwise.
-        for constraint in cardContainer.constraints
-        where constraint.firstItem === textStack && constraint.firstAttribute == .leading {
-            cardContainer.removeConstraint(constraint)
-        }
-        textStack.leadingAnchor.constraint(
-            equalTo: playButton.trailingAnchor, constant: AppSpacing.sp3
-        ).isActive = true
-    }
-
-    @objc private func playTapped() {
-        onPlayTapped?()
+        contentView.alpha = isEnabled ? 1.0 : 0.45
+        isUserInteractionEnabled = isEnabled
     }
 
     override func prepareForReuse() {
         super.prepareForReuse()
-        onPlayTapped = nil
         checkmark.isHidden = true
+        divider.isHidden = false
         lastIsSelected = false
+        contentView.alpha = 1.0
+        isUserInteractionEnabled = true
     }
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/SoundPickerViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/SoundPickerViewController.swift
@@ -1,62 +1,141 @@
 import UIKit
 import AudioToolbox
 
-/// Full-screen sound picker pushed onto the navigation stack.
+/// Full-screen sound picker pushed onto the navigation stack (V3 — #285).
 ///
-/// Each row uses the SP design-system primitives (`SPRow` + `SPCard` + a
-/// `SPButton(.quiet, .sm)` play / pause head) so the screen reads the same
-/// as the rest of the brand-refreshed surfaces (#150). The selected row
-/// flips to a money-tinted SPCard so the active sound stands out without
-/// needing a separate trailing checkmark badge — although the checkmark is
-/// kept on the trailing edge per the design spec.
+/// Structure per `SPMore.jsx:330-409`:
+/// - a single `SPCard` list — each row is a `SoundPickerRowCell` (36×36 icon
+///   tile, descriptive subtitle, trailing money checkmark on the selected
+///   row), with a disabled «Своя мелодия · скоро» slot pinned at the bottom;
+/// - a bottom «Превью» player card with a money-gradient play/pause head that
+///   previews the currently-highlighted sound through `previewSound`;
+/// - a «Готово» quiet-sm header button. Selection no longer auto-pops — the
+///   user leaves via «Готово» or the back chevron.
 ///
-/// `onSelect` and `previewSound` callbacks intentionally keep the same
-/// signatures as the pre-refresh picker so callers (the alarm form) do not
-/// need to change.
+/// `onSelect` / `previewSound` keep their pre-V3 signatures so the alarm form
+/// caller doesn't change.
 final class SoundPickerViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
 
     // MARK: - Properties
 
-    private let sounds: [(id: String, name: String)]
+    private let sounds: [SoundCatalogue.Entry]
     private var selectedSoundID: String
     private let onSelect: (String) -> Void
     private let previewSound: (String) -> Void
 
-    /// `id` of the sound whose preview is currently being broadcast — drives
-    /// the "play" / "pause" toggling on the row's head SPButton. Reset by a
-    /// short timer keyed to the average preview length so the icon doesn't
-    /// stay stuck on `pause.fill` once the system sound finishes.
-    private var currentlyPlayingID: String?
+    /// `true` while the «Превью» head is in its "playing" affordance. System
+    /// sounds are fire-and-forget, so this is a UI state reset by a timer keyed
+    /// to the typical preview length.
+    private var isPreviewing = false
     private var previewResetWorkItem: DispatchWorkItem?
 
+    /// The disabled custom-melody slot is appended after the catalogue rows.
+    private var rowCount: Int { sounds.count + 1 }
+
     // MARK: - UI
+
+    private let scrollView: UIScrollView = {
+        let view = UIScrollView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.alwaysBounceVertical = true
+        return view
+    }()
+
+    private let contentStack: UIStackView = {
+        let stack = UIStackView()
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .vertical
+        stack.spacing = AppSpacing.sp5
+        return stack
+    }()
+
+    private let listCard: SPCard = {
+        let card = SPCard(tone: .surface, padding: 0, cornerRadius: AppRadius.lg)
+        card.translatesAutoresizingMaskIntoConstraints = false
+        return card
+    }()
 
     private let tableView: UITableView = {
         let table = UITableView(frame: .zero, style: .plain)
         table.translatesAutoresizingMaskIntoConstraints = false
         table.separatorStyle = .none
         table.backgroundColor = .clear
-        // Generous row spacing keeps consecutive SPCards from visually
-        // running into each other — `tableView.separatorInset` doesn't
-        // help when each row has its own card chrome.
+        table.isScrollEnabled = false
         table.rowHeight = UITableView.automaticDimension
         table.estimatedRowHeight = 64
-        table.contentInset = UIEdgeInsets(
-            top: AppSpacing.sp3, left: 0, bottom: AppSpacing.sp4, right: 0
-        )
+        // Clip rows to the card's rounded corners (the card itself keeps
+        // masksToBounds off for its shadow).
+        table.layer.cornerRadius = AppRadius.lg
+        table.layer.masksToBounds = true
         return table
+    }()
+
+    private let previewCapsLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.attributedText = NSAttributedString(
+            string: "Превью".uppercased(),
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.fg3
+            ]
+        )
+        return label
+    }()
+
+    private let previewCard: SPCard = {
+        let card = SPCard(tone: .surface, padding: AppSpacing.sp5, cornerRadius: AppRadius.md)
+        card.translatesAutoresizingMaskIntoConstraints = false
+        return card
+    }()
+
+    /// 48×48 money-gradient round play/pause head inside the preview card.
+    private let previewPlayButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.layer.cornerRadius = 24
+        button.layer.masksToBounds = true
+        button.tintColor = AppColors.fgOnMoney
+        button.setImage(
+            UIImage(systemName: "play.fill")?
+                .withConfiguration(UIImage.SymbolConfiguration(pointSize: 18, weight: .semibold)),
+            for: .normal
+        )
+        return button
+    }()
+
+    private let previewPlayGradient = CAGradientLayer()
+
+    private let previewTitleLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = AppTypography.bodyLg
+        label.textColor = AppColors.fg1
+        label.numberOfLines = 1
+        return label
+    }()
+
+    private let previewHintLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = AppTypography.meta
+        label.textColor = AppColors.fg3
+        label.text = "Нажмите, чтобы прослушать"
+        label.numberOfLines = 1
+        return label
     }()
 
     // MARK: - Init
 
     /// - Parameters:
-    ///   - sounds: Available sounds list (id + display name).
+    ///   - sounds: Available sounds (id + display name + descriptive subtitle).
     ///   - selectedID: Currently selected sound id.
-    ///   - onSelect: Callback fired when the user picks a sound. The picker
-    ///     pops itself shortly afterwards so the user hears the preview.
-    ///   - previewSound: Callback to play preview for a given sound id.
+    ///   - onSelect: Fired when the user picks a sound. The picker no longer
+    ///     pops itself — the user leaves via «Готово» / back.
+    ///   - previewSound: Plays a preview for a given sound id.
     init(
-        sounds: [(id: String, name: String)],
+        sounds: [SoundCatalogue.Entry],
         selectedID: String,
         onSelect: @escaping (String) -> Void,
         previewSound: @escaping (String) -> Void
@@ -78,9 +157,25 @@ final class SoundPickerViewController: UIViewController, UITableViewDataSource, 
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = AppColors.bg0
-        // V2 caps title — accessibility label keeps the long "Выбор звука"
-        // string so VoiceOver still announces the screen purpose, while the
-        // visible label collapses to the JSX caps recipe.
+        setupHeader()
+        setupContent()
+        refreshPreviewLabel()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        previewResetWorkItem?.cancel()
+        previewResetWorkItem = nil
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        previewPlayGradient.frame = previewPlayButton.bounds
+    }
+
+    // MARK: - Setup
+
+    private func setupHeader() {
         let titleLabel = UILabel()
         titleLabel.attributedText = NSAttributedString(
             string: "Звук".uppercased(),
@@ -92,32 +187,109 @@ final class SoundPickerViewController: UIViewController, UITableViewDataSource, 
         )
         titleLabel.accessibilityLabel = "Выбор звука"
         navigationItem.titleView = titleLabel
-        setupTableView()
+
+        // «Готово» quiet-sm — the only way out beyond the back chevron now that
+        // selection doesn't auto-pop.
+        let doneButton = SPButton(title: "Готово", variant: .quiet, size: .sm)
+        doneButton.addTarget(self, action: #selector(doneTapped), for: .touchUpInside)
+        navigationItem.rightBarButtonItem = UIBarButtonItem(customView: doneButton)
     }
 
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        previewResetWorkItem?.cancel()
-        previewResetWorkItem = nil
-    }
-
-    // MARK: - Setup
-
-    private func setupTableView() {
+    private func setupContent() {
         tableView.dataSource = self
         tableView.delegate = self
         tableView.register(SoundPickerRowCell.self, forCellReuseIdentifier: SoundPickerRowCell.reuseID)
-        view.addSubview(tableView)
+        // padding 0 card → pin the table to the card edges; rows draw their
+        // own 16pt inset to match the JSX «padding "4px 20px"» list recipe.
+        listCard.addSubview(tableView)
         NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            tableView.leadingAnchor.constraint(
-                equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: AppSpacing.sp4
-            ),
-            tableView.trailingAnchor.constraint(
-                equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -AppSpacing.sp4
-            ),
-            tableView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+            tableView.topAnchor.constraint(equalTo: listCard.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: listCard.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: listCard.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: listCard.bottomAnchor)
         ])
+
+        contentStack.addArrangedSubview(listCard)
+        contentStack.addArrangedSubview(makePreviewBlock())
+
+        scrollView.addSubview(contentStack)
+        view.addSubview(scrollView)
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            contentStack.topAnchor.constraint(
+                equalTo: scrollView.contentLayoutGuide.topAnchor, constant: AppSpacing.sp5
+            ),
+            contentStack.leadingAnchor.constraint(
+                equalTo: scrollView.frameLayoutGuide.leadingAnchor, constant: AppSpacing.sp4
+            ),
+            contentStack.trailingAnchor.constraint(
+                equalTo: scrollView.frameLayoutGuide.trailingAnchor, constant: -AppSpacing.sp4
+            ),
+            contentStack.bottomAnchor.constraint(
+                equalTo: scrollView.contentLayoutGuide.bottomAnchor, constant: -AppSpacing.sp5
+            ),
+
+            previewPlayButton.widthAnchor.constraint(equalToConstant: 48),
+            previewPlayButton.heightAnchor.constraint(equalToConstant: 48)
+        ])
+
+        // The table is non-scrolling — drive its height from content so it
+        // fits inside the SPCard and the whole screen scrolls as one.
+        let tableHeight = tableView.heightAnchor.constraint(equalToConstant: CGFloat(rowCount) * 64)
+        tableHeight.priority = .defaultHigh
+        tableHeight.isActive = true
+        self.tableHeightConstraint = tableHeight
+    }
+
+    /// Builds the bottom «Превью» player block (caps label + player card with
+    /// money-gradient play head). Kept separate so `setupContent` stays small.
+    private func makePreviewBlock() -> UIStackView {
+        previewPlayGradient.startPoint = SPSupport.gradientStart
+        previewPlayGradient.endPoint = SPSupport.gradientEnd
+        previewPlayGradient.colors = SPSupport.moneyGradientColors
+        previewPlayGradient.locations = SPSupport.moneyGradientLocations
+        previewPlayButton.layer.insertSublayer(previewPlayGradient, at: 0)
+        previewPlayButton.addTarget(self, action: #selector(previewTapped), for: .touchUpInside)
+
+        let previewTextStack = UIStackView(arrangedSubviews: [previewTitleLabel, previewHintLabel])
+        previewTextStack.translatesAutoresizingMaskIntoConstraints = false
+        previewTextStack.axis = .vertical
+        previewTextStack.spacing = 2
+        previewTextStack.alignment = .leading
+
+        let previewRow = UIStackView(arrangedSubviews: [previewPlayButton, previewTextStack])
+        previewRow.translatesAutoresizingMaskIntoConstraints = false
+        previewRow.axis = .horizontal
+        previewRow.spacing = AppSpacing.sp3
+        previewRow.alignment = .center
+        previewCard.addSubview(previewRow)
+        NSLayoutConstraint.activate([
+            previewRow.topAnchor.constraint(equalTo: previewCard.layoutMarginsGuide.topAnchor),
+            previewRow.leadingAnchor.constraint(equalTo: previewCard.layoutMarginsGuide.leadingAnchor),
+            previewRow.trailingAnchor.constraint(equalTo: previewCard.layoutMarginsGuide.trailingAnchor),
+            previewRow.bottomAnchor.constraint(equalTo: previewCard.layoutMarginsGuide.bottomAnchor)
+        ])
+
+        let previewBlock = UIStackView(arrangedSubviews: [previewCapsLabel, previewCard])
+        previewBlock.translatesAutoresizingMaskIntoConstraints = false
+        previewBlock.axis = .vertical
+        previewBlock.spacing = AppSpacing.sp2 + 2
+        return previewBlock
+    }
+
+    private var tableHeightConstraint: NSLayoutConstraint?
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        // Match the SPCard height to the table's laid-out content so no rows
+        // are clipped on larger Dynamic Type sizes.
+        tableView.layoutIfNeeded()
+        tableHeightConstraint?.constant = tableView.contentSize.height
     }
 
     // MARK: - Table view
@@ -125,7 +297,7 @@ final class SoundPickerViewController: UIViewController, UITableViewDataSource, 
     func numberOfSections(in tableView: UITableView) -> Int { 1 }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        sounds.count
+        rowCount
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -134,105 +306,105 @@ final class SoundPickerViewController: UIViewController, UITableViewDataSource, 
         ) as? SoundPickerRowCell else {
             return UITableViewCell()
         }
+        let isLast = indexPath.row == rowCount - 1
 
-        let sound = sounds[indexPath.row]
-        let isSelected = sound.id == selectedSoundID
-        let isPlaying = sound.id == currentlyPlayingID
-        cell.configure(
-            name: sound.name,
-            duration: Self.previewDuration(for: sound.id),
-            isSelected: isSelected,
-            isPlaying: isPlaying
-        )
-        cell.onPlayTapped = { [weak self] in
-            self?.handlePreviewToggle(for: sound.id)
+        if indexPath.row < sounds.count {
+            let sound = sounds[indexPath.row]
+            cell.configure(
+                name: sound.name,
+                subtitle: sound.subtitle,
+                isSelected: sound.id == selectedSoundID,
+                isLast: isLast,
+                isEnabled: true
+            )
+        } else {
+            // Disabled «Своя мелодия · скоро» slot.
+            let slot = SoundCatalogue.customSlot
+            cell.configure(
+                name: "\(slot.name) · скоро",
+                subtitle: "Импорт своей мелодии появится позже",
+                isSelected: false,
+                isLast: isLast,
+                isEnabled: false
+            )
         }
         return cell
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
+        guard indexPath.row < sounds.count else { return } // custom slot is inert
         let sound = sounds[indexPath.row]
         selectedSoundID = sound.id
         onSelect(sound.id)
+        // Preview the freshly-picked sound, but DON'T pop — the user stays on
+        // the screen and leaves via «Готово».
         previewSound(sound.id)
+        startPreviewAffordance(for: sound.id)
         tableView.reloadData()
-        // Pop back after a short delay so the user hears the chosen preview
-        // before the picker disappears.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
-            self?.navigationController?.popViewController(animated: true)
-        }
+        refreshPreviewLabel()
     }
 
-    // MARK: - Preview handling
+    // MARK: - Preview player
 
-    /// Toggle preview playback on the row's "play" / "pause" head. We don't
-    /// have a real audio session for previews (the live alarm sound is what
-    /// uses the AVAudioSession) — system sounds fire-and-forget, so the
-    /// "pause" state is a UI affordance backed by a timer that resets the
-    /// icon when the typical preview length elapses.
-    private func handlePreviewToggle(for soundID: String) {
-        previewResetWorkItem?.cancel()
+    private func refreshPreviewLabel() {
+        let name = sounds.first(where: { $0.id == selectedSoundID })?.name ?? selectedSoundID
+        previewTitleLabel.text = name
+    }
 
-        if currentlyPlayingID == soundID {
-            // Tap on the same row → cancel the visual "playing" state.
-            // System sounds can't actually be stopped mid-play, but the
-            // icon flip honours the user's intent.
-            currentlyPlayingID = nil
-            tableView.reloadData()
+    @objc private func previewTapped() {
+        if isPreviewing {
+            isPreviewing = false
+            previewResetWorkItem?.cancel()
+            updatePreviewIcon()
             return
         }
+        previewSound(selectedSoundID)
+        startPreviewAffordance(for: selectedSoundID)
+    }
 
-        currentlyPlayingID = soundID
-        previewSound(soundID)
-        tableView.reloadData()
+    /// Flip the preview head to its "playing" state and schedule a reset once
+    /// the typical preview length elapses (system sounds can't be stopped).
+    private func startPreviewAffordance(for soundID: String) {
+        previewResetWorkItem?.cancel()
+        isPreviewing = true
+        updatePreviewIcon()
 
-        // Auto-reset the play state after the configured preview length
-        // so the row icon reverts to "play" once the system sound has
-        // realistically finished.
         let duration = Self.previewDurationSeconds(for: soundID)
         let workItem = DispatchWorkItem { [weak self] in
             guard let self else { return }
-            guard self.currentlyPlayingID == soundID else { return }
-            self.currentlyPlayingID = nil
-            self.tableView.reloadData()
+            self.isPreviewing = false
+            self.updatePreviewIcon()
         }
         previewResetWorkItem = workItem
         DispatchQueue.main.asyncAfter(deadline: .now() + duration, execute: workItem)
     }
 
+    private func updatePreviewIcon() {
+        let symbol = isPreviewing ? "pause.fill" : "play.fill"
+        previewPlayButton.setImage(
+            UIImage(systemName: symbol)?
+                .withConfiguration(UIImage.SymbolConfiguration(pointSize: 18, weight: .semibold)),
+            for: .normal
+        )
+    }
+
+    @objc private func doneTapped() {
+        navigationController?.popViewController(animated: true)
+    }
+
     // MARK: - Preview duration metadata
 
-    /// Approximate preview length per sound id. Used both for the
-    /// "0:42" subtitle copy and the visual reset timer. Numbers are
-    /// hand-tuned against the AudioToolbox `SystemSoundID` table — the
-    /// production soundbank will eventually ship real durations on the
-    /// alarm-sound model itself.
+    /// Approximate preview length per sound id — drives the visual reset timer.
     private static let previewDurations: [String: Double] = [
-        "dawn": 6,
-        "radar": 4,
-        "drops": 2,
-        "piano": 3,
-        "guitar": 3,
-        "bell": 2,
-        "waves": 8,
-        "birds": 6,
-        "classic": 5,
-        "jazz": 5
+        "dawn": 6, "radar": 4, "drops": 2, "piano": 3, "guitar": 3,
+        "bell": 2, "waves": 8, "birds": 6, "classic": 5, "jazz": 5
     ]
 
     private static func previewDurationSeconds(for soundID: String) -> Double {
         previewDurations[soundID] ?? 3
     }
-
-    private static func previewDuration(for soundID: String) -> String {
-        let total = Int(previewDurationSeconds(for: soundID))
-        let minutes = total / 60
-        let seconds = total % 60
-        return String(format: "%d:%02d", minutes, seconds)
-    }
 }
 
 // `SoundPickerRowCell` lives in
-// `ViewControllers/Alarms/Cells/SoundPickerRowCell.swift` so this file stays
-// under the SwiftLint `file_length` cap.
+// `ViewControllers/Alarms/Cells/SoundPickerRowCell.swift`.

--- a/SnoozePay/SnoozePay/ViewModels/CreateAlarmViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/CreateAlarmViewModel.swift
@@ -203,18 +203,13 @@ final class CreateAlarmViewModel {
 
     // MARK: - Available sounds (10 sounds matching Figma design)
 
-    let availableSounds: [(id: String, name: String)] = [
-        ("dawn", "Рассвет"),
-        ("radar", "Радар"),
-        ("drops", "Капли"),
-        ("piano", "Пиано"),
-        ("guitar", "Гитара"),
-        ("bell", "Колокольчик"),
-        ("waves", "Волны"),
-        ("birds", "Птицы"),
-        ("classic", "Классика"),
-        ("jazz", "Джаз")
-    ]
+    /// Sound catalogue surfaced to `SoundPickerViewController`. Each entry now
+    /// carries a short Russian `subtitle` describing the timbre (V3 card list —
+    /// `SPMore.jsx:332-339` style, e.g. «Тёплый рассвет с птицами»). The
+    /// `id`/`name` members keep their existing meaning so all named-member
+    /// callers (`+Sections`, list VM) compile unchanged. soundID defaults are
+    /// owned by #278 — this list only adds descriptive copy.
+    let availableSounds: [SoundCatalogue.Entry] = SoundCatalogue.entries
 
     // MARK: - System sound mapping (placeholder until custom audio files are bundled)
 

--- a/SnoozePay/SnoozePayTests/SoundThemePickerCatalogueTests.swift
+++ b/SnoozePay/SnoozePayTests/SoundThemePickerCatalogueTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+@testable import SnoozePay
+
+/// Unit tests for the extracted V3 picker logic (#285): the sound catalogue +
+/// subtitle mapping and the alarm-theme subtitle mapping. Pure-value tests —
+/// no simulator/UIKit layout exercised.
+final class SoundThemePickerCatalogueTests: XCTestCase {
+
+    // MARK: - Sound catalogue
+
+    func testSoundCatalogue_keepsAllTenSounds() {
+        XCTAssertEqual(SoundCatalogue.entries.count, 10, "Catalogue must keep all 10 sounds, not cut to 6")
+    }
+
+    func testSoundCatalogue_idsAreUnique() {
+        let ids = SoundCatalogue.entries.map { $0.id }
+        XCTAssertEqual(ids.count, Set(ids).count, "Sound ids must be unique")
+    }
+
+    func testSoundCatalogue_everyEntryHasNameAndSubtitle() {
+        for entry in SoundCatalogue.entries {
+            XCTAssertFalse(entry.name.isEmpty, "Sound '\(entry.id)' has empty name")
+            XCTAssertFalse(entry.subtitle.isEmpty, "Sound '\(entry.id)' has empty subtitle")
+        }
+    }
+
+    func testSoundCatalogue_subtitleLookup_resolvesKnownIDs() {
+        XCTAssertEqual(SoundCatalogue.subtitle(for: "dawn"), "Тёплый рассвет с птицами")
+        XCTAssertEqual(SoundCatalogue.subtitle(for: "birds"), "Только щебет, без музыки")
+    }
+
+    func testSoundCatalogue_subtitleLookup_returnsNilForUnknownID() {
+        XCTAssertNil(SoundCatalogue.subtitle(for: "nonexistent"))
+        XCTAssertNil(SoundCatalogue.subtitle(for: ""))
+    }
+
+    func testSoundCatalogue_customSlot_isDistinctAndNotInEntries() {
+        XCTAssertEqual(SoundCatalogue.customSlot.id, "custom")
+        XCTAssertFalse(
+            SoundCatalogue.entries.contains(where: { $0.id == SoundCatalogue.customSlot.id }),
+            "The custom slot must not be part of the selectable catalogue"
+        )
+    }
+
+    func testCreateAlarmViewModel_availableSounds_mirrorsCatalogue() {
+        let suite = "test.catalogue.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let vm = CreateAlarmViewModel(repository: AlarmRepository(defaults: defaults))
+        XCTAssertEqual(vm.availableSounds.map { $0.id }, SoundCatalogue.entries.map { $0.id })
+    }
+
+    // MARK: - Theme subtitles
+
+    func testThemeSubtitles_everyBuiltInThemeHasSubtitle() {
+        for theme in AlarmTheme.builtInOrder {
+            XCTAssertFalse(
+                AlarmThemeSubtitles.subtitle(for: theme).isEmpty,
+                "Theme '\(theme.id)' is missing a subtitle"
+            )
+        }
+    }
+
+    func testThemeSubtitles_knownThemesResolve() {
+        XCTAssertEqual(AlarmThemeSubtitles.subtitle(for: .dawn), "Тёплый янтарь")
+        XCTAssertEqual(AlarmThemeSubtitles.subtitle(for: .ocean), "Холодный мятный")
+    }
+
+    func testThemeSubtitles_customThemeUsesGallerySubtitle() {
+        let custom = AlarmTheme.custom(imagePath: URL(fileURLWithPath: "/tmp/x.jpg"))
+        XCTAssertEqual(AlarmThemeSubtitles.subtitle(for: custom), AlarmThemeSubtitles.customSlotSubtitle)
+        XCTAssertEqual(AlarmThemeSubtitles.customSlotSubtitle, "Из галереи")
+    }
+}


### PR DESCRIPTION
Fixes #285

## Что сделано
Sound picker (SoundPickerViewController + SoundPickerRowCell):
- Single SPCard list of rows: 36×36 icon tile (money-gradient when selected), descriptive Russian subtitles per sound, trailing money checkmark on the selected row.
- Bottom «Превью» player card with a money-gradient play/pause head that previews the highlighted sound through previewSound.
- «Готово» quiet-sm header button; removed the auto-pop-after-select — the user leaves via Готово/back.
- Kept all 10 sounds; added a disabled «Своя мелодия · скоро» slot at the bottom.

Theme picker (AlarmThemePickerViewController + AlarmThemeTileCell):
- 3-column grid, tiles 1:1.2, name+subtitle overlaid bottom-left with text shadow, 22px money checkmark badge top-right, money outline+offset on selected, caps «Готовые темы» section header, «Готово» quiet-sm header button.
- Gradient direction fixed to 135° diagonal everywhere (tiles + preview), matching ThemeRowCell.
- Custom-photo flow unchanged.

Extracted logic (pure, unit-tested):
- SoundCatalogue (10 entries + subtitles + disabled custom slot); CreateAlarmViewModel.availableSounds now derives from it (no soundID default changes — #278 scope untouched).
- AlarmThemeSubtitles (id→subtitle map + custom «Из галереи»).

## Verify
- ✅ swiftlint: 0 errors (0 serious across 176 files)
- ✅ xcodebuild build: BUILD SUCCEEDED (generic iOS Simulator, CODE_SIGNING_ALLOWED=NO)
- ✅ xcodebuild build-for-testing: succeeded
- ✅ Tests added: SoundThemePickerCatalogueTests (catalogue + subtitle mapping); CI runs the suite

Base: design-refresh-2026-04-27 (integration branch).