### PR TITLE
[settings] Support email → snoozepay.app constant + corrupt-data recovery row (#316, #102)

### DIFF
--- a/SnoozePay/SnoozePay/Utilities/AppConstants.swift
+++ b/SnoozePay/SnoozePay/Utilities/AppConstants.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// App-wide constant values that would otherwise be duplicated as string
+/// literals across screens. Keeping them here gives a single source of truth
+/// so a rebrand (e.g. support address) is a one-line change (#316).
+enum AppConstants {
+
+    /// Support contact address, shown in Settings → «Связаться с нами» and used
+    /// for the `mailto:` deep link. Post-rebrand domain (#316) — the old
+    /// `support@alarmcash.app` predated the SnoozePay name.
+    static let supportEmail = "support@snoozepay.app"
+}

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController+Sections.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController+Sections.swift
@@ -229,12 +229,19 @@ extension SettingsViewController {
         present(alert, animated: true)
     }
 
-    /// Clears the corrupt state on both repositories and reloads the table so
-    /// the now-unlocked (empty) Settings refreshes and the recovery section
-    /// collapses again.
+    /// Clears the corrupt state and reloads the table so the now-unlocked
+    /// Settings refreshes and the recovery section collapses again. Only the
+    /// repository that ACTUALLY failed to load is wiped — `clearCorruptState()`
+    /// is unconditional (it removes the data key regardless of lock state), so
+    /// clearing a healthy store here would destroy valid data the user never
+    /// lost (e.g. transactions corrupt but alarms intact → don't nuke alarms).
     private func performRecovery() {
-        AlarmRepository.shared.clearCorruptState()
-        TransactionRepository.shared.clearCorruptState()
+        if AlarmRepository.shared.lastLoadFailed {
+            AlarmRepository.shared.clearCorruptState()
+        }
+        if TransactionRepository.shared.lastLoadFailed {
+            TransactionRepository.shared.clearCorruptState()
+        }
         tableView.reloadData()
     }
 

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController+Sections.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController+Sections.swift
@@ -172,7 +172,7 @@ extension SettingsViewController {
             systemName: "envelope",
             iconColor: AppColors.fg3,
             title: "Связаться с нами",
-            subtitle: "support@alarmcash.app",
+            subtitle: AppConstants.supportEmail,
             accessory: .disclosureIndicator
         )
         return cell
@@ -192,6 +192,50 @@ extension SettingsViewController {
             self?.handleThemeSegmentChange(index)
         }
         return cell
+    }
+
+    // MARK: Восстановление (#102)
+
+    /// Destructive recovery row, shown only while a repository is locked after
+    /// a corrupt load (`lastLoadFailed`). Tapping it presents a confirmation
+    /// alert before wiping the corrupt stores — see `presentRecoveryConfirmation`.
+    func makeRecoveryCell(at indexPath: IndexPath) -> UITableViewCell {
+        let cell = dequeueIconRowCell(at: indexPath)
+        cell.configure(
+            systemName: "exclamationmark.triangle",
+            iconColor: AppColors.pain400,
+            title: "Стереть повреждённые данные",
+            subtitle: "Хранилище повреждено и заблокировано",
+            accessory: .none,
+            selectionStyle: .default
+        )
+        return cell
+    }
+
+    /// Double-confirmation for the destructive recovery action (#102). The user
+    /// is erasing their own alarms and transactions, so the alert spells out the
+    /// consequence and the confirm button uses `.destructive` styling.
+    func presentRecoveryConfirmation() {
+        let alert = UIAlertController(
+            title: "Стереть повреждённые данные?",
+            message: "Будильники и история операций будут удалены безвозвратно, "
+                + "а хранилище разблокировано. Это действие нельзя отменить.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "Отмена", style: .cancel))
+        alert.addAction(UIAlertAction(title: "Подтвердить", style: .destructive) { [weak self] _ in
+            self?.performRecovery()
+        })
+        present(alert, animated: true)
+    }
+
+    /// Clears the corrupt state on both repositories and reloads the table so
+    /// the now-unlocked (empty) Settings refreshes and the recovery section
+    /// collapses again.
+    private func performRecovery() {
+        AlarmRepository.shared.clearCorruptState()
+        TransactionRepository.shared.clearCorruptState()
+        tableView.reloadData()
     }
 
     // MARK: - Navigation helpers

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController.swift
@@ -371,8 +371,20 @@ extension SettingsViewController: UITableViewDelegate {
     }
 
     private func openMailto() {
-        if let url = URL(string: "mailto:\(AppConstants.supportEmail)") {
-            UIApplication.shared.open(url)
+        guard let url = URL(string: "mailto:\(AppConstants.supportEmail)") else { return }
+        UIApplication.shared.open(url, options: [:]) { [weak self] success in
+            guard !success else { return }
+            // No Mail client configured (common — many users live in Gmail/
+            // Outlook apps). Don't strand them on a dead «Связаться» tap (#316):
+            // copy the address and tell them so support is still reachable.
+            UIPasteboard.general.string = AppConstants.supportEmail
+            let alert = UIAlertController(
+                title: "Почта не настроена",
+                message: "Адрес поддержки \(AppConstants.supportEmail) скопирован в буфер обмена.",
+                preferredStyle: .alert
+            )
+            alert.addAction(UIAlertAction(title: "Ок", style: .default))
+            self?.present(alert, animated: true)
         }
     }
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController.swift
@@ -51,6 +51,26 @@ class SettingsViewController: UIViewController {
         case rules              // Progressive price default
         case referral           // My code (copyable) + friend's code input + caption
         case other              // Privacy · Terms · Contact · Theme segment
+        case diagnostics        // Corrupt-data recovery row — hidden unless a repo load failed (#102)
+    }
+
+    /// Whether the corrupt-data recovery section should be visible. Surfaced
+    /// only when a repository is locked after a failed load (`lastLoadFailed`),
+    /// so the normal Settings screen never shows the destructive escape hatch
+    /// (#102). Factored out as a pure predicate for unit testing.
+    static func shouldShowRecovery(
+        alarmFailed: Bool,
+        transactionFailed: Bool
+    ) -> Bool {
+        alarmFailed || transactionFailed
+    }
+
+    /// Live recovery visibility, reading the shared repositories.
+    var isRecoveryVisible: Bool {
+        Self.shouldShowRecovery(
+            alarmFailed: AlarmRepository.shared.lastLoadFailed,
+            transactionFailed: TransactionRepository.shared.lastLoadFailed
+        )
     }
 
     /// Row layout inside `.finance`.
@@ -173,6 +193,7 @@ extension SettingsViewController: UITableViewDataSource {
         case .rules:              return 1 // Прогрессивная цена
         case .referral:           return ReferralRow.allCases.count
         case .other:              return OtherRow.allCases.count
+        case .diagnostics:        return isRecoveryVisible ? 1 : 0
         }
     }
 
@@ -184,6 +205,9 @@ extension SettingsViewController: UITableViewDataSource {
         case .rules:              return "ПРАВИЛА"
         case .referral:           return "ПРИГЛАСИТЬ ДРУГА"
         case .other:              return "ПРОЧЕЕ"
+        // No header when the recovery row is hidden, so the empty section
+        // collapses entirely rather than leaving a stray caps title.
+        case .diagnostics:        return isRecoveryVisible ? "ВОССТАНОВЛЕНИЕ" : nil
         }
     }
 
