### PR TITLE
[ui] Settings: editable default snooze price row (#315)

### DIFF
--- a/SnoozePay/SnoozePay/Services/AlarmDefaults.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmDefaults.swift
@@ -29,6 +29,7 @@ final class AlarmDefaults {
         static let volume = "default_volume"
         static let vibration = "default_vibration"
         static let progressiveScale = "default_progressive_scale"
+        static let penaltyAmount = "default_penalty_amount"
     }
 
     // MARK: - Factory fallbacks
@@ -40,6 +41,7 @@ final class AlarmDefaults {
     static let fallbackVolume: Float = 1.0
     static let fallbackVibration = true
     static let fallbackProgressiveScale = false
+    static let fallbackPenaltyAmount: Double = 50
 
     // MARK: - Snooze duration
 
@@ -109,5 +111,26 @@ final class AlarmDefaults {
             return defaults.bool(forKey: Key.progressiveScale)
         }
         set { defaults.set(newValue, forKey: Key.progressiveScale) }
+    }
+
+    // MARK: - Default snooze price
+
+    /// Default snooze price (₽) seeding new alarms (#315). Free value floored
+    /// at 1 ₽ with no upper cap (per #230); a non-finite or sub-1 stored blob
+    /// falls back to the 1 ₽ floor so `Alarm.init` never seeds a zero/NaN
+    /// penalty. Editing only affects alarms created afterwards.
+    var penaltyAmount: Double {
+        get {
+            guard defaults.object(forKey: Key.penaltyAmount) != nil else {
+                return Self.fallbackPenaltyAmount
+            }
+            let raw = defaults.double(forKey: Key.penaltyAmount)
+            guard raw.isFinite else { return Self.fallbackPenaltyAmount }
+            return max(raw, 1)
+        }
+        set {
+            let clamped = newValue.isFinite ? max(newValue, 1) : Self.fallbackPenaltyAmount
+            defaults.set(clamped, forKey: Key.penaltyAmount)
+        }
     }
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController+Sections.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController+Sections.swift
@@ -19,21 +19,21 @@ extension SettingsViewController {
         }
     }
 
-    /// Display-only "Цена откладывания по умолчанию · 50 ₽" row (#237/#283).
-    /// The value mirrors `AlarmsListViewModel.defaultPenaltyAmount` (the
-    /// `Alarm.init` default applied to new alarms); per-alarm price editing
-    /// lives on the Create/Edit screen, so this row carries no navigation
-    /// (chevron-to-edit is tracked separately in #230).
+    /// Tappable "Цена откладывания по умолчанию · 50 ₽" row (#237/#283/#315).
+    /// The value is the global default penalty seeding new alarms
+    /// (`AlarmDefaults.penaltyAmount`); tapping opens a price editor and the
+    /// chevron signals the affordance, symmetric with the snooze-duration row
+    /// (design `SPMore4.jsx:362`). Existing alarms keep their own saved price.
     func makeDefaultPriceRow(at indexPath: IndexPath) -> UITableViewCell {
         let cell = dequeueIconRowCell(at: indexPath)
         cell.configure(
             systemName: "rublesign.circle",
             iconColor: AppColors.warn400,
             title: "Цена откладывания по умолчанию",
-            trailingText: Decimal(AlarmsListViewModel.defaultPenaltyAmount).formattedRubles(),
+            trailingText: Decimal(alarmDefaults.penaltyAmount).formattedRubles(),
             trailingColor: AppColors.warn400,
-            accessory: .none,
-            selectionStyle: .none
+            accessory: .disclosureIndicator,
+            selectionStyle: .default
         )
         return cell
     }
