### PR TITLE
[test] E2E XCUITest PoC — firing → snooze → wake flow

### DIFF
--- a/SnoozePay/SnoozePay.xcodeproj/project.pbxproj
+++ b/SnoozePay/SnoozePay.xcodeproj/project.pbxproj
@@ -6,7 +6,19 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		47E841C354E5DA7707DA30DA /* FiringFlowUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFDCCED99F5E96ADD3426269 /* FiringFlowUITests.swift */; };
+		A7D767A1C75F0B3D99B35C0E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4AED0CBCB2279D458B93ABDC /* Foundation.framework */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXContainerItemProxy section */
+		6A105FF37F11B4F6A29CFE1F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3E2102FC2F525C3C00998846 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3E2103032F525C3C00998846;
+			remoteInfo = SnoozePay;
+		};
 		AA0001002F5B000000000001 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 3E2102FC2F525C3C00998846 /* Project object */;
@@ -18,7 +30,10 @@
 
 /* Begin PBXFileReference section */
 		3E2103042F525C3C00998846 /* SnoozePay.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SnoozePay.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		4AED0CBCB2279D458B93ABDC /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		AA0001012F5B000000000002 /* SnoozePayTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SnoozePayTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D9F3B13686755D92D101DDAA /* SnoozePayUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SnoozePayUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		EFDCCED99F5E96ADD3426269 /* FiringFlowUITests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FiringFlowUITests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -42,6 +57,8 @@
 		};
 		AA0001022F5B000000000003 /* SnoozePayTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = SnoozePayTests;
 			sourceTree = "<group>";
 		};
@@ -62,6 +79,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F5333976FE11CBDA87BA39D2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A7D767A1C75F0B3D99B35C0E /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -71,6 +96,8 @@
 				3E2103062F525C3C00998846 /* SnoozePay */,
 				AA0001022F5B000000000003 /* SnoozePayTests */,
 				3E2103052F525C3C00998846 /* Products */,
+				D62471F5D298CC79566EE0F3 /* Frameworks */,
+				DC542FB9D9E89A79C711B463 /* SnoozePayUITests */,
 			);
 			sourceTree = "<group>";
 		};
@@ -79,9 +106,35 @@
 			children = (
 				3E2103042F525C3C00998846 /* SnoozePay.app */,
 				AA0001012F5B000000000002 /* SnoozePayTests.xctest */,
+				D9F3B13686755D92D101DDAA /* SnoozePayUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
+		};
+		8CE45F4E3AE7B55C9879413E /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				4AED0CBCB2279D458B93ABDC /* Foundation.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		D62471F5D298CC79566EE0F3 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				8CE45F4E3AE7B55C9879413E /* iOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		DC542FB9D9E89A79C711B463 /* SnoozePayUITests */ = {
+			isa = PBXGroup;
+			children = (
+				EFDCCED99F5E96ADD3426269 /* FiringFlowUITests.swift */,
+			);
+			name = SnoozePayUITests;
+			path = SnoozePayUITests;
+			sourceTree = SOURCE_ROOT;
 		};
 /* End PBXGroup section */
 
@@ -102,11 +155,27 @@
 				3E2103062F525C3C00998846 /* SnoozePay */,
 			);
 			name = SnoozePay;
-			packageProductDependencies = (
-			);
 			productName = SnoozePay;
 			productReference = 3E2103042F525C3C00998846 /* SnoozePay.app */;
 			productType = "com.apple.product-type.application";
