### PR TITLE
[test] Expand e2e XCUITest — no-balance top-up + create-alarm flows (#340)

### DIFF
--- a/SnoozePay/SnoozePay.xcodeproj/project.pbxproj
+++ b/SnoozePay/SnoozePay.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		47E841C354E5DA7707DA30DA /* FiringFlowUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFDCCED99F5E96ADD3426269 /* FiringFlowUITests.swift */; };
 		A7D767A1C75F0B3D99B35C0E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4AED0CBCB2279D458B93ABDC /* Foundation.framework */; };
 /* End PBXBuildFile section */
 
@@ -33,7 +32,6 @@
 		4AED0CBCB2279D458B93ABDC /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		AA0001012F5B000000000002 /* SnoozePayTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SnoozePayTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D9F3B13686755D92D101DDAA /* SnoozePayUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SnoozePayUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		EFDCCED99F5E96ADD3426269 /* FiringFlowUITests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FiringFlowUITests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -60,6 +58,13 @@
 			exceptions = (
 			);
 			path = SnoozePayTests;
+			sourceTree = "<group>";
+		};
+		DC542FB9D9E89A79C711B463 /* SnoozePayUITests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			path = SnoozePayUITests;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -127,15 +132,6 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		DC542FB9D9E89A79C711B463 /* SnoozePayUITests */ = {
-			isa = PBXGroup;
-			children = (
-				EFDCCED99F5E96ADD3426269 /* FiringFlowUITests.swift */,
-			);
-			name = SnoozePayUITests;
-			path = SnoozePayUITests;
-			sourceTree = SOURCE_ROOT;
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -171,6 +167,9 @@
 			);
 			dependencies = (
 				770DE757B810E951F845988D /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				DC542FB9D9E89A79C711B463 /* SnoozePayUITests */,
 			);
 			name = SnoozePayUITests;
 			productName = SnoozePayUITests;
