### PR TITLE
[ui] Firing balance pill: state colour (green/red), drop theme-accent tint (#342)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Theme.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Theme.swift
@@ -140,10 +140,10 @@ extension AlarmFiringViewController {
     }
 
     /// Accent pass — tint the clock halo + bell tile with the resolved
-    /// palette. The balance pill and eyebrow are re-tinted on every
-    /// `updateUI()` (their colour interacts with the zero-balance state), so
-    /// they live in `applyThemeAccentToBalancePill()` /
-    /// `updateAtmosphereTone()` instead.
+    /// palette. The balance pill is deliberately excluded: its money/pain tone
+    /// is a functional affordability signal kept un-themed in every theme so
+    /// «money / no money» always reads (#342). The eyebrow atmosphere is
+    /// re-tinted on every `updateUI()` via `updateAtmosphereTone()` instead.
     private func applyThemeAccents() {
         guard let palette = firingPalette else {
             // `.custom` photo — keep the neutral chrome and skip the bell
@@ -157,21 +157,6 @@ extension AlarmFiringViewController {
         bellTile.isHidden = false
     }
 
-    /// Re-tint the balance pill with the theme accent. The themed colours
-    /// only apply while the pill is in its normal `.money` tone — at zero
-    /// balance the stock pain (red) tint is a functional signal and stays
-    /// un-themed in every theme. Called from `updateUI()` after
-    /// `updateBalancePill()` so a tone-flip rebuild gets re-tinted too.
-    func applyThemeAccentToBalancePill() {
-        guard let palette = firingPalette,
-              let pill = balancePill,
-              pill.tone == .money else { return }
-        pill.applyCustomColors(
-            background: palette.pillBackground,
-            border: palette.pillBorder,
-            foreground: palette.accent
-        )
-    }
 }
 
 // MARK: - Drained-atmosphere view storage

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
@@ -401,7 +401,11 @@ class AlarmFiringViewController: UIViewController {
         }
 
         updateBalancePill()
-        applyThemeAccentToBalancePill()
+        // The balance pill is intentionally NOT theme-tinted: its money (green)
+        // / pain (red) tone is a functional affordability signal that must read
+        // identically in every firing theme (#342). It used to be re-tinted
+        // with the theme accent here, which turned the green chip gold under
+        // Dawn and hid the «money / no money» state.
         updateAtmosphereTone()
 
         // Swap between the normal snooze + dismiss group and the no-balance

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPPill.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPPill.swift
@@ -143,10 +143,8 @@ final class SPPill: UIView {
     }
 
     private func applyTone() {
-        // swiftlint:disable identifier_name
         let bg: UIColor
         let fg: UIColor
-        // swiftlint:enable identifier_name
         switch tone {
         case .neutral:
             bg = AppColors.whiteOverlay08

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPPill.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPPill.swift
@@ -133,20 +133,6 @@ final class SPPill: UIView {
         label.attributedText = result
     }
 
-    /// Override the tone-derived colours with theme-accent values — used by
-    /// the V3 themed firing screen (#225) where the balance pill picks up
-    /// the alarm theme's accent (`pillBg` / `pillBorder` / `accent` in
-    /// `SPThemedFiring.jsx`) instead of the stock money tint. The hairline
-    /// border only exists in this themed variant, so it's installed here
-    /// rather than in `applyTone()`.
-    func applyCustomColors(background: UIColor, border: UIColor, foreground: UIColor) {
-        backgroundColor = background
-        layer.borderWidth = 1
-        layer.borderColor = border.cgColor
-        label.textColor = foreground
-        iconView.tintColor = foreground
-    }
-
     private func setIcon(_ icon: UIImage?) {
         if let icon = icon {
             iconView.image = icon.withRenderingMode(.alwaysTemplate)


### PR DESCRIPTION
## Что сделано
Пилюля «Баланс N ₽» на firing-экране красилась в **акцент темы** (золото под Dawn) на каждом `updateUI`, затирая зелёный `.money`-тон. Это скрывало affordability-сигнал из прототипа: **зелёная при достатке, красная при нуле**.

- Удалён `applyThemeAccentToBalancePill()` + его вызов в `updateUI()` → пилюля сохраняет функциональный `money`(зелёный)/`pain`(красный) тон в любой теме.
- Удалён ставший мёртвым `SPPill.applyCustomColors` (его единственный вызов был в удалённом theme-tint пути) + осиротевший swiftlint-disable в `applyTone`.

## Тесты
- build_sim: ✅ succeeded
- swiftlint: ✅ 0 violations в изменённых файлах
- Логика тон-флипа (`balance == 0 ? .pain : .money`) не тронута; `palette.pillBackground/Border` остаются (используются в `+SnoozedViews` и `AlarmFiringThemePaletteTests`).

## Review
Пройден gauntlet (round 1): silent-failure-hunter APPROVE; code-reviewer REQUEST_CHANGES → исправлено (мёртвый `applyCustomColors` удалён, база ветки перенесена с #340 на design-refresh).

## Визуальная верификация
screenshot-vs-Figma gate отключён; источник истины — HTML-прототип `docs/design/snoozepay-2026-04-27`, ряд «Будильник срабатывает».

Fixes #342