### PR TITLE
[ui] Stats: fixed page-title header + Серия chip (#319, #318)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Statistics/StatisticsViewController.swift
@@ -25,6 +25,13 @@ final class StatisticsViewController: UIViewController {
     let scrollView = UIScrollView()
     let contentStack = UIStackView()
 
+    /// Fixed page-title header (#319) — same chrome as Будильники / Кошелёк.
+    private let header: SPPageHeader = {
+        let view = SPPageHeader(title: "Статистика")
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
     /// Shown over the scroll content when the user has no charges and no wake
     /// events — nothing to aggregate yet (`SPMore.jsx` `EmptyStats`, #289).
     let emptyState: SPStatsEmptyState = {
@@ -143,8 +150,12 @@ final class StatisticsViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        // The fixed page-title header carries the title; suppress the nav bar's
+        // own title so the screen doesn't render «Статистика» twice (#319,
+        // matching the AlarmsList #280 chrome).
         title = "Статистика"
-        navigationController?.navigationBar.prefersLargeTitles = true
+        navigationItem.title = ""
+        navigationController?.navigationBar.prefersLargeTitles = false
         view.backgroundColor = AppColors.bg0
         setupLayout()
         bindViewModel()
@@ -152,6 +163,8 @@ final class StatisticsViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        // Hidden on this tab — the in-screen header owns the title (#319).
+        navigationController?.setNavigationBarHidden(true, animated: animated)
         viewModel.loadData()
     }
 
@@ -191,8 +204,15 @@ final class StatisticsViewController: UIViewController {
         view.addSubview(scrollView)
         scrollView.addSubview(contentStack)
         view.addSubview(emptyState)
+        view.addSubview(header)
         NSLayoutConstraint.activate([
-            emptyState.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            header.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            header.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            header.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+
+            // Empty state fills the area below the header (not from safeArea
+            // top — the header now occupies that band, #319).
+            emptyState.topAnchor.constraint(equalTo: header.bottomAnchor),
             emptyState.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             emptyState.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             emptyState.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
@@ -201,7 +221,7 @@ final class StatisticsViewController: UIViewController {
 
     private func installContainerConstraints() {
         NSLayoutConstraint.activate([
-            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.topAnchor.constraint(equalTo: header.bottomAnchor),
             scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPPageHeader.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPPageHeader.swift
@@ -1,0 +1,72 @@
+import UIKit
+
+/// Fixed page-title header — an h1 title row over a 1pt hairline, with no back
+/// button. Mirrors the chrome of `SPAlarmsListHeader` (#280) minus the balance
+/// pill, for screens whose design calls for the same title block as Будильники
+/// / Кошелёк (`SPMore4.jsx:100-109`). The host controller hides the system nav
+/// bar so the screen doesn't render the title twice.
+///
+/// ```
+///  ┌────────────────────────────────────────┐
+///  │ Статистика                              │   <- h1, 16pt insets
+///  └────────────────────────────────────────┘
+///  ── 1pt whiteOverlay06 hairline ──
+/// ```
+final class SPPageHeader: UIView {
+
+    private let titleLabel = UILabel()
+
+    private let bottomHairline: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = AppColors.whiteOverlay06
+        return view
+    }()
+
+    init(title: String) {
+        super.init(frame: .zero)
+        backgroundColor = AppColors.bg0
+        configure(title: title)
+        if #available(iOS 17.0, *) {
+            registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (view: SPPageHeader, _) in
+                // CALayer-backed colours don't auto-resolve on trait change.
+                view.bottomHairline.backgroundColor = AppColors.whiteOverlay06
+            }
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func configure(title: String) {
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        // h1 32pt extrabold with full -0.02em tracking — same recipe as the
+        // AlarmsList header title (`SPScreensV2.jsx:315`, tokens.css L80).
+        titleLabel.attributedText = NSAttributedString(
+            string: title,
+            attributes: [
+                .font: AppTypography.h1,
+                .kern: AppTypography.kern(em: -0.02, size: 32),
+                .foregroundColor: AppColors.fg1
+            ]
+        )
+
+        addSubview(titleLabel)
+        addSubview(bottomHairline)
+
+        let inset = AppSpacing.screenInset
+        NSLayoutConstraint.activate([
+            // 16pt insets per the design page-title block.
+            titleLabel.topAnchor.constraint(equalTo: topAnchor, constant: AppSpacing.sp4),
+            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: inset),
+            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -inset),
+            titleLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -AppSpacing.sp4),
+
+            bottomHairline.leadingAnchor.constraint(equalTo: leadingAnchor),
+            bottomHairline.trailingAnchor.constraint(equalTo: trailingAnchor),
+            bottomHairline.bottomAnchor.constraint(equalTo: bottomAnchor),
+            bottomHairline.heightAnchor.constraint(equalToConstant: 1)
+        ])
+    }
+}

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPStatsEmptyState.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPStatsEmptyState.swift
@@ -15,7 +15,7 @@ import UIKit
 ///            Пока нечего считать          <- h2 fg1
 ///   Статистика появится после первой
 ///   недели использования.                <- body-lg fg2
-///        ( 🔥 Стрик · 2 дня )            <- money-tinted pill
+///        ( 🔥 Серия · 2 дня )            <- money-tinted pill
 /// ```
 final class SPStatsEmptyState: UIView {
 
@@ -72,7 +72,7 @@ final class SPStatsEmptyState: UIView {
         return label
     }()
 
-    /// Money-tinted pill: flame icon + "Стрик · N дня".
+    /// Money-tinted pill: flame icon + "Серия · N дня".
     private let streakChip = UIView()
     private let streakChipLabel: UILabel = {
         let label = UILabel()
@@ -98,7 +98,9 @@ final class SPStatsEmptyState: UIView {
     /// Update the streak chip's day count + Russian declension.
     func setStreak(_ days: Int) {
         let word = StreakModalViewController.dayWord(for: days)
-        streakChipLabel.text = "Стрик · \(days) \(word)"
+        // Canonical term is «Серия», not the «Стрик» anglicism (#318) — the
+        // hero card of this same screen already reads «Серия».
+        streakChipLabel.text = "Серия · \(days) \(word)"
         // Hide the chip entirely when there is no streak to celebrate.
         streakChip.isHidden = days <= 0
     }


### PR DESCRIPTION
Fixes #319
Fixes #318

Both Stats-screen, bundled.

## #319 — page-title header
The Stats tab used a system large-title; the design calls for a fixed page-title block (h1 «Статистика» + 16pt insets + 1pt `whiteOverlay06` hairline, no back button) — «тот же паттерн что у Будильники / Кошелёк» (`SPMore4.jsx:100-109`, audit item 12). AlarmsList already moved to this in #280.

- New `SPPageHeader` design-system view (lean: title + hairline, no balance pill).
- Stats VC hides the nav bar on `viewWillAppear`, suppresses its title, and anchors both the scroll content and the empty state **below** the header (empty state previously pinned to safeArea top).

## #318 — «Стрик» → «Серия»
Empty-state chip carried the lone handoff anglicism «Стрик»; canonical term is «Серия» (the hero card of the same screen already uses it). One string + docstrings.

## Verification
- swiftlint: 0 violations (3 files).
- build_sim: SUCCEEDED (new file auto-included via synchronized group).

🤖 Generated with [Claude Code](https://claude.com/claude-code)