### PR TITLE
[ui] Create/Edit copy per design — откладывание wording, no штраф/снуз (#278)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/PenaltyCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/PenaltyCell.swift
@@ -19,9 +19,37 @@ final class PenaltyCell: UITableViewCell {
 
     // MARK: - UI
 
-    /// Mono-font live "{N} ₽" label sitting above the chip row — pulls the
-    /// "ЦЕНА ОТКЛАДЫВАНИЯ" caps from the section header and uses the
-    /// `moneyMd` typography role tinted `warn400`.
+    /// In-card caps caption «Цена откладывания» — the word «штраф» does not
+    /// exist in the design copy (SPMore2.jsx:176). Lives inside the card so
+    /// the table no longer needs a separate section header (#278).
+    private let captionLabel: UILabel = {
+        let label = UILabel()
+        label.attributedText = NSAttributedString(
+            string: "Цена откладывания".uppercased(),
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.fg3
+            ]
+        )
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    /// Meta hint under the caption — «Сколько спишется при „отложить“»
+    /// (SPMore2.jsx:268-269 hint pattern).
+    private let hintLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Сколько спишется при «отложить»"
+        label.font = AppTypography.meta
+        label.textColor = AppColors.fg3
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    /// Mono-font live "{N} ₽" label sitting above the chip row — mirrors the
+    /// in-card caption and uses the `moneyMd` typography role tinted `warn400`.
     private let valueLabel: UILabel = {
         let label = UILabel()
         label.font = AppTypography.moneyMd
@@ -89,16 +117,25 @@ final class PenaltyCell: UITableViewCell {
             presetStack.addArrangedSubview(button)
         }
 
+        contentView.addSubview(captionLabel)
+        contentView.addSubview(hintLabel)
         contentView.addSubview(valueLabel)
         contentView.addSubview(presetStack)
 
         NSLayoutConstraint.activate([
+            captionLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.lg),
+            captionLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: AppSpacing.sm),
+
+            hintLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.lg),
+            hintLabel.topAnchor.constraint(equalTo: captionLabel.bottomAnchor, constant: 2),
+            hintLabel.trailingAnchor.constraint(lessThanOrEqualTo: valueLabel.leadingAnchor, constant: -AppSpacing.sm),
+
             valueLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.lg),
-            valueLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: AppSpacing.sm),
+            valueLabel.firstBaselineAnchor.constraint(equalTo: captionLabel.firstBaselineAnchor),
 
             presetStack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.lg),
             presetStack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.lg),
-            presetStack.topAnchor.constraint(equalTo: valueLabel.bottomAnchor, constant: AppSpacing.sm),
+            presetStack.topAnchor.constraint(equalTo: hintLabel.bottomAnchor, constant: AppSpacing.sm),
             presetStack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -AppSpacing.md)
         ])
     }

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/SnoozeSliderCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/SnoozeSliderCell.swift
@@ -17,6 +17,33 @@ final class SnoozeSliderCell: UITableViewCell {
 
     // MARK: - UI
 
+    /// In-card caps caption «Длительность откладывания» (SPMore2.jsx:268).
+    /// Lives inside the card so the table no longer needs a section header (#278).
+    private let captionLabel: UILabel = {
+        let label = UILabel()
+        label.attributedText = NSAttributedString(
+            string: "Длительность откладывания".uppercased(),
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: AppColors.fg3
+            ]
+        )
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    /// Meta hint «На сколько минут отодвигается звонок» (SPMore2.jsx:269).
+    private let hintLabel: UILabel = {
+        let label = UILabel()
+        label.text = "На сколько минут отодвигается звонок"
+        label.font = AppTypography.meta
+        label.textColor = AppColors.fg3
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
     private let slider: UISlider = {
         let view = UISlider()
         view.minimumValue = Float(SnoozeSliderCell.minMinutes)
@@ -66,21 +93,28 @@ final class SnoozeSliderCell: UITableViewCell {
         backgroundColor = AppColors.bg1
         selectionStyle = .none
 
+        contentView.addSubview(captionLabel)
+        contentView.addSubview(hintLabel)
         contentView.addSubview(slider)
         contentView.addSubview(valueLabel)
 
         NSLayoutConstraint.activate([
-            slider.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.lg),
-            slider.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            slider.topAnchor.constraint(equalTo: contentView.topAnchor, constant: AppSpacing.md),
-            slider.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -AppSpacing.md),
+            captionLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.lg),
+            captionLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: AppSpacing.sm),
 
-            valueLabel.leadingAnchor.constraint(equalTo: slider.trailingAnchor, constant: AppSpacing.md),
+            hintLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.lg),
+            hintLabel.topAnchor.constraint(equalTo: captionLabel.bottomAnchor, constant: 2),
+            hintLabel.trailingAnchor.constraint(lessThanOrEqualTo: valueLabel.leadingAnchor, constant: -AppSpacing.sm),
+
             valueLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.lg),
