### PR TITLE
[ui] Fix SPButton gradient vanishing on trait change (#320)

### DIFF
--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPButton.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPButton.swift
@@ -355,6 +355,9 @@ final class SPButton: UIControl {
             backgroundColor = AppColors.whiteOverlay06
             setForeground(AppColors.fg1)
         }
+        // Refresh the brand-shadow path (and gradient frame) for the new chrome —
+        // a trait change re-tints here but doesn't guarantee a layout pass.
+        setNeedsLayout()
     }
 
     private func installGradient(colors: [CGColor], locations: [NSNumber]) {
@@ -364,6 +367,14 @@ final class SPButton: UIControl {
         gradient.startPoint = SPSupport.gradientStart
         gradient.endPoint = SPSupport.gradientEnd
         gradient.cornerRadius = size.cornerRadius
+        // Size the layer to the current bounds up front. `applyVariant()` runs
+        // on trait changes when the button is already laid out, and re-inserting
+        // a sublayer doesn't itself trigger `layoutSubviews` — without this the
+        // fresh gradient would sit at `.zero` frame (invisible), leaving only the
+        // dark on-money text so the CTA reads as disabled (#320). `layoutSubviews`
+        // keeps it in sync afterwards and corrects the cold-start case where
+        // `bounds` is still zero at first install.
+        gradient.frame = bounds
         layer.insertSublayer(gradient, at: 0)
         gradientLayer = gradient
         backgroundColor = .clear


### PR DESCRIPTION
Fixes #320

## Problem
On device the Wallet header «Пополнить» (`SPButton(.money) size .sm`) rendered dark — reading as disabled — instead of the bright money gradient. Same latent bug affects every money/pain/warn CTA after a light↔dark theme switch.

## Root cause
`installGradient` created the `CAGradientLayer` with no frame, relying on `layoutSubviews` to set `frame = bounds`. On a trait change `applyVariant()` recreates the layer at `.zero` frame; re-inserting a sublayer doesn't trigger a layout pass, so the fresh gradient stayed invisible — only the dark `fgOnMoney` text remained.

## Fix
- Size the gradient layer to `bounds` at install time (correct immediately on trait change when the button is already laid out; `layoutSubviews` still keeps it in sync and handles the cold-start zero-bounds case).
- `setNeedsLayout()` at the end of `applyVariant()` so the brand-shadow path also refreshes after a re-tint.

## Verification
- swiftlint: 0 errors (1 pre-existing unrelated warning on line 30).
- build_sim: SUCCEEDED.
- Covers all gradient variants (money/pain/warn) — single shared code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)