### PR TITLE
[ui] Wallet/TxHistory: row sums money-md 20pt (#321)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletTransactionHistoryViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletTransactionHistoryViewController.swift
@@ -442,18 +442,20 @@ final class WalletTransactionHistoryViewController: UIViewController {
 
     private static func makeAmountLabel(for transaction: Transaction) -> UILabel {
         let label = UILabel()
-        label.font = AppTypography.moneySm
+        // Row sums use money-md (700 20px mono) per design, not 14pt moneySm
+        // (#321; full history SPMore3.jsx:178, role "Row sums" SPDesignSystem.jsx:254).
+        label.font = AppTypography.moneyMd
         label.translatesAutoresizingMaskIntoConstraints = false
         let absAmount = Int(abs(transaction.amount))
         switch transaction.type {
         case .topup, .promotion:
             label.attributedText = MoneyFormatter.attributed(
-                Decimal(absAmount), digitsFont: AppTypography.moneySm, prefix: "+"
+                Decimal(absAmount), digitsFont: AppTypography.moneyMd, prefix: "+"
             )
             label.textColor = AppColors.money400
         case .charge:
             label.attributedText = MoneyFormatter.attributed(
-                Decimal(absAmount), digitsFont: AppTypography.moneySm, prefix: "−"
+                Decimal(absAmount), digitsFont: AppTypography.moneyMd, prefix: "−"
             )
             label.textColor = AppColors.pain400
         }

--- a/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletViewController+Layout.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletViewController+Layout.swift
@@ -179,7 +179,9 @@ extension WalletViewController {
     private func makeTxAmountLabel(text: String, isDebit: Bool) -> UILabel {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = AppTypography.moneySm
+        // Row sums use money-md (700 20px mono) per design — 14pt moneySm read
+        // as a secondary caption (#321; SPScreensV2.jsx:543, SPMore3.jsx:178).
+        label.font = AppTypography.moneyMd
         label.textColor = isDebit ? AppColors.pain400 : AppColors.money400
         label.text = text
         return label


### PR DESCRIPTION
Fixes #321

Trailing operation amounts in both the Wallet preview rows (`WalletViewController+Layout.swift`) and the full transaction history (`WalletTransactionHistoryViewController.swift`) used 14pt `moneySm`, reading as a secondary caption. The design assigns 'Row sums' the **money-md** role (700 20px JetBrains Mono) — `SPScreensV2.jsx:543`, `SPMore3.jsx:178`, `SPDesignSystem.jsx:254`.

Switched the label fonts and the `MoneyFormatter` `digitsFont` to `AppTypography.moneyMd`.

## Verification
- swiftlint: 0 violations.
- build_sim: SUCCEEDED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)