### PR TITLE
[ui] Firing snoozed state V3 — countdown, zZ badge, progressive ticker, charge ladder (#226)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Snoozed.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Snoozed.swift
@@ -25,6 +25,12 @@ extension AlarmFiringViewController {
     /// recreation). Called from `snoozeTapped()` after a successful charge.
     func enterSnoozedState() {
         guard !isSnoozedStateActive else { return }
+        // Defensive: if the next ring is already due (clock skew, or a
+        // backgrounded-then-foregrounded VC where the snooze interval has
+        // already elapsed), there's nothing to count down to — stay in the
+        // active firing UI rather than installing a timer that fires once to
+        // undo itself and flashes 00:00.
+        guard viewModel.secondsUntilNextRing(from: Date()) > 0 else { return }
         isSnoozedStateActive = true
 
         installSnoozedChromeIfNeeded()
@@ -44,6 +50,11 @@ extension AlarmFiringViewController {
         countdownTimer?.invalidate()
         countdownTimer = nil
         showSnoozedChrome(false)
+        // Restore the active hero name — `refreshSnoozedChrome` overwrote it with
+        // the "… · отложено до 07:05" suffix on entry, and `showSnoozedChrome`
+        // only toggles the clock/eyebrow/badge, not the name. Without this the
+        // active firing UI returns with a stale "отложено до …" label (#226 QA).
+        nameLabel.text = viewModel.heroTitle
     }
 
     /// Invalidate the countdown timer on teardown — mirrors the `clockTimer`

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Snoozed.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Snoozed.swift
@@ -1,0 +1,222 @@
+import UIKit
+
+// MARK: - Snoozed firing state (#226)
+//
+// After a foreground «Поспать ещё» tap the firing screen does NOT dismiss —
+// it transitions in place into the "отложено" state described by
+// `docs/design/v2-handoff/components/SPFiringThemeSnoozed.jsx`:
+//   • the big live clock is replaced by a live mm:ss countdown to the next ring,
+//   • the bell tile dims (.7) and gains a `zZ` badge,
+//   • the hero name reads "… · отложено до 07:05",
+//   • a fly-up «−N ₽» rises over the (already-decremented) balance pill,
+//   • progressive alarms also surface a "Прогрессив · N-й поспать ещё" pill +
+//     the 4-rung charge ladder.
+// At countdown zero the chrome tears down and the active firing UI returns.
+//
+// The theme only affects accents — colours are pulled from `firingPalette`
+// exactly as the active firing screen does. Storage lives in associated
+// objects (the host type body is at the SwiftLint `type_body_length` cap).
+
+extension AlarmFiringViewController {
+
+    // MARK: - Entry / exit
+
+    /// Switch the live firing screen into the snoozed state in place (no VC
+    /// recreation). Called from `snoozeTapped()` after a successful charge.
+    func enterSnoozedState() {
+        guard !isSnoozedStateActive else { return }
+        isSnoozedStateActive = true
+
+        installSnoozedChromeIfNeeded()
+        refreshSnoozedChrome()
+        showSnoozedChrome(true)
+        flyUpLastCharge()
+        startCountdownTicker()
+    }
+
+    /// Tear down the snoozed chrome and restore the active firing UI — the big
+    /// clock re-appears, the countdown / ladder / zZ badge hide, and the alarm
+    /// "rings again" visually. Audio re-fire is owned by the scheduler.
+    func exitSnoozedState() {
+        guard isSnoozedStateActive else { return }
+        isSnoozedStateActive = false
+
+        countdownTimer?.invalidate()
+        countdownTimer = nil
+        showSnoozedChrome(false)
+    }
+
+    /// Invalidate the countdown timer on teardown — mirrors the `clockTimer`
+    /// teardown in `viewDidDisappear`. Call from the host's `viewDidDisappear`.
+    func teardownSnoozedTimers() {
+        countdownTimer?.invalidate()
+        countdownTimer = nil
+    }
+
+    // MARK: - Chrome install
+
+    private func installSnoozedChromeIfNeeded() {
+        guard snoozedCountdownLabel == nil else { return }
+
+        let countdown = UILabel()
+        countdown.font = AppTypography.clockXl.monospacedDigit()
+        countdown.textColor = .white
+        countdown.textAlignment = .center
+        countdown.adjustsFontSizeToFitWidth = true
+        countdown.minimumScaleFactor = 0.7
+        countdown.translatesAutoresizingMaskIntoConstraints = false
+        // Same warm halo as the active clock; re-tinted to the theme below.
+        countdown.layer.shadowColor = (firingPalette?.timeShadowColor ?? .white).cgColor
+        countdown.layer.shadowOpacity = firingPalette?.timeShadowOpacity ?? 0.2
+        countdown.layer.shadowRadius = 30
+        countdown.layer.shadowOffset = CGSize(width: 0, height: 4)
+        countdown.layer.masksToBounds = false
+        countdown.isHidden = true
+        view.addSubview(countdown)
+        snoozedCountdownLabel = countdown
+
+        let ladder = makeLadderStack()
+        snoozedLadderStack = ladder
+
+        let pill = makeProgressivePill()
+        snoozedProgressivePill = pill
+
+        // Vertical stack: progressive pill (mt 14) then ladder (mt 16).
+        let center = UIStackView(arrangedSubviews: [pill, ladder])
+        center.translatesAutoresizingMaskIntoConstraints = false
+        center.axis = .vertical
+        center.alignment = .center
+        center.spacing = AppSpacing.sp4 - 2   // ≈16; the 14/16 deltas are within token tolerance
+        center.isHidden = true
+        view.addSubview(center)
+        snoozedCenterStack = center
+
+        installZzBadge()
+
+        NSLayoutConstraint.activate([
+            // Countdown takes the big clock's slot.
+            countdown.centerXAnchor.constraint(equalTo: timeLabel.centerXAnchor),
+            countdown.centerYAnchor.constraint(equalTo: timeLabel.centerYAnchor),
+            countdown.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: AppSpacing.sp4),
+            countdown.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -AppSpacing.sp4),
+
+            center.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            center.topAnchor.constraint(equalTo: countdown.bottomAnchor, constant: AppSpacing.sp4 - 2)
+        ])
+    }
+
+    // MARK: - Visibility
+
+    /// Swap between the active firing hero and the snoozed chrome. Progressive
+    /// pill + ladder only show for progressive alarms; the countdown + zZ badge
+    /// always show in the snoozed state.
+    private func showSnoozedChrome(_ snoozed: Bool) {
+        // Active-state elements hidden while snoozed.
+        timeLabel.isHidden = snoozed
+        wakeUpCapsLabel.isHidden = snoozed
+        progressiveStack?.isHidden = snoozed
+
+        // Snoozed-state elements.
+        snoozedCountdownLabel?.isHidden = !snoozed
+        snoozedZzBadge?.isHidden = !snoozed
+        bellTile.alpha = snoozed ? 0.7 : 1.0
+
+        let showLadder = snoozed && viewModel.isProgressiveActive
+        snoozedCenterStack?.isHidden = !showLadder
+    }
+
+    // MARK: - Refresh (text + ladder + accents)
+
+    /// Re-render the snoozed chrome from the current VM state. Updates the hero
+    /// name suffix, countdown label, progressive pill copy and the ladder rungs.
+    func refreshSnoozedChrome() {
+        guard isSnoozedStateActive else { return }
+        let now = Date()
+        nameLabel.text = viewModel.snoozedHeroTitle(after: now)
+        updateCountdownLabel(now: now)
+
+        guard viewModel.isProgressiveActive else { return }
+        snoozedProgressivePill?.text =
+            AlarmFiringViewController.progressivePillText(snoozeCount: viewModel.snoozeCount)
+        rebuildLadder()
+    }
+
+    // MARK: - Countdown ticker
+
+    private func startCountdownTicker() {
+        countdownTimer?.invalidate()
+        updateCountdownLabel(now: Date())
+        countdownTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
+            self?.tickCountdown()
+        }
+    }
+
+    private func tickCountdown() {
+        let now = Date()
+        updateCountdownLabel(now: now)
+        if viewModel.secondsUntilNextRing(from: now) <= 0 {
+            exitSnoozedState()
+        }
+    }
+
+    private func updateCountdownLabel(now: Date) {
+        let seconds = viewModel.secondsUntilNextRing(from: now)
+        snoozedCountdownLabel?.text = AlarmFiringViewModel.countdownText(seconds: seconds)
+    }
+
+    // MARK: - Fly-up «−N ₽»
+
+    /// Animate a transient «−N ₽» label rising over the balance pill (the pill
+    /// itself already shows the decremented balance). 1500ms: fade-in + rise,
+    /// then fade-out + continued rise, matching the JSX keyframes.
+    private func flyUpLastCharge() {
+        guard let pill = balancePill else { return }
+        let charge = Int(viewModel.lastChargeAmount.rounded())
+        guard charge > 0 else { return }
+
+        let label = UILabel()
+        label.text = "−\(charge) ₽"
+        label.font = AppFonts.mono(.bold, 14)
+        label.textColor = UIColor(snoozedRGB: 0xFF7A6B)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(label)
+        NSLayoutConstraint.activate([
+            label.centerXAnchor.constraint(equalTo: pill.centerXAnchor),
+            label.bottomAnchor.constraint(equalTo: pill.topAnchor, constant: -AppSpacing.sp1)
+        ])
+        label.alpha = 0
+        label.transform = CGAffineTransform(translationX: 0, y: 6)
+
+        // opacity 0/+6 → 1/−8 → 1/−28 → 0/−36 over 1500ms.
+        UIView.animateKeyframes(withDuration: 1.5, delay: 0, options: []) {
+            UIView.addKeyframe(withRelativeStartTime: 0, relativeDuration: 0.2) {
+                label.alpha = 1
+                label.transform = CGAffineTransform(translationX: 0, y: -8)
+            }
+            UIView.addKeyframe(withRelativeStartTime: 0.2, relativeDuration: 0.6) {
+                label.transform = CGAffineTransform(translationX: 0, y: -28)
+            }
+            UIView.addKeyframe(withRelativeStartTime: 0.8, relativeDuration: 0.2) {
+                label.alpha = 0
+                label.transform = CGAffineTransform(translationX: 0, y: -36)
+            }
+        } completion: { _ in
+            label.removeFromSuperview()
+        }
+    }
+}
+
+// MARK: - Hex helper (file-scoped)
+
+private extension UIColor {
+    /// `0xRRGGBB` literal initializer for the snoozed-state colours. File-scoped
+    /// copy — `private` is file-scope in Swift, mirroring the identical helpers
+    /// in the sibling +Layout / +Theme files (the brand-token `UIColor(hex:)`
+    /// in AppColors is itself `private` and not visible across files).
+    convenience init(snoozedRGB rgb: UInt32, alpha: CGFloat = 1) {
+        let red = CGFloat((rgb >> 16) & 0xFF) / 255.0
+        let green = CGFloat((rgb >> 8) & 0xFF) / 255.0
+        let blue = CGFloat(rgb & 0xFF) / 255.0
+        self.init(red: red, green: green, blue: blue, alpha: alpha)
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+SnoozedViews.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+SnoozedViews.swift
@@ -1,0 +1,246 @@
+import UIKit
+
+// MARK: - Snoozed-state subview builders + storage (#226)
+//
+// Split out of `AlarmFiringViewController+Snoozed.swift` so neither file trips
+// SwiftLint's `file_length` cap. Builders are pure view factories; the
+// associated-object slots mirror the +Theme storage pattern (the host type
+// body is at the `type_body_length` limit so new stored properties can't live
+// on the type itself). Main-thread only — the firing screen is main-only.
+
+extension AlarmFiringViewController {
+
+    // MARK: - zZ badge on the bell tile
+
+    func installZzBadge() {
+        guard snoozedZzBadge == nil else { return }
+        let badge = PaddedLabel(insets: UIEdgeInsets(top: 2, left: 8, bottom: 2, right: 8))
+        badge.text = "zZ"
+        badge.font = AppFonts.mono(.bold, 10)
+        badge.textColor = firingPalette?.accent ?? .white
+        badge.backgroundColor = UIColor.black.withAlphaComponent(0.55)
+        badge.layer.cornerRadius = AppRadius.pill
+        badge.layer.borderWidth = 1
+        badge.layer.borderColor = (firingPalette?.pillBorder ?? UIColor.white.withAlphaComponent(0.22)).cgColor
+        badge.layer.masksToBounds = true
+        badge.translatesAutoresizingMaskIntoConstraints = false
+        badge.isHidden = true
+        view.addSubview(badge)
+        snoozedZzBadge = badge
+
+        // Top-right of the tile, offset −6/−8 per the JSX recipe.
+        NSLayoutConstraint.activate([
+            badge.trailingAnchor.constraint(equalTo: bellTile.trailingAnchor, constant: 6),
+            badge.topAnchor.constraint(equalTo: bellTile.topAnchor, constant: -8)
+        ])
+    }
+
+    // MARK: - Progressive pill
+
+    /// "Прогрессив · N-й поспать ещё" pill — pad 6×12 r999, pain-tinted fill +
+    /// border, leading 8pt glowing dot, caps `#FFB4A8` text.
+    func makeProgressivePill() -> PaddedLabel {
+        let pill = PaddedLabel(insets: UIEdgeInsets(top: 6, left: 30, bottom: 6, right: 12))
+        pill.font = AppFonts.mono(.bold, 11)
+        pill.textColor = UIColor(snoozedRGB: 0xFFB4A8)
+        pill.backgroundColor = UIColor(snoozedRGB: 0xF4523F, alpha: 0.14)
+        pill.layer.cornerRadius = AppRadius.pill
+        pill.layer.borderWidth = 1
+        pill.layer.borderColor = UIColor(snoozedRGB: 0xF4523F, alpha: 0.28).cgColor
+        pill.layer.masksToBounds = true
+        pill.translatesAutoresizingMaskIntoConstraints = false
+
+        // Leading glowing dot (8pt) — drawn as a sibling inside the pill's
+        // left padding so the pill keeps its single-label sizing.
+        let dot = UIView()
+        dot.translatesAutoresizingMaskIntoConstraints = false
+        dot.backgroundColor = UIColor(snoozedRGB: 0xF4523F, alpha: 0.85)
+        dot.layer.cornerRadius = 4
+        dot.layer.shadowColor = UIColor(snoozedRGB: 0xF4523F).cgColor
+        dot.layer.shadowRadius = 6
+        dot.layer.shadowOpacity = 0.6
+        dot.layer.shadowOffset = .zero
+        pill.addSubview(dot)
+        NSLayoutConstraint.activate([
+            dot.widthAnchor.constraint(equalToConstant: 8),
+            dot.heightAnchor.constraint(equalToConstant: 8),
+            dot.leadingAnchor.constraint(equalTo: pill.leadingAnchor, constant: 12),
+            dot.centerYAnchor.constraint(equalTo: pill.centerYAnchor)
+        ])
+        return pill
+    }
+
+    // MARK: - Charge ladder
+
+    /// Build the empty 4-column ladder row (mt 16, gap 8). Columns are filled /
+    /// recoloured by `rebuildLadder()` on every refresh.
+    func makeLadderStack() -> UIStackView {
+        let row = UIStackView()
+        row.translatesAutoresizingMaskIntoConstraints = false
+        row.axis = .horizontal
+        row.alignment = .top
+        row.spacing = AppSpacing.sp2   // 8pt
+        return row
+    }
+
+    /// Rebuild the ladder columns from `viewModel.ladderSteps`. Each column is
+    /// an amount label (mono 700 11) + a bar (h4 r2). done: #FFB4A8 label /
+    /// #FF7A6B bar w28; current: theme-accent label + bar w10; future: muted
+    /// white label + bar w10.
+    func rebuildLadder() {
+        guard let row = snoozedLadderStack else { return }
+        row.arrangedSubviews.forEach {
+            row.removeArrangedSubview($0)
+            $0.removeFromSuperview()
+        }
+        let accent = firingPalette?.accent ?? .white
+        for step in viewModel.ladderSteps {
+            row.addArrangedSubview(makeLadderColumn(step: step, accent: accent))
+        }
+    }
+
+    private func makeLadderColumn(
+        step: AlarmFiringViewModel.LadderStep,
+        accent: UIColor
+    ) -> UIStackView {
+        let colours = ladderColours(for: step.state, accent: accent)
+
+        let amount = UILabel()
+        amount.text = "\(step.amount)"
+        amount.font = AppFonts.mono(.bold, 11)
+        amount.textColor = colours.label
+        amount.textAlignment = .center
+
+        let bar = UIView()
+        bar.translatesAutoresizingMaskIntoConstraints = false
+        bar.backgroundColor = colours.bar
+        bar.layer.cornerRadius = 2
+
+        let column = UIStackView(arrangedSubviews: [amount, bar])
+        column.axis = .vertical
+        column.alignment = .center
+        column.spacing = AppSpacing.sp1   // 4pt
+        NSLayoutConstraint.activate([
+            bar.widthAnchor.constraint(equalToConstant: colours.barWidth),
+            bar.heightAnchor.constraint(equalToConstant: 4)
+        ])
+        return column
+    }
+
+    private func ladderColours(
+        for state: AlarmFiringViewModel.LadderStepState,
+        accent: UIColor
+    ) -> LadderColours {
+        switch state {
+        case .done:
+            return LadderColours(label: UIColor(snoozedRGB: 0xFFB4A8), bar: UIColor(snoozedRGB: 0xFF7A6B), barWidth: 28)
+        case .current:
+            return LadderColours(label: accent, bar: accent, barWidth: 10)
+        case .future:
+            return LadderColours(
+                label: UIColor.white.withAlphaComponent(0.32),
+                bar: UIColor.white.withAlphaComponent(0.15),
+                barWidth: 10
+            )
+        }
+    }
+}
+
+// MARK: - Ladder column colours
+
+/// Resolved colours + bar width for one ladder rung in the snoozed state.
+private struct LadderColours {
+    let label: UIColor
+    let bar: UIColor
+    let barWidth: CGFloat
+}
+
+// MARK: - Padded label
+
+/// Capsule label with content insets — used for the `zZ` badge and the
+/// progressive pill, which both need symmetric padding around a single line.
+final class PaddedLabel: UILabel {
+    private let insets: UIEdgeInsets
+
+    init(insets: UIEdgeInsets) {
+        self.insets = insets
+        super.init(frame: .zero)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func drawText(in rect: CGRect) {
+        super.drawText(in: rect.inset(by: insets))
+    }
+
+    override var intrinsicContentSize: CGSize {
+        let base = super.intrinsicContentSize
+        return CGSize(
+            width: base.width + insets.left + insets.right,
+            height: base.height + insets.top + insets.bottom
+        )
+    }
+}
+
+// MARK: - Associated-object storage
+
+private var isSnoozedStateActiveKey: UInt8 = 0
+private var countdownTimerKey: UInt8 = 0
+private var snoozedCountdownLabelKey: UInt8 = 0
+private var snoozedCenterStackKey: UInt8 = 0
+private var snoozedProgressivePillKey: UInt8 = 0
+private var snoozedLadderStackKey: UInt8 = 0
+private var snoozedZzBadgeKey: UInt8 = 0
+
+extension AlarmFiringViewController {
+
+    var isSnoozedStateActive: Bool {
+        get { (objc_getAssociatedObject(self, &isSnoozedStateActiveKey) as? Bool) ?? false }
+        set { objc_setAssociatedObject(self, &isSnoozedStateActiveKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
+    }
+
+    var countdownTimer: Timer? {
+        get { objc_getAssociatedObject(self, &countdownTimerKey) as? Timer }
+        set { objc_setAssociatedObject(self, &countdownTimerKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
+    }
+
+    var snoozedCountdownLabel: UILabel? {
+        get { objc_getAssociatedObject(self, &snoozedCountdownLabelKey) as? UILabel }
+        set { objc_setAssociatedObject(self, &snoozedCountdownLabelKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
+    }
+
+    var snoozedCenterStack: UIStackView? {
+        get { objc_getAssociatedObject(self, &snoozedCenterStackKey) as? UIStackView }
+        set { objc_setAssociatedObject(self, &snoozedCenterStackKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
+    }
+
+    var snoozedProgressivePill: PaddedLabel? {
+        get { objc_getAssociatedObject(self, &snoozedProgressivePillKey) as? PaddedLabel }
+        set { objc_setAssociatedObject(self, &snoozedProgressivePillKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
+    }
+
+    var snoozedLadderStack: UIStackView? {
+        get { objc_getAssociatedObject(self, &snoozedLadderStackKey) as? UIStackView }
+        set { objc_setAssociatedObject(self, &snoozedLadderStackKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
+    }
+
+    var snoozedZzBadge: PaddedLabel? {
+        get { objc_getAssociatedObject(self, &snoozedZzBadgeKey) as? PaddedLabel }
+        set { objc_setAssociatedObject(self, &snoozedZzBadgeKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
+    }
+}
+
+// MARK: - Hex helper (file-scoped)
+
+private extension UIColor {
+    /// `0xRRGGBB` literal initializer for the snoozed-state colours. File-scoped
+    /// copy mirroring the sibling +Snoozed file (Swift `private` is file-scope).
+    convenience init(snoozedRGB rgb: UInt32, alpha: CGFloat = 1) {
+        let red = CGFloat((rgb >> 16) & 0xFF) / 255.0
+        let green = CGFloat((rgb >> 8) & 0xFF) / 255.0
+        let blue = CGFloat(rgb & 0xFF) / 255.0
+        self.init(red: red, green: green, blue: blue, alpha: alpha)
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+ViewLifecycle.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+ViewLifecycle.swift
@@ -85,8 +85,14 @@ extension AlarmFiringViewController {
                 self.presentSnoozeRefundFailedAlert(error: error)
             }
         }
+        // Foreground snooze (#226): instead of dismissing, transition the live
+        // firing screen into the "отложено" state in place — countdown to the
+        // next ring, zZ badge, progressive ladder. At countdown zero the active
+        // firing UI restores. `viewModel.snooze` already bumped `snoozeCount`
+        // and fired `onStateChanged → updateUI`, so the balance pill / ladder
+        // reflect the charge before we render the snoozed chrome.
         if success {
-            dismiss(animated: true)
+            enterSnoozedState()
         }
     }
 

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+ViewLifecycle.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+ViewLifecycle.swift
@@ -80,8 +80,17 @@ extension AlarmFiringViewController {
             case .scheduled:
                 break
             case .scheduleFailed(let error):
+                // The charge was refunded and the alarm will NOT re-fire, so the
+                // snoozed chrome (a live countdown to a phantom ring + the
+                // decremented pill) would lie. Tear it back down to the active
+                // firing UI BEFORE surfacing the alert so the screen matches the
+                // alert's "будильник не зазвенит повторно / деньги возвращены".
+                self.exitSnoozedState()
                 self.presentSnoozeScheduleFailureAlert(error: error)
             case .scheduleFailedAndRefundFailed(let error):
+                // Worse: billed, no re-fire, refund also failed. Same teardown so
+                // the countdown stops lying; the alert routes the user to support.
+                self.exitSnoozedState()
                 self.presentSnoozeRefundFailedAlert(error: error)
             }
         }

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
@@ -343,6 +343,7 @@ class AlarmFiringViewController: UIViewController {
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         clockTimer?.invalidate()
+        teardownSnoozedTimers()
         dawnBackgroundView.sunLayer.removeAllAnimations()
 
         // Stop alarm sound only if AudioService still belongs to *this*
@@ -407,6 +408,10 @@ class AlarmFiringViewController: UIViewController {
         // (Apple Pay 500 ₽) stack based on affordability. `canSnooze` is
         // the single source of truth.
         refreshNoBalanceVisibility()
+
+        // While the snoozed state is live (#226) re-render its chrome too — a
+        // back-to-back snooze bumps the ladder rung / countdown / hero suffix.
+        refreshSnoozedChrome()
     }
 
     /// Build the eyebrow caps copy below the clock. Mirrors `SPDawnV3.jsx`

--- a/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
@@ -112,6 +112,102 @@ final class AlarmFiringViewModel {
 
     var alarmName: String { alarm.name }
 
+    /// Amount charged by the MOST RECENT snooze — the rung the user just paid
+    /// for. `snooze()` bumps `snoozeCount` before this reads, so it equals
+    /// `penalty(forSnoozeCount: snoozeCount)`. Drives the fly-up «−N ₽» in the
+    /// snoozed state. `0` before the first snooze.
+    var lastChargeAmount: Double {
+        snoozeCount > 0 ? alarm.penalty(forSnoozeCount: snoozeCount) : 0
+    }
+
+    // MARK: - Snoozed state (#226)
+
+    /// Per-step state of the 4-rung charge ladder rendered in the snoozed
+    /// firing chrome (`SPFiringThemeSnoozed.jsx`). `done` rungs are already
+    /// paid, `current` is the rung the user just landed on, `future` rungs are
+    /// still ahead. Pure value type so the ladder layout is unit-testable
+    /// without a view hierarchy.
+    enum LadderStepState: Equatable {
+        case done
+        case current
+        case future
+    }
+
+    /// One rung of the charge ladder: its amount (₽) plus its state.
+    struct LadderStep: Equatable {
+        let amount: Int
+        let state: LadderStepState
+    }
+
+    /// The 4-rung progressive charge ladder for the snoozed state. Amounts are
+    /// the doubling schedule `base, ×2, ×4, ×8` (the same ceiling
+    /// `penalty(forSnoozeCount:)` walks). State keys off `snoozeCount`: rungs
+    /// strictly before it are `done`, the rung AT it is `current`, the rest are
+    /// `future`. `snoozeCount` past the last rung clamps `current` to rung 4 so
+    /// the ladder never blanks out at the ceiling. Returns `[]` when the alarm
+    /// isn't progressive (the snoozed state hides the ladder entirely).
+    var ladderSteps: [LadderStep] {
+        guard isProgressiveActive else { return [] }
+        let base = alarm.penaltyAmount
+        let amounts = (0..<4).map { Int((base * pow(2.0, Double($0))).rounded()) }
+        let currentIdx = min(snoozeCount, amounts.count - 1)
+        return amounts.enumerated().map { idx, amount in
+            let state: LadderStepState
+            if idx < currentIdx {
+                state = .done
+            } else if idx == currentIdx {
+                state = .current
+            } else {
+                state = .future
+            }
+            return LadderStep(amount: amount, state: state)
+        }
+    }
+
+    /// Wall-clock `Date` of the next ring after the current snooze — the
+    /// alarm's time-of-day shifted forward `snoozeMinutes × snoozeCount`
+    /// minutes, anchored to `reference`'s calendar day. Pure (takes `now` +
+    /// `calendar`) so the countdown maths is testable without the system clock.
+    func nextRingDate(after reference: Date, calendar: Calendar = .current) -> Date {
+        let timeParts = calendar.dateComponents([.hour, .minute], from: alarm.time)
+        let base = calendar.date(
+            bySettingHour: timeParts.hour ?? 0,
+            minute: timeParts.minute ?? 0,
+            second: 0,
+            of: reference
+        ) ?? reference
+        return base.addingTimeInterval(TimeInterval(alarm.snoozeMinutes * snoozeCount * 60))
+    }
+
+    /// `HH:mm` label of the next ring — "отложено до 07:05" / status-bar time.
+    func nextRingTimeText(after reference: Date, calendar: Calendar = .current) -> String {
+        AlarmFiringTimeFormatter.string(from: nextRingDate(after: reference, calendar: calendar))
+    }
+
+    /// Hero name + next-ring suffix shown in the snoozed state, e.g.
+    /// "Будни · отложено до 07:05". Degrades to "отложено до …" when the alarm
+    /// has no name, so the row never renders a dangling "·".
+    func snoozedHeroTitle(after reference: Date, calendar: Calendar = .current) -> String {
+        let time = nextRingTimeText(after: reference, calendar: calendar)
+        let name = alarm.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let suffix = "отложено до \(time)"
+        return name.isEmpty ? suffix : "\(name) · \(suffix)"
+    }
+
+    /// Remaining seconds until the next ring (never negative). Used by the live
+    /// countdown; at `0` the firing screen restores the active state.
+    func secondsUntilNextRing(from reference: Date, calendar: Calendar = .current) -> Int {
+        let target = nextRingDate(after: reference, calendar: calendar)
+        return max(0, Int(target.timeIntervalSince(reference).rounded()))
+    }
+
+    /// `mm:ss` countdown label clamped at `00:00`. Static so the formatting is
+    /// testable from a raw second count without a clock.
+    static func countdownText(seconds: Int) -> String {
+        let clamped = max(0, seconds)
+        return String(format: "%02d:%02d", clamped / 60, clamped % 60)
+    }
+
     /// "Будни · 07:00" hero title above the big clock — alarm name plus its
     /// scheduled time (V3 themed firing, `SPThemedFiring.jsx` line 152).
     /// A blank / whitespace-only name degrades to just the time so the row

--- a/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
@@ -124,9 +124,10 @@ final class AlarmFiringViewModel {
 
     /// Per-step state of the 4-rung charge ladder rendered in the snoozed
     /// firing chrome (`SPFiringThemeSnoozed.jsx`). `done` rungs are already
-    /// paid, `current` is the rung the user just landed on, `future` rungs are
-    /// still ahead. Pure value type so the ladder layout is unit-testable
-    /// without a view hierarchy.
+    /// paid, `current` is the rung the user will pay on the NEXT snooze (it
+    /// matches the snooze CTA's next-step price and the «N-й поспать ещё» pill,
+    /// where N = snoozeCount + 1), `future` rungs are still ahead. Pure value
+    /// type so the ladder layout is unit-testable without a view hierarchy.
     enum LadderStepState: Equatable {
         case done
         case current
@@ -142,7 +143,10 @@ final class AlarmFiringViewModel {
     /// The 4-rung progressive charge ladder for the snoozed state. Amounts are
     /// the doubling schedule `base, ×2, ×4, ×8` (the same ceiling
     /// `penalty(forSnoozeCount:)` walks). State keys off `snoozeCount`: rungs
-    /// strictly before it are `done`, the rung AT it is `current`, the rest are
+    /// strictly before it are `done` (already paid), the rung AT `snoozeCount`
+    /// is `current` — the NEXT charge (after paying rung `i` the user has
+    /// snoozed `i+1` times, so `snoozeCount` indexes the next unpaid rung, which
+    /// is why it lines up with the CTA's next-step price) — and the rest are
     /// `future`. `snoozeCount` past the last rung clamps `current` to rung 4 so
     /// the ladder never blanks out at the ceiling. Returns `[]` when the alarm
     /// isn't progressive (the snoozed state hides the ladder entirely).

--- a/SnoozePay/SnoozePayTests/AlarmFiringSnoozedStateTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmFiringSnoozedStateTests.swift
@@ -1,0 +1,156 @@
+import XCTest
+@testable import SnoozePay
+
+/// Coverage for the snoozed firing state (#226) — the pure VM logic that drives
+/// the "отложено" chrome: next-ring time, the 4-rung charge ladder, and the
+/// countdown formatting. UIKit-free so it runs without a view hierarchy.
+final class AlarmFiringSnoozedStateTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Build an alarm whose time is a fixed 07:00 on a known calendar day so the
+    /// next-ring maths is deterministic regardless of the test machine's clock.
+    private func makeAlarm(
+        penalty: Double = 50,
+        progressive: Bool = false,
+        snoozeMinutes: Int = 5
+    ) -> Alarm {
+        var components = DateComponents()
+        components.year = 2026
+        components.month = 4
+        components.day = 27
+        components.hour = 7
+        components.minute = 0
+        let time = Calendar.current.date(from: components) ?? Date()
+        return Alarm(
+            time: time,
+            name: "Будни",
+            snoozeMinutes: snoozeMinutes,
+            penaltyAmount: penalty,
+            progressiveScale: progressive
+        )
+    }
+
+    /// A reference "now" of 07:01 on the alarm's day — one minute after the ring.
+    private func reference(hour: Int, minute: Int) -> Date {
+        var components = DateComponents()
+        components.year = 2026
+        components.month = 4
+        components.day = 27
+        components.hour = hour
+        components.minute = minute
+        return Calendar.current.date(from: components) ?? Date()
+    }
+
+    // MARK: - Next-ring time
+
+    func testNextRingTime_firstSnooze_shiftsByOneInterval() {
+        let vm = AlarmFiringViewModel(alarm: makeAlarm(snoozeMinutes: 5), snoozeCount: 1)
+        let text = vm.nextRingTimeText(after: reference(hour: 7, minute: 1))
+        XCTAssertEqual(text, "07:05", "07:00 + 5min × 1 snooze = 07:05")
+    }
+
+    func testNextRingTime_thirdSnooze_accumulates() {
+        let vm = AlarmFiringViewModel(alarm: makeAlarm(snoozeMinutes: 5), snoozeCount: 3)
+        let text = vm.nextRingTimeText(after: reference(hour: 7, minute: 11))
+        XCTAssertEqual(text, "07:15", "07:00 + 5min × 3 snoozes = 07:15")
+    }
+
+    func testNextRingTime_customInterval() {
+        let vm = AlarmFiringViewModel(alarm: makeAlarm(snoozeMinutes: 9), snoozeCount: 2)
+        let text = vm.nextRingTimeText(after: reference(hour: 7, minute: 10))
+        XCTAssertEqual(text, "07:18", "07:00 + 9min × 2 snoozes = 07:18")
+    }
+
+    func testSnoozedHeroTitle_includesNameAndNextRing() {
+        let vm = AlarmFiringViewModel(alarm: makeAlarm(snoozeMinutes: 5), snoozeCount: 1)
+        let title = vm.snoozedHeroTitle(after: reference(hour: 7, minute: 1))
+        XCTAssertEqual(title, "Будни · отложено до 07:05")
+    }
+
+    func testSnoozedHeroTitle_blankNameDropsSeparator() {
+        let alarm = makeAlarm(snoozeMinutes: 5)
+        let renamed = alarm.with(name: "   ")
+        let vm = AlarmFiringViewModel(alarm: renamed, snoozeCount: 1)
+        let title = vm.snoozedHeroTitle(after: reference(hour: 7, minute: 1))
+        XCTAssertEqual(title, "отложено до 07:05", "Whitespace name must not leave a dangling «·»")
+    }
+
+    // MARK: - Countdown
+
+    func testSecondsUntilNextRing_countsRemainder() {
+        let vm = AlarmFiringViewModel(alarm: makeAlarm(snoozeMinutes: 5), snoozeCount: 1)
+        // Next ring 07:05; now 07:00:37 → 4min 23s = 263s.
+        let now = reference(hour: 7, minute: 0).addingTimeInterval(37)
+        XCTAssertEqual(vm.secondsUntilNextRing(from: now), 263)
+    }
+
+    func testSecondsUntilNextRing_clampsAtZeroPastRing() {
+        let vm = AlarmFiringViewModel(alarm: makeAlarm(snoozeMinutes: 5), snoozeCount: 1)
+        // Past the 07:05 next ring — never negative.
+        XCTAssertEqual(vm.secondsUntilNextRing(from: reference(hour: 7, minute: 10)), 0)
+    }
+
+    func testCountdownText_formatsMinutesSeconds() {
+        XCTAssertEqual(AlarmFiringViewModel.countdownText(seconds: 263), "04:23")
+        XCTAssertEqual(AlarmFiringViewModel.countdownText(seconds: 5), "00:05")
+        XCTAssertEqual(AlarmFiringViewModel.countdownText(seconds: 0), "00:00")
+    }
+
+    func testCountdownText_clampsNegative() {
+        XCTAssertEqual(AlarmFiringViewModel.countdownText(seconds: -10), "00:00")
+    }
+
+    // MARK: - Charge ladder
+
+    func testLadderSteps_emptyWhenNotProgressive() {
+        let vm = AlarmFiringViewModel(alarm: makeAlarm(progressive: false), snoozeCount: 2)
+        XCTAssertTrue(vm.ladderSteps.isEmpty, "Non-progressive alarms hide the ladder")
+    }
+
+    func testLadderSteps_amountsAreDoublingSchedule() {
+        let vm = AlarmFiringViewModel(alarm: makeAlarm(penalty: 50, progressive: true), snoozeCount: 1)
+        XCTAssertEqual(vm.ladderSteps.map { $0.amount }, [50, 100, 200, 400])
+    }
+
+    func testLadderSteps_stateAfterFirstSnooze() {
+        let vm = AlarmFiringViewModel(alarm: makeAlarm(penalty: 50, progressive: true), snoozeCount: 1)
+        XCTAssertEqual(
+            vm.ladderSteps.map { $0.state },
+            [.done, .current, .future, .future],
+            "After 1 snooze, rung 0 is paid, rung 1 is the current rung"
+        )
+    }
+
+    func testLadderSteps_stateAtStart() {
+        let vm = AlarmFiringViewModel(alarm: makeAlarm(penalty: 50, progressive: true), snoozeCount: 0)
+        XCTAssertEqual(vm.ladderSteps.map { $0.state }, [.current, .future, .future, .future])
+    }
+
+    func testLadderSteps_clampsCurrentAtCeiling() {
+        let vm = AlarmFiringViewModel(alarm: makeAlarm(penalty: 50, progressive: true), snoozeCount: 6)
+        XCTAssertEqual(
+            vm.ladderSteps.map { $0.state },
+            [.done, .done, .done, .current],
+            "Past the last rung, current clamps to rung 4 so the ladder never blanks"
+        )
+    }
+
+    // MARK: - Last charge (fly-up amount)
+
+    func testLastChargeAmount_zeroBeforeSnooze() {
+        let vm = AlarmFiringViewModel(alarm: makeAlarm(penalty: 50, progressive: true), snoozeCount: 0)
+        XCTAssertEqual(vm.lastChargeAmount, 0)
+    }
+
+    func testLastChargeAmount_progressiveTracksRung() {
+        // snoozeCount == 2 → most recent charge was rung 2 = base × 2 = 100.
+        let vm = AlarmFiringViewModel(alarm: makeAlarm(penalty: 50, progressive: true), snoozeCount: 2)
+        XCTAssertEqual(vm.lastChargeAmount, 100)
+    }
+
+    func testLastChargeAmount_flatWhenNotProgressive() {
+        let vm = AlarmFiringViewModel(alarm: makeAlarm(penalty: 50, progressive: false), snoozeCount: 3)
+        XCTAssertEqual(vm.lastChargeAmount, 50, "Flat penalty alarms charge the base each time")
+    }
+}


### PR DESCRIPTION
Fixes #226

> Auto-close won't fire on the integration branch — orchestrator closes #226 manually after merge.

## Что сделано
- Foreground «Поспать ещё» теперь НЕ закрывает экран, а переключает firing-экран в состояние «отложено» in place (без пересоздания VC): большие часы → живой countdown `mm:ss` до следующего звонка, по нулю UI возвращается в активный firing.
- Bell-тайл приглушается (opacity .7) + бейдж `zZ` сверху-справа; имя → «Будни · отложено до 07:05»; над balance pill всплывает fly-up «−N ₽» (1500ms keyframes), постоянного чипа нет.
- Прогрессив: pill «Прогрессив · N-й поспать ещё» (точка с glow) + шкала списаний 50/100/200/400 (done/current/future). Без прогрессива шкала/pill скрыты, цена постоянная, countdown + zZ остаются. CTA показывает цену следующей ступени + hint.
- Тема влияет только на акценты — countdown glow / zZ-текст+border / current-rung берутся из `firingPalette`.

## Где код
- VM (testable, no UIKit): `AlarmFiringViewModel` — `nextRingDate/nextRingTimeText`, `snoozedHeroTitle`, `secondsUntilNextRing`, `countdownText`, `ladderSteps`, `lastChargeAmount`.
- UI: новые `AlarmFiringViewController+Snoozed.swift` (entry/exit, countdown ticker, fly-up) и `+SnoozedViews.swift` (zZ badge, progressive pill, ladder, PaddedLabel, associated-object storage).
- Минимальные правки shared-файлов: `snoozeTapped()` (+ViewLifecycle) теперь `enterSnoozedState()` вместо dismiss; `updateUI()` зовёт `refreshSnoozedChrome()`; `viewDidDisappear` — `teardownSnoozedTimers()`. `dismissTapped()` НЕ тронут.

## Testing
- `AlarmFiringSnoozedStateTests` — next-ring time (×1/×3/custom interval), hero title (+blank-name degrade), countdown seconds/clamp/format, ladder amounts+state (start/after-1/ceiling-clamp/non-progressive), last-charge amount.
- swiftlint: 0 violations в затронутых файлах.
- build_sim (iPhone 17 Pro Max, iOS 26.5 — единственный доступный runtime; назначенный iPhone 17 Pro iOS 26.2 не установлен): SUCCEEDED.
- test_sim не запускался (disabled — нестабилен; CI прогонит тесты).

🤖 Generated with [Claude Code](https://claude.com/claude-code)