@@ -228,6 +228,36 @@ extension SettingsViewController {
         if let popover = sheet.popoverPresentationController {
             let indexPath = IndexPath(
                 row: FinanceRow.snoozeDuration.rawValue,
+                section: Section.finance.rawValue
+            )
+            popover.sourceView = tableView
+            popover.sourceRect = tableView.rectForRow(at: indexPath)
+        }
+        present(sheet, animated: true)
+    }
+
+    /// Interim default-price editor (#315). The design ultimately calls for the
+    /// free-numeric SnoozePriceCard input (#230); until that lands this mirrors
+    /// `presentSnoozeDurationPicker()` with the canonical price chips. Writing
+    /// the global default never rewrites existing alarms — only new ones inherit.
+    func presentDefaultPricePicker() {
+        let sheet = UIAlertController(
+            title: "Цена откладывания по умолчанию",
+            message: "Применяется к новым будильникам",
+            preferredStyle: .actionSheet
+        )
+        for amount in [20, 50, 100, 200, 500] {
+            let title = Decimal(amount).formattedRubles()
+            sheet.addAction(UIAlertAction(title: title, style: .default) { [weak self] _ in
+                self?.alarmDefaults.penaltyAmount = Double(amount)
+                self?.tableView.reloadData()
+            })
+        }
+        sheet.addAction(UIAlertAction(title: "Отмена", style: .cancel))
+        // iPad: anchor the popover to the tapped row.
+        if let popover = sheet.popoverPresentationController {
+            let indexPath = IndexPath(
+                row: FinanceRow.defaultPrice.rawValue,
                 section: Section.finance.rawValue
             )
             popover.sourceView = tableView

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController.swift
@@ -269,9 +269,7 @@ extension SettingsViewController: UITableViewDelegate {
 
         switch section {
         case .finance:
-            if FinanceRow(rawValue: indexPath.row) == .snoozeDuration {
-                presentSnoozeDurationPicker()
-            }
+            handleFinanceTap(row: indexPath.row)
 
         case .soundNotifications:
             if SoundRow(rawValue: indexPath.row) == .volume {
@@ -291,6 +289,16 @@ extension SettingsViewController: UITableViewDelegate {
 
         case .other:
             handleOtherTap(row: indexPath.row)
+        }
+    }
+
+    /// `.finance` row taps split off so `didSelectRowAt` stays under SwiftLint's
+    /// cyclomatic-complexity cap (same reason as `handleOtherTap`).
+    private func handleFinanceTap(row: Int) {
+        switch FinanceRow(rawValue: row) {
+        case .defaultPrice:   presentDefaultPricePicker()
+        case .snoozeDuration: presentSnoozeDurationPicker()
+        case .none:           break
         }
     }
 

--- a/SnoozePay/SnoozePay/ViewModels/CreateAlarmViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/CreateAlarmViewModel.swift
@@ -63,7 +63,7 @@ final class CreateAlarmViewModel {
         // minutes (old stepper range). The form's slider now caps at 15.
         let rawSnooze = alarm?.snoozeMinutes ?? defaults.snoozeMinutes
         self.snoozeMinutes = min(max(rawSnooze, Self.snoozeMinutesRange.lowerBound), Self.snoozeMinutesRange.upperBound)
-        self.penaltyAmount = alarm?.penaltyAmount ?? 50
+        self.penaltyAmount = alarm?.penaltyAmount ?? defaults.penaltyAmount
         self.progressiveScale = alarm?.progressiveScale ?? defaults.progressiveScale
         self.enabled = alarm?.enabled ?? true
         self.volume = alarm?.volume ?? defaults.volume

--- a/SnoozePay/SnoozePayTests/AlarmDefaultsTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmDefaultsTests.swift
@@ -94,6 +94,36 @@ final class AlarmDefaultsTests: XCTestCase {
         XCTAssertTrue(AlarmDefaults(defaults: defaults).progressiveScale)
     }
 
+    // MARK: - Default snooze price (#315)
+
+    func testPenaltyAmount_defaultsToFactoryFallback() {
+        XCTAssertEqual(sut.penaltyAmount, AlarmDefaults.fallbackPenaltyAmount, accuracy: 0.0001)
+        XCTAssertEqual(sut.penaltyAmount, 50, accuracy: 0.0001)
+    }
+
+    func testPenaltyAmount_persistsWrite() {
+        sut.penaltyAmount = 200
+        XCTAssertEqual(sut.penaltyAmount, 200, accuracy: 0.0001)
+        XCTAssertEqual(AlarmDefaults(defaults: defaults).penaltyAmount, 200, accuracy: 0.0001)
+    }
+
+    func testPenaltyAmount_floorsAtOne() {
+        sut.penaltyAmount = 0
+        XCTAssertEqual(sut.penaltyAmount, 1, accuracy: 0.0001)
+        sut.penaltyAmount = -100
+        XCTAssertEqual(sut.penaltyAmount, 1, accuracy: 0.0001)
+    }
+
+    func testPenaltyAmount_hasNoUpperCap() {
+        sut.penaltyAmount = 99_999
+        XCTAssertEqual(sut.penaltyAmount, 99_999, accuracy: 0.0001)
+    }
+
+    func testPenaltyAmount_nonFiniteFallsBack() {
+        sut.penaltyAmount = .nan
+        XCTAssertEqual(sut.penaltyAmount, AlarmDefaults.fallbackPenaltyAmount, accuracy: 0.0001)
+    }
+
     // MARK: - Seeds new alarms
 
     func testDefaults_seedNewAlarmDraft() {
@@ -101,6 +131,7 @@ final class AlarmDefaultsTests: XCTestCase {
         sut.vibrationEnabled = false
         sut.volume = 0.8
         sut.progressiveScale = true
+        sut.penaltyAmount = 150
 
         let viewModel = CreateAlarmViewModel(alarm: nil, defaults: sut)
 
@@ -108,17 +139,20 @@ final class AlarmDefaultsTests: XCTestCase {
         XCTAssertFalse(viewModel.vibrationEnabled)
         XCTAssertEqual(viewModel.volume, 0.8, accuracy: 0.0001)
         XCTAssertTrue(viewModel.progressiveScale)
+        XCTAssertEqual(viewModel.penaltyAmount, 150, accuracy: 0.0001)
     }
 
     func testDefaults_doNotOverrideExistingAlarm() {
         sut.snoozeMinutes = 5
         sut.vibrationEnabled = false
+        sut.penaltyAmount = 150
 
-        let existing = Alarm(vibrationEnabled: true, snoozeMinutes: 12)
+        let existing = Alarm(vibrationEnabled: true, snoozeMinutes: 12, penaltyAmount: 75)
         let viewModel = CreateAlarmViewModel(alarm: existing, defaults: sut)
 
         // Editing keeps the alarm's own values, ignoring the global default.
         XCTAssertEqual(viewModel.snoozeMinutes, 12)
         XCTAssertTrue(viewModel.vibrationEnabled)
+        XCTAssertEqual(viewModel.penaltyAmount, 75, accuracy: 0.0001)
     }
 }


### PR DESCRIPTION
Fixes #315

The «Цена откладывания по умолчанию» row was display-only (`accessory: .none`, `selectionStyle: .none`), asymmetric with the «Длительность» row's chevron, and read a hardcoded constant.

## Changes
- **`AlarmDefaults.penaltyAmount`** — new persisted global default (key `default_penalty_amount`), floored at 1 ₽ with no upper cap (#230 spec), non-finite/sub-1 blobs fall back to the 1 ₽ floor / 50 ₽ factory default.
- **Seeding** — `CreateAlarmViewModel` now seeds a new alarm's penalty from `defaults.penaltyAmount` (was literal `50`). Existing alarms keep their own saved price.
- **Row** — `.disclosureIndicator` + `selectionStyle: .default`, value read from `AlarmDefaults`.
- **Editor** — interim action-sheet picker (20/50/100/200/500 ₽) mirroring `presentSnoozeDurationPicker()`, until the #230 free-numeric SnoozePriceCard lands. Tap wired via a `handleFinanceTap` helper (keeps `didSelectRowAt` under the cyclomatic cap).

## Tests
`AlarmDefaultsTests`: fallback, persistence, 1 ₽ floor, no upper cap, non-finite fallback, and new-alarm seeding + existing-alarm override.

## Verification
- swiftlint: 0 violations.
- build_sim: SUCCEEDED. (Test suite runs in CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)