@@ -284,7 +283,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				47E841C354E5DA7707DA30DA /* FiringFlowUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+NoBalance.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+NoBalance.swift
@@ -174,6 +174,8 @@ extension AlarmFiringViewController {
             fullWidth: true
         )
         button.translatesAutoresizingMaskIntoConstraints = false
+        // Stable selector for the no-balance top-up e2e UI test (#340).
+        button.accessibilityIdentifier = "firing.noBalance.topUp"
         button.addTarget(
             self,
             action: #selector(noBalanceApplePayTapped),

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/NameCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/NameCell.swift
@@ -28,6 +28,9 @@ final class NameCell: UITableViewCell {
         )
         field.returnKeyType = .done
         field.clearButtonMode = .whileEditing
+        // Stable selector for the create-alarm e2e UI test (#340) — targets
+        // the field by id, not the localized «Название» placeholder.
+        field.accessibilityIdentifier = "create.nameField"
         return field
     }()
 

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
@@ -137,6 +137,8 @@ final class CreateAlarmViewController: UIViewController {
             variant: .money,
             size: .sm
         )
+        // Stable selector for the create-alarm e2e UI test (#340).
+        saveButton.accessibilityIdentifier = "create.saveButton"
         saveButton.addTarget(self, action: #selector(saveTapped), for: .touchUpInside)
         navigationItem.rightBarButtonItem = UIBarButtonItem(customView: saveButton)
 

--- a/SnoozePay/SnoozePayUITests/CreateAlarmUITests.swift
+++ b/SnoozePay/SnoozePayUITests/CreateAlarmUITests.swift
@@ -1,0 +1,54 @@
+import XCTest
+
+/// E2e for creating an alarm and seeing it land in the list.
+///
+/// `-uitour create` presents `CreateAlarmViewController` over the alarms tab.
+/// The test types a unique name, taps «Готово», and asserts the modal unwinds
+/// and the new alarm shows up in the list (the list reloads on
+/// `viewWillAppear`). The default time/penalty are left untouched — the wheel
+/// picker is deliberately not driven, since this flow only needs to prove the
+/// create → persist → list-refresh loop end to end.
+///
+/// Selectors are stable `accessibilityIdentifier`s; the new row is matched by
+/// the (uppercased, case-insensitively compared) name we typed.
+final class CreateAlarmUITests: XCTestCase {
+
+    /// A token unlikely to collide with the seeded alarms (Работа / Спортзал /
+    /// Рейс в Стамбул). ASCII keeps simulator keyboard entry reliable.
+    private let alarmName = "ZZ UITEST"
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    func testCreateAlarmAppearsInList() {
+        let app = XCUIApplication()
+        app.launchArguments = ["-uitour", "create", "-uitour-seed"]
+        app.launch()
+
+        // 1. Create form presents — the name field is up.
+        let nameField = app.textFields["create.nameField"]
+        XCTAssertTrue(nameField.waitForExistence(timeout: 10),
+                      "Create form should present with the name field")
+
+        // 2. Name the alarm.
+        nameField.tap()
+        nameField.typeText(alarmName)
+
+        // 3. Save.
+        let save = app.buttons["create.saveButton"]
+        XCTAssertTrue(save.exists, "«Готово» save button should be present")
+        save.tap()
+
+        // 4. The form dismisses and the new alarm shows up in the list. The
+        //    eyebrow is uppercased, so compare case-insensitively.
+        XCTAssertTrue(nameField.waitForNonExistence(timeout: 10),
+                      "Create form should dismiss after saving")
+        let created = app.descendants(matching: .any)
+            .matching(NSPredicate(format: "label CONTAINS[c] %@", alarmName))
+            .firstMatch
+        XCTAssertTrue(created.waitForExistence(timeout: 10),
+                      "The newly created alarm should appear in the list")
+    }
+}

--- a/SnoozePay/SnoozePayUITests/NoBalanceTopUpUITests.swift
+++ b/SnoozePay/SnoozePayUITests/NoBalanceTopUpUITests.swift
@@ -1,0 +1,42 @@
+import XCTest
+
+/// E2e for the no-balance → top-up recovery path on the firing screen.
+///
+/// `-uitour firing-nobalance` mounts `AlarmFiringViewController` with a forced
+/// zero balance, so the disabled snooze card + «Пополнить» CTA are up and the
+/// normal snooze CTA is suppressed. Tapping «Пополнить» credits the balance
+/// (StoreKit isn't configured in the UI-test host, so the VC's documented
+/// `BalanceService.topUp` fallback runs) and the `balanceChanged` observer
+/// flips the screen back to the affordable snooze CTA.
+///
+/// Selectors are stable `accessibilityIdentifier`s, not localized copy.
+final class NoBalanceTopUpUITests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    func testNoBalanceTopUpRestoresSnooze() {
+        let app = XCUIApplication()
+        app.launchArguments = ["-uitour", "firing-nobalance", "-uitour-seed"]
+        app.launch()
+
+        // 1. No-balance state: «Пополнить» CTA present, snooze CTA suppressed.
+        let topUp = app.buttons["firing.noBalance.topUp"]
+        let snooze = app.buttons["firing.snoozeButton"]
+        XCTAssertTrue(topUp.waitForExistence(timeout: 10),
+                      "No-balance «Пополнить» CTA should appear when balance is 0")
+        XCTAssertFalse(snooze.exists,
+                       "The normal snooze CTA must be hidden while balance is 0")
+
+        // 2. Top up → balance crosses the affordability threshold.
+        topUp.tap()
+
+        // 3. The balance-changed observer flips back to the snooze CTA.
+        XCTAssertTrue(snooze.waitForExistence(timeout: 10),
+                      "Snooze CTA should return once the top-up credits the balance")
+        XCTAssertFalse(topUp.exists,
+                       "No-balance «Пополнить» CTA should be gone after recovery")
+    }
+}

--- a/SnoozePay/SnoozePayUITests/OnboardingUITests.swift
+++ b/SnoozePay/SnoozePayUITests/OnboardingUITests.swift
@@ -1,0 +1,25 @@
+import XCTest
+
+/// E2e for the onboarding walk-through (concept → mechanics → deposit → main).
+///
+/// SKIPPED for now. The `-uitour onboarding` mount builds
+/// `OnboardingViewController()` without wiring its `onFinished` callback, so
+/// finishing the flow (Пропустить / Позже / Пополнить) does not navigate
+/// anywhere — there is no observable "reached the main screen" end state to
+/// assert. Driving the horizontal pager (the «Дальше» CTA swaps its own
+/// instance on the deposit page) is also animation-timing sensitive.
+///
+/// To enable: have `UITourLauncher` wire `onboarding`'s `onFinished` to mount
+/// the main tab bar (e.g. a `-uitour-onboarding-finishes-to-main` flag), and
+/// add stable ids to the primary CTA and a page-3 marker. Then assert tapping
+/// «Дальше» twice reaches the deposit page and finishing lands on the tab bar.
+final class OnboardingUITests: XCTestCase {
+
+    func testOnboardingReachesMain() throws {
+        throw XCTSkip("""
+            Needs harness support: the -uitour onboarding mount does not wire \
+            onFinished, so the flow has no observable terminal state. See the \
+            file header for the enablement steps (#340).
+            """)
+    }
+}

--- a/SnoozePay/SnoozePayUITests/ProgressiveSnoozeUITests.swift
+++ b/SnoozePay/SnoozePayUITests/ProgressiveSnoozeUITests.swift
@@ -1,0 +1,25 @@
+import XCTest
+
+/// E2e for the progressive-snooze price ladder (each snooze costs more, with a
+/// «N-й раз» indicator pill).
+///
+/// SKIPPED for now. `-uitour firing` mounts the standard (non-progressive)
+/// sample alarm, so there is no tour entry point that fires a `progressiveScale`
+/// alarm — the escalating price + indicator chrome never installs, leaving
+/// nothing to assert. The progressive indicator pill / price ticker also lack
+/// stable accessibility ids.
+///
+/// To enable: add a `-uitour firing-progressive` mount in `UITourLauncher`
+/// that fires an alarm with `progressiveScale: true` (mirror the seeded
+/// «Спортзал» alarm), add ids to the progressive indicator pill and the
+/// snooze price, then assert the price grows across consecutive snoozes.
+final class ProgressiveSnoozeUITests: XCTestCase {
+
+    func testProgressiveSnoozeLadderGrows() throws {
+        throw XCTSkip("""
+            Needs harness support: no -uitour mount fires a progressiveScale \
+            alarm, and the progressive chrome lacks stable ids. See the file \
+            header for the enablement steps (#340).
+            """)
+    }
+}


### PR DESCRIPTION
## ⚠️ Needs `pm-override` to merge

This PR edits `project.pbxproj` (converts the UITests group to a file-system-synchronized root group), so the `no-touch-guard` hook will block auto-merge. Per #340, it needs the **`pm-override`** label + a manual merge by the PM. I have NOT merged it.

## What

Expands the e2e XCUITest suite from the single firing PoC to cover two more product paths, with documented `XCTSkip` stubs for the two that need harness work first.

- **NoBalanceTopUpUITests** — `-uitour firing-nobalance` → tap «Пополнить» → balance recovers → snooze CTA returns (exercises the documented `BalanceService.topUp` fallback; StoreKit isn't configured in the UI-test host).
- **CreateAlarmUITests** — `-uitour create` → type a name → «Готово» → the new alarm appears in the list (which reloads on `viewWillAppear`).
- **OnboardingUITests / ProgressiveSnoozeUITests** — `XCTSkip` with the exact harness extension each needs (the `onboarding` tour mount doesn't wire `onFinished`; there's no `-uitour` mount that fires a `progressiveScale` alarm). File headers spell out the enablement steps.

## Prod changes

Stable `accessibilityIdentifier`s added to: the no-balance top-up button (`firing.noBalance.topUp`), the create name field (`create.nameField`), the create «Готово» button (`create.saveButton`).

## Project change

Converted the `SnoozePayUITests` group to a **file-system-synchronized root group** (matching the app + unit-test targets). UI-test files are now picked up by folder membership — **future UI tests need no `project.pbxproj` edit**, so this is the last UITests-file PR that should require a `pm-override`.

## Verification

`xcodebuild test -only-testing:SnoozePayUITests` on iPhone 17 Pro Max → **5 executed, 2 skipped, 0 failures**. SwiftLint clean.

Fixes #340