### PR TITLE
[fix] Firing no-balance: stop center copy overlapping the disabled snooze card (#345)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+NoBalance.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+NoBalance.swift
@@ -77,6 +77,15 @@ extension AlarmFiringViewController {
                 constant: -AppSpacing.sp7   // 32pt bottom inset per V2 spec
             )
         ])
+
+        // Keep the center "Баланса не осталось" block from colliding with the
+        // disabled price card at the top of this stack (#345). Required, so it
+        // wins over the block's breakable hero pin when the column is tight.
+        if let centerBlock = noBalanceCenterBlock {
+            centerBlock.bottomAnchor.constraint(
+                lessThanOrEqualTo: stack.topAnchor, constant: -AppSpacing.sp4
+            ).isActive = true
+        }
     }
 
     /// Build the center "БАЛАНСА НЕ ОСТАЛОСЬ" pill + body text. Pinned below
@@ -109,11 +118,23 @@ extension AlarmFiringViewController {
         view.addSubview(block)
         noBalanceCenterBlock = block
 
+        // Tuck under the eyebrow caps — V3 moved the name label above the
+        // clock (#225), so the eyebrow is now the hero's bottom edge. This pin
+        // is breakable (.defaultHigh) so the required "stay above the bottom
+        // stack" constraint in `installNoBalanceStack` can win on a tight
+        // column: the no-balance bottom stack is taller than the normal one
+        // (disabled card + Apple Pay + dismiss + choose-amount, vs snooze +
+        // dismiss), and without that safety net the body text overlaps the
+        // disabled price card (#345). On the regular screen height there's
+        // ample room, so this pin holds and the block stays tucked.
+        let heroPin = block.topAnchor.constraint(
+            equalTo: wakeUpCapsLabel.bottomAnchor, constant: AppSpacing.sp6
+        )
+        heroPin.priority = .defaultHigh
+
         NSLayoutConstraint.activate([
             block.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            // Below the eyebrow caps — V3 moved the name label above the
-            // clock (#225), so the eyebrow is now the hero's bottom edge.
-            block.topAnchor.constraint(equalTo: wakeUpCapsLabel.bottomAnchor, constant: AppSpacing.sp6),
+            heroPin,
             block.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: inset),
             block.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor, constant: -inset)
         ])


### PR DESCRIPTION
## Problem

On the firing screen with no balance (`-uitour firing-nobalance`), the center copy block («Баланса не осталось» pill + «Откладывать больше не получится. Только встать.») overlapped the disabled price card («−50 ₽ / Недостаточно средств»), making both unreadable.

Root cause: the center block was pinned only to the hero (top), while the bottom stack was pinned to the bottom — and the no-balance bottom stack (disabled card + Apple Pay + dismiss + choose-amount) is taller than the normal snooze+dismiss pair, so nothing kept them apart.

## Fix

Make the center block's hero pin breakable (`.defaultHigh`) and add a required constraint keeping its bottom above the bottom stack. On normal screen height the pin holds (block tucked under the eyebrow); when tight, the no-overlap constraint wins.

## Verification

Rebuilt and re-captured `-uitour firing-nobalance` on iPhone 17 Pro Max (dark): the disabled card now renders «−50 ₽ / Недостаточно средств» cleanly with the body copy separated above it. Found via `/audit design` (#339).

Fixes #345