### PR TITLE
[ui] WokeMorning summary screen after «Я встал» — clean / recovered variants (#228)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
@@ -510,9 +510,25 @@ class AlarmFiringViewController: UIViewController {
 
     /// `internal` so the +NoBalance extension can wire its big ghost
     /// "Я встал — выключить" button to the same dismiss path.
+    ///
+    /// Instead of an instant dismiss we present the WokeMorning summary (#228)
+    /// over this VC. Because WokeMorning sits ON TOP, our `viewDidDisappear`
+    /// won't fire, so we stop the alarm audio explicitly here (mirroring the
+    /// guarded teardown in `viewDidDisappear`) — otherwise the sound lingers
+    /// behind the summary (watchdog #199). «Закрыть» on WokeMorning calls
+    /// `presentingViewController?.dismiss` on THIS firing VC, unwinding both
+    /// screens back to the app.
     @objc func dismissTapped() {
+        let snoozes = viewModel.snoozeCount
+        let charged = viewModel.chargedThisMorning
         viewModel.dismiss()
-        dismiss(animated: true)
+        if AudioService.shared.currentAlarmID == viewModel.alarm.id {
+            AudioService.shared.stopAlarmSound()
+        }
+        let woke = WokeMorningViewController(snoozes: snoozes, charged: charged) { [weak self] in
+            self?.presentingViewController?.dismiss(animated: true)
+        }
+        present(woke, animated: true)
     }
 
     // Clock ticking, glow breathing, snooze tap handler, top-up sheet, and

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
@@ -524,10 +524,31 @@ class AlarmFiringViewController: UIViewController {
         viewModel.dismiss()
         if AudioService.shared.currentAlarmID == viewModel.alarm.id {
             AudioService.shared.stopAlarmSound()
+        } else {
+            // Stacking handoff (another alarm took over audio) — mirror the
+            // diagnostic from `viewDidDisappear` so this primary dismiss path
+            // isn't silent about skipping the stop (#199 observability).
+            let ownerDesc = String(describing: AudioService.shared.currentAlarmID)
+            let ours = viewModel.alarm.id
+            AppLogger.audio.notice(
+                "dismissTapped: skip stop — owner=\(ownerDesc, privacy: .private), ours=\(ours, privacy: .private)"
+            )
         }
+        // `presentingViewController?.dismiss` unwinds both the firing VC and the
+        // WokeMorning overlay back to the app. If that chain is unexpectedly nil
+        // (firing VC deallocated, or presented outside the normal chain) the
+        // user would be stranded on the summary with a dead «Закрыть» — fall
+        // back to dismissing the summary itself, and log so it isn't swallowed.
+        weak var wokeRef: WokeMorningViewController?
         let woke = WokeMorningViewController(snoozes: snoozes, charged: charged) { [weak self] in
-            self?.presentingViewController?.dismiss(animated: true)
+            if let presenter = self?.presentingViewController {
+                presenter.dismiss(animated: true)
+            } else {
+                AppLogger.ui.error("WokeMorning close: no presenting chain — dismissing summary only")
+                wokeRef?.dismiss(animated: true)
+            }
         }
+        wokeRef = woke
         present(woke, animated: true)
     }
 

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/WokeMorningContent.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/WokeMorningContent.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// Pure copy/variant logic for the WokeMorning summary screen (#228).
+///
+/// Factored out of `WokeMorningViewController` so the variant selection,
+/// declension, and rendered strings are unit-testable without spinning up
+/// UIKit. The view controller owns only layout / animation; every word the
+/// user reads is decided here.
+///
+/// Spec — `docs/design/v2-handoff/components/SPWokeMorning.jsx`:
+///   • `snoozes == 0` → "clean": "Встал с первого раза" /
+///     "Баланс в полной сохранности. Так держать."
+///   • `snoozes  > 0` → "recovered": "Удержались после N откладываний" /
+///     "Сегодня списано N ₽. Завтра попробуем не списать ничего."
+struct WokeMorningContent {
+
+    /// Two visual / copy scenarios driven purely by the snooze count.
+    enum Variant: Equatable {
+        /// Got up on the first ring — no money moved.
+        case clean
+        /// Snoozed `N` times before getting up — `N ₽` charged.
+        case recovered
+    }
+
+    /// Always "Доброе утро" — the eyebrow doesn't vary by scenario.
+    static let eyebrow = "Доброе утро"
+
+    let snoozes: Int
+    let charged: Int
+
+    /// - Parameters:
+    ///   - snoozes: Times the user snoozed this wake (>= 0).
+    ///   - charged: Roubles charged across those snoozes (rounded to whole ₽
+    ///     for display, matching the JSX `${charged} ₽`).
+    init(snoozes: Int, charged: Int) {
+        self.snoozes = max(0, snoozes)
+        self.charged = max(0, charged)
+    }
+
+    var variant: Variant { snoozes == 0 ? .clean : .recovered }
+
+    var headline: String {
+        switch variant {
+        case .clean:
+            return "Встал с первого раза"
+        case .recovered:
+            return "Удержались после \(snoozes) \(Self.snoozeWord(for: snoozes))"
+        }
+    }
+
+    var subtitle: String {
+        switch variant {
+        case .clean:
+            return "Баланс в полной сохранности. Так держать."
+        case .recovered:
+            return "Сегодня списано \(charged) ₽. Завтра попробуем не списать ничего."
+        }
+    }
+
+    /// Genitive of «откладывание» governed by the numeral after «после N …».
+    ///
+    /// Unlike the nominative 2–4 rule used in `StreakModalViewController
+    /// .dayWord` (день/дня/дней), the preposition «после» forces the genitive
+    /// throughout, so the only split is singular-vs-rest:
+    ///   • `N % 10 == 1 && N % 100 != 11` → "откладывания"
+    ///     ("после 1 откладывания", "после 21 откладывания")
+    ///   • otherwise → "откладываний"
+    ///     ("после 2 откладываний", "после 5 откладываний", "после 11 …")
+    static func snoozeWord(for count: Int) -> String {
+        let mod100 = count % 100
+        let mod10 = count % 10
+        if mod10 == 1 && mod100 != 11 {
+            return "откладывания"
+        }
+        return "откладываний"
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/WokeMorningViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/WokeMorningViewController.swift
@@ -263,3 +263,17 @@ final class WokeMorningViewController: UIViewController {
         onClose()
     }
 }
+
+// MARK: - Hex helper (file-scoped)
+
+private extension UIColor {
+    /// `0xRRGGBB` literal initializer for this screen's mint accent / base
+    /// colours. File-scoped — `private` is file-scope in Swift; the brand-token
+    /// `UIColor(hex:)` in AppColors is `private` and not visible across files.
+    convenience init(hex rgb: UInt32, alpha: CGFloat = 1) {
+        let red = CGFloat((rgb >> 16) & 0xFF) / 255.0
+        let green = CGFloat((rgb >> 8) & 0xFF) / 255.0
+        let blue = CGFloat(rgb & 0xFF) / 255.0
+        self.init(red: red, green: green, blue: blue, alpha: alpha)
+    }
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/WokeMorningViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/WokeMorningViewController.swift
@@ -1,0 +1,265 @@
+import UIKit
+
+/// Morning summary screen shown immediately after the user taps
+/// «Я встал — выключить» on a firing alarm (#228).
+///
+/// A full-screen dark screen in a single mint-green theme (regardless of the
+/// alarm's firing theme): a money-gradient ✓ tile, a caps eyebrow, a headline
+/// and subtitle that swap between the **clean** (snoozed 0 times) and
+/// **recovered** (snoozed N times, N ₽ charged) variants, and a ghost
+/// «Закрыть» button that unwinds the whole presentation stack back to the app.
+///
+/// Spec — `docs/design/v2-handoff/components/SPWokeMorning.jsx`. The copy /
+/// variant / declension logic lives in the pure, testable `WokeMorningContent`.
+final class WokeMorningViewController: UIViewController {
+
+    // MARK: - Configuration
+
+    private let content: WokeMorningContent
+    private let onClose: () -> Void
+
+    // MARK: - Subviews
+
+    private let background = SPWokeMorningBackgroundView()
+
+    /// ✓ tile — 84×84, r20, money gradient fill with a soft glow underlay.
+    private let checkTile = UIView()
+    private let checkTileGradient = CAGradientLayer()
+    private let checkTileGlow = CAGradientLayer()
+    private let checkIcon = UIImageView()
+
+    private let eyebrowLabel = UILabel()
+    private let headlineLabel = UILabel()
+    private let subtitleLabel = UILabel()
+
+    private let closeButton = SPButton(
+        title: "Закрыть",
+        variant: .ghost,
+        size: .lg,
+        fullWidth: true
+    )
+
+    /// Ordered top → bottom for the staggered entry animation.
+    private var animatedElements: [UIView] { [checkTile, eyebrowLabel, headlineLabel, subtitleLabel, closeButton] }
+
+    private var didAnimateIn = false
+
+    // MARK: - Init
+
+    /// - Parameters:
+    ///   - snoozes: Times the user snoozed this wake. `0` selects the clean
+    ///     variant; `> 0` the recovered variant.
+    ///   - charged: Roubles charged across those snoozes (whole ₽ for display).
+    ///   - onClose: Invoked from «Закрыть». The caller is responsible for
+    ///     unwinding the full presentation stack (firing VC + this screen) —
+    ///     see `AlarmFiringViewController.dismissTapped()`.
+    init(snoozes: Int, charged: Double, onClose: @escaping () -> Void) {
+        self.content = WokeMorningContent(snoozes: snoozes, charged: Int(charged.rounded()))
+        self.onClose = onClose
+        super.init(nibName: nil, bundle: nil)
+        overrideUserInterfaceStyle = .dark
+        modalPresentationStyle = .overFullScreen
+        modalTransitionStyle = .crossDissolve
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = UIColor(hex: 0x060F0E)
+        configureBackground()
+        configureCheckTile()
+        configureLabels()
+        configureCloseButton()
+        layout()
+        // Hide the content until the entry animation drives it in.
+        animatedElements.forEach { $0.alpha = 0 }
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        checkTileGradient.frame = checkTile.bounds
+        checkTileGlow.frame = checkTile.bounds.insetBy(dx: -30, dy: -30)
+        checkTile.layer.shadowPath = UIBezierPath(
+            roundedRect: checkTile.bounds,
+            cornerRadius: AppRadius.lg
+        ).cgPath
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        guard !didAnimateIn else { return }
+        didAnimateIn = true
+        animateIn()
+    }
+
+    override var prefersStatusBarHidden: Bool { true }
+    override var prefersHomeIndicatorAutoHidden: Bool { true }
+
+    // MARK: - Configuration
+
+    private func configureBackground() {
+        view.addSubview(background)
+        NSLayoutConstraint.activate([
+            background.topAnchor.constraint(equalTo: view.topAnchor),
+            background.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            background.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            background.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+    }
+
+    private func configureCheckTile() {
+        checkTile.translatesAutoresizingMaskIntoConstraints = false
+        checkTile.layer.cornerRadius = AppRadius.lg
+        checkTile.layer.cornerCurve = .continuous
+        // Drop shadow `0 16 48 rgba(46,219,159,.45)`.
+        checkTile.layer.shadowColor = AppColors.money400.cgColor
+        checkTile.layer.shadowOpacity = 0.45
+        checkTile.layer.shadowOffset = CGSize(width: 0, height: 16)
+        checkTile.layer.shadowRadius = 24
+
+        // Soft outer glow underlay (`radial accent .42 → clear`), behind the tile.
+        checkTileGlow.type = .radial
+        checkTileGlow.colors = [
+            AppColors.money400.withAlphaComponent(0.42).cgColor,
+            UIColor.clear.cgColor
+        ]
+        checkTileGlow.locations = [0.0, 0.7]
+        checkTileGlow.startPoint = CGPoint(x: 0.5, y: 0.5)
+        checkTileGlow.endPoint = CGPoint(x: 1.0, y: 1.0)
+        checkTile.layer.addSublayer(checkTileGlow)
+
+        // Money gradient fill.
+        checkTileGradient.colors = SPSupport.moneyGradientColors
+        checkTileGradient.locations = SPSupport.moneyGradientLocations
+        checkTileGradient.startPoint = SPSupport.gradientStart
+        checkTileGradient.endPoint = SPSupport.gradientEnd
+        checkTileGradient.cornerRadius = AppRadius.lg
+        checkTile.layer.addSublayer(checkTileGradient)
+
+        let config = UIImage.SymbolConfiguration(pointSize: 44, weight: .bold)
+        checkIcon.image = UIImage(systemName: "checkmark", withConfiguration: config)
+        checkIcon.tintColor = .white
+        checkIcon.contentMode = .scaleAspectFit
+        checkIcon.translatesAutoresizingMaskIntoConstraints = false
+        checkTile.addSubview(checkIcon)
+
+        NSLayoutConstraint.activate([
+            checkTile.widthAnchor.constraint(equalToConstant: 84),
+            checkTile.heightAnchor.constraint(equalToConstant: 84),
+            checkIcon.centerXAnchor.constraint(equalTo: checkTile.centerXAnchor),
+            checkIcon.centerYAnchor.constraint(equalTo: checkTile.centerYAnchor)
+        ])
+    }
+
+    private func configureLabels() {
+        eyebrowLabel.attributedText = NSAttributedString(
+            string: WokeMorningContent.eyebrow,
+            attributes: [
+                .font: AppTypography.caps,
+                .kern: AppTypography.capsKerning,
+                .foregroundColor: UIColor(hex: 0x7CE0B9)
+            ]
+        )
+        eyebrowLabel.textAlignment = .center
+        eyebrowLabel.numberOfLines = 0
+        eyebrowLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        headlineLabel.text = content.headline
+        headlineLabel.font = AppFonts.sans(.medium, 28)
+        headlineLabel.textColor = .white
+        headlineLabel.textAlignment = .center
+        headlineLabel.numberOfLines = 0
+        headlineLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        subtitleLabel.text = content.subtitle
+        subtitleLabel.font = AppFonts.sans(.regular, 15)
+        subtitleLabel.textColor = UIColor.white.withAlphaComponent(0.62)
+        subtitleLabel.textAlignment = .center
+        subtitleLabel.numberOfLines = 0
+        subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
+    }
+
+    private func configureCloseButton() {
+        closeButton.translatesAutoresizingMaskIntoConstraints = false
+        // Green outline per spec — border 1pt rgba(124,224,185,.45).
+        closeButton.ghostBorderOverride = (
+            1,
+            UIColor(red: 124 / 255, green: 224 / 255, blue: 185 / 255, alpha: 0.45)
+        )
+        closeButton.addTarget(self, action: #selector(closeTapped), for: .touchUpInside)
+    }
+
+    private func layout() {
+        // Centred content column: ✓ tile + eyebrow + headline + subtitle.
+        let column = UIStackView(arrangedSubviews: [
+            checkTile,
+            eyebrowLabel,
+            headlineLabel,
+            subtitleLabel
+        ])
+        column.axis = .vertical
+        column.alignment = .center
+        column.spacing = AppSpacing.sp3
+        column.setCustomSpacing(26, after: checkTile)     // eyebrow mt 26
+        column.setCustomSpacing(AppSpacing.sp3, after: eyebrowLabel)  // headline mt 14 (≈12)
+        column.setCustomSpacing(AppSpacing.sp3, after: headlineLabel) // subtitle mt 14
+        column.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(column)
+        view.addSubview(closeButton)
+
+        let guide = view.safeAreaLayoutGuide
+        NSLayoutConstraint.activate([
+            // Column centred vertically in the space above the button.
+            column.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            column.leadingAnchor.constraint(equalTo: guide.leadingAnchor, constant: AppSpacing.sp6),
+            column.trailingAnchor.constraint(equalTo: guide.trailingAnchor, constant: -AppSpacing.sp6),
+
+            // Headline maxWidth 320, subtitle maxWidth 300 — centred wrap.
+            headlineLabel.widthAnchor.constraint(lessThanOrEqualToConstant: 320),
+            subtitleLabel.widthAnchor.constraint(lessThanOrEqualToConstant: 300),
+
+            // Bottom «Закрыть» — full width within the screen inset (padding 24).
+            closeButton.leadingAnchor.constraint(equalTo: guide.leadingAnchor, constant: AppSpacing.sp6),
+            closeButton.trailingAnchor.constraint(equalTo: guide.trailingAnchor, constant: -AppSpacing.sp6),
+            closeButton.bottomAnchor.constraint(equalTo: guide.bottomAnchor, constant: -AppSpacing.sp7)
+        ])
+    }
+
+    // MARK: - Entry animation
+
+    /// Fade + translateY 18 → 0, 600ms `cubic-bezier(.2,.8,.2,1)`, staggered
+    /// 0 / 80 / 160 / 240 / 320ms across the 5 content elements. Driven with
+    /// `UIView` keyframe animations + a `CAMediaTimingFunction` to match the
+    /// JSX easing exactly.
+    private func animateIn() {
+        let timing = CAMediaTimingFunction(controlPoints: 0.2, 0.8, 0.2, 1)
+        for (index, element) in animatedElements.enumerated() {
+            element.alpha = 0
+            element.transform = CGAffineTransform(translationX: 0, y: 18)
+            let delay = TimeInterval(index) * 0.08
+            CATransaction.begin()
+            CATransaction.setAnimationTimingFunction(timing)
+            UIView.animate(
+                withDuration: 0.6,
+                delay: delay,
+                options: [.allowUserInteraction],
+                animations: {
+                    element.alpha = 1
+                    element.transform = .identity
+                }
+            )
+            CATransaction.commit()
+        }
+    }
+
+    // MARK: - Actions
+
+    @objc private func closeTapped() {
+        onClose()
+    }
+}

--- a/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
@@ -96,6 +96,11 @@ final class AlarmFiringViewModel {
         return (1...snoozeCount).map { alarm.penalty(forSnoozeCount: $0) }
     }
 
+    /// Total roubles charged this wake — the sum of every snooze penalty taken
+    /// (`pastPenalties`). Drives the WokeMorning «recovered» subtitle
+    /// "Сегодня списано N ₽" (#228); `0` when the user got up on the first ring.
+    var chargedThisMorning: Double { pastPenalties.reduce(0, +) }
+
     var canSnooze: Bool {
         balanceService.canAfford(currentPenalty)
     }

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPWokeMorningBackgroundView.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPWokeMorningBackgroundView.swift
@@ -34,7 +34,9 @@ final class SPWokeMorningBackgroundView: UIView {
     private static let horizonFraction: CGFloat = 0.44
 
     private static let mistColor = UIColor(hex: 0x9EE6CC)
-    private static let glowColor = UIColor(hex: 0x2EDB9F)
+    /// Byte-identical to the brand `AppColors.money400` token — reuse it rather
+    /// than re-literal the hex (design-system single-source-of-truth).
+    private static let glowColor = AppColors.money400
 
     // MARK: - Layers
 
@@ -149,5 +151,21 @@ final class SPWokeMorningBackgroundView: UIView {
         )
 
         CATransaction.commit()
+    }
+}
+
+// MARK: - Hex helper (file-scoped)
+
+private extension UIColor {
+    /// `0xRRGGBB` literal initializer for this screen's mint atmosphere stops.
+    /// File-scoped copy — `private` is file-scope in Swift, mirroring the
+    /// identical helpers in the firing `+Layout` / `+Theme` / `+Snoozed` files
+    /// (the brand-token `UIColor(hex:)` in AppColors is itself `private` and not
+    /// visible across files).
+    convenience init(hex rgb: UInt32, alpha: CGFloat = 1) {
+        let red = CGFloat((rgb >> 16) & 0xFF) / 255.0
+        let green = CGFloat((rgb >> 8) & 0xFF) / 255.0
+        let blue = CGFloat(rgb & 0xFF) / 255.0
+        self.init(red: red, green: green, blue: blue, alpha: alpha)
     }
 }

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPWokeMorningBackgroundView.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPWokeMorningBackgroundView.swift
@@ -1,0 +1,153 @@
+import UIKit
+
+/// Atmospheric background for the WokeMorning summary screen (#228).
+///
+/// Spec — `docs/design/v2-handoff/components/SPWokeMorning.jsx`. A single
+/// mint-green "misty morning" theme regardless of the alarm's firing theme.
+/// Four layers, bottom → top:
+/// 1. **Base sky** — 180° vertical linear gradient `#244E45 → #16332E (30%)
+///    → #0B1C1A (60%) → #07110F (100%)`, painted over an opaque `#060F0E`.
+/// 2. **Top mint mist** — a 560pt radial circle whose centre sits 160pt above
+///    the top edge: `rgba(158,230,204,.32) 0% → .10 38% → clear 68%`.
+/// 3. **Horizon hairline** — a 1pt horizontal line at 44% height:
+///    `clear → rgba(158,230,204,.10) 50% → clear`.
+/// 4. **Bottom green glow** — a 520pt radial circle 160pt below the bottom
+///    edge: `rgba(46,219,159,.28) 0% → .06 45% → clear 72%`.
+///
+/// UIKit has no cheap layer blur, so the JSX `filter: blur()` is approximated
+/// by the soft radial falloff of each gradient. The view owns its layers and
+/// reflows them on every layout pass (rotation / safe-area), mirroring
+/// `SPThemedFiringBackgroundView`.
+final class SPWokeMorningBackgroundView: UIView {
+
+    // MARK: - Geometry constants
+
+    /// Top mist — 560pt circle, horizontally centred, centre 160pt above top.
+    private static let mistDiameter: CGFloat = 560
+    private static let mistTopOverhang: CGFloat = 160
+
+    /// Bottom glow — 520pt circle, horizontally centred, centre 160pt below.
+    private static let glowDiameter: CGFloat = 520
+    private static let glowBottomOverhang: CGFloat = 160
+
+    /// Horizon hairline sits at 44% of the height, 1pt tall.
+    private static let horizonFraction: CGFloat = 0.44
+
+    private static let mistColor = UIColor(hex: 0x9EE6CC)
+    private static let glowColor = UIColor(hex: 0x2EDB9F)
+
+    // MARK: - Layers
+
+    /// `linear-gradient(180deg, …)` — top → bottom, so the unit axis is
+    /// (0.5, 0) → (0.5, 1).
+    private let baseLayer: CAGradientLayer = {
+        let gradient = CAGradientLayer()
+        gradient.type = .axial
+        gradient.startPoint = CGPoint(x: 0.5, y: 0)
+        gradient.endPoint = CGPoint(x: 0.5, y: 1)
+        gradient.colors = [
+            UIColor(hex: 0x244E45).cgColor,
+            UIColor(hex: 0x16332E).cgColor,
+            UIColor(hex: 0x0B1C1A).cgColor,
+            UIColor(hex: 0x07110F).cgColor
+        ]
+        gradient.locations = [0.0, 0.3, 0.6, 1.0]
+        return gradient
+    }()
+
+    private let mistLayer: CAGradientLayer = {
+        let gradient = CAGradientLayer()
+        gradient.type = .radial
+        gradient.startPoint = CGPoint(x: 0.5, y: 0.5)
+        gradient.endPoint = CGPoint(x: 1.0, y: 1.0)
+        gradient.colors = [
+            mistColor.withAlphaComponent(0.32).cgColor,
+            mistColor.withAlphaComponent(0.10).cgColor,
+            mistColor.withAlphaComponent(0).cgColor
+        ]
+        gradient.locations = [0.0, 0.38, 0.68]
+        return gradient
+    }()
+
+    private let horizonLayer: CAGradientLayer = {
+        let gradient = CAGradientLayer()
+        gradient.type = .axial
+        gradient.startPoint = CGPoint(x: 0, y: 0.5)
+        gradient.endPoint = CGPoint(x: 1, y: 0.5)
+        gradient.colors = [
+            mistColor.withAlphaComponent(0).cgColor,
+            mistColor.withAlphaComponent(0.10).cgColor,
+            mistColor.withAlphaComponent(0).cgColor
+        ]
+        gradient.locations = [0.0, 0.5, 1.0]
+        return gradient
+    }()
+
+    private let glowLayer: CAGradientLayer = {
+        let gradient = CAGradientLayer()
+        gradient.type = .radial
+        gradient.startPoint = CGPoint(x: 0.5, y: 0.5)
+        gradient.endPoint = CGPoint(x: 1.0, y: 1.0)
+        gradient.colors = [
+            glowColor.withAlphaComponent(0.28).cgColor,
+            glowColor.withAlphaComponent(0.06).cgColor,
+            glowColor.withAlphaComponent(0).cgColor
+        ]
+        gradient.locations = [0.0, 0.45, 0.72]
+        return gradient
+    }()
+
+    // MARK: - Init
+
+    init() {
+        super.init(frame: .zero)
+        translatesAutoresizingMaskIntoConstraints = false
+        clipsToBounds = true
+        isUserInteractionEnabled = false
+        backgroundColor = UIColor(hex: 0x060F0E)
+        layer.addSublayer(baseLayer)
+        layer.addSublayer(mistLayer)
+        layer.addSublayer(horizonLayer)
+        layer.addSublayer(glowLayer)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Layout
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+
+        baseLayer.frame = bounds
+
+        // Centre 160pt above top edge → origin.y = centreY - radius.
+        let mist = Self.mistDiameter
+        mistLayer.frame = CGRect(
+            x: bounds.midX - mist / 2,
+            y: -(Self.mistTopOverhang + mist / 2),
+            width: mist,
+            height: mist
+        )
+
+        horizonLayer.frame = CGRect(
+            x: 0,
+            y: (bounds.height * Self.horizonFraction).rounded(),
+            width: bounds.width,
+            height: 1
+        )
+
+        let glow = Self.glowDiameter
+        glowLayer.frame = CGRect(
+            x: bounds.midX - glow / 2,
+            y: bounds.height + Self.glowBottomOverhang - glow / 2,
+            width: glow,
+            height: glow
+        )
+
+        CATransaction.commit()
+    }
+}

--- a/SnoozePay/SnoozePayTests/WokeMorningContentTests.swift
+++ b/SnoozePay/SnoozePayTests/WokeMorningContentTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+@testable import SnoozePay
+
+/// Tests for the WokeMorning summary screen (#228) copy logic — variant
+/// selection (clean vs recovered), the genitive declension of «откладывание»
+/// after «после N …», and the rendered headline / subtitle strings.
+///
+/// Lives in the pure `WokeMorningContent` so no UIKit is needed.
+final class WokeMorningContentTests: XCTestCase {
+
+    // MARK: - Variant selection
+
+    func testZeroSnoozesSelectsClean() {
+        XCTAssertEqual(WokeMorningContent(snoozes: 0, charged: 0).variant, .clean)
+    }
+
+    func testPositiveSnoozesSelectRecovered() {
+        XCTAssertEqual(WokeMorningContent(snoozes: 1, charged: 50).variant, .recovered)
+        XCTAssertEqual(WokeMorningContent(snoozes: 5, charged: 300).variant, .recovered)
+    }
+
+    func testNegativeSnoozesClampToClean() {
+        // Defensive: a stray negative count must not crash or read "recovered".
+        XCTAssertEqual(WokeMorningContent(snoozes: -3, charged: 0).variant, .clean)
+    }
+
+    // MARK: - Eyebrow (constant)
+
+    func testEyebrowIsGoodMorning() {
+        XCTAssertEqual(WokeMorningContent.eyebrow, "Доброе утро")
+    }
+
+    // MARK: - Clean variant copy
+
+    func testCleanHeadlineAndSubtitle() {
+        let content = WokeMorningContent(snoozes: 0, charged: 0)
+        XCTAssertEqual(content.headline, "Встал с первого раза")
+        XCTAssertEqual(content.subtitle, "Баланс в полной сохранности. Так держать.")
+    }
+
+    // MARK: - Recovered variant copy
+
+    func testRecoveredHeadlineEmbedsCountAndDeclension() {
+        XCTAssertEqual(
+            WokeMorningContent(snoozes: 1, charged: 50).headline,
+            "Удержались после 1 откладывания"
+        )
+        XCTAssertEqual(
+            WokeMorningContent(snoozes: 2, charged: 100).headline,
+            "Удержались после 2 откладываний"
+        )
+        XCTAssertEqual(
+            WokeMorningContent(snoozes: 5, charged: 300).headline,
+            "Удержались после 5 откладываний"
+        )
+    }
+
+    func testRecoveredSubtitleEmbedsChargedSum() {
+        XCTAssertEqual(
+            WokeMorningContent(snoozes: 2, charged: 150).subtitle,
+            "Сегодня списано 150 ₽. Завтра попробуем не списать ничего."
+        )
+    }
+
+    // MARK: - Declension («после N откладывани…», genitive after «после»)
+
+    func testSnoozeWordSingularGenitive() {
+        // N % 10 == 1 && N % 100 != 11 → "откладывания".
+        XCTAssertEqual(WokeMorningContent.snoozeWord(for: 1), "откладывания")
+        XCTAssertEqual(WokeMorningContent.snoozeWord(for: 21), "откладывания")
+        XCTAssertEqual(WokeMorningContent.snoozeWord(for: 101), "откладывания")
+    }
+
+    func testSnoozeWordPluralGenitive() {
+        // Everything else → "откладываний" (incl. the 2-4 paucal: genitive
+        // after «после» does NOT take the nominative 2-4 form).
+        XCTAssertEqual(WokeMorningContent.snoozeWord(for: 0), "откладываний")
+        XCTAssertEqual(WokeMorningContent.snoozeWord(for: 2), "откладываний")
+        XCTAssertEqual(WokeMorningContent.snoozeWord(for: 3), "откладываний")
+        XCTAssertEqual(WokeMorningContent.snoozeWord(for: 4), "откладываний")
+        XCTAssertEqual(WokeMorningContent.snoozeWord(for: 5), "откладываний")
+        XCTAssertEqual(WokeMorningContent.snoozeWord(for: 22), "откладываний")
+    }
+
+    func testSnoozeWordTeensAlwaysPlural() {
+        // 11 ends in 1 but the -teen exception forces the plural form.
+        XCTAssertEqual(WokeMorningContent.snoozeWord(for: 11), "откладываний")
+        XCTAssertEqual(WokeMorningContent.snoozeWord(for: 111), "откладываний")
+    }
+}


### PR DESCRIPTION
Fixes #228 (auto-close will not fire on the integration branch — close manually after merge).

## Что сделано
- New full-screen dark **WokeMorning** summary shown after «Я встал — выключить» (single mint-green theme regardless of the alarm theme), replacing the instant dismiss.
- `SPWokeMorningBackgroundView` — owns 4 CAGradientLayers (base sky 180° gradient, top mint mist, horizon hairline at 44%, bottom green glow), reflows in `layoutSubviews`, mirroring `SPThemedFiringBackgroundView`.
- `WokeMorningViewController` — money-gradient ✓ tile + soft glow, caps eyebrow «Доброе утро», headline/subtitle, ghost «Закрыть» with green border override; staggered fade+slide-up entry animation (0/80/160/240/320ms, `cubic-bezier(.2,.8,.2,1)`).
- `WokeMorningContent` — pure, testable variant/copy/declension logic (clean vs recovered, genitive «откладывания/откладываний» after «после N»).
- Integration: `AlarmFiringViewController.dismissTapped()` captures snoozes + charged, stops alarm audio explicitly (WokeMorning sits over firing so `viewDidDisappear` won’t fire — watchdog #199), then presents WokeMorning; «Закрыть» unwinds the whole stack via `presentingViewController?.dismiss`.
- `AlarmFiringViewModel.chargedThisMorning` = `pastPenalties.reduce(0, +)`.

## Variants
- **clean** (0 snoozes): «Встал с первого раза» / «Баланс в полной сохранности. Так держать.»
- **recovered** (N > 0): «Удержались после N откладывани…» / «Сегодня списано N ₽. Завтра попробуем не списать ничего.» — N and the sum are real values.

## Testing
- ✅ swiftlint: 0 violations across all 6 touched files (cyclomatic ≤10, line_length 120 ok).
- ✅ build_sim: SUCCEEDED (iPhone 17 Pro Max).
- ✅ Unit tests added: `WokeMorningContentTests` — variant selection (incl. negative clamp), eyebrow, clean/recovered headline+subtitle strings, declension (singular genitive 1/21/101, plural incl. 2-4 paucal → genitive, -teen exception 11/111). Not run here (test_sim disabled per orchestrator); CI / orchestrator will run.
- Runtime present/unwind + audio teardown verified by reading, not executed (screenshot/sim-run disabled).

## Shared-file changes (for clean rebase against #226)
- `AlarmFiringViewModel.swift`: added ONE computed property `chargedThisMorning` right before `canSnooze`.
- `AlarmFiringViewController.swift`: rewrote ONLY the body of `dismissTapped()` (+ doc comment). No other code moved/reformatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)