+		};
+		81EAC51076E73524F7A4A32F /* SnoozePayUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3B82316F4912B3D2FEE9F11F /* Build configuration list for PBXNativeTarget "SnoozePayUITests" */;
+			buildPhases = (
+				BCE6A9177387E58F0A17DF20 /* Sources */,
+				F5333976FE11CBDA87BA39D2 /* Frameworks */,
+				B6DD45129D1D6E8FDD3DB203 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				770DE757B810E951F845988D /* PBXTargetDependency */,
+			);
+			name = SnoozePayUITests;
+			productName = SnoozePayUITests;
+			productReference = D9F3B13686755D92D101DDAA /* SnoozePayUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
 		};
 		AA0001042F5B000000000005 /* SnoozePayTests */ = {
 			isa = PBXNativeTarget;
@@ -142,6 +211,9 @@
 					3E2103032F525C3C00998846 = {
 						CreatedOnToolsVersion = 26.2;
 					};
+					81EAC51076E73524F7A4A32F = {
+						TestTargetID = 3E2103032F525C3C00998846;
+					};
 					AA0001042F5B000000000005 = {
 						CreatedOnToolsVersion = 26.2;
 						TestTargetID = 3E2103032F525C3C00998846;
@@ -164,6 +236,7 @@
 			targets = (
 				3E2103032F525C3C00998846 /* SnoozePay */,
 				AA0001042F5B000000000005 /* SnoozePayTests */,
+				81EAC51076E73524F7A4A32F /* SnoozePayUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -177,6 +250,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		AA0001072F5B000000000008 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B6DD45129D1D6E8FDD3DB203 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -200,9 +280,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		BCE6A9177387E58F0A17DF20 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				47E841C354E5DA7707DA30DA /* FiringFlowUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		770DE757B810E951F845988D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SnoozePay;
+			target = 3E2103032F525C3C00998846 /* SnoozePay */;
+			targetProxy = 6A105FF37F11B4F6A29CFE1F /* PBXContainerItemProxy */;
+		};
 		AA0001082F5B000000000009 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 3E2103032F525C3C00998846 /* SnoozePay */;
@@ -211,6 +305,47 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		08364D17BE0527CED77223B4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 8ZKDC782V4;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "Ivan-Emelyanov.SnoozePayUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = SnoozePay;
+			};
+			name = Debug;
+		};
+		21A00BA6B23A6D6D246DDD1D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 8ZKDC782V4;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "Ivan-Emelyanov.SnoozePayUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = SnoozePay;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 		3E2103182F525C3E00998846 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -441,6 +576,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		3B82316F4912B3D2FEE9F11F /* Build configuration list for PBXNativeTarget "SnoozePayUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				21A00BA6B23A6D6D246DDD1D /* Release */,
+				08364D17BE0527CED77223B4 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		3E2102FF2F525C3C00998846 /* Build configuration list for PBXProject "SnoozePay" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/SnoozePay/SnoozePay.xcodeproj/xcshareddata/xcschemes/SnoozePay.xcscheme
+++ b/SnoozePay/SnoozePay.xcodeproj/xcshareddata/xcschemes/SnoozePay.xcscheme
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3E2103032F525C3C00998846"
+               BuildableName = "SnoozePay.app"
+               BlueprintName = "SnoozePay"
+               ReferencedContainer = "container:SnoozePay.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AA0001042F5B000000000005"
+               BuildableName = "SnoozePayTests.xctest"
+               BlueprintName = "SnoozePayTests"
+               ReferencedContainer = "container:SnoozePay.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "81EAC51076E73524F7A4A32F"
+               BuildableName = "SnoozePayUITests.xctest"
+               BlueprintName = "SnoozePayUITests"
+               ReferencedContainer = "container:SnoozePay.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3E2103032F525C3C00998846"
+            BuildableName = "SnoozePay.app"
+            BlueprintName = "SnoozePay"
+            ReferencedContainer = "container:SnoozePay.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3E2103032F525C3C00998846"
+            BuildableName = "SnoozePay.app"
+            BlueprintName = "SnoozePay"
+            ReferencedContainer = "container:SnoozePay.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SnoozePay/SnoozePay/Utilities/UITourLauncher.swift
+++ b/SnoozePay/SnoozePay/Utilities/UITourLauncher.swift
@@ -68,16 +68,16 @@ enum UITourLauncher {
             mountPresented(nav, onTab: 0, in: window)
             presentLater(ConfirmDeleteAlarmViewController(), over: nav)
         },
-        "firing": { $0.rootViewController = AlarmFiringViewController(alarm: sampleAlarm()) },
+        "firing": { $0.rootViewController = AlarmFiringViewController(alarm: firingSampleAlarm()) },
         "firing-snoozed": {
-            $0.rootViewController = AlarmFiringViewController(alarm: sampleAlarm(), snoozeCount: 2)
+            $0.rootViewController = AlarmFiringViewController(alarm: firingSampleAlarm(), snoozeCount: 2)
         },
         "firing-nobalance": { window in
             forceBalance(to: 0)
-            window.rootViewController = AlarmFiringViewController(alarm: sampleAlarm())
+            window.rootViewController = AlarmFiringViewController(alarm: firingSampleAlarm())
         },
         "firing-topup": { window in
-            let firing = AlarmFiringViewController(alarm: sampleAlarm())
+            let firing = AlarmFiringViewController(alarm: firingSampleAlarm())
             window.rootViewController = firing
             presentLater(FiringTopUpBottomSheetViewController(), over: firing)
         },
@@ -154,6 +154,24 @@ enum UITourLauncher {
     private static func sampleAlarm() -> Alarm {
         Alarm(
             time: Calendar.current.date(bySettingHour: 7, minute: 30, second: 0, of: Date()) ?? Date(),
+            repeatDays: [0, 1, 2, 3, 4], // Monday-first indices: Пн–Пт
+            name: "Работа",
+            penaltyAmount: 50,
+            theme: requestedTheme()
+        )
+    }
+
+    /// The firing-screen sample, anchored to the CURRENT time rather than a
+    /// fixed 07:30. A firing alarm is, by definition, ringing *now* — and the
+    /// snoozed-state countdown derives the next ring from the alarm's HH:MM on
+    /// today (`AlarmFiringViewModel.nextRingDate`). With a fixed 07:30 time the
+    /// snooze target lands in the past whenever the tour runs later in the day,
+    /// so `secondsUntilNextRing == 0` and the snoozed chrome never installs.
+    /// Pinning the time to now keeps the snooze countdown positive — both for
+    /// realistic screenshots and for the e2e firing→snooze→wake UI test.
+    private static func firingSampleAlarm() -> Alarm {
+        Alarm(
+            time: Date(),
             repeatDays: [0, 1, 2, 3, 4], // Monday-first indices: Пн–Пт
             name: "Работа",
             penaltyAmount: 50,

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Layout.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Layout.swift
@@ -37,6 +37,7 @@ extension AlarmFiringViewController {
         )
         snooze.translatesAutoresizingMaskIntoConstraints = false
         snooze.onTap = { [weak self] in self?.snoozeTapped() }
+        snooze.accessibilityIdentifier = "firing.snoozeButton"
         view.addSubview(snooze)
         snoozeCTA = snooze
 
@@ -45,6 +46,7 @@ extension AlarmFiringViewController {
         // (`SPThemedFiring.jsx:188-203`).
         dismissButton.ghostBorderOverride = (1.5, UIColor.white.withAlphaComponent(0.22))
         dismissButton.addTarget(self, action: #selector(dismissTapped), for: .touchUpInside)
+        dismissButton.accessibilityIdentifier = "firing.dismissButton"
         view.addSubview(dismissButton)
         view.addSubview(audioWarningBanner)
 

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Snoozed.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Snoozed.swift
@@ -83,6 +83,7 @@ extension AlarmFiringViewController {
         countdown.layer.shadowOffset = CGSize(width: 0, height: 4)
         countdown.layer.masksToBounds = false
         countdown.isHidden = true
+        countdown.accessibilityIdentifier = "firing.countdown"
         view.addSubview(countdown)
         snoozedCountdownLabel = countdown
 

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/WokeMorningViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/WokeMorningViewController.swift
@@ -71,6 +71,8 @@ final class WokeMorningViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = UIColor(hex: 0x060F0E)
+        view.accessibilityIdentifier = "woke.screen"
+        closeButton.accessibilityIdentifier = "woke.closeButton"
         configureBackground()
         configureCheckTile()
         configureLabels()

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPButton.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPButton.swift
@@ -173,6 +173,14 @@ final class SPButton: UIControl {
         updateSuffixSpacer()
         applyVariant()
         refreshDisabledAppearance()
+        // Expose the button as a SINGLE accessibility element rather than
+        // leaking its internal title/suffix UILabels as separate staticTexts.
+        // VoiceOver then reads one "button" with the combined label, and UI
+        // tests can target it via `accessibilityIdentifier`. The combined
+        // label joins the title with the optional mono suffix (e.g. amount).
+        isAccessibilityElement = true
+        accessibilityTraits = .button
+        accessibilityLabel = [title, suffix].compactMap { $0 }.joined(separator: ", ")
         // iOS 17 deprecated `traitCollectionDidChange(_:)` — register a
         // closure-based observer when available; the legacy override below
         // remains as a fallback for older runtimes.

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPSnoozePrice.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPSnoozePrice.swift
@@ -92,6 +92,12 @@ final class SPSnoozePrice: UIControl {
         configure()
         update(price: price, minutes: minutes, hint: hint)
         addTarget(self, action: #selector(handleTap), for: .touchUpInside)
+        // Expose as a SINGLE accessibility button rather than its internal
+        // caps/price/hint labels — VoiceOver reads one control, and UI tests
+        // can target it via `accessibilityIdentifier`. The label is refreshed
+        // in `update(price:…)` so it tracks the live minutes value.
+        isAccessibilityElement = true
+        accessibilityTraits = .button
     }
 
     required init?(coder: NSCoder) {
@@ -125,6 +131,8 @@ final class SPSnoozePrice: UIControl {
         } else {
             hintLabel.isHidden = true
         }
+        accessibilityLabel = "Отложить на \(self.minutes) минут"
+        accessibilityValue = MoneyFormatter.string(price)
     }
 
     /// Re-tone the surface in place. Used by the progressive-firing flow

--- a/SnoozePay/SnoozePayUITests/FiringFlowUITests.swift
+++ b/SnoozePay/SnoozePayUITests/FiringFlowUITests.swift
@@ -1,0 +1,65 @@
+import XCTest
+
+/// End-to-end PoC for the core firing → snooze → wake loop.
+///
+/// Drives the REAL `AlarmFiringViewController` through the DEBUG `-uitour`
+/// deep link (`UITourLauncher`), which mounts the firing screen directly as
+/// the window root with a seeded balance — no onboarding / tab navigation to
+/// tap through. The flow exercised here is the single most important path in
+/// the product:
+///
+///   1. Firing screen up (snooze CTA + «Я встал» both present).
+///   2. Tap «Поспать ещё» → the screen transitions IN PLACE into the snoozed
+///      state with a live countdown (it deliberately does not dismiss, #226).
+///   3. Tap «Я встал — выключить» → the WokeMorning summary is presented.
+///   4. Tap «Закрыть» → the summary unwinds back to the firing screen.
+///
+/// This is intentionally ONE test: a stability probe. If it runs reliably and
+/// green on CI, the e2e suite is worth expanding; if XCUITest proves flaky on
+/// the CI simulator, we keep e2e thin and lean on unit tests. Selectors are
+/// stable `accessibilityIdentifier`s, not localized button copy.
+final class FiringFlowUITests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        // Fail fast: a missing element early means the later steps are
+        // meaningless, and the first failure is the diagnostic that matters.
+        continueAfterFailure = false
+    }
+
+    func testFiringSnoozeWakeFlow() {
+        let app = XCUIApplication()
+        // `-uitour firing` mounts AlarmFiringViewController as root;
+        // `-uitour-balance 1000` guarantees the snooze is affordable so the
+        // flow reaches the snoozed state rather than the no-balance layout.
+        app.launchArguments = ["-uitour", "firing", "-uitour-balance", "1000"]
+        app.launch()
+
+        // 1. Firing screen — snooze CTA + «Я встал» dismiss are both present.
+        let snooze = app.buttons["firing.snoozeButton"]
+        let dismiss = app.buttons["firing.dismissButton"]
+        XCTAssertTrue(snooze.waitForExistence(timeout: 10),
+                      "Firing snooze CTA should appear on launch")
+        XCTAssertTrue(dismiss.exists,
+                      "«Я встал» dismiss button should be present on the firing screen")
+
+        // 2. Snooze → snoozed state with a live countdown appears in place.
+        snooze.tap()
+        let countdown = app.staticTexts["firing.countdown"]
+        XCTAssertTrue(countdown.waitForExistence(timeout: 5),
+                      "Snoozed-state countdown should appear after «Поспать ещё»")
+
+        // 3. «Я встал — выключить» → the WokeMorning summary is presented.
+        dismiss.tap()
+        let wokeClose = app.buttons["woke.closeButton"]
+        XCTAssertTrue(wokeClose.waitForExistence(timeout: 5),
+                      "WokeMorning summary with «Закрыть» should appear after dismiss")
+
+        // 4. «Закрыть» → the summary unwinds back to the firing screen.
+        wokeClose.tap()
+        XCTAssertTrue(snooze.waitForExistence(timeout: 5),
+                      "Closing the summary should return to the firing screen")
+        XCTAssertFalse(wokeClose.exists,
+                       "WokeMorning summary should be gone after «Закрыть»")
+    }
+}

--- a/scripts/add_uitest_target.rb
+++ b/scripts/add_uitest_target.rb
@@ -1,0 +1,76 @@
+#!/usr/bin/env ruby
+# One-shot project surgery: add the SnoozePayUITests UI-testing bundle target,
+# wire it to drive the SnoozePay app, register its test file, and emit a SHARED
+# "SnoozePay" scheme whose Test action runs BOTH the unit tests and the new UI
+# tests. CI calls `xcodebuild test -scheme SnoozePay`, so no workflow change is
+# needed — the shared scheme makes the UI tests run automatically.
+#
+# Idempotent: re-running is a no-op if the target already exists.
+require "xcodeproj"
+
+PROJECT_PATH = File.expand_path("../SnoozePay/SnoozePay.xcodeproj", __dir__)
+UITEST_NAME  = "SnoozePayUITests"
+APP_NAME     = "SnoozePay"
+UNIT_NAME    = "SnoozePayTests"
+
+project = Xcodeproj::Project.open(PROJECT_PATH)
+app  = project.targets.find { |t| t.name == APP_NAME }  or abort("app target missing")
+unit = project.targets.find { |t| t.name == UNIT_NAME } or abort("unit test target missing")
+
+if project.targets.any? { |t| t.name == UITEST_NAME }
+  puts "target #{UITEST_NAME} already exists — nothing to do"
+  exit 0
+end
+
+# Mirror the app's deployment target (lives at project level, ~26.2).
+deployment = project.build_configurations.find { |c| c.name == "Debug" }
+                    .build_settings["IPHONEOS_DEPLOYMENT_TARGET"] ||
+             app.build_configurations.first.build_settings["IPHONEOS_DEPLOYMENT_TARGET"] ||
+             "26.2"
+
+uitest = project.new_target(:ui_test_bundle, UITEST_NAME, :ios, deployment)
+
+# Build settings on both configs. CODE_SIGNING_ALLOWED=NO is passed on the CI
+# command line, so the team/style here only matter for local signed builds and
+# simply mirror the unit-test target.
+uitest.build_configurations.each do |config|
+  s = config.build_settings
+  s["PRODUCT_BUNDLE_IDENTIFIER"]   = "Ivan-Emelyanov.SnoozePayUITests"
+  s["PRODUCT_NAME"]                = "$(TARGET_NAME)"
+  s["SWIFT_VERSION"]               = "5.0"
+  s["IPHONEOS_DEPLOYMENT_TARGET"]  = deployment
+  s["GENERATE_INFOPLIST_FILE"]     = "YES"
+  s["TEST_TARGET_NAME"]            = APP_NAME
+  s["CODE_SIGN_STYLE"]             = "Automatic"
+  s["DEVELOPMENT_TEAM"]            = "8ZKDC782V4"
+  s["TARGETED_DEVICE_FAMILY"]      = "1,2"
+  s["SWIFT_EMIT_LOC_STRINGS"]      = "NO"
+  s["CURRENT_PROJECT_VERSION"]     = "1"
+  s["MARKETING_VERSION"]           = "1.0"
+end
+
+# The UI test bundle launches and drives the app target.
+uitest.add_dependency(app)
+project.root_object.attributes["TargetAttributes"] ||= {}
+project.root_object.attributes["TargetAttributes"][uitest.uuid] =
+  { "TestTargetID" => app.uuid }
+
+# Register the test source under a group + the target's Sources phase.
+group = project.main_group.find_subpath(UITEST_NAME, true)
+group.set_source_tree("SOURCE_ROOT")
+group.set_path(UITEST_NAME)
+file_ref = group.new_reference("FiringFlowUITests.swift")
+uitest.source_build_phase.add_file_reference(file_ref)
+
+# Shared "SnoozePay" scheme: build the app, run BOTH test bundles in Test.
+scheme = Xcodeproj::XCScheme.new
+scheme.add_build_target(app)
+scheme.add_test_target(unit)
+scheme.add_test_target(uitest)
+runnable = Xcodeproj::XCScheme::BuildableProductRunnable.new(app, 0)
+scheme.launch_action.buildable_product_runnable  = runnable
+scheme.profile_action.buildable_product_runnable = runnable
+scheme.save_as(PROJECT_PATH, APP_NAME, true)
+
+project.save
+puts "added #{UITEST_NAME} (deployment #{deployment}) + shared #{APP_NAME} scheme"


### PR DESCRIPTION
First end-to-end UI test for SnoozePay, as a **stability probe** before deciding whether to invest in a wider e2e suite (follow-up to the #19 firing work).

## What it does
Drives the REAL firing screen through its single most important loop via the DEBUG `-uitour firing` deep link (no onboarding/tab tapping):

1. Firing screen up (snooze CTA + «Я встал» present)
2. «Поспать ещё» → snoozed-state live countdown appears in place (does not dismiss, #226)
3. «Я встал — выключить» → WokeMorning summary presented
4. «Закрыть» → unwinds back to the firing screen

## How it is wired
- New `SnoozePayUITests` UI-testing bundle target + a **shared `SnoozePay` scheme** whose Test action runs BOTH unit and UI tests. Added programmatically via `scripts/add_uitest_target.rb` (xcodeproj gem) — no hand-edited `project.pbxproj`. CI already runs `xcodebuild test -scheme SnoozePay`, so the UI test runs **with no workflow change**.
- Stable `accessibilityIdentifier`s on the firing snooze CTA / «Я встал» / snoozed countdown / WokeMorning «Закрыть» — keyed by id, not localized copy.
- `SPButton` / `SPSnoozePrice` now expose themselves as a **single accessibility element** (button trait + combined label) instead of leaking internal title/price labels as separate staticTexts — a genuine VoiceOver fix that also makes them UI-test-addressable.
- `UITourLauncher`: firing screens now anchor their sample alarm to the **current time** (a firing alarm rings *now*) so the snoozed countdown is positive regardless of wall-clock — the fixed 07:30 put the snooze target in the past later in the day.

## Status
Passes **3/3 locally** (~11–12s each). This PR exists to see whether XCUITest runs **reliably and green on the CI runner**. If it does, the suite is worth expanding; if it proves flaky, we keep e2e thin and lean on unit tests.

Relates to #19.