### PR TITLE
[ui] Token polish — buttons/cards/pills/presets/segmented/switch/input per design recipes (#287)

### DIFF
--- a/SnoozePay/SnoozePay/Utilities/AppColors.swift
+++ b/SnoozePay/SnoozePay/Utilities/AppColors.swift
@@ -246,10 +246,6 @@ enum AppRadius {
     /// Pill / fully-rounded — call sites typically clamp to `bounds.height/2`,
     /// but this constant keeps intent explicit and matches `tokens.css`.
     static let pill: CGFloat = 999
-
-    /// Canonical card corner radius — every standalone surface should round to
-    /// this value so cards on different screens read as the same primitive.
-    static let card: CGFloat = md
 }
 
 /// Typography roles from `tokens.css`. Each role returns a configured `UIFont`

--- a/SnoozePay/SnoozePay/Utilities/UIView+CardStyle.swift
+++ b/SnoozePay/SnoozePay/Utilities/UIView+CardStyle.swift
@@ -15,11 +15,14 @@ extension UIView {
     /// (the shadow needs to render outside `bounds`); subviews should be
     /// constrained inside the card via Auto Layout instead of being clipped.
     ///
-    /// Use `cornerRadius` to override the default `AppRadius.sm` (e.g. 8pt for
+    /// Use `cornerRadius` to override the default `AppRadius.md` (e.g. 8pt for
     /// individual table-view cells nested inside `.insetGrouped` sections that
     /// already provide outer rounding).
-    func applyCardStyle(cornerRadius: CGFloat = AppRadius.sm) {
-        backgroundColor = AppColors.surface
+    func applyCardStyle(cornerRadius: CGFloat = AppRadius.md) {
+        // `.sp-card` fills the brand surface token (`--sp-bg-1`), not the
+        // system `secondarySystemBackground` the legacy recipe used — so
+        // legacy cards line up tonally with `SPCard(.surface)`.
+        backgroundColor = AppColors.bg1
         layer.cornerRadius = cornerRadius
         layer.masksToBounds = false
         // Brand `shadow1` is theme-aware: dark mode gets a single deep stop
@@ -70,7 +73,7 @@ extension UIView {
     /// Pre-rasterise the shadow against the rounded card frame so scrolling
     /// doesn't pay the per-pixel offscreen pass cost. Call from
     /// `layoutSubviews()`.
-    func updateCardShadowPath(cornerRadius: CGFloat = AppRadius.sm) {
+    func updateCardShadowPath(cornerRadius: CGFloat = AppRadius.md) {
         layer.shadowPath = UIBezierPath(
             roundedRect: bounds,
             cornerRadius: cornerRadius
@@ -97,7 +100,7 @@ final class CardView: UIView {
 
     private let cardCornerRadius: CGFloat
 
-    init(cornerRadius: CGFloat = AppRadius.sm) {
+    init(cornerRadius: CGFloat = AppRadius.md) {
         self.cardCornerRadius = cornerRadius
         super.init(frame: .zero)
         applyCardStyle(cornerRadius: cornerRadius)

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPAmountPreset.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPAmountPreset.swift
@@ -3,11 +3,15 @@ import UIKit
 /// Top-up amount preset tile — `.sp-preset` in `components.css`.
 ///
 /// Visual: outlined card (1.5pt `stroke1`) with a centered mono amount
-/// (`moneyMd` 20pt) and an optional secondary label (`meta` 13pt). When
-/// `selected` is true the border switches to `money500`, the fill takes a
-/// 10% money tint, and a 4pt outer glow ring renders. A "Популярно" badge
-/// floats above the top edge when `popular` is true.
+/// (700 18pt mono per `.sp-preset__value`) and an optional secondary label
+/// (`meta` 13pt). When `selected` is true the border switches to `money400`,
+/// the fill takes a 10% money tint, and a 4pt outer glow ring renders. A
+/// "Популярно" badge with the money gradient fill floats above the top edge
+/// when `popular` is true.
 final class SPAmountPreset: UIControl {
+
+    /// `.sp-preset__value { font: 700 18px/22px var(--sp-font-mono) }`.
+    private static var valueFont: UIFont { AppFonts.mono(.bold, 18) }
 
     // MARK: - State
 
@@ -38,7 +42,10 @@ final class SPAmountPreset: UIControl {
 
     private let valueLabel = UILabel()
     private let labelView = UILabel()
-    private let popularBadge = UILabel()
+    private let popularBadge = InsetLabel(insets: UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10))
+    /// Money-gradient backing for the «Популярно» badge (`.sp-preset__pop`
+    /// fills with `--sp-grad-money`). Inserted behind the badge label.
+    private let popularGradient = CAGradientLayer()
     private let stack = UIStackView()
 
     // MARK: - Init
@@ -92,6 +99,8 @@ final class SPAmountPreset: UIControl {
             roundedRect: bounds,
             cornerRadius: AppRadius.md
         ).cgPath
+        // Keep the «Популярно» gradient backing matched to the badge bounds.
+        popularGradient.frame = popularBadge.bounds
     }
 
     @available(iOS, deprecated: 17.0, message: "Replaced by registerForTraitChanges; kept for iOS 15/16.")
@@ -109,7 +118,7 @@ final class SPAmountPreset: UIControl {
         self.value = value
         self.label = label
         valueLabel.attributedText = MoneyFormatter.attributed(
-            value, digitsFont: AppTypography.moneyMd
+            value, digitsFont: Self.valueFont
         )
         if let label = label {
             labelView.text = label
@@ -128,7 +137,7 @@ final class SPAmountPreset: UIControl {
         layer.borderWidth = 1.5
 
         valueLabel.translatesAutoresizingMaskIntoConstraints = false
-        valueLabel.font = AppTypography.moneyMd
+        valueLabel.font = Self.valueFont
         valueLabel.textColor = AppColors.fg1
         valueLabel.textAlignment = .center
 
@@ -147,19 +156,29 @@ final class SPAmountPreset: UIControl {
         addSubview(stack)
 
         // Popular badge — small caps pill that floats above the top edge.
+        // `.sp-preset__pop` uses mixed-case «Популярно», the money gradient
+        // fill, and `3px 10px` padding (no fixed width — it hugs its text).
         popularBadge.translatesAutoresizingMaskIntoConstraints = false
         popularBadge.attributedText = NSAttributedString(
-            string: "ПОПУЛЯРНО",
+            string: "Популярно",
             attributes: [
                 .font: AppTypography.caps,
-                .kern: 12 * 0.12,
+                .kern: AppTypography.capsKerning,
                 .foregroundColor: AppColors.fgOnMoney
             ]
         )
-        popularBadge.backgroundColor = AppColors.money500
+        popularBadge.textAlignment = .center
+        // Inset the text via layoutMargins-style padding using contentInset on
+        // a label isn't supported, so pad with leading/trailing constraints on
+        // a hugging label below; the gradient backs the whole badge bounds.
+        popularGradient.colors = SPSupport.moneyGradientColors
+        popularGradient.locations = SPSupport.moneyGradientLocations
+        popularGradient.startPoint = SPSupport.gradientStart
+        popularGradient.endPoint = SPSupport.gradientEnd
+        popularGradient.cornerRadius = 10
+        popularBadge.layer.insertSublayer(popularGradient, at: 0)
         popularBadge.layer.cornerRadius = 10
         popularBadge.layer.masksToBounds = true
-        popularBadge.textAlignment = .center
         addSubview(popularBadge)
 
         NSLayoutConstraint.activate([
@@ -172,20 +191,22 @@ final class SPAmountPreset: UIControl {
 
             popularBadge.centerXAnchor.constraint(equalTo: centerXAnchor),
             popularBadge.centerYAnchor.constraint(equalTo: topAnchor),
-            popularBadge.heightAnchor.constraint(equalToConstant: 20),
-            popularBadge.widthAnchor.constraint(greaterThanOrEqualToConstant: 86)
+            popularBadge.heightAnchor.constraint(equalToConstant: 22)
         ])
     }
 
     private func applySelectionState(animated: Bool) {
         let apply: () -> Void = {
             if self.isSelected {
-                self.backgroundColor = AppColors.money500.withAlphaComponent(0.10)
-                self.layer.borderColor = AppColors.money500.cgColor
+                // `.sp-preset.is-selected` tints with money400 (`#2EDB9F` —
+                // `rgba(46,219,159,…)`), a hair brighter than money500, so the
+                // selected fill/ring pop against the surface.
+                self.backgroundColor = AppColors.money400.withAlphaComponent(0.10)
+                self.layer.borderColor = AppColors.money400.cgColor
                 // Tight selection ring: 4pt radius / 0.10 opacity reads as a
                 // crisp brand outline rather than a diffuse glow that bled
                 // into adjacent presets at radius 8 / opacity 0.18.
-                self.layer.shadowColor = AppColors.money500.cgColor
+                self.layer.shadowColor = AppColors.money400.cgColor
                 self.layer.shadowOpacity = 0.10
                 self.layer.shadowOffset = .zero
                 self.layer.shadowRadius = 4
@@ -207,5 +228,35 @@ final class SPAmountPreset: UIControl {
     @objc
     private func handleTap() {
         onTap?()
+    }
+}
+
+/// `UILabel` that pads its text content — used for the «Популярно» badge so it
+/// hugs its (mixed-case) text plus a 10pt horizontal inset rather than relying
+/// on a fixed width.
+private final class InsetLabel: UILabel {
+
+    private let insets: UIEdgeInsets
+
+    init(insets: UIEdgeInsets) {
+        self.insets = insets
+        super.init(frame: .zero)
+        textAlignment = .center
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func drawText(in rect: CGRect) {
+        super.drawText(in: rect.inset(by: insets))
+    }
+
+    override var intrinsicContentSize: CGSize {
+        let base = super.intrinsicContentSize
+        return CGSize(
+            width: base.width + insets.left + insets.right,
+            height: base.height + insets.top + insets.bottom
+        )
     }
 }

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPButton.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPButton.swift
@@ -60,9 +60,12 @@ final class SPButton: UIControl {
         }
 
         var cornerRadius: CGFloat {
+            // `.sp-btn--lg` overrides the base `--sp-r-md` with `--sp-r-lg`
+            // (20pt); `--md` inherits the 16pt base; `--sm` drops to `--sp-r-sm`
+            // (12pt). Matches `components.css:18-20`.
             switch self {
-            case .lg: return AppRadius.md          // 16pt — matches sp-r-md
-            case .md: return AppRadius.md
+            case .lg: return AppRadius.lg          // 20pt — matches sp-r-lg
+            case .md: return AppRadius.md          // 16pt — matches sp-r-md
             case .sm: return AppRadius.sm          // 12pt — matches sp-r-sm
             }
         }
@@ -97,7 +100,10 @@ final class SPButton: UIControl {
     /// the button stretches to match its superview width via the trailing
     /// constraint installed by the parent.
     var isFullWidth: Bool = false {
-        didSet { invalidateIntrinsicContentSize() }
+        didSet {
+            updateSuffixSpacer()
+            invalidateIntrinsicContentSize()
+        }
     }
 
     /// Optional heavier stroke for `.ghost` buttons that need to read as a
@@ -115,7 +121,16 @@ final class SPButton: UIControl {
     private let iconView = UIImageView()
     private let titleLabel = UILabel()
     private let suffixLabel = UILabel()
+    /// Flexible gap that pushes the suffix to the trailing edge — mirrors the
+    /// CSS `.sp-btn__suffix { margin-left: auto }`. Only inflated (and only
+    /// hugs at a low priority) when the button is full-width *and* carries a
+    /// suffix; otherwise it collapses so a hugging button stays centred.
+    private let suffixSpacer = UIView()
     private var gradientLayer: CAGradientLayer?
+    /// Edge pins toggled on for full-width + suffix layouts (see
+    /// `updateSuffixSpacer`).
+    private var stackLeadingPin: NSLayoutConstraint?
+    private var stackTrailingPin: NSLayoutConstraint?
 
     // MARK: - Init
 
@@ -155,6 +170,7 @@ final class SPButton: UIControl {
         } else {
             suffixLabel.isHidden = true
         }
+        updateSuffixSpacer()
         applyVariant()
         refreshDisabledAppearance()
         // iOS 17 deprecated `traitCollectionDidChange(_:)` — register a
@@ -192,9 +208,13 @@ final class SPButton: UIControl {
     override func layoutSubviews() {
         super.layoutSubviews()
         gradientLayer?.frame = bounds
+        // Inset the shadow path by 6pt to reproduce the CSS `-6` spread on the
+        // brand-coloured shadows (`--sp-shadow-{money,pain,warn}`), so the glow
+        // sits tucked under the button rather than haloing past its edges.
+        let spreadInset: CGFloat = layer.shadowOpacity > 0 && layer.borderWidth == 0 ? 6 : 0
         layer.shadowPath = UIBezierPath(
-            roundedRect: bounds,
-            cornerRadius: size.cornerRadius
+            roundedRect: bounds.insetBy(dx: spreadInset, dy: spreadInset),
+            cornerRadius: max(size.cornerRadius - spreadInset, 0)
         ).cgPath
     }
 
@@ -224,11 +244,18 @@ final class SPButton: UIControl {
 
         suffixLabel.translatesAutoresizingMaskIntoConstraints = false
         // Mono font for trailing amount suffixes — matches CSS recipe
-        // `font-family: var(--sp-font-mono); opacity: .85`.
+        // `font-family: var(--sp-font-mono)`. The design dropped the legacy
+        // `opacity: .85` dim, so the suffix now reads at full foreground
+        // weight (`components.css:22`).
         suffixLabel.font = size == .sm ? AppTypography.moneySm : AppTypography.moneyMd
         suffixLabel.textAlignment = .right
-        suffixLabel.alpha = 0.85
         suffixLabel.setContentHuggingPriority(.required, for: .horizontal)
+
+        suffixSpacer.translatesAutoresizingMaskIntoConstraints = false
+        // Hugs weakly so it only stretches when the stack has slack (full-width
+        // buttons); a hugging button keeps it collapsed and stays centred.
+        suffixSpacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        suffixSpacer.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
         stack.translatesAutoresizingMaskIntoConstraints = false
         stack.axis = .horizontal
@@ -237,8 +264,24 @@ final class SPButton: UIControl {
         stack.isUserInteractionEnabled = false
         stack.addArrangedSubview(iconView)
         stack.addArrangedSubview(titleLabel)
+        stack.addArrangedSubview(suffixSpacer)
         stack.addArrangedSubview(suffixLabel)
         addSubview(stack)
+
+        // Centre the content for hugging buttons; lower the priority so the
+        // full-width edge constraints can override it when the suffix needs to
+        // be pinned to the trailing edge.
+        let centerX = stack.centerXAnchor.constraint(equalTo: centerXAnchor)
+        centerX.priority = .defaultHigh
+        // Pin the stack to both edges — toggled on only for full-width buttons
+        // carrying a suffix so the flexible spacer can stretch and shove the
+        // suffix to the trailing edge (`margin-left: auto`).
+        stackLeadingPin = stack.leadingAnchor.constraint(
+            equalTo: leadingAnchor, constant: size.horizontalPadding
+        )
+        stackTrailingPin = stack.trailingAnchor.constraint(
+            equalTo: trailingAnchor, constant: -size.horizontalPadding
+        )
 
         NSLayoutConstraint.activate([
             heightAnchor.constraint(equalToConstant: size.height),
@@ -251,10 +294,20 @@ final class SPButton: UIControl {
                 lessThanOrEqualTo: trailingAnchor,
                 constant: -size.horizontalPadding
             ),
-            stack.centerXAnchor.constraint(equalTo: centerXAnchor),
+            centerX,
             iconView.widthAnchor.constraint(equalToConstant: size.iconSize),
             iconView.heightAnchor.constraint(equalToConstant: size.iconSize)
         ])
+    }
+
+    /// Stretch the stack edge-to-edge (and let the flexible spacer expand) only
+    /// when the button is full-width *and* carries a suffix; otherwise collapse
+    /// the spacer so a hugging / suffix-less button stays centred.
+    private func updateSuffixSpacer() {
+        let active = isFullWidth && !suffixLabel.isHidden
+        suffixSpacer.isHidden = !active
+        stackLeadingPin?.isActive = active
+        stackTrailingPin?.isActive = active
     }
 
     private func applyVariant() {
@@ -276,7 +329,7 @@ final class SPButton: UIControl {
                 colors: SPSupport.painGradientColors,
                 locations: SPSupport.painGradientLocations
             )
-            applyColoredShadow(color: AppColors.pain500)
+            applyColoredShadow(color: AppColors.pain500, painLike: true)
             setForeground(AppColors.fgOnPain)
         case .warn:
             installGradient(
@@ -291,8 +344,10 @@ final class SPButton: UIControl {
                 layer.borderWidth = override.width
                 layer.borderColor = override.color.resolvedColor(with: traitCollection).cgColor
             } else {
-                let scale = traitCollection.displayScale > 0 ? traitCollection.displayScale : 1
-                layer.borderWidth = 1.0 / scale
+                // `.sp-btn--ghost { border: 1px solid var(--sp-stroke-2) }` —
+                // a flat 1pt, not a sub-pixel hairline, so the affordance reads
+                // clearly across scales (`components.css:47`).
+                layer.borderWidth = 1.0
                 layer.borderColor = AppColors.stroke2.resolvedColor(with: traitCollection).cgColor
             }
             setForeground(AppColors.fg1)
@@ -314,11 +369,16 @@ final class SPButton: UIControl {
         backgroundColor = .clear
     }
 
-    private func applyColoredShadow(color: UIColor) {
+    private func applyColoredShadow(color: UIColor, painLike: Bool = false) {
+        // `--sp-shadow-{money,warn}: 0 8px 22px -6px rgba(...,.40)`,
+        // `--sp-shadow-pain: ... .45`. CSS blur 22 ≈ CALayer shadowRadius 11
+        // (CALayer radius is roughly half the CSS blur). The −6 spread is
+        // reproduced by insetting the shadowPath in `layoutSubviews`.
         layer.shadowColor = color.cgColor
-        layer.shadowOpacity = traitCollection.userInterfaceStyle == .light ? 0.30 : 0.40
+        let base: Float = painLike ? 0.45 : 0.40
+        layer.shadowOpacity = traitCollection.userInterfaceStyle == .light ? base - 0.10 : base
         layer.shadowOffset = CGSize(width: 0, height: 8)
-        layer.shadowRadius = 16
+        layer.shadowRadius = 11
     }
 
     private func setForeground(_ color: UIColor) {

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPCard.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPCard.swift
@@ -148,19 +148,21 @@ final class SPCard: UIView {
         switch tone {
         case .surface:
             backgroundColor = AppColors.bg1
-            applyHairlineStroke()
+            // `.sp-card { box-shadow: var(--sp-shadow-1) }` with no border in
+            // the canon. Dark mode keeps the stroke off (the shadow + bg1/bg0
+            // contrast carry the edge); light mode adds a hairline per
+            // `feedback_design_system_consistency.md` where the near-white
+            // surfaces would otherwise merge into the page.
+            applyHairlineStrokeIfLight()
             applyShadow1()
         case .raised:
             backgroundColor = AppColors.bg2
-            // Light mode: bg2 (#ECEEF6) vs bg0 (#F4F6FB) is only ~5%
-            // luminance — the card visually merges with the page without a
-            // stroke. Memory `feedback_design_system_consistency.md`
-            // requires "shadow + border" on light cards, so add a hairline
-            // there. Dark mode keeps the stroke off — bg2 already has
-            // enough contrast against bg0 and a border would read as a
-            // double-edge.
+            // `.sp-card--raised` only swaps the fill to bg2 — it inherits the
+            // base `.sp-card` `--sp-shadow-1`, not the heavier shadow-2 (which
+            // the canon reserves for sheets/overlays). Light mode keeps the
+            // hairline so bg2 (#ECEEF6) doesn't merge into bg0 (#F4F6FB).
             applyRaisedHairlineIfLight()
-            applyShadow2()
+            applyShadow1()
         case .outline:
             backgroundColor = .clear
             applyOutlineStroke()
@@ -188,7 +190,11 @@ final class SPCard: UIView {
         }
     }
 
-    private func applyHairlineStroke() {
+    private func applyHairlineStrokeIfLight() {
+        guard traitCollection.userInterfaceStyle != .dark else {
+            layer.borderWidth = 0
+            return
+        }
         let scale = traitCollection.displayScale > 0 ? traitCollection.displayScale : 1
         layer.borderWidth = 1.0 / scale
         layer.borderColor = AppColors.stroke1.resolvedColor(with: traitCollection).cgColor
@@ -225,10 +231,6 @@ final class SPCard: UIView {
         layer.borderColor = AppColors.stroke1.resolvedColor(with: traitCollection).cgColor
     }
 
-    private func applyShadow2() {
-        AppShadow.shadow2(for: traitCollection).apply(to: layer)
-    }
-
     private func applyColoredShadow(_ kind: ColoredShadow) {
         // `--sp-shadow-{money,pain,warn}: 0 8px 22px -6px rgba(...,.40)`. The
         // CSS uses a negative spread we can't replicate on CALayer, so fold
@@ -263,11 +265,11 @@ final class SPCard: UIView {
         // Re-resolve the same recipe that `applyTone()` first installed.
         switch tone {
         case .surface:
-            applyHairlineStroke()
+            applyHairlineStrokeIfLight()
             applyShadow1()
         case .raised:
             applyRaisedHairlineIfLight()
-            applyShadow2()
+            applyShadow1()
         case .outline:
             applyOutlineStroke()
         case .money:

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPInput.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPInput.swift
@@ -110,6 +110,14 @@ final class SPInput: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
         fieldContainer.layer.cornerRadius = AppRadius.md     // matches sp-r-md
+        // `.sp-input__field:focus-within { box-shadow: 0 0 0 4px rgba(...,.12) }`
+        // is a hard 4pt ring (spread, zero blur). CALayer has no spread, so we
+        // expand the shadowPath 4pt past the field and keep `shadowRadius` near
+        // zero — that renders a crisp outline rather than a diffuse glow.
+        fieldContainer.layer.shadowPath = UIBezierPath(
+            roundedRect: fieldContainer.bounds.insetBy(dx: -4, dy: -4),
+            cornerRadius: AppRadius.md + 4
+        ).cgPath
     }
 
     @available(iOS, deprecated: 17.0, message: "Replaced by registerForTraitChanges; kept for iOS 15/16.")
@@ -141,11 +149,12 @@ final class SPInput: UIView {
         fieldContainer.backgroundColor = AppColors.bg2
         fieldContainer.layer.cornerRadius = AppRadius.md
         fieldContainer.layer.borderWidth = 1.5
-        // Pre-configure the focus glow so editingDidBegin only has to flip
-        // shadowOpacity. Kept off by default (opacity 0) so the field reads
-        // flat at rest.
-        fieldContainer.layer.shadowColor = AppColors.money500.cgColor
-        fieldContainer.layer.shadowRadius = 4
+        // Pre-configure the focus ring so editingDidBegin only has to flip
+        // shadowOpacity. Money400 (`#2EDB9F`), zero blur + zero offset — the
+        // expanded shadowPath in `layoutSubviews` turns it into a hard 4pt
+        // ring. Kept off by default (opacity 0) so the field reads flat at rest.
+        fieldContainer.layer.shadowColor = AppColors.money400.cgColor
+        fieldContainer.layer.shadowRadius = 0
         fieldContainer.layer.shadowOpacity = 0
         fieldContainer.layer.shadowOffset = .zero
         fieldContainer.layer.masksToBounds = false
@@ -221,9 +230,9 @@ final class SPInput: UIView {
             fieldContainer.layer.borderColor = AppColors.stroke1
                 .resolvedColor(with: traitCollection).cgColor
         }
-        // Re-resolve the focus glow tint so a light/dark switch keeps
-        // the ring colour in sync with the active border.
-        fieldContainer.layer.shadowColor = AppColors.money500
+        // Re-resolve the focus ring tint (money400 per the CSS recipe) so a
+        // light/dark switch keeps the ring colour stable.
+        fieldContainer.layer.shadowColor = AppColors.money400
             .resolvedColor(with: traitCollection).cgColor
     }
 

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPPill.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPPill.swift
@@ -27,8 +27,10 @@ final class SPPill: UIView {
     // MARK: - Init
 
     /// - Parameters:
-    ///   - text: Caps-styled label (uppercased automatically per the
-    ///     `--sp-t-caps` recipe — bold 12pt + 0.14em tracking).
+    ///   - text: Caps-styled label. The `.sp-pill` recipe applies only the
+    ///     `--sp-t-caps` font + default `.12em` tracking — no `text-transform`,
+    ///     so the caller's casing is preserved (the design mixes case, e.g.
+    ///     «Популярно»).
     ///   - tone: Background + text colour mapping. Defaults to `.neutral`.
     ///   - icon: Optional 12pt leading icon (rendered as template, tinted
     ///     to match the label) — JSX chips use `<Icon size={12} />`.
@@ -91,14 +93,15 @@ final class SPPill: UIView {
     /// a long-lived pill instance (e.g. the progressive-snooze indicator on
     /// the firing screen counts up "1-е откладывание" → "2-е откладывание" → ...).
     func setText(_ text: String) {
-        // CSS pairs caps tracking (.14em ≈ 12 * 0.14 = 1.68pt) with the
-        // bold 12pt size; bake that into an attributed string so the label
-        // stays in one node (not a stack of label + spacer).
+        // `.sp-pill` uses the bold 12pt caps font with the default caps
+        // tracking (`.12em` per `tokens.css` `--sp-t-caps` / `.sp-caps`) and
+        // *no* `text-transform`, so the caller's mixed-case string is kept
+        // verbatim.
         let attributed = NSAttributedString(
-            string: text.uppercased(),
+            string: text,
             attributes: [
                 .font: AppTypography.caps,
-                .kern: 12 * 0.14
+                .kern: AppTypography.capsKerning
             ]
         )
         label.attributedText = attributed
@@ -112,10 +115,10 @@ final class SPPill: UIView {
     func setBalance(label labelText: String, value: String) {
         let ink = label.textColor ?? AppColors.fg2
         let result = NSMutableAttributedString(
-            string: labelText.uppercased(),
+            string: labelText,
             attributes: [
                 .font: AppTypography.caps,
-                .kern: 12 * 0.14,
+                .kern: AppTypography.capsKerning,
                 .foregroundColor: ink.withAlphaComponent(0.55)
             ]
         )

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPSegmented.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPSegmented.swift
@@ -65,9 +65,9 @@ final class SPSegmented: UIControl {
         super.layoutSubviews()
         layer.cornerRadius = AppRadius.sm
         track.layer.cornerRadius = AppRadius.sm
-        // Indicator slides into place via constraints; corner radius scales
-        // with track padding so it visually nests.
-        indicator.layer.cornerRadius = AppRadius.sm - 4
+        // `.sp-seg__opt { border-radius: 10px }` — the active indicator nests
+        // inside the 12pt track with a fixed 10pt radius.
+        indicator.layer.cornerRadius = 10
         // Re-position indicator after layout cycle resolves geometries.
         positionIndicator(animated: false)
     }
@@ -83,17 +83,20 @@ final class SPSegmented: UIControl {
 
         indicator.translatesAutoresizingMaskIntoConstraints = false
         indicator.backgroundColor = AppColors.bg1
+        // `.sp-seg__opt.is-on { box-shadow: var(--sp-shadow-1) }` — soft lift
+        // so the active option floats off the track. shadow-1 dark is a single
+        // `0 2px 8px rgba(0,0,0,.35)` stop; mirror those values directly.
         indicator.layer.shadowColor = UIColor.black.cgColor
-        indicator.layer.shadowOpacity = 0.18
+        indicator.layer.shadowOpacity = 0.35
         indicator.layer.shadowOffset = CGSize(width: 0, height: 2)
-        indicator.layer.shadowRadius = 6
+        indicator.layer.shadowRadius = 8
         track.addSubview(indicator)
 
         let stack = UIStackView()
         stack.translatesAutoresizingMaskIntoConstraints = false
         stack.axis = .horizontal
         stack.distribution = .fillEqually
-        stack.spacing = 0
+        stack.spacing = 2     // `.sp-seg { gap: 2px }`
         stack.isUserInteractionEnabled = true
         track.addSubview(stack)
 

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPSupport.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPSupport.swift
@@ -103,6 +103,37 @@ enum SPSupport {
     /// keyframe animations for every press feedback.
     static let easeOut: UIView.AnimationOptions = [.curveEaseOut]
 
+    // MARK: - Spring easing
+
+    /// Approximation of `--sp-ease-spring: cubic-bezier(.34,1.56,.64,1)` — the
+    /// overshoot curve the design uses for the switch knob and "success"
+    /// moments. The `> 1` control point produces a small bounce past the
+    /// target, which `UISpringTimingParameters` reproduces with a light damping
+    /// ratio. Tuned so the settle feels playful but doesn't visibly oscillate.
+    static let springDampingRatio: CGFloat = 0.72
+    static let springInitialVelocity = CGVector(dx: 0, dy: 0.4)
+
+    /// Run `animations` with the spring overshoot curve over `duration`
+    /// (defaults to `durationBase`). Use for switch toggles and success
+    /// confirmations where the `cubic-bezier(.34,1.56,.64,1)` bounce is wanted;
+    /// keep plain `animatePress` for the flat press scale.
+    static func animateSpring(
+        duration: TimeInterval = durationBase,
+        animations: @escaping () -> Void,
+        completion: ((Bool) -> Void)? = nil
+    ) {
+        let timing = UISpringTimingParameters(
+            dampingRatio: springDampingRatio,
+            initialVelocity: springInitialVelocity
+        )
+        let animator = UIViewPropertyAnimator(duration: duration, timingParameters: timing)
+        animator.addAnimations(animations)
+        if let completion = completion {
+            animator.addCompletion { _ in completion(true) }
+        }
+        animator.startAnimation()
+    }
+
     // MARK: - Press feedback
 
     /// Animate a 0.97 scale press (or restore to identity) on a view.

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPSwitch.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPSwitch.swift
@@ -22,10 +22,18 @@ final class SPSwitch: UISwitch {
     }
 
     private func applyBrandTint() {
-        // `--sp-switch.is-on { background: var(--sp-grad-money) }` — UISwitch
-        // doesn't render a gradient natively, so we fall back to the
-        // `money500` flat fill which lines up with the dominant gradient
-        // stop and keeps the toggle indistinguishable in motion.
+        // `--sp-switch.is-on { background: var(--sp-grad-money) }` and a knob
+        // that translates on `--sp-ease-spring`.
+        //
+        // Documented limitation (per #287): a true gradient on-track + the
+        // spring knob physics would require fully re-implementing the control
+        // (custom track view + thumb + pan gesture + a11y), which is a high
+        // regression risk for a tiny visual delta — the `money500` flat fill
+        // already lines up with the dominant gradient stop and is
+        // indistinguishable from the gradient in motion. UISwitch also owns its
+        // own native (already springy) knob animation, so we inherit a close
+        // match to `--sp-ease-spring` for free. If a future task does build the
+        // custom track, `SPSupport.animateSpring` provides the matching curve.
         onTintColor = AppColors.money500
     }
 }


### PR DESCRIPTION
Fixes #287

Token polish pack per `docs/AUDIT_DESIGN_GAP_2026-06-12.md`, aligning the SP* design-system primitives with `docs/design/v2-handoff/components/components.css` + `tokens.css`. Confined to `Views/DesignSystem/*` and token defs (`Utilities/AppColors.swift`, `Utilities/UIView+CardStyle.swift`); no view controllers touched.

## Done
- **SPButton**: `lg` radius → `--sp-r-lg` (20pt, was md 16); colored shadow → blur 22 (`shadowRadius` 11) + −6 spread (path inset), pain opacity .45 / others .40; ghost border → flat 1pt (was sub-pixel hairline); suffix → dropped `.85` alpha and pinned to the trailing edge via a flexible spacer for full-width buttons (`margin-left: auto`).
- **SPCard**: surface stroke now light-mode-only (no stroke in dark, per canon); `.raised` now keeps `shadow-1` (was `shadow-2`) — inherits base `.sp-card` shadow.
- **UIView+CardStyle (legacy)**: fill `surface` → `bg1`; default radius 12 → 16 (`applyCardStyle` / `updateCardShadowPath` / `CardView`); killed dead `AppRadius.card`.
- **SPPill**: stopped force-uppercasing (`setText` / `setBalance` keep caller casing — design is mixed-case); tracking → default `.12em` (`capsKerning`, was `.14em`).
- **SPAmountPreset**: value → 700 18px mono (was moneyMd 20pt); selected tint → money400 (was money500); «Популярно» badge → money-gradient fill, mixed-case, no fixed width (hugs text + 10pt inset).
- **SPSegmented**: 2px option gap; indicator radius → 10; indicator shadow → `shadow-1` values.
- **SPInput**: focus ring → money400, hard 4pt (expanded shadowPath, zero blur) matching `0 0 0 4px rgba(46,219,159,.12)`.
- **SPSupport**: added `animateSpring` helper approximating `--sp-ease-spring: cubic-bezier(.34,1.56,.64,1)` via `UISpringTimingParameters`.

## Skipped (out of confined area — noted per issue caution)
- **Hardcoded colors → tokens** (warn400/warn600/systemRed literals): all live in view controllers (`AlarmFiringViewController`, `SplashViewController`, `OnboardingPages`, `ReferralViewController`, `AlarmsListViewController:429`) — VCs owned by parallel agents / outside `Views/DesignSystem`. Left for a follow-up that can edit those VCs safely.
- **SPPill sound-icon restore on enabled card pill / disabled cards lose icons**: lives in `AlarmCell.swift` (AlarmsList area, parallel agent). Skipped.
- **Day chips 36×36 circles**: `DayPickerCell.swift` is under `ViewControllers/Alarms/Cells` (CreateAlarm area, parallel agent). Skipped.
- **SPSwitch money-gradient on-track**: documented the limitation per the issue's "else document" — a true gradient track + custom knob physics would require fully re-implementing UISwitch (high regression risk for a tiny delta); kept the safe `money500` `onTintColor` and referenced `animateSpring` for any future custom track.

## Verify
- swiftlint: 0 errors (2 pre-existing superfluous_disable_command warnings, not in touched regions)
- xcodebuild build (iphonesimulator, CODE_SIGNING_ALLOWED=NO): BUILD SUCCEEDED
- xcodebuild build-for-testing: TEST BUILD SUCCEEDED
- Pure chrome — no logic extracted, so no new tests (per issue: chrome exempt)