### PR TITLE
[test] Extend e2e XCUITest suite — no-balance, progressive, create, onboarding (#340)

### DIFF
--- a/SnoozePay/SnoozePay.xcodeproj/project.pbxproj
+++ b/SnoozePay/SnoozePay.xcodeproj/project.pbxproj
@@ -8,6 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		47E841C354E5DA7707DA30DA /* FiringFlowUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFDCCED99F5E96ADD3426269 /* FiringFlowUITests.swift */; };
+		A3400000000000000000B001 /* NoBalanceTopUpUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3400000000000000000F001 /* NoBalanceTopUpUITests.swift */; };
+		A3400000000000000000B002 /* CreateAlarmUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3400000000000000000F002 /* CreateAlarmUITests.swift */; };
+		A3400000000000000000B003 /* ProgressiveSnoozeUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3400000000000000000F003 /* ProgressiveSnoozeUITests.swift */; };
+		A3400000000000000000B004 /* OnboardingFlowUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3400000000000000000F004 /* OnboardingFlowUITests.swift */; };
 		A7D767A1C75F0B3D99B35C0E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4AED0CBCB2279D458B93ABDC /* Foundation.framework */; };
 /* End PBXBuildFile section */
 
@@ -34,6 +38,10 @@
 		AA0001012F5B000000000002 /* SnoozePayTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SnoozePayTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D9F3B13686755D92D101DDAA /* SnoozePayUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SnoozePayUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EFDCCED99F5E96ADD3426269 /* FiringFlowUITests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FiringFlowUITests.swift; sourceTree = "<group>"; };
+		A3400000000000000000F001 /* NoBalanceTopUpUITests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NoBalanceTopUpUITests.swift; sourceTree = "<group>"; };
+		A3400000000000000000F002 /* CreateAlarmUITests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CreateAlarmUITests.swift; sourceTree = "<group>"; };
+		A3400000000000000000F003 /* ProgressiveSnoozeUITests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ProgressiveSnoozeUITests.swift; sourceTree = "<group>"; };
+		A3400000000000000000F004 /* OnboardingFlowUITests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OnboardingFlowUITests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -131,6 +139,10 @@
 			isa = PBXGroup;
 			children = (
 				EFDCCED99F5E96ADD3426269 /* FiringFlowUITests.swift */,
+				A3400000000000000000F001 /* NoBalanceTopUpUITests.swift */,
+				A3400000000000000000F002 /* CreateAlarmUITests.swift */,
+				A3400000000000000000F003 /* ProgressiveSnoozeUITests.swift */,
+				A3400000000000000000F004 /* OnboardingFlowUITests.swift */,
 			);
 			name = SnoozePayUITests;
 			path = SnoozePayUITests;
