### PR TITLE
[ui] One-way stake — refund-free copy + wallet footer (#242, #322)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletViewController+Layout.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletViewController+Layout.swift
@@ -187,14 +187,16 @@ extension WalletViewController {
         return label
     }
 
-    /// Footer caption "Покупка не возвращается · штрафы списываются с баланса".
+    /// Footer caption "Покупка не возвращается · списывается только при
+    /// откладывании" — one-way stake framing per screen 19 canon (#322).
+    /// The word «штрафы» is dropped here too for a unified soft tone (#278).
     func makeFooterCaption() -> UILabel {
         let label = UILabel()
         label.font = AppTypography.meta
         label.textColor = AppColors.fg4
         label.numberOfLines = 0
         label.textAlignment = .center
-        label.text = "Покупка не возвращается · штрафы списываются с баланса"
+        label.text = "Покупка не возвращается · списывается только при откладывании"
         return label
     }
 }


### PR DESCRIPTION
Fixes #242
Fixes #322

## Что сделано
- **#322 — Wallet footer:** «Покупка не возвращается · штрафы списываются с баланса» → «Покупка не возвращается · списывается только при откладывании» (screen 19 canon, drops «штрафы» for unified soft tone with #278). `WalletViewController+Layout.swift`.
- **#242 — One-way stake audit:** verified the codebase has NO withdrawal flow — no `вывод`/`вывести`/`withdraw` entry points, screen, or Settings row exist (design never built screen 20 here). Nothing to remove/hide.
- **#242 — Возврат→Бонус:** no-op. `TransactionType` enum is only `topup/charge/promotion`; there is no «Возврат» label/category. Snooze-failure refunds post as an offsetting `topUp` (rendered «Пополнение баланса»), so no refund-style ledger label exists to rename.
- **#242 — refund-promise sweep:** deposit sheet («Деньги попадают в баланс. Списываются только при откладывании.») and onboarding («Это запас, из которого спишутся откладывания.») already use commitment framing — no refund promises found.

## Notes
- The internal refund logic in `AlarmFiringCoordinator`/`AlarmFiringViewModel` is failure-recovery for a charge that failed to schedule — NOT a user-facing withdrawal promise. Left untouched intentionally.
- Did NOT touch `SettingsViewController` (no withdrawal row there) — no merge ordering conflict with the parallel Settings agent.

## Testing
- ✅ swiftlint: 0 violations in touched file
- ✅ build_sim (iPhone 17 Pro Max, full build): SUCCEEDED (16.4s, real recompile)
- Pure copy edit, no logic change → no unit test added. Возврат→Бонус mapping doesn't exist in the model, so nothing testable was introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)