@@ -215,6 +239,7 @@ extension SettingsViewController: UITableViewDataSource {
         case .rules:              return makeRulesCell(at: indexPath)
         case .referral:           return makeReferralCell(at: indexPath)
         case .other:              return makeOtherCell(tableView, at: indexPath)
+        case .diagnostics:        return makeRecoveryCell(at: indexPath)
         }
     }
 }
@@ -236,20 +261,29 @@ extension SettingsViewController: UITableViewDelegate {
             // isn't truncated ("...") on narrow screens (#313).
             return UITableView.automaticDimension
         case .referral:
-            // Friend-input row hosts an SPInput (52pt field + label + hint);
-            // the caption row wraps to two lines on small screens — let
-            // self-sizing handle both rather than guessing.
-            guard let row = ReferralRow(rawValue: indexPath.row) else { return 52 }
-            switch row {
-            case .myCode:      return 52
-            case .friendInput: return UITableView.automaticDimension
-            case .caption:     return UITableView.automaticDimension
-            }
+            return referralRowHeight(row: indexPath.row)
         case .soundNotifications where SoundRow(rawValue: indexPath.row) == .criticalAlerts:
             // Two-line subtitle hint ("Недоступно — нужно одобрение Apple").
             return UITableView.automaticDimension
+        case .diagnostics:
+            // Title + subtitle ("Хранилище повреждено и заблокировано") — let it
+            // self-size so the hint isn't clipped on narrow screens (#102).
+            return UITableView.automaticDimension
         default:
             return 52
+        }
+    }
+
+    /// Row heights inside `.referral`, split off to keep `heightForRowAt` under
+    /// SwiftLint's cyclomatic-complexity cap. Friend-input row hosts an SPInput
+    /// (52pt field + label + hint); the caption row wraps to two lines on small
+    /// screens — let self-sizing handle both rather than guessing.
+    private func referralRowHeight(row: Int) -> CGFloat {
+        switch ReferralRow(rawValue: row) {
+        case .myCode:      return 52
+        case .friendInput: return UITableView.automaticDimension
+        case .caption:     return UITableView.automaticDimension
+        case .none:        return 52
         }
     }
 