-            valueLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            // Reserve a fixed minimum so "1 мин" / "15 мин" don't reflow the
-            // slider's effective track length as the user drags.
-            valueLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 56)
+            valueLabel.firstBaselineAnchor.constraint(equalTo: captionLabel.firstBaselineAnchor),
+            // Reserve a fixed minimum so "1 мин" / "15 мин" don't reflow.
+            valueLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 56),
+
+            slider.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: AppSpacing.lg),
+            slider.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -AppSpacing.lg),
+            slider.topAnchor.constraint(equalTo: hintLabel.bottomAnchor, constant: AppSpacing.sm),
+            slider.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -AppSpacing.md)
         ])
     }
 
@@ -97,7 +131,7 @@ final class SnoozeSliderCell: UITableViewCell {
     func configure(minutes: Int) {
         let clamped = min(max(minutes, Self.minMinutes), Self.maxMinutes)
         slider.value = Float(clamped)
-        valueLabel.text = "\(clamped) мин"
+        valueLabel.attributedText = Self.valueText(clamped)
     }
 
     // MARK: - Actions
@@ -108,8 +142,28 @@ final class SnoozeSliderCell: UITableViewCell {
         let rounded = Int(roundf(slider.value))
         let clamped = min(max(rounded, Self.minMinutes), Self.maxMinutes)
         slider.value = Float(clamped)
-        valueLabel.text = "\(clamped) мин"
+        valueLabel.attributedText = Self.valueText(clamped)
         onValueChanged?(clamped)
+    }
+
+    /// "{N} мин" with the «мин» suffix dimmed to `fg3` per the V2 slider
+    /// recipe (SPScreensV2.jsx:733-751) so the number reads as the headline.
+    private static func valueText(_ minutes: Int) -> NSAttributedString {
+        let text = NSMutableAttributedString(
+            string: "\(minutes)",
+            attributes: [
+                .font: AppTypography.moneyMd,
+                .foregroundColor: AppColors.fg1
+            ]
+        )
+        text.append(NSAttributedString(
+            string: " мин",
+            attributes: [
+                .font: AppTypography.h4,
+                .foregroundColor: AppColors.fg3
+            ]
+        ))
+        return text
     }
 
     // MARK: - Thumb image

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
@@ -86,7 +86,7 @@ final class CreateAlarmViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = viewModel.isEditing ? "Редактировать" : "Новый будильник"
+        title = viewModel.isEditing ? "Будильник" : "Новый будильник"
         view.backgroundColor = AppColors.bg0
         setupNavigationBar()
         setupTableView()
@@ -156,7 +156,7 @@ final class CreateAlarmViewController: UIViewController {
         // custom title view label.
         let titleLabel = UILabel()
         titleLabel.attributedText = NSAttributedString(
-            string: (viewModel.isEditing ? "Редактировать" : "Новый будильник").uppercased(),
+            string: (viewModel.isEditing ? "Будильник" : "Новый будильник").uppercased(),
             attributes: [
                 .font: AppTypography.caps,
                 .kern: AppTypography.capsKerning,
@@ -332,8 +332,10 @@ extension CreateAlarmViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         guard let sec = Section(rawValue: section) else { return nil }
         switch sec {
-        case .penalty: return "ШТРАФ ЗА ОТКЛАДЫВАНИЕ"
-        case .snoozeTime: return "ВРЕМЯ ОТКЛАДЫВАНИЯ"
+        // The «Цена откладывания» / «Длительность откладывания» captions + hints
+        // now live inside PenaltyCell / SnoozeSliderCell per the design canon
+        // (SPMore2.jsx:268-269), so these sections are header-less (#278). The
+        // word «штраф» is gone — it never existed in the design copy.
         // Name no longer carries a header — the large in-cell placeholder
         // already reads as the field's purpose (#143). The settings and
         // progressive cards are header-less per the V2 artboard (#231).
@@ -397,9 +399,10 @@ extension CreateAlarmViewController: UITableViewDelegate {
         // below self-sizes (the hint wraps to 1–2 lines per mode, #229).
         case .repeatDays:
             return RepeatRow(rawValue: indexPath.row) == .days ? 60 : UITableView.automaticDimension
-        // V2 penalty row stacks a moneyMd value label above a 40pt chip row
-        // — the prior 60pt height clipped the chip ladder, so bump to 96pt.
-        case .penalty: return 96
+        // V2 penalty row stacks an in-card caption + hint above the moneyMd
+        // value and the 40pt chip ladder (#278) — self-size so the caption/
+        // hint never clip when the hint wraps.
+        case .penalty: return UITableView.automaticDimension
         default: return UITableView.automaticDimension
         }
     }

--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController+Pages.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController+Pages.swift
@@ -173,7 +173,7 @@ extension OnboardingViewController {
         titleLabel.numberOfLines = 0
 
         let rows = [
-            ("1", "Положили \(MoneyFormatter.string(500))", "Это запас, из которого спишутся штрафы."),
+            ("1", "Положили \(MoneyFormatter.string(500))", "Это запас, из которого спишутся откладывания."),
             ("2", "Поспать ещё в 07:00 → −\(MoneyFormatter.string(50))", "Каждый раз когда вы тянете, деньги уходят."),
             ("3", "Встали с первого раза → ничего", "Баланс продолжает лежать. Готов к завтрашнему утру.")
         ].map { OnboardingStepRow(number: $0.0, title: $0.1, body: $0.2) }

--- a/SnoozePay/SnoozePay/ViewControllers/Statistics/ReferralViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Statistics/ReferralViewController.swift
@@ -460,7 +460,7 @@ final class ReferralViewController: UIViewController {
     }
 
     @objc private func shareTapped() {
-        let text = "Снузь меньше — копи больше. Используй мой код в SnoozePay: "
+        let text = "Откладывай меньше — копи больше. Используй мой код в SnoozePay: "
             + "\(Self.personalCode) — оба получим +\(MoneyFormatter.string(200)) на баланс."
         let activity = UIActivityViewController(activityItems: [text], applicationActivities: nil)
         activity.popoverPresentationController?.sourceView = view


### PR DESCRIPTION
Fixes #278

## Что сделано
- In-card captions per design canon (SPMore2.jsx:268-269, :176): «Цена откладывания» + hint «Сколько спишется при «отложить»» в PenaltyCell, «Длительность откладывания» + hint «На сколько минут отодвигается звонок» в SnoozeSliderCell. Слово «штраф» убрано — его нет в дизайне.
- Section headers «ШТРАФ ЗА ОТКЛАДЫВАНИЕ» / «ВРЕМЯ ОТКЛАДЫВАНИЯ» удалены (captions теперь живут в карточке), penalty-строка self-sizes.
- Edit-mode nav title «Редактировать» → «Будильник» (SPMore2.jsx:218).
- Slider: «мин»-суффикс приглушён до fg3/h4 (SPScreensV2.jsx:733-751).
- Убран жаргон «снуз»/«штраф» из user-facing строк вне зоны других агентов: ReferralViewController share-текст («Откладывай меньше — копи больше»), Onboarding step copy («спишутся откладывания»).

## Заметка для оркестратора
Осталась одна user-facing строка с «штраф» в `WalletViewController+Layout.swift:195` — это зона параллельного Wallet-агента (CAUTION в задании), не трогал во избежание конфликта.

## Verify
- ✅ swiftlint: 0 violations (5 файлов)
- ✅ xcodebuild build: BUILD SUCCEEDED (generic iOS Simulator, signing off)
- ✅ xcodebuild build-for-testing: TEST BUILD SUCCEEDED
- Тесты копи-ассертов на изменённые строки не существуют (section headers / nav title — VC-level, без покрытия); существующие firing/scheduler copy-тесты не затронуты.