### PR TITLE
[fix] StoreKit deferred-purchase local-notification feedback + conservative dedup hardening (#45, #209)

### DIFF
--- a/SnoozePay/SnoozePay/Services/StoreKitService.swift
+++ b/SnoozePay/SnoozePay/Services/StoreKitService.swift
@@ -1,6 +1,22 @@
 import StoreKit
 import Foundation
+import UserNotifications
 import os
+
+/// Minimal seam for posting an immediate local notification. Extracted so the
+/// deferred-purchase fallback (#45) can be unit-tested without bringing up the
+/// process-wide `UNUserNotificationCenter` singleton. Production uses
+/// `UNUserNotificationCenter.current()`; tests inject a spy.
+@MainActor
+protocol LocalNotificationPosting {
+    func add(_ request: UNNotificationRequest)
+}
+
+extension UNUserNotificationCenter: LocalNotificationPosting {
+    nonisolated func add(_ request: UNNotificationRequest) {
+        add(request, withCompletionHandler: nil)
+    }
+}
 
 /// Manages consumable In-App Purchases using StoreKit 2.
 /// Five fixed packages: 49, 149, 299, 499, 999 RUB.
@@ -55,6 +71,12 @@ final class StoreKitService {
     /// hard-coding the same Russian string in two places. See #115.
     static let ledgerLockedFailureMessage = "Не удалось зачислить покупку. Свяжитесь с поддержкой."
 
+    /// User-facing copy when the dedup table is in a degraded (type-drifted)
+    /// state and we refuse to process new transactions to avoid a double-credit
+    /// (#209). Surfaced as a constant so tests can assert it.
+    static let degradedDedupFailureMessage =
+        "Не удалось обработать покупку. Перезапустите приложение или свяжитесь с поддержкой."
+
     private(set) var products: [Product] = []
 
     /// Background listener for `Transaction.updates`. Required by StoreKit 2 to
@@ -71,12 +93,76 @@ final class StoreKitService {
     private static let processedTxKey = "storekit.processed_tx_ids"
     private static let processedTxCap = 200
 
+    /// Backup key for a dedup blob whose plist type has drifted (#209). When the
+    /// stored value exists but is no longer `[String]`, we copy it here (once)
+    /// for diagnosis instead of silently overwriting it — mirrors
+    /// `TransactionRepository.corruptBackupKey`.
+    static let processedBackupCorruptKey = "stored_processed_backup_corrupt"
+
+    /// Number of UI screens currently subscribed to purchase-feedback
+    /// notifications (Deposit / Firing top-up sheets). When zero, a deferred
+    /// purchase result (Ask-to-Buy approval, refund, restore, verification
+    /// failure) would broadcast into the void — so we post a local notification
+    /// instead so the feedback is never silently lost (#45). Screens bump this
+    /// via `beginObservingPurchaseFeedback()` / `endObservingPurchaseFeedback()`.
+    private var purchaseFeedbackSubscribers = 0
+
+    /// Whether any UI screen is currently mounted to receive purchase feedback.
+    var hasPurchaseFeedbackSubscriber: Bool { purchaseFeedbackSubscribers > 0 }
+
+    /// Seam for posting the deferred-purchase fallback notification (#45).
+    private let notificationPoster: LocalNotificationPosting
+
+    /// Backing store for the dedup table. Injected so tests can drive the
+    /// conservative corruption path (#209) against an isolated suite instead of
+    /// `.standard`; production uses `.standard`.
+    private let defaults: UserDefaults
+
+    /// Identifier prefix for the deferred-purchase fallback notifications so
+    /// they can be inspected / cleared as a group if needed.
+    private static let feedbackNotificationIDPrefix = "snoozepay.storekit.feedback."
+
     private init() {
+        self.notificationPoster = UNUserNotificationCenter.current()
+        self.defaults = .standard
         transactionListener = Self.makeTransactionListener()
+    }
+
+    /// Test-only initializer. Injects the notification + storage seams and skips
+    /// spawning the `Transaction.updates` listener (which can't be driven in a
+    /// unit test without a StoreKit substitution refactor). Never used in
+    /// production — production MUST go through `.shared`.
+    init(
+        notificationPoster: LocalNotificationPosting,
+        defaults: UserDefaults = .standard,
+        startListener: Bool = false
+    ) {
+        self.notificationPoster = notificationPoster
+        self.defaults = defaults
+        if startListener {
+            transactionListener = Self.makeTransactionListener()
+        }
     }
 
     deinit {
         transactionListener?.cancel()
+    }
+
+    // MARK: - Purchase-feedback subscriber tracking (#45)
+
+    /// Register that a UI screen is now observing purchase-feedback
+    /// notifications. While at least one screen is registered, purchase results
+    /// are delivered only via the NotificationCenter broadcast (no local
+    /// notification — avoids double-notifying).
+    func beginObservingPurchaseFeedback() {
+        purchaseFeedbackSubscribers += 1
+    }
+
+    /// Balance a prior `beginObservingPurchaseFeedback()`. Clamped at zero so a
+    /// stray extra `end` can't drive the counter negative and suppress the
+    /// fallback notification forever.
+    func endObservingPurchaseFeedback() {
+        purchaseFeedbackSubscribers = max(0, purchaseFeedbackSubscribers - 1)
     }
 
     private static func makeTransactionListener() -> Task<Void, Never> {
@@ -120,12 +206,20 @@ final class StoreKitService {
                     postPurchaseFailed("Неизвестный пакет пополнения. Обнови приложение.")
                     return
                 }
-                guard markProcessed(transactionID: transaction.id) else {
+                switch markProcessed(transactionID: transaction.id) {
+                case .alreadyProcessed:
                     AppLogger.storeKit.notice(
                         "tx \(transaction.id, privacy: .private) already processed — skipping double credit"
                     )
                     await transaction.finish()
                     return
+                case .degraded:
+                    // Dedup table corrupt — refuse to credit AND don't finish, so
+                    // StoreKit replays once the degraded state is recovered (#209).
+                    postPurchaseFailed(Self.degradedDedupFailureMessage)
+                    return
+                case .recorded:
+                    break
                 }
                 guard BalanceService.shared.topUp(amount: amount) else {
                     // Ledger locked / record() failed — money already collected by
@@ -195,12 +289,21 @@ final class StoreKitService {
             }
             // Idempotency — guard against StoreKit replaying a transaction we already
             // credited (e.g. if the previous run crashed between topUp and finish()).
-            guard markProcessed(transactionID: transaction.id) else {
+            switch markProcessed(transactionID: transaction.id) {
+            case .alreadyProcessed:
                 AppLogger.storeKit.notice(
                     "tx \(transaction.id, privacy: .private) already processed — finishing without re-credit"
                 )
                 await transaction.finish()
                 return
+            case .degraded:
+                // Dedup table corrupt — refuse to credit AND don't finish, so the
+                // deferred transaction replays after recovery (#209). Surface so a
+                // background approval/restore failure isn't silent.
+                postPurchaseFailed(Self.degradedDedupFailureMessage)
+                return
+            case .recorded:
+                break
             }
             guard BalanceService.shared.topUp(amount: amount) else {
                 // Ledger locked / record() failed — money already collected by Apple.
@@ -239,7 +342,20 @@ final class StoreKitService {
         )
     }
 
-    private func postPurchaseCompleted(_ amount: Double) {
+    /// `internal` so #45 fallback tests can drive the no-subscriber path and
+    /// assert a local notification is posted. Not public.
+    func postPurchaseCompleted(_ amount: Double) {
+        // A mounted screen handles the in-app banner. If none is mounted the
+        // broadcast is lost — fall back to a local notification so a deferred
+        // approval / restore credited in the background is never silent (#45).
+        guard hasPurchaseFeedbackSubscriber else {
+            let rubles = Int(amount.rounded())
+            postLocalFeedbackNotification(
+                title: "Баланс пополнен",
+                body: "Баланс пополнен на \(rubles) ₽."
+            )
+            return
+        }
         NotificationCenter.default.post(
             name: Self.purchaseCompletedNotification,
             object: self,
@@ -247,12 +363,40 @@ final class StoreKitService {
         )
     }
 
-    private func postPurchaseFailed(_ message: String) {
+    /// `internal` for the same reason as `postPurchaseCompleted` — testable
+    /// no-subscriber fallback (#45). Not public.
+    func postPurchaseFailed(_ message: String) {
+        // Same rationale as `postPurchaseCompleted` — a refund / verification
+        // failure arriving with no screen mounted must not vanish silently (#45).
+        guard hasPurchaseFeedbackSubscriber else {
+            postLocalFeedbackNotification(title: "Покупка пополнения", body: message)
+            return
+        }
         NotificationCenter.default.post(
             name: Self.purchaseFailedNotification,
             object: self,
             userInfo: [Self.messageUserInfoKey: message]
         )
+    }
+
+    /// Schedule an immediate local notification carrying purchase feedback.
+    /// Reuses the notification authorization the alarm flow already holds
+    /// (`.alert` / `.sound`) — does NOT request a new permission. A `nil`
+    /// trigger fires as soon as the system delivers it (#45).
+    private func postLocalFeedbackNotification(title: String, body: String) {
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        content.sound = .default
+        let request = UNNotificationRequest(
+            identifier: Self.feedbackNotificationIDPrefix + UUID().uuidString,
+            content: content,
+            trigger: nil
+        )
+        AppLogger.storeKit.notice(
+            "deferred purchase feedback — no screen mounted, posting local notification"
+        )
+        notificationPoster.add(request)
     }
 
     private func postPurchasePending() {
@@ -264,26 +408,67 @@ final class StoreKitService {
 
     // MARK: - Idempotency
 
-    /// Returns true if this transaction is new (recorded for the first time);
-    /// false if it was already processed in a previous app session.
+    /// Outcome of attempting to record a transaction in the dedup table (#209).
+    enum MarkResult: Equatable {
+        /// New transaction — recorded for the first time; proceed to credit.
+        case recorded
+        /// Already processed in a previous session — skip credit, finish() it.
+        case alreadyProcessed
+        /// The dedup blob exists but its plist type has drifted (tampering /
+        /// schema migration by another build). We refuse to operate: crediting
+        /// would risk a double-credit, and overwriting would wipe the table.
+        /// Caller must NOT credit and must NOT finish() — leave for retry after
+        /// the degraded state is recovered.
+        case degraded
+    }
+
+    /// Records a transaction in the dedup table.
     ///
     /// Storage is `[String]` (not `[UInt64]`) because UserDefaults plist storage
     /// silently fails the `as? [UInt64]` cast in some cases — a nil cast result
     /// would reset the set and re-enable double-crediting. Strings round-trip safely.
     /// We keep insertion order (Array, not Set) so we can trim the oldest IDs once
     /// the cap is exceeded, keeping UserDefaults bounded.
-    private func markProcessed(transactionID: UInt64) -> Bool {
-        let defaults = UserDefaults.standard
+    ///
+    /// CONSERVATIVE corruption handling (#209): if the stored value exists but is
+    /// no longer `[String]`, we DO NOT blank the table (the old `?? []` did, which
+    /// re-enabled double-crediting). Instead we back the corrupt blob up to
+    /// `processedBackupCorruptKey` (once, mirroring `TransactionRepository`), log
+    /// it, and return `.degraded` so the caller refuses to credit.
+    ///
+    /// `internal` (not `private`) so money-correctness unit tests can drive the
+    /// recorded / already-processed / degraded outcomes against an injected
+    /// `UserDefaults` suite. Not part of the public surface.
+    func markProcessed(transactionID: UInt64) -> MarkResult {
         let key = Self.processedTxKey
         let idString = String(transactionID)
-        var processed = (defaults.array(forKey: key) as? [String]) ?? []
-        guard !processed.contains(idString) else { return false }
+
+        let stored = defaults.object(forKey: key)
+        var processed: [String]
+        if stored == nil {
+            // Brand-new install / table not yet written — legitimate empty state.
+            processed = []
+        } else if let casted = stored as? [String] {
+            processed = casted
+        } else {
+            // Blob present but its plist type drifted. Refuse — never wipe, never
+            // double-credit. Back it up once for diagnosis.
+            if defaults.object(forKey: Self.processedBackupCorruptKey) == nil {
+                defaults.set(stored, forKey: Self.processedBackupCorruptKey)
+            }
+            AppLogger.storeKit.error(
+                "markProcessed: dedup table corrupt (type drift) — refusing to credit, backed up tx=\(transactionID, privacy: .private)"
+            )
+            return .degraded
+        }
+
+        guard !processed.contains(idString) else { return .alreadyProcessed }
         processed.append(idString)
         if processed.count > Self.processedTxCap {
             processed = Array(processed.suffix(Self.processedTxCap))
         }
         defaults.set(processed, forKey: key)
-        return true
+        return .recorded
     }
 
     /// Roll back a `markProcessed(transactionID:)` recorded earlier in the same
@@ -292,7 +477,6 @@ final class StoreKitService {
     /// would look "already processed" on StoreKit's retry replay and finish
     /// silently without crediting (the very money-loss bug #115 is fixing).
     private func unmarkProcessed(transactionID: UInt64) {
-        let defaults = UserDefaults.standard
         let key = Self.processedTxKey
         let idString = String(transactionID)
         guard var processed = defaults.array(forKey: key) as? [String] else {
@@ -323,11 +507,22 @@ final class StoreKitService {
 
     // MARK: - Helpers
 
-    private static func creditAmount(for productID: String, fallbackPrice: Decimal?) -> Double {
+    static func creditAmount(for productID: String, fallbackPrice: Decimal?) -> Double {
         if let mapped = productAmounts[productID] {
             return mapped
         }
-        return fallbackPrice?.doubleValue ?? 0
+        // Unknown product. We do NOT support free/promo products (#209), so a
+        // zero here means a misconfiguration (a SKU added to App Store Connect
+        // but not to `productAmounts`). The caller treats 0 as "unknown package"
+        // and refuses to finish — log loudly so a future misconfig isn't silent
+        // rather than being mistaken for an intentional zero-priced product.
+        let resolved = fallbackPrice?.doubleValue ?? 0
+        if resolved <= 0 {
+            AppLogger.storeKit.error(
+                "creditAmount: unknown product \(productID, privacy: .public) resolved to \(resolved, privacy: .public) — no free/promo products exist; likely a missing productAmounts entry"
+            )
+        }
+        return resolved
     }
 
     // MARK: - Display / catalogue amounts (#275)

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/FiringTopUpBottomSheetViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/FiringTopUpBottomSheetViewController.swift
@@ -118,6 +118,9 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
     /// Notification observer tokens torn down in `deinit`.
     private var purchaseCompletedObserver: NSObjectProtocol?
     private var purchaseFailedObserver: NSObjectProtocol?
+    /// True while registered as a purchase-feedback subscriber so begin/end
+    /// stay balanced across appear/disappear (#45).
+    private var isObservingPurchaseFeedback = false
 
     // MARK: - Subviews
 
@@ -319,6 +322,12 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
         startAutoResumeTimer()
         startCountdownTimer()
         updatePauseLabel()
+        // While visible, route purchase feedback to the in-app banner rather
+        // than a fallback local notification (#45). Balanced below.
+        if !isObservingPurchaseFeedback {
+            isObservingPurchaseFeedback = true
+            StoreKitService.shared.beginObservingPurchaseFeedback()
+        }
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -327,6 +336,10 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
         autoResumeTimer = nil
         countdownTimer?.invalidate()
         countdownTimer = nil
+        if isObservingPurchaseFeedback {
+            isObservingPurchaseFeedback = false
+            StoreKitService.shared.endObservingPurchaseFeedback()
+        }
 
         // Resume audio + escalation unless we got here via success path —
         // the host VC may have already torn down the firing flow on success.

--- a/SnoozePay/SnoozePay/ViewControllers/Wallet/DepositBottomSheetViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Wallet/DepositBottomSheetViewController.swift
@@ -35,6 +35,9 @@ final class DepositBottomSheetViewController: UIViewController {
 
     private var purchaseCompletedObserver: NSObjectProtocol?
     private var purchaseFailedObserver: NSObjectProtocol?
+    /// True while this screen is registered as a purchase-feedback subscriber
+    /// so `begin`/`end` stay balanced across appear/disappear (#45).
+    private var isObservingPurchaseFeedback = false
 
     // MARK: - Subviews
 
@@ -186,6 +189,25 @@ final class DepositBottomSheetViewController: UIViewController {
         view.backgroundColor = AppColors.bg1
         setupLayout()
         observePurchaseNotifications()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        // While this screen is visible, purchase feedback routes to the in-app
+        // banner; tell StoreKitService so it doesn't also post a fallback local
+        // notification (#45). Balanced in `viewWillDisappear`.
+        if !isObservingPurchaseFeedback {
+            isObservingPurchaseFeedback = true
+            StoreKitService.shared.beginObservingPurchaseFeedback()
+        }
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        if isObservingPurchaseFeedback {
+            isObservingPurchaseFeedback = false
+            StoreKitService.shared.endObservingPurchaseFeedback()
+        }
     }
 
     // MARK: - Layout

--- a/SnoozePay/SnoozePayTests/StoreKitServiceTests.swift
+++ b/SnoozePay/SnoozePayTests/StoreKitServiceTests.swift
@@ -1,5 +1,17 @@
 import XCTest
+import UserNotifications
 @testable import SnoozePay
+
+/// Spy that captures the `UNNotificationRequest`s StoreKitService posts when no
+/// UI screen is mounted (#45). Avoids touching the real
+/// `UNUserNotificationCenter` singleton in unit tests.
+@MainActor
+final class LocalNotificationPosterSpy: LocalNotificationPosting {
+    private(set) var requests: [UNNotificationRequest] = []
+    func add(_ request: UNNotificationRequest) {
+        requests.append(request)
+    }
+}
 
 /// Smoke tests for StoreKitService.
 ///
@@ -137,5 +149,170 @@ final class StoreKitServiceTests: XCTestCase {
 
         wait(for: [exp], timeout: 1.0)
         XCTAssertEqual(receivedMessage, StoreKitService.ledgerLockedFailureMessage)
+    }
+
+    // MARK: - #45: deferred-purchase local-notification fallback
+
+    /// A fresh test instance with an injected notification spy and an isolated
+    /// UserDefaults suite — never the `.shared` singleton (which spawns the
+    /// `Transaction.updates` listener and reads `.standard`).
+    private func makeService(
+        poster: LocalNotificationPosterSpy,
+        defaults: UserDefaults
+    ) -> StoreKitService {
+        StoreKitService(notificationPoster: poster, defaults: defaults, startListener: false)
+    }
+
+    private func makeSuite() -> (UserDefaults, String) {
+        let name = "test_storekit_\(UUID().uuidString)"
+        return (UserDefaults(suiteName: name)!, name)
+    }
+
+    /// With no screen mounted, a completed purchase posts a local notification
+    /// (option B) instead of broadcasting into the void.
+    func testPurchaseCompleted_noSubscriber_postsLocalNotification() {
+        let poster = LocalNotificationPosterSpy()
+        let (defaults, name) = makeSuite()
+        defer { defaults.removePersistentDomain(forName: name) }
+        let service = makeService(poster: poster, defaults: defaults)
+
+        XCTAssertFalse(service.hasPurchaseFeedbackSubscriber)
+        service.postPurchaseCompleted(149)
+
+        XCTAssertEqual(poster.requests.count, 1)
+        let content = poster.requests.first?.content
+        XCTAssertEqual(content?.title, "Баланс пополнен")
+        XCTAssertEqual(content?.body, "Баланс пополнен на 149 ₽.")
+        // Immediate delivery — no trigger.
+        XCTAssertNil(poster.requests.first?.trigger)
+    }
+
+    /// With a screen mounted, the completed purchase broadcasts via
+    /// NotificationCenter and does NOT post a local notification (no double-notify).
+    func testPurchaseCompleted_withSubscriber_doesNotPostLocalNotification() {
+        let poster = LocalNotificationPosterSpy()
+        let (defaults, name) = makeSuite()
+        defer { defaults.removePersistentDomain(forName: name) }
+        let service = makeService(poster: poster, defaults: defaults)
+
+        service.beginObservingPurchaseFeedback()
+        XCTAssertTrue(service.hasPurchaseFeedbackSubscriber)
+        service.postPurchaseCompleted(149)
+
+        XCTAssertTrue(poster.requests.isEmpty, "must not double-notify when a screen is mounted")
+    }
+
+    /// A failure (refund / verification failure) with no screen mounted posts a
+    /// local notification carrying the message so it's never silently lost.
+    func testPurchaseFailed_noSubscriber_postsLocalNotificationWithMessage() {
+        let poster = LocalNotificationPosterSpy()
+        let (defaults, name) = makeSuite()
+        defer { defaults.removePersistentDomain(forName: name) }
+        let service = makeService(poster: poster, defaults: defaults)
+
+        service.postPurchaseFailed("Покупка отменена и возвращена.")
+
+        XCTAssertEqual(poster.requests.count, 1)
+        XCTAssertEqual(poster.requests.first?.content.body, "Покупка отменена и возвращена.")
+    }
+
+    /// begin/end subscriber tracking is balanced and clamps at zero so a stray
+    /// extra `end` can't suppress the fallback forever.
+    func testSubscriberTracking_balancesAndClampsAtZero() {
+        let poster = LocalNotificationPosterSpy()
+        let (defaults, name) = makeSuite()
+        defer { defaults.removePersistentDomain(forName: name) }
+        let service = makeService(poster: poster, defaults: defaults)
+
+        service.beginObservingPurchaseFeedback()
+        service.beginObservingPurchaseFeedback()
+        XCTAssertTrue(service.hasPurchaseFeedbackSubscriber)
+        service.endObservingPurchaseFeedback()
+        XCTAssertTrue(service.hasPurchaseFeedbackSubscriber, "still one screen mounted")
+        service.endObservingPurchaseFeedback()
+        XCTAssertFalse(service.hasPurchaseFeedbackSubscriber)
+        // Over-balance must not drive negative.
+        service.endObservingPurchaseFeedback()
+        XCTAssertFalse(service.hasPurchaseFeedbackSubscriber)
+    }
+
+    // MARK: - #209.1: conservative dedup-corruption handling
+
+    func testMarkProcessed_freshTable_recordsAndDedupes() {
+        let poster = LocalNotificationPosterSpy()
+        let (defaults, name) = makeSuite()
+        defer { defaults.removePersistentDomain(forName: name) }
+        let service = makeService(poster: poster, defaults: defaults)
+
+        XCTAssertEqual(service.markProcessed(transactionID: 42), .recorded)
+        // Replay of the same ID is recognised — no double-credit.
+        XCTAssertEqual(service.markProcessed(transactionID: 42), .alreadyProcessed)
+    }
+
+    /// THE money-correctness test: a dedup blob whose plist type has drifted must
+    /// NOT be wiped (old `?? []` behavior re-enabled double-crediting). The table
+    /// is backed up, and the call returns `.degraded` so the caller refuses to credit.
+    func testMarkProcessed_corruptBlob_refusesAndBacksUpWithoutWiping() {
+        let poster = LocalNotificationPosterSpy()
+        let (defaults, name) = makeSuite()
+        defer { defaults.removePersistentDomain(forName: name) }
+        let service = makeService(poster: poster, defaults: defaults)
+
+        // Plant a type-drifted blob (a dictionary where `[String]` is expected).
+        let corrupt: [String: Int] = ["unexpected": 1]
+        defaults.set(corrupt, forKey: "storekit.processed_tx_ids")
+
+        XCTAssertEqual(service.markProcessed(transactionID: 7), .degraded)
+
+        // Original corrupt blob is preserved (NOT wiped to []).
+        XCTAssertNotNil(defaults.object(forKey: "storekit.processed_tx_ids"))
+        XCTAssertNil(
+            defaults.array(forKey: "storekit.processed_tx_ids") as? [String],
+            "corrupt blob must remain non-[String] — never silently reset"
+        )
+        // Backup written for diagnosis (mirrors TransactionRepository).
+        XCTAssertNotNil(defaults.object(forKey: StoreKitService.processedBackupCorruptKey))
+    }
+
+    /// In the degraded state the dedup table is never overwritten across repeated
+    /// attempts — every call refuses rather than double-crediting.
+    func testMarkProcessed_corruptBlob_repeatedCallsStayDegraded() {
+        let poster = LocalNotificationPosterSpy()
+        let (defaults, name) = makeSuite()
+        defer { defaults.removePersistentDomain(forName: name) }
+        let service = makeService(poster: poster, defaults: defaults)
+
+        defaults.set(["bad": true], forKey: "storekit.processed_tx_ids")
+        XCTAssertEqual(service.markProcessed(transactionID: 1), .degraded)
+        XCTAssertEqual(service.markProcessed(transactionID: 2), .degraded)
+        XCTAssertNil(defaults.array(forKey: "storekit.processed_tx_ids") as? [String])
+    }
+
+    // MARK: - #209.2: credit-amount unknown-product logging
+
+    func testCreditAmount_knownProduct_returnsCatalogueAmount() {
+        XCTAssertEqual(
+            StoreKitService.creditAmount(for: "com.snooze_pay.balance.299", fallbackPrice: 999),
+            299,
+            "known SKU must credit the catalogue amount, ignoring any fallback price"
+        )
+    }
+
+    func testCreditAmount_unknownProductNoFallback_returnsZero() {
+        // No free/promo products exist (#209) — a zero here means misconfiguration.
+        // The caller's `amount > 0` gate then refuses to finish. (Logging side
+        // effect is asserted indirectly: the path is exercised.)
+        XCTAssertEqual(
+            StoreKitService.creditAmount(for: "com.snooze_pay.balance.unknown", fallbackPrice: nil),
+            0
+        )
+    }
+
+    func testCreditAmount_unknownProductWithFallback_usesFallback() {
+        XCTAssertEqual(
+            StoreKitService.creditAmount(for: "com.snooze_pay.balance.unknown", fallbackPrice: 199),
+            199,
+            "an unmapped SKU with a resolved StoreKit price still credits that price"
+        )
     }
 }


### PR DESCRIPTION
Fixes #45
Fixes #209

## Что сделано

### #45 — Deferred-purchase feedback via local notification (option B)
- `StoreKitService` now tracks whether a UI screen is mounted to receive purchase-feedback notifications via `beginObservingPurchaseFeedback()` / `endObservingPurchaseFeedback()` (a clamped subscriber counter).
- When `postPurchaseCompleted` / `postPurchaseFailed` fire with **no screen mounted**, they post an immediate `UNUserNotificationCenter` local notification instead of broadcasting into the void — so deferred Ask-to-Buy approvals, refunds, restores and verification failures are never silently lost. Russian copy («Баланс пополнен на N ₽.» / the failure message).
- When a screen **is** mounted the existing NotificationCenter broadcast path is kept — no double-notify.
- `DepositBottomSheetViewController` and `FiringTopUpBottomSheetViewController` register/unregister around `viewWillAppear` / `viewWillDisappear`.
- Reuses the notification authorization the alarm flow already holds — no new permission flow, no Info.plist / entitlement changes.

### #209.1 — Conservative dedup-corruption handling
- `markProcessed` no longer collapses a type-drifted dedup blob to `[]` (the old `?? []` re-enabled double-crediting). It now returns a `MarkResult` enum (`.recorded` / `.alreadyProcessed` / `.degraded`); on a corrupt blob it backs the blob up to `stored_processed_backup_corrupt` (once, mirroring `TransactionRepository`), logs, and returns `.degraded`. Callers refuse to credit AND do not `finish()` — never a double-credit, never a wipe.

### #209.2 — Credit-amount unknown-product logging
- `creditAmount` keeps its return type (no free/promo products planned) but now logs loudly when an unknown product resolves to a zero/no-usable-price amount, so a future missing-`productAmounts` misconfig isn't silent.

## Notes
- Pure code change in `StoreKitService.swift` + two VCs. No App Store Connect / IAP price / entitlement / Info.plist changes (those remain no-touch).
- Added a `LocalNotificationPosting` seam + a test-only injecting initializer (notification spy + isolated `UserDefaults` suite) so the money-correctness paths are unit-tested without driving real StoreKit / the process-wide notification center.

## Testing
- ✅ swiftlint: 0 errors (8 warnings — pre-existing line-length/TODO, none introduced as errors)
- ✅ build_sim: succeeded (simulator: iPhone 17 Pro Max), confirmed real recompile after touching source
- ✅ `xcodebuild build-for-testing`: TEST BUILD SUCCEEDED (new tests compile)
- ⏸️ test_sim not run (disabled in this environment) — new XCTest cases added in `StoreKitServiceTests.swift`:
  - deferred-purchase fallback posts a local notification when no subscriber; suppressed when a screen is mounted; failure message carried through; subscriber counter balances + clamps at zero
  - dedup: fresh-table record + replay dedup; corrupt-blob refuses (`.degraded`) without wiping + backs up; repeated corrupt calls stay degraded
  - creditAmount: known SKU, unknown+no-fallback returns 0, unknown+fallback uses fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)
