### PR TITLE
[fix] Reconcile orphaned custom-theme JPEGs on launch (#357)

### DIFF
--- a/SnoozePay/SnoozePay/AppDelegate.swift
+++ b/SnoozePay/SnoozePay/AppDelegate.swift
@@ -51,6 +51,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Handle notification responses
         UNUserNotificationCenter.current().delegate = self
 
+        // Reclaim orphaned custom-theme JPEGs (#357): re-picking a photo or
+        // deleting a `.custom`-themed alarm leaves its image on disk forever.
+        // Sweep off the main thread against the live alarm set — only files no
+        // current alarm references are removed.
+        DispatchQueue.global(qos: .utility).async {
+            let referenced = Set(AlarmRepository.shared.fetchAll().compactMap { alarm -> URL? in
+                if case .custom(let url) = alarm.theme { return url }
+                return nil
+            })
+            AlarmThemeImageStore.reconcileCaches(referencedURLs: referenced)
+        }
+
         return true
     }
 

--- a/SnoozePay/SnoozePay/Services/AlarmThemeImageStore.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmThemeImageStore.swift
@@ -61,4 +61,43 @@ enum AlarmThemeImageStore {
         guard let data = try? Data(contentsOf: url) else { return nil }
         return UIImage(data: data)
     }
+
+    /// Best-effort delete of a single persisted image. Silent on failure — a
+    /// missing or already-purged file is not an error for cleanup callers.
+    static func deleteImage(at url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    /// Sweep `directory`, deleting every `alarm-theme-*.jpg` not present in
+    /// `referencedURLs` (#357). Because `saveImage` writes a fresh UUID file on
+    /// every pick and nothing deletes the old one, re-picking a custom photo or
+    /// deleting a `.custom`-themed alarm orphans its JPEG forever. Reconciling
+    /// against the live alarm set on launch reclaims both orphan sources in one
+    /// safe place — at launch no in-flight create/edit form survives, so any
+    /// unreferenced file is genuinely dead (this avoids the "cancel the form
+    /// after re-picking" hazard of deleting eagerly on re-pick).
+    ///
+    /// Files are matched by `lastPathComponent` so a path that round-tripped
+    /// through `URL(string:)` (how `.custom` persists, see `AlarmTheme`) still
+    /// matches the file on disk regardless of `file://` vs raw-path spelling.
+    /// Exposed with an explicit `directory` so tests can drive a temp folder.
+    static func reconcile(in directory: URL, referencedURLs: Set<URL>) {
+        let manager = FileManager.default
+        guard let files = try? manager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil
+        ) else { return }
+        let keep = Set(referencedURLs.map { $0.lastPathComponent })
+        for file in files where !keep.contains(file.lastPathComponent) {
+            try? manager.removeItem(at: file)
+        }
+    }
+
+    /// Reconcile the real Caches theme directory against the currently
+    /// referenced custom images. No-op if the directory can't be resolved
+    /// (e.g. first launch before any photo was ever saved).
+    static func reconcileCaches(referencedURLs: Set<URL>) {
+        guard let directory = try? directoryURL() else { return }
+        reconcile(in: directory, referencedURLs: referencedURLs)
+    }
 }

--- a/SnoozePay/SnoozePayTests/AlarmThemeTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmThemeTests.swift
@@ -172,3 +172,91 @@ final class AlarmThemeTests: XCTestCase {
         )
     }
 }