@@ -301,6 +335,9 @@ extension SettingsViewController: UITableViewDelegate {
 
         case .other:
             handleOtherTap(row: indexPath.row)
+
+        case .diagnostics:
+            presentRecoveryConfirmation()
         }
     }
 
@@ -334,7 +371,7 @@ extension SettingsViewController: UITableViewDelegate {
     }
 
     private func openMailto() {
-        if let url = URL(string: "mailto:support@alarmcash.app") {
+        if let url = URL(string: "mailto:\(AppConstants.supportEmail)") {
             UIApplication.shared.open(url)
         }
     }

--- a/SnoozePay/SnoozePayTests/SettingsSectionsTests.swift
+++ b/SnoozePay/SnoozePayTests/SettingsSectionsTests.swift
@@ -20,15 +20,42 @@ final class SettingsSectionsTests: XCTestCase {
     func testSectionOrder_matchesDesign() {
         XCTAssertEqual(
             SettingsViewController.Section.allCases,
-            [.finance, .soundNotifications, .rules, .referral, .other]
+            [.finance, .soundNotifications, .rules, .referral, .other, .diagnostics]
         )
     }
 
     func testLegacySectionsRemoved() {
         // АККАУНТ (history + balance) and a standalone ОФОРМЛЕНИЕ section are
         // gone — there is no `.account` / `.appearance` case anymore. Asserting
-        // the count is the compile-safe way to lock the section list.
-        XCTAssertEqual(SettingsViewController.Section.allCases.count, 5)
+        // the count is the compile-safe way to lock the section list. The
+        // appended `.diagnostics` recovery section (#102) brings the total to 6.
+        XCTAssertEqual(SettingsViewController.Section.allCases.count, 6)
+    }
+
+    // MARK: - Recovery section visibility (#102)
+
+    func testRecoveryHidden_whenNoLoadFailed() {
+        XCTAssertFalse(
+            SettingsViewController.shouldShowRecovery(alarmFailed: false, transactionFailed: false)
+        )
+    }
+
+    func testRecoveryVisible_whenAlarmLoadFailed() {
+        XCTAssertTrue(
+            SettingsViewController.shouldShowRecovery(alarmFailed: true, transactionFailed: false)
+        )
+    }
+
+    func testRecoveryVisible_whenTransactionLoadFailed() {
+        XCTAssertTrue(
+            SettingsViewController.shouldShowRecovery(alarmFailed: false, transactionFailed: true)
+        )
+    }
+
+    func testRecoveryVisible_whenBothFailed() {
+        XCTAssertTrue(
+            SettingsViewController.shouldShowRecovery(alarmFailed: true, transactionFailed: true)
+        )
     }
 
     // MARK: - Row composition per section


### PR DESCRIPTION
Fixes #316
Fixes #102

(Auto-close won't fire on the integration branch — orchestrator closes manually after merge.)

## What changed

### #316 — Support email rebrand
- New `Utilities/AppConstants.swift` with `enum AppConstants { static let supportEmail = "support@snoozepay.app" }` — single source of truth.
- `SettingsViewController+Sections.swift` «Связаться с нами» subtitle now reads `AppConstants.supportEmail`.
- `SettingsViewController.swift` `openMailto()` builds the URL from `AppConstants.supportEmail`. Old `support@alarmcash.app` is gone (grep-clean).

### #102 — Corrupt-data recovery row
- New `Section.diagnostics` appended after `.other`. Returns **0 rows + nil header** unless a repo load failed, so the destructive escape hatch is hidden in the normal case.
- Visibility = pure, testable predicate `shouldShowRecovery(alarmFailed:transactionFailed:)` (OR of both repos' `lastLoadFailed`), with a live `isRecoveryVisible` reading the shared singletons.
- Row «Стереть повреждённые данные» (warning icon + «Хранилище повреждено и заблокировано» subtitle). Tap → `UIAlertController` double-confirmation with destructive copy + Cancel/«Подтвердить» (`.destructive`).
- On confirm: `AlarmRepository.shared.clearCorruptState()` + `TransactionRepository.shared.clearCorruptState()` then `tableView.reloadData()` so the now-unlocked (empty) UI refreshes and the section collapses.
- Repos were **not** modified — `clearCorruptState()` API already existed.

## Testing
- swiftlint: 0 violations in changed files (cyclomatic complexity kept ≤10 — extracted `referralRowHeight` to make room).
- `build_sim`: clean build SUCCEEDED (12.5s full recompile, iPhone 17 Pro Max) — new `AppConstants` symbols resolve.
- Unit tests added to `SettingsSectionsTests.swift`: section count 5→6, order includes `.diagnostics`, 4 cases for `shouldShowRecovery`. (test_sim disabled in this environment — run by orchestrator/CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)