@@ -285,6 +297,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				47E841C354E5DA7707DA30DA /* FiringFlowUITests.swift in Sources */,
+				A3400000000000000000B001 /* NoBalanceTopUpUITests.swift in Sources */,
+				A3400000000000000000B002 /* CreateAlarmUITests.swift in Sources */,
+				A3400000000000000000B003 /* ProgressiveSnoozeUITests.swift in Sources */,
+				A3400000000000000000B004 /* OnboardingFlowUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SnoozePay/SnoozePay/Utilities/UITourLauncher.swift
+++ b/SnoozePay/SnoozePay/Utilities/UITourLauncher.swift
@@ -9,13 +9,15 @@ import UIKit
 /// tapping through the UI (no UI-automation tooling required).
 ///
 /// Optional arguments:
+///   `-uitour-reset`          wipe persisted alarms before mounting (clean state)
 ///   `-uitour-seed`           seed demo alarms / transactions / wake history
 ///   `-uitour-balance <n>`    force balance to exactly n ₽ (via service APIs)
 ///   `-uitour-theme <id>`     firing-screen theme: dawn|ocean|mountains|forest|neon|abstract
 ///
 /// Supported screens: onboarding, permissions, alarms, wallet, stats,
 /// settings, create, edit, theme-picker, sound-picker, volume-picker,
-/// confirm-delete, firing, firing-snoozed, firing-nobalance, firing-topup,
+/// confirm-delete, firing, firing-snoozed, firing-progressive,
+/// firing-nobalance, firing-topup,
 /// txhistory, periodpicker, deposit, streak.
 enum UITourLauncher {
 
@@ -24,6 +26,7 @@ enum UITourLauncher {
     // MARK: - Mounting
 
     static func mount(_ screen: String, in window: UIWindow) {
+        resetIfRequested()
         seedIfRequested()
         // Unknown screen id — land on the alarms tab so the audit
         // screenshot makes the mistake obvious instead of hanging.
@@ -35,7 +38,21 @@ enum UITourLauncher {
     /// keeps `mount` trivially simple for the linter and makes the supported
     /// screen list greppable in one place.
     private static let mounters: [String: (UIWindow) -> Void] = [
-        "onboarding": { $0.rootViewController = OnboardingViewController() },
+        "onboarding": { window in
+            // Mirror SceneDelegate's onboarding → permissions → main tab bar
+            // chain so an e2e walk can run the whole first-launch journey end
+            // to end (the production wiring lives in SceneDelegate, which the
+            // -uitour direct mount bypasses).
+            let onboarding = OnboardingViewController()
+            onboarding.onFinished = { [weak window] in
+                let permissions = PermissionsViewController()
+                permissions.onFinished = { [weak window] in
+                    window?.rootViewController = SceneDelegate.makeMainTabBar()
+                }
+                window?.rootViewController = permissions
+            }
+            window.rootViewController = onboarding
+        },
         "permissions": { $0.rootViewController = PermissionsViewController() },
         "alarms": { $0.rootViewController = tabBar(selected: 0) },
         "wallet": { $0.rootViewController = tabBar(selected: 1) },
@@ -69,6 +86,9 @@ enum UITourLauncher {
             presentLater(ConfirmDeleteAlarmViewController(), over: nav)
         },
         "firing": { $0.rootViewController = AlarmFiringViewController(alarm: firingSampleAlarm()) },
+        "firing-progressive": {
+            $0.rootViewController = AlarmFiringViewController(alarm: progressiveFiringAlarm())
+        },
         "firing-snoozed": {
             $0.rootViewController = AlarmFiringViewController(alarm: firingSampleAlarm(), snoozeCount: 2)
         },
@@ -179,6 +199,22 @@ enum UITourLauncher {
         )
     }
 
+    /// A progressive-scale variant of the firing sample. Used by the
+    /// `firing-progressive` screen so the snoozed-state progressive pill
+    /// («N-й поспать ещё») and the growing charge ladder render for the e2e
+    /// progressive-snooze test. Anchored to `Date()` for the same
+    /// positive-countdown reason as `firingSampleAlarm()`.
+    private static func progressiveFiringAlarm() -> Alarm {
+        Alarm(
+            time: Date(),
+            repeatDays: [0, 1, 2, 3, 4], // Monday-first indices: Пн–Пт
+            name: "Спортзал",
+            penaltyAmount: 50,
+            progressiveScale: true,
+            theme: requestedTheme()
+        )
+    }
+
     private static func requestedTheme() -> AlarmTheme {
         switch value(after: "-uitour-theme") {
         case "ocean": return .ocean
@@ -191,6 +227,18 @@ enum UITourLauncher {
     }
 
     // MARK: - Seeding
+
+    /// `-uitour-reset` — wipe persisted alarms before mounting so a flow that
+    /// asserts on list contents (e.g. the create-alarm e2e) starts from a known
+    /// empty state. Simulator `UserDefaults` survive across `app.launch()`, so
+    /// without this a previous run's alarms leak into the next test's counts.
+    private static func resetIfRequested() {
+        guard ProcessInfo.processInfo.arguments.contains("-uitour-reset") else { return }
+        let repo = AlarmRepository.shared
+        for alarm in repo.fetchAll() {
+            _ = repo.delete(id: alarm.id)
+        }
+    }
 
     private static func seedIfRequested() {
         if ProcessInfo.processInfo.arguments.contains("-uitour-seed") {

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+NoBalance.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+NoBalance.swift
@@ -174,6 +174,7 @@ extension AlarmFiringViewController {
             fullWidth: true
         )
         button.translatesAutoresizingMaskIntoConstraints = false
+        button.accessibilityIdentifier = "firing.noBalance.topUpButton"
         button.addTarget(
             self,
             action: #selector(noBalanceApplePayTapped),

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+SnoozedViews.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+SnoozedViews.swift
@@ -67,6 +67,8 @@ extension AlarmFiringViewController {
             dot.leadingAnchor.constraint(equalTo: pill.leadingAnchor, constant: 12),
             dot.centerYAnchor.constraint(equalTo: pill.centerYAnchor)
         ])
+        pill.isAccessibilityElement = true
+        pill.accessibilityIdentifier = "firing.snoozed.progressivePill"
         return pill
     }
 
@@ -80,6 +82,7 @@ extension AlarmFiringViewController {
         row.axis = .horizontal
         row.alignment = .top
         row.spacing = AppSpacing.sp2   // 8pt
+        row.accessibilityIdentifier = "firing.snoozed.ladder"
         return row
     }
 

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/NameCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/NameCell.swift
@@ -28,6 +28,7 @@ final class NameCell: UITableViewCell {
         )
         field.returnKeyType = .done
         field.clearButtonMode = .whileEditing
+        field.accessibilityIdentifier = "createAlarm.nameField"
         return field
     }()
 

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/PenaltyCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/PenaltyCell.swift
@@ -57,6 +57,7 @@ final class PenaltyCell: UITableViewCell {
         field.setContentHuggingPriority(.required, for: .horizontal)
         field.setContentCompressionResistancePriority(.required, for: .horizontal)
         field.accessibilityLabel = "Цена откладывания, рублей"
+        field.accessibilityIdentifier = "createAlarm.penaltyField"
         field.translatesAutoresizingMaskIntoConstraints = false
         return field
     }()

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
@@ -137,6 +137,7 @@ final class CreateAlarmViewController: UIViewController {
             variant: .money,
             size: .sm
         )
+        saveButton.accessibilityIdentifier = "createAlarm.saveButton"
         saveButton.addTarget(self, action: #selector(saveTapped), for: .touchUpInside)
         navigationItem.rightBarButtonItem = UIBarButtonItem(customView: saveButton)
 

--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController+Pages.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController+Pages.swift
@@ -327,6 +327,9 @@ extension OnboardingViewController {
 
     private func swapPrimary(with newButton: SPButton) {
         let oldButton = primaryButton
+        // Keep the test id stable across the per-page instance swaps (the
+        // "Дальше" advance variant ↔ the page-3 "Пополнить" deposit CTA).
+        newButton.accessibilityIdentifier = "onboarding.primaryButton"
         newButton.addTarget(self, action: #selector(primaryTapped), for: .touchUpInside)
         if let index = ctaStack.arrangedSubviews.firstIndex(of: oldButton) {
             ctaStack.removeArrangedSubview(oldButton)

--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController.swift
@@ -322,8 +322,11 @@ final class OnboardingViewController: UIViewController {
 
     private func wireActionTargets() {
         scrollView.delegate = self
+        primaryButton.accessibilityIdentifier = "onboarding.primaryButton"
         primaryButton.addTarget(self, action: #selector(primaryTapped), for: .touchUpInside)
+        laterButton.accessibilityIdentifier = "onboarding.laterButton"
         laterButton.addTarget(self, action: #selector(laterTapped), for: .touchUpInside)
+        skipButton.accessibilityIdentifier = "onboarding.skipButton"
         skipButton.addTarget(self, action: #selector(skipTapped), for: .touchUpInside)
     }
 

--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/PermissionsViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/PermissionsViewController.swift
@@ -130,6 +130,7 @@ final class PermissionsViewController: UIViewController {
         view.backgroundColor = AppColors.bg0
         setupUI()
         refreshNotificationSettings()
+        ctaButton.accessibilityIdentifier = "permissions.doneButton"
         ctaButton.addTarget(self, action: #selector(ctaTapped), for: .touchUpInside)
     }
 

--- a/SnoozePay/SnoozePayUITests/CreateAlarmUITests.swift
+++ b/SnoozePay/SnoozePayUITests/CreateAlarmUITests.swift
@@ -1,0 +1,52 @@
+import XCTest
+
+/// End-to-end for creating an alarm from the form.
+///
+/// Mounts the REAL `CreateAlarmViewController` (presented over the alarms tab)
+/// via `-uitour create`, with `-uitour-reset` wiping any persisted alarms first
+/// so the post-save count is deterministic. The path exercised:
+///
+///   1. Create form up — name + Save controls present.
+///   2. Type a name, leave the safe default time/penalty, tap «Готово».
+///   3. `save` persists via the repository and dismisses ONLY on success — so a
+///      dismissed sheet proves the happy path (a persist/scheduling failure
+///      would surface an inline alert and keep the sheet up instead).
+///   4. Back on the list, exactly one alarm row (its toggle) is present.
+///
+/// The list cell renders time / days / price / sound but NOT the name, so the
+/// assertion keys on the row's toggle count from a known-empty start rather
+/// than on the typed name. Selectors are stable `accessibilityIdentifier`s.
+final class CreateAlarmUITests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    func testCreateAlarmAddsRowToList() {
+        let app = XCUIApplication()
+        app.launchArguments = ["-uitour", "create", "-uitour-reset"]
+        app.launch()
+
+        // 1. Create form up (presented after the root lays out).
+        let nameField = app.textFields["createAlarm.nameField"]
+        XCTAssertTrue(nameField.waitForExistence(timeout: 10),
+                      "Create-alarm name field should appear")
+        let save = app.buttons["createAlarm.saveButton"]
+        XCTAssertTrue(save.exists, "Save button should be present on the create form")
+
+        // 2. Fill the name (the form auto-focuses it on appear).
+        nameField.tap()
+        nameField.typeText("Подъём на работу")
+
+        // 3. Save → success path dismisses the sheet.
+        save.tap()
+        XCTAssertTrue(nameField.waitForNonExistence(timeout: 5),
+                      "Create sheet should dismiss after a successful save")
+
+        // 4. The new alarm is present in the list (one toggle from empty start).
+        let firstToggle = app.switches.firstMatch
+        XCTAssertTrue(firstToggle.waitForExistence(timeout: 5),
+                      "A newly created alarm row should appear in the list")
+    }
+}

--- a/SnoozePay/SnoozePayUITests/NoBalanceTopUpUITests.swift
+++ b/SnoozePay/SnoozePayUITests/NoBalanceTopUpUITests.swift
@@ -1,0 +1,46 @@
+import XCTest
+
+/// End-to-end for the no-balance recovery loop on the firing screen.
+///
+/// Drives the REAL `AlarmFiringViewController` in its no-balance layout via the
+/// DEBUG `-uitour firing-nobalance` deep link (`UITourLauncher`), which forces
+/// the balance to 0 before mounting. The path exercised:
+///
+///   1. No-balance layout up — the «Пополнить» top-up CTA is present and the
+///      normal snooze CTA is NOT (it lives behind the no-balance swap).
+///   2. Tap «Пополнить» → with StoreKit products not loaded in the test
+///      environment, `noBalanceApplePayTapped` falls back to a direct
+///      `BalanceService.topUp`, crediting the balance deterministically.
+///   3. The balance observer re-runs `updateUI`, the no-balance swap flips back,
+///      and the normal `firing.snoozeButton` becomes available again.
+///
+/// Selectors are stable `accessibilityIdentifier`s, not localized button copy
+/// (the top-up CTA reads «Пополнить», so id-targeting is mandatory here).
+final class NoBalanceTopUpUITests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    func testNoBalanceTopUpReenablesSnooze() {
+        let app = XCUIApplication()
+        app.launchArguments = ["-uitour", "firing-nobalance"]
+        app.launch()
+
+        // 1. No-balance layout — top-up CTA present, normal snooze absent.
+        let topUp = app.buttons["firing.noBalance.topUpButton"]
+        XCTAssertTrue(topUp.waitForExistence(timeout: 10),
+                      "No-balance top-up CTA should appear when balance is 0")
+        XCTAssertFalse(app.buttons["firing.snoozeButton"].exists,
+                       "Normal snooze CTA should be hidden in the no-balance layout")
+
+        // 2 + 3. Top up → snooze becomes available again.
+        topUp.tap()
+        let snooze = app.buttons["firing.snoozeButton"]
+        XCTAssertTrue(snooze.waitForExistence(timeout: 10),
+                      "Snooze CTA should re-appear after the balance is topped up")
+        XCTAssertTrue(snooze.isEnabled,
+                      "Re-appeared snooze CTA should be enabled with a positive balance")
+    }
+}

--- a/SnoozePay/SnoozePayUITests/OnboardingFlowUITests.swift
+++ b/SnoozePay/SnoozePayUITests/OnboardingFlowUITests.swift
@@ -1,0 +1,54 @@
+import XCTest
+
+/// End-to-end walk through the first-launch journey.
+///
+/// Mounts the REAL `OnboardingViewController` via `-uitour onboarding`, which
+/// (in tour mode) wires the production `onFinished` chain onboarding →
+/// `PermissionsViewController` → main tab bar — the same order SceneDelegate
+/// drives on a real first launch. The path exercised:
+///
+///   1. Onboarding up — the primary «Дальше» CTA present.
+///   2. Tap it across the 3 pages; on the last page it becomes «Пополнить» and
+///      tapping it finishes onboarding.
+///   3. The permissions screen appears with its «Готово» CTA.
+///   4. Tapping «Готово» lands on the main tab bar.
+///
+/// The primary CTA instance is swapped per page, so the test re-queries the
+/// stable `onboarding.primaryButton` id each tap rather than holding a handle.
+final class OnboardingFlowUITests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    func testOnboardingThroughPermissionsToMain() {
+        let app = XCUIApplication()
+        app.launchArguments = ["-uitour", "onboarding"]
+        app.launch()
+
+        // 1. Onboarding up.
+        XCTAssertTrue(app.buttons["onboarding.primaryButton"].waitForExistence(timeout: 10),
+                      "Onboarding primary CTA should appear on launch")
+
+        // 2. Advance through all 3 pages (page 1→2, 2→3, then finish on page 3).
+        // The button instance is replaced on each page change, so re-resolve the
+        // id every tap.
+        for step in 1...3 {
+            let primary = app.buttons["onboarding.primaryButton"]
+            XCTAssertTrue(primary.waitForExistence(timeout: 5),
+                          "Primary CTA should be present before onboarding step \(step)")
+            primary.tap()
+        }
+
+        // 3. Permissions screen reached via the onFinished chain.
+        let done = app.buttons["permissions.doneButton"]
+        XCTAssertTrue(done.waitForExistence(timeout: 5),
+                      "Permissions «Готово» CTA should appear after finishing onboarding")
+
+        // 4. «Готово» → main tab bar.
+        done.tap()
+        XCTAssertTrue(app.tabBars.firstMatch.waitForExistence(timeout: 5),
+                      "Main tab bar should appear after completing permissions")
+    }
+}

--- a/SnoozePay/SnoozePayUITests/ProgressiveSnoozeUITests.swift
+++ b/SnoozePay/SnoozePayUITests/ProgressiveSnoozeUITests.swift
@@ -1,0 +1,50 @@
+import XCTest
+
+/// End-to-end for the progressive-scale snooze chrome.
+///
+/// Drives the REAL `AlarmFiringViewController` for a `progressiveScale: true`
+/// alarm via `-uitour firing-progressive` (`UITourLauncher`), with a seeded
+/// balance so the snooze is affordable. The path exercised:
+///
+///   1. Firing screen up with the progressive sample alarm.
+///   2. Tap «Поспать ещё» → the screen enters the snoozed state in place.
+///   3. The progressive pill («Прогрессив · 1-й поспать ещё») and the growing
+///      charge ladder render — the chrome that only appears for progressive
+///      alarms, proving the escalation UI is wired through the firing flow.
+///
+/// Selectors are stable `accessibilityIdentifier`s.
+final class ProgressiveSnoozeUITests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    func testProgressiveSnoozeShowsPillAndLadder() {
+        let app = XCUIApplication()
+        app.launchArguments = ["-uitour", "firing-progressive", "-uitour-balance", "1000"]
+        app.launch()
+
+        // 1. Firing screen — affordable snooze present.
+        let snooze = app.buttons["firing.snoozeButton"]
+        XCTAssertTrue(snooze.waitForExistence(timeout: 10),
+                      "Progressive firing screen should show the snooze CTA")
+
+        // 2. Snooze → snoozed state in place (live countdown).
+        snooze.tap()
+        let countdown = app.staticTexts["firing.countdown"]
+        XCTAssertTrue(countdown.waitForExistence(timeout: 5),
+                      "Snoozed-state countdown should appear after «Поспать ещё»")
+
+        // 3. Progressive chrome — the pill names the next snooze ordinal.
+        let pill = app.staticTexts["firing.snoozed.progressivePill"]
+        XCTAssertTrue(pill.waitForExistence(timeout: 5),
+                      "Progressive pill should appear in the snoozed state for a progressive alarm")
+        XCTAssertTrue(pill.label.contains("поспать ещё"),
+                      "Progressive pill should read the «N-й поспать ещё» escalation copy, got: \(pill.label)")
+
+        // The growing charge ladder is a sibling container in the same state.
+        XCTAssertTrue(app.otherElements["firing.snoozed.ladder"].exists,
+                      "Charge ladder should render alongside the progressive pill")
+    }
+}


### PR DESCRIPTION
## Что

Расширяет e2e XCUITest-набор с одного PoC-флоу (`FiringFlowUITests`) до 5 флоу — по одному файлу на флоу, в стиле существующего теста.

| Файл | Флоу | uitour |
|------|------|--------|
| `NoBalanceTopUpUITests` | баланс 0 → «Пополнить» → снуз снова доступен | `firing-nobalance` |
| `ProgressiveSnoozeUITests` | прогрессив-будильник → снуз → пилюля «N-й поспать ещё» + ladder | `firing-progressive` |
| `CreateAlarmUITests` | заполнить форму → сохранить → новый ряд в списке | `create -uitour-reset` |
| `OnboardingFlowUITests` | 3 страницы → permissions → главный таб-бар | `onboarding` |

## Прод-изменения (аддитивные)

- **accessibilityIdentifier** на прод-VC (по образцу `firing.*`): `firing.noBalance.topUpButton`, `firing.snoozed.progressivePill`, `firing.snoozed.ladder`, `createAlarm.nameField/penaltyField/saveButton`, `onboarding.primaryButton/laterButton/skipButton`, `permissions.doneButton`.
- **UITourLauncher (DEBUG-only):** новый экран `firing-progressive`; флаг `-uitour-reset` (чистый старт для create-флоу — UserDefaults симулятора переживают `app.launch()`); провязка `onboarding → permissions → main` в tour-режиме (зеркалит SceneDelegate, который прямой mount обходит).

## Verification

- ✅ `xcodebuild test -only-testing:SnoozePayUITests` — **5/5 passed** локально (iPhone 17 Pro Max, iOS 26.5), включая существующий FiringFlow (без регрессии).
- ✅ swiftlint — 0 нарушений в изменённых файлах.
- Ни один флоу не оказался флаки → **XCTSkip не понадобился**.

## ⚠️ Требуется PM: `pm-override` для merge

Новые UI-тест-файлы добавлены в таргет `SnoozePayUITests`, который (в отличие от `SnoozePay`/`SnoozePayTests`) **не** использует синхронизированную группу → правит `project.pbxproj` → hook `no-touch-guard` блокирует auto-merge. Нужен label `pm-override` + merge отдельной командой (как описано в issue #340). Автопилот реализовал и проверил, но merge оставляет на тебя.

> Примечание: база PR — `design-refresh-2026-04-27`. «Fixes #340» на интеграционной ветке issue автоматически не закроет — закрой вручную после merge.

Fixes #340