### PR TITLE
[ui] Settings: self-size theme & progressive-price rows (#314, #313)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController+Sections.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController+Sections.swift
@@ -127,7 +127,9 @@ extension SettingsViewController {
             systemName: "flame",
             iconColor: AppColors.pain400,
             title: "Прогрессивная цена",
-            subtitle: "Цена откладывания удваивается за каждый повтор",
+            // Design copy (`SPMore4.jsx:381`) — the doubling ramp reads clearer
+            // than prose and won't clip (#313).
+            subtitle: "50 → 100 → 200 → 400",
             isOn: alarmDefaults.progressiveScale,
             onChange: { [weak self] isOn in
                 self?.alarmDefaults.progressiveScale = isOn

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController.swift
@@ -227,7 +227,14 @@ extension SettingsViewController: UITableViewDelegate {
         guard let section = Section(rawValue: indexPath.section) else { return 52 }
         switch section {
         case .other where OtherRow(rawValue: indexPath.row) == .theme:
-            return 56
+            // Two-storey cell — glyph + «Тема» title, then a 36pt SPSegmented
+            // below (~90pt total). A fixed 56pt clipped the title and squashed
+            // the segment; self-size instead (#314).
+            return UITableView.automaticDimension
+        case .rules:
+            // «Прогрессивная цена» carries a wrapping subtitle — self-size so it
+            // isn't truncated ("...") on narrow screens (#313).
+            return UITableView.automaticDimension
         case .referral:
             // Friend-input row hosts an SPInput (52pt field + label + hint);
             // the caption row wraps to two lines on small screens — let
@@ -248,9 +255,14 @@ extension SettingsViewController: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
         // `automaticDimension` paths above need an estimate or the table
-        // collapses on first layout pass. 52pt matches the rest of the
-        // settings rows for visual continuity.
-        52
+        // collapses on first layout pass. The two-storey theme row (~90pt) gets
+        // its own estimate so it doesn't jump on first display; the rest match
+        // the 52pt row rhythm.
+        if Section(rawValue: indexPath.section) == .other,
+           OtherRow(rawValue: indexPath.row) == .theme {
+            return 90
+        }
+        return 52
     }
 
     /// Apply the shared card-style background to every row so each


### PR DESCRIPTION
Fixes #314
Fixes #313

Two Settings row-height bugs in the same `heightForRowAt` — bundled to avoid a guaranteed merge conflict.

## #314 — «Тема» row clipped
`ThemeSegmentCell` is two-storey (glyph + title, then a 36pt SPSegmented ≈ 90pt) but `heightForRowAt` returned a fixed **56pt**, clipping the title and squashing the segment. → `UITableView.automaticDimension`, with a dedicated 90pt estimate so it doesn't jump on first display.

## #313 — «Прогрессивная цена» subtitle truncated
The `.rules` row fell into the `default: 52pt` branch, truncating its multiline subtitle («…за каж…»). → `automaticDimension`, and adopt the design copy **«50 → 100 → 200 → 400»** (`SPMore4.jsx:381`) which is shorter and more informative than the previous prose.

## Verification
- swiftlint: 0 violations.
- build_sim: SUCCEEDED.
- Self-sizing constraints already complete in both cells; no layout-engine changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)