+
+/// Coverage for the orphaned-image reconcile sweep (#357). Co-located in this
+/// file (rather than a new `AlarmThemeImageStoreTests.swift`) on purpose: the
+/// SnoozePayTests group is an explicit Xcode group, so a brand-new file would
+/// require a `project.pbxproj` edit — a no-touch zone gated behind PM override.
+/// These tests stay in the AlarmTheme domain file to keep the fix mergeable
+/// without touching the project file.
+final class AlarmThemeImageStoreReconcileTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AlarmThemeReconcileTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempDir { try? FileManager.default.removeItem(at: tempDir) }
+        try super.tearDownWithError()
+    }
+
+    /// Write an empty placeholder file and return its URL.
+    private func makeFile(_ name: String) throws -> URL {
+        let url = tempDir.appendingPathComponent(name)
+        try Data("x".utf8).write(to: url)
+        return url
+    }
+
+    private func exists(_ url: URL) -> Bool {
+        FileManager.default.fileExists(atPath: url.path)
+    }
+
+    func testReconcileDeletesUnreferencedFiles() throws {
+        let kept = try makeFile("alarm-theme-KEEP.jpg")
+        let orphanA = try makeFile("alarm-theme-ORPHAN-A.jpg")
+        let orphanB = try makeFile("alarm-theme-ORPHAN-B.jpg")
+
+        AlarmThemeImageStore.reconcile(in: tempDir, referencedURLs: [kept])
+
+        XCTAssertTrue(exists(kept), "Referenced image must survive the sweep")
+        XCTAssertFalse(exists(orphanA), "Orphaned image A should be deleted")
+        XCTAssertFalse(exists(orphanB), "Orphaned image B should be deleted")
+    }
+
+    func testReconcileKeepsAllWhenEveryFileIsReferenced() throws {
+        let first = try makeFile("alarm-theme-A.jpg")
+        let second = try makeFile("alarm-theme-B.jpg")
+
+        AlarmThemeImageStore.reconcile(in: tempDir, referencedURLs: [first, second])
+
+        XCTAssertTrue(exists(first))
+        XCTAssertTrue(exists(second))
+    }
+
+    func testReconcileDeletesAllWhenNothingReferenced() throws {
+        let first = try makeFile("alarm-theme-A.jpg")
+        let second = try makeFile("alarm-theme-B.jpg")
+
+        AlarmThemeImageStore.reconcile(in: tempDir, referencedURLs: [])
+
+        XCTAssertFalse(exists(first))
+        XCTAssertFalse(exists(second))
+    }
+
+    func testReconcileMatchesByFilenameAcrossURLSpelling() throws {
+        // `.custom` persists its path via `URL(string:)`, which can yield a
+        // `file://`-prefixed URL whose `.path` differs from the on-disk
+        // `URL(fileURLWithPath:)` spelling. Matching by lastPathComponent must
+        // still treat them as the same image and keep it.
+        let onDisk = try makeFile("alarm-theme-SAME.jpg")
+        let referenced = URL(string: "file://\(tempDir.path)/alarm-theme-SAME.jpg")!
+
+        AlarmThemeImageStore.reconcile(in: tempDir, referencedURLs: [referenced])
+
+        XCTAssertTrue(exists(onDisk),
+                      "A file referenced under a different URL spelling must not be deleted")
+    }
+
+    func testDeleteImageRemovesFileAndIsSilentWhenMissing() throws {
+        let url = try makeFile("alarm-theme-DELETE.jpg")
+        AlarmThemeImageStore.deleteImage(at: url)
+        XCTAssertFalse(exists(url), "deleteImage should remove the file")
+        // Second call on an already-gone file must not throw/crash.
+        AlarmThemeImageStore.deleteImage(at: url)
+    }
+}


### PR DESCRIPTION
Fixes #357

## Проблема
`AlarmThemeImageStore.saveImage` пишет свежий `alarm-theme-<UUID>.jpg` при каждом выборе фото, но в коде нет ни одного `removeItem`. Итог: ре-пик кастомной темы или удаление `.custom`-будильника осиротляют JPEG в `Caches/AlarmThemes/` навсегда — медленный неограниченный рост диска.

## Решение
Reconcile-свип на старте (`AppDelegate.didFinishLaunching`, off-main, `.utility`): удаляет любой файл в директории тем, не referenced текущими `.custom(imagePath:)`. Запуск на launch покрывает **оба** источника сирот в одном безопасном месте — на холодном старте нет незавершённой create/edit-формы, поэтому исключён риск снести картинку формы, из которой пользователь ещё не вышел (hazard у eager-delete на ре-пике).

- `AlarmThemeImageStore.reconcile(in:referencedURLs:)` — тестируемый overload (matching по `lastPathComponent`, устойчив к `file://` vs raw-path спеллингу `.custom`-URL).
- `AlarmThemeImageStore.reconcileCaches(referencedURLs:)` — обёртка над реальной Caches-директорией.
- `AlarmThemeImageStore.deleteImage(at:)` — single-file cleanup, silent при отсутствии.

## Почему тесты в `AlarmThemeTests.swift`, а не в новом файле
`SnoozePayTests` — explicit Xcode-группа: новый файл потребовал бы правки `project.pbxproj` (no-touch зона, нужен PM-override на merge). Тесты ко-локированы в доменном файле, чтобы фикс мержился без касания project-файла.

## Тесты
`AlarmThemeImageStoreReconcileTests` — 5 кейсов:
- удаляет unreferenced, сохраняет referenced;
- keep-all когда всё referenced; delete-all когда ничего;
- matching по filename across URL-спеллинг;
- `deleteImage` удаляет и молчит на отсутствующем файле.

## Verification
- ✅ `swiftlint` чисто на изменённых файлах (новых нарушений нет)
- ✅ `build_sim` SUCCEEDED (0 warnings/errors)
- ✅ `test_sim -only-testing:…AlarmThemeImageStoreReconcileTests` — **5 passed, 0 failed**
- ✅ Дифф не трогает `project.pbxproj`

🤖 Generated with [Claude Code](https://claude.com/claude-code)