### PR TITLE
[ui] Firing no-balance V3 — drained palettes, red glow, green Пополнить (#227)

### DIFF
--- a/SnoozePay/SnoozePay/Utilities/AlarmFiringThemePalette.swift
+++ b/SnoozePay/SnoozePay/Utilities/AlarmFiringThemePalette.swift
@@ -195,6 +195,47 @@ struct AlarmFiringThemePalette: Equatable {
     /// Bell-tile gradient stop locations — the JSX recipe is
     /// `linear-gradient(135deg, A 0%, B 60%, C 100%)` for every theme.
     static let bellGradientLocations: [NSNumber] = [0.0, 0.6, 1.0]
+
+    // MARK: - Drained variant (no-balance firing, #227)
+
+    /// Resolve the DRAINED palette for the no-balance firing state (#227,
+    /// `SPFiringNoBalanceThemes.jsx`). The drained background is a calmer-but-
+    /// brighter (~+20%) wash of the theme so the screen still reads as "this
+    /// theme" while signalling the spent wallet; the accent shifts to the
+    /// drained tint used for the eyebrow caps and the wake-glass border.
+    ///
+    /// Only `backgroundColors` / `backgroundLocations` / `accent` / `accentSoft`
+    /// differ — the pill / bell / time-shadow fields are inherited from the
+    /// normal palette because in the no-balance layout the pills render red
+    /// (pain) and the clock shadow is forced neutral by the host VC, so those
+    /// fields are unused. Returns nil for `.custom` (photo keeps its own bg).
+    static func drainedPalette(for theme: AlarmTheme) -> AlarmFiringThemePalette? {
+        guard let base = palette(for: theme) else { return nil }
+        let drained: (bg: [UInt32], accent: UInt32)
+        switch theme {
+        case .dawn:      drained = ([0x41290F, 0x804F1E, 0xCE8A30], 0xFAD89A)
+        case .ocean:     drained = ([0x11324C, 0x266384, 0x4DA597], 0xB4ECD8)
+        case .mountains: drained = ([0x28313F, 0x586A92, 0xAAB5CB], 0xDEE3EB)
+        case .forest:    drained = ([0x0E250E, 0x2A4C30, 0x4D7340], 0xB6DEA0)
+        case .neon:      drained = ([0x1A1648, 0x582A90, 0xCE469E], 0xF4A6D2)
+        case .abstract:  drained = ([0x26262A, 0x47474F], 0xDADADA)
+        case .custom:    return nil
+        }
+        let locations: [NSNumber] = drained.bg.count == 2 ? [0.0, 1.0] : [0.0, 0.5, 1.0]
+        return AlarmFiringThemePalette(
+            backgroundColors: drained.bg.map { UIColor(firingRGB: $0) },
+            backgroundLocations: locations,
+            scrimInnerAlpha: base.scrimInnerAlpha,
+            scrimOuterAlpha: base.scrimOuterAlpha,
+            accent: UIColor(firingRGB: drained.accent),
+            accentSoft: UIColor(firingRGB: drained.accent, alpha: 0.18),
+            pillBackground: base.pillBackground,
+            pillBorder: base.pillBorder,
+            bellGradientColors: base.bellGradientColors,
+            timeShadowColor: base.timeShadowColor,
+            timeShadowOpacity: base.timeShadowOpacity
+        )
+    }
 }
 
 // MARK: - Hex helper (file-scoped)

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+NoBalance.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+NoBalance.swift
@@ -83,12 +83,12 @@ extension AlarmFiringViewController {
     /// the hero name label so it slots into the centered column when the
     /// no-balance state activates. Mirrors `SPScreensV2.jsx` lines 239–251.
     private func installNoBalanceCenterPill(inset: CGFloat) {
-        // Pain-tinted shield pill — wider than a stock SPPill (custom padding)
-        // so the V2 spec's "10px 18px" reads correctly.
+        // Pain-tinted "coin off" pill — V3 swaps the shield glyph for the
+        // crossed-out-coin icon used across the zero-balance surfaces (#227).
         let shieldPill = SPPill(
             text: "Баланса не осталось",
             tone: .pain,
-            icon: UIImage(systemName: "shield.fill")
+            icon: SPIcons.coinOff(size: 14)
         )
         shieldPill.translatesAutoresizingMaskIntoConstraints = false
 
@@ -128,23 +128,27 @@ extension AlarmFiringViewController {
         )
         card.translatesAutoresizingMaskIntoConstraints = false
         card.isEnabled = false
-        // Spec calls for an extra-faded surface (alpha 0.45 vs the
+        // Spec calls for an extra-faded surface (alpha 0.5 vs the
         // `SPSnoozePrice` default 0.35) — the .35 reads as "tap me" still,
-        // .45 reads as "this is the goal you can't hit yet". Override the
+        // .5 reads as "this is the goal you can't hit yet" (#227). Override the
         // disabled appearance after the fact since it's set in the setter.
-        card.alpha = 0.45
+        card.alpha = 0.5
         return card
     }
 
     private func makeNoBalanceApplePayButton() -> SPButton {
-        // V2 spec line 258–266: money variant with apple-logo icon, "Apple Pay"
-        // title, suffix = catalogue amount of the resolved SKU (#275). The
-        // suffix uses the mono font so the amount reads as a money column.
+        // V3 (#227): neutral green money CTA — wallet icon + «Пополнить» + the
+        // amount suffix. NO "Apple Pay ·" in the label (cross-platform neutral
+        // copy, PM decision chat2); the purchase still runs through StoreKit /
+        // Apple Pay under the hood — only the visible branding is dropped, so
+        // the `applePay*` identifiers stay accurate. Suffix keeps the catalogue
+        // amount of the resolved SKU (#275: display == charge == credit) rather
+        // than a hardcoded 500 ₽, so the rendered number matches what's charged.
         let button = SPButton(
-            title: "Apple Pay",
+            title: "Пополнить",
             variant: .money,
             size: .lg,
-            icon: UIImage(systemName: "applelogo"),
+            icon: SPIcons.wallet(size: 20),
             suffix: MoneyFormatter.string(Self.noBalanceDisplayAmount),
             fullWidth: true
         )
@@ -212,6 +216,8 @@ extension AlarmFiringViewController {
         }
         noBalanceContainer?.isHidden = !needsNoBalance
         noBalanceCenterBlock?.isHidden = !needsNoBalance
+        // Drained background + red glow + neutral clock + accent wake-border.
+        applyDrainedAtmosphere(needsNoBalance)
         // Hide the normal-state group when the no-balance stack takes over.
         // The progressive chrome (centre-hero indicator pill + ticker) is also
         // hidden so it doesn't float over the no-balance layout.

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Theme.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Theme.swift
@@ -68,6 +68,9 @@ extension AlarmFiringViewController {
                 background.trailingAnchor.constraint(equalTo: view.trailingAnchor),
                 background.bottomAnchor.constraint(equalTo: view.bottomAnchor)
             ])
+            // Keep the ref so the no-balance state can swap it to the DRAINED
+            // palette in place (#227); dawn / custom have no themed bg to swap.
+            themedFiringBackground = background
             themeImageView.isHidden = true
             themeImageDimView.isHidden = true
         } else {
@@ -79,7 +82,61 @@ extension AlarmFiringViewController {
             themeImageDimView.isHidden = true
         }
 
+        // Red "drained" glow rises from the bottom in the no-balance state
+        // (#227), over every theme + custom photo. Added now (before the
+        // +Layout content installers run) so it layers above the background /
+        // photo but below the clock, pills and CTAs. Hidden until no-balance.
+        let drainedGlow = SPFiringDrainedGlowView()
+        view.addSubview(drainedGlow)
+        NSLayoutConstraint.activate([
+            drainedGlow.topAnchor.constraint(equalTo: view.topAnchor),
+            drainedGlow.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            drainedGlow.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            drainedGlow.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+        drainedGlow.setBreathing(false)
+        drainedGlowView = drainedGlow
+
         applyThemeAccents()
+    }
+
+    /// Flip the firing atmosphere into / out of the no-balance "drained" look
+    /// (#227): swap a themed background to its drained palette, breathe the red
+    /// glow, force the clock shadow neutral (the design calls for a plain black
+    /// halo here, not the thematic accent), and tint the wake-glass border with
+    /// the theme accent. Dawn's drained background is already driven by
+    /// `updateAtmosphereTone()`; custom photos keep their image. Idempotent —
+    /// called from `refreshNoBalanceVisibility` on every affordability change.
+    func applyDrainedAtmosphere(_ drained: Bool) {
+        let theme = viewModel.alarm.theme
+
+        // Themed (non-dawn, non-custom) background: swap the gradient in place.
+        if let background = themedFiringBackground {
+            let palette = drained
+                ? AlarmFiringThemePalette.drainedPalette(for: theme)
+                : AlarmFiringThemePalette.palette(for: theme)
+            if let palette = palette { background.apply(palette: palette) }
+        }
+
+        drainedGlowView?.setBreathing(drained)
+
+        // Clock halo: neutral black .45 while drained, thematic otherwise.
+        if drained {
+            timeLabel.layer.shadowColor = UIColor.black.cgColor
+            timeLabel.layer.shadowOpacity = 0.45
+        } else if let palette = firingPalette {
+            timeLabel.layer.shadowColor = palette.timeShadowColor.cgColor
+            timeLabel.layer.shadowOpacity = palette.timeShadowOpacity
+        }
+
+        // Wake-glass border = theme accent (drained accent while spent), 1.5pt
+        // per spec. Custom photo (no palette) keeps the default hairline.
+        let accent = (drained
+            ? AlarmFiringThemePalette.drainedPalette(for: theme)?.accent
+            : firingPalette?.accent)
+        if let accent = accent {
+            noBalanceDismissButton?.ghostBorderOverride = (1.5, accent.withAlphaComponent(0.55))
+        }
     }
 
     /// Accent pass — tint the clock halo + bell tile with the resolved
@@ -114,5 +171,39 @@ extension AlarmFiringViewController {
             border: palette.pillBorder,
             foreground: palette.accent
         )
+    }
+}
+
+// MARK: - Drained-atmosphere view storage
+//
+// The host VC body is at the SwiftLint `type_body_length` limit, so these two
+// references are routed through associated objects (the same approach as
+// `noBalanceCenterBlock`). Single slots keyed by unique pointers; main-thread
+// only (the firing screen is main-only).
+
+private var themedFiringBackgroundKey: UInt8 = 0
+private var drainedGlowViewKey: UInt8 = 0
+
+extension AlarmFiringViewController {
+    /// The themed (non-dawn) firing background, kept so the no-balance state
+    /// can swap it to its drained palette in place (#227). Nil for dawn /
+    /// custom-photo themes, which have no `SPThemedFiringBackgroundView`.
+    var themedFiringBackground: SPThemedFiringBackgroundView? {
+        get { objc_getAssociatedObject(self, &themedFiringBackgroundKey) as? SPThemedFiringBackgroundView }
+        set {
+            objc_setAssociatedObject(
+                self, &themedFiringBackgroundKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+            )
+        }
+    }
+
+    /// The red drained-glow overlay (#227), breathed on in the no-balance state.
+    var drainedGlowView: SPFiringDrainedGlowView? {
+        get { objc_getAssociatedObject(self, &drainedGlowViewKey) as? SPFiringDrainedGlowView }
+        set {
+            objc_setAssociatedObject(
+                self, &drainedGlowViewKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+            )
+        }
     }
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
@@ -460,7 +460,10 @@ class AlarmFiringViewController: UIViewController {
     /// boundary and the chip needs to flip from money → pain or back.
     private func rebuildBalancePill(tone: SPPill.Tone, value: String) {
         guard let old = balancePill else { return }
-        let new = SPPill(text: "", tone: tone, icon: SPIcons.coin(size: 12))
+        // Zero-balance pill swaps the coin glyph for the crossed-out «coin off»
+        // icon (⊘) per the no-balance spec (#227); the money tone keeps the coin.
+        let icon = tone == .pain ? SPIcons.coinOff(size: 12) : SPIcons.coin(size: 12)
+        let new = SPPill(text: "", tone: tone, icon: icon)
         new.setBalance(label: "Баланс", value: value)
         new.translatesAutoresizingMaskIntoConstraints = false
         if let index = topHeaderRow.arrangedSubviews.firstIndex(of: old) {

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPFiringDrainedGlowView.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPFiringDrainedGlowView.swift
@@ -1,0 +1,80 @@
+import UIKit
+
+/// Red "drained" glow that rises from the bottom of the firing screen in the
+/// no-balance state (#227, `SPFiringNoBalanceThemes.jsx`). The same warning
+/// glow renders over every theme (and the custom photo), layered above the
+/// background but below the content, so the spent-wallet cue is consistent.
+///
+/// Spec: a 480pt red circle whose centre sits 170pt below the bottom edge —
+/// `rgba(244,82,63,.28) → .08 @40% → clear @68%` — breathing on an 8s loop
+/// (scale 1 → 1.06). A radial `CAGradientLayer` stands in for the CSS blur 26.
+final class SPFiringDrainedGlowView: UIView {
+
+    private static let diameter: CGFloat = 480
+    private static let bottomOverhang: CGFloat = 170
+    private static let breatheDuration: CFTimeInterval = 8
+    private static let breatheKey = "drainedGlowBreathe"
+
+    /// `0xF4523F` = rgba(244, 82, 63). Identical across all themes.
+    private static let glowRed = UIColor(red: 244 / 255, green: 82 / 255, blue: 63 / 255, alpha: 1)
+
+    private let glowLayer: CAGradientLayer = {
+        let gradient = CAGradientLayer()
+        gradient.type = .radial
+        gradient.startPoint = CGPoint(x: 0.5, y: 0.5)
+        gradient.endPoint = CGPoint(x: 1.0, y: 1.0)
+        gradient.colors = [
+            SPFiringDrainedGlowView.glowRed.withAlphaComponent(0.28).cgColor,
+            SPFiringDrainedGlowView.glowRed.withAlphaComponent(0.08).cgColor,
+            SPFiringDrainedGlowView.glowRed.withAlphaComponent(0).cgColor
+        ]
+        gradient.locations = [0.0, 0.40, 0.68]
+        return gradient
+    }()
+
+    init() {
+        super.init(frame: .zero)
+        translatesAutoresizingMaskIntoConstraints = false
+        isUserInteractionEnabled = false
+        clipsToBounds = true
+        layer.addSublayer(glowLayer)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        let diameter = Self.diameter
+        glowLayer.frame = CGRect(
+            x: bounds.midX - diameter / 2,
+            y: bounds.height + Self.bottomOverhang - diameter,
+            width: diameter,
+            height: diameter
+        )
+        glowLayer.cornerRadius = diameter / 2
+        CATransaction.commit()
+    }
+
+    /// Start/stop the 8s breathing pulse alongside the view's visibility so a
+    /// hidden glow isn't animating off-screen.
+    func setBreathing(_ active: Bool) {
+        isHidden = !active
+        if active {
+            guard glowLayer.animation(forKey: Self.breatheKey) == nil else { return }
+            let pulse = CABasicAnimation(keyPath: "transform.scale")
+            pulse.fromValue = 1.0
+            pulse.toValue = 1.06
+            pulse.duration = Self.breatheDuration / 2
+            pulse.autoreverses = true
+            pulse.repeatCount = .infinity
+            pulse.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            glowLayer.add(pulse, forKey: Self.breatheKey)
+        } else {
+            glowLayer.removeAnimation(forKey: Self.breatheKey)
+        }
+    }
+}

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPThemedFiringBackgroundView.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPThemedFiringBackgroundView.swift
@@ -82,7 +82,11 @@ final class SPThemedFiringBackgroundView: UIView {
 
     // MARK: - Palette
 
-    private func apply(palette: AlarmFiringThemePalette) {
+    /// Swap the gradient / scrim / glow to a new palette in place — used to
+    /// flip a themed firing background to its DRAINED variant in the no-balance
+    /// state (#227) without rebuilding the view. Disable implicit layer actions
+    /// so the swap is instant, not a cross-fade.
+    func apply(palette: AlarmFiringThemePalette) {
         baseLayer.colors = palette.backgroundColors.map { $0.cgColor }
         baseLayer.locations = palette.backgroundLocations
         scrimLayer.colors = [

--- a/SnoozePay/SnoozePayTests/AlarmFiringThemePaletteTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmFiringThemePaletteTests.swift
@@ -126,6 +126,69 @@ final class AlarmFiringThemePaletteTests: XCTestCase {
         XCTAssertEqual(neon.timeShadowOpacity, 0.40, accuracy: 0.001)
     }
 
+    // MARK: - Drained variant (#227)
+
+    /// Expected drained accent per stock theme — the no-balance table in
+    /// `SPFiringNoBalanceThemes.jsx`.
+    private let expectedDrainedAccents: [(AlarmTheme, UInt32)] = [
+        (.dawn, 0xFAD89A),
+        (.ocean, 0xB4ECD8),
+        (.mountains, 0xDEE3EB),
+        (.forest, 0xB6DEA0),
+        (.neon, 0xF4A6D2),
+        (.abstract, 0xDADADA)
+    ]
+
+    func testEveryStockThemeHasADrainedPalette() {
+        for theme in AlarmTheme.builtInOrder {
+            XCTAssertNotNil(
+                AlarmFiringThemePalette.drainedPalette(for: theme),
+                "Stock theme \(theme.id) must map to a drained firing palette"
+            )
+        }
+    }
+
+    func testCustomThemeHasNoDrainedPalette() {
+        let url = URL(fileURLWithPath: "/tmp/photo.jpg")
+        XCTAssertNil(
+            AlarmFiringThemePalette.drainedPalette(for: .custom(imagePath: url)),
+            "Photo themes keep their image — no drained palette"
+        )
+    }
+
+    func testDrainedAccentsMatchDesignTable() {
+        for (theme, hex) in expectedDrainedAccents {
+            guard let palette = AlarmFiringThemePalette.drainedPalette(for: theme) else {
+                XCTFail("Missing drained palette for \(theme.id)")
+                continue
+            }
+            assertColor(palette.accent, matchesHex: hex, "drained accent for \(theme.id)")
+        }
+    }
+
+    func testDrainedBackgroundStopsPairWithLocations() {
+        for theme in AlarmTheme.builtInOrder {
+            guard let palette = AlarmFiringThemePalette.drainedPalette(for: theme) else { continue }
+            XCTAssertEqual(
+                palette.backgroundColors.count,
+                palette.backgroundLocations.count,
+                "Drained colour/location count mismatch for \(theme.id)"
+            )
+            let expectedStops = theme == .abstract ? 2 : 3
+            XCTAssertEqual(palette.backgroundColors.count, expectedStops)
+        }
+    }
+
+    func testDrainedDawnBackgroundMatchesDesignTable() {
+        // Spot-check the dawn drained gradient end-to-end.
+        guard let dawn = AlarmFiringThemePalette.drainedPalette(for: .dawn) else {
+            return XCTFail("Missing dawn drained palette")
+        }
+        assertColor(dawn.backgroundColors[0], matchesHex: 0x41290F, "dawn drained bg stop 0")
+        assertColor(dawn.backgroundColors[1], matchesHex: 0x804F1E, "dawn drained bg stop 1")
+        assertColor(dawn.backgroundColors[2], matchesHex: 0xCE8A30, "dawn drained bg stop 2")
+    }
+
     // MARK: - AlarmThemeRendering delegation
 
     func testPickerTileGradientsDelegateToPaletteForNonDawnThemes() {


### PR DESCRIPTION
Fixes #227

Reskins the no-balance («Баланса не осталось») firing state per `SPFiringNoBalanceThemes.jsx`.

## Changes
- **Drained palettes** — `AlarmFiringThemePalette.drainedPalette(for:)` adds the 6 brighter-but-drained theme washes + drained accents (exact handoff hex). Inherits pill/bell/time-shadow from the base palette (unused in this layout).
- **Red glow** — new `SPFiringDrainedGlowView`: a 480pt red breathing (8s, scale 1→1.06) bottom glow rendered over **every** theme + the custom photo.
- **`applyDrainedAtmosphere()`** — swaps a themed background to its drained palette in place, breathes the glow, forces a **neutral black** clock halo (spec: not thematic here), and tints the wake-glass border 1.5pt with the theme accent. Wired from `refreshNoBalanceVisibility`; auto-recovery on top-up restores the normal atmosphere. Dawn keeps its existing `SPDawnBackgroundView` drained tone; custom keeps its photo.
- **Primary CTA** — neutral green «Пополнить» + wallet icon; coinOff (⊘) glyph on the header + centre zero-balance pills; disabled snooze card faded to .5.
- Drained-palette tests.

## ⚠️ Two judgment calls for your review
1. **Amount suffix** — spec text shows «500 ₽», but I kept the **catalogue amount** of the resolved SKU (per #275: display == charge == credit). Hardcoding 500 over the 499 SKU would reintroduce the display≠charge bug #275 fixed. If you want a literal 500, that's a SKU/PM decision.
2. **«Apple Pay» identifiers** — visible branding is dropped (neutral «Пополнить») per chat2, but the internal `applePay*` symbol names are kept since the purchase still routes through StoreKit/Apple Pay.

## ⚠️ Visual verification
This is a 6-theme + custom visual change on the firing screen and **can't be verified by build alone** (screenshot/qa gates disabled). swiftlint 0 / build_sim SUCCEEDED / palette tests in CI — but please eyeball it across themes (esp. dawn vs themed bg swap, glow placement, wake-border accent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)