### PR TITLE
[config] Local StoreKit Configuration for IAP testing without paid Apple Dev (#195)

### DIFF
--- a/SnoozePay/SnoozePay.storekit
+++ b/SnoozePay/SnoozePay.storekit
@@ -1,0 +1,101 @@
+{
+  "identifier" : "65B0A509-5E62-4BA2-9998-68F8E6AF4827",
+  "nonRenewingSubscriptions" : [
+
+  ],
+  "products" : [
+    {
+      "displayPrice" : "49.00",
+      "familyShareable" : false,
+      "internalID" : "64216C2C-707C-480A-A3E9-EDC137A7DE37",
+      "localizations" : [
+        {
+          "description" : "Пополнение баланса на 49 ₽",
+          "displayName" : "Пополнение 49 ₽",
+          "locale" : "ru"
+        }
+      ],
+      "productID" : "com.snooze_pay.balance.49",
+      "referenceName" : "Balance 49 ₽",
+      "type" : "Consumable"
+    },
+    {
+      "displayPrice" : "149.00",
+      "familyShareable" : false,
+      "internalID" : "062EA255-6FD5-4A59-8097-68C417EB4F1E",
+      "localizations" : [
+        {
+          "description" : "Пополнение баланса на 149 ₽",
+          "displayName" : "Пополнение 149 ₽",
+          "locale" : "ru"
+        }
+      ],
+      "productID" : "com.snooze_pay.balance.149",
+      "referenceName" : "Balance 149 ₽",
+      "type" : "Consumable"
+    },
+    {
+      "displayPrice" : "299.00",
+      "familyShareable" : false,
+      "internalID" : "E63F3567-7BDB-4356-8202-12E0C42E5A93",
+      "localizations" : [
+        {
+          "description" : "Пополнение баланса на 299 ₽",
+          "displayName" : "Пополнение 299 ₽",
+          "locale" : "ru"
+        }
+      ],
+      "productID" : "com.snooze_pay.balance.299",
+      "referenceName" : "Balance 299 ₽",
+      "type" : "Consumable"
+    },
+    {
+      "displayPrice" : "499.00",
+      "familyShareable" : false,
+      "internalID" : "30E5CCC1-66E0-4E7A-8D4E-1CE4E6D063FF",
+      "localizations" : [
+        {
+          "description" : "Пополнение баланса на 499 ₽",
+          "displayName" : "Пополнение 499 ₽",
+          "locale" : "ru"
+        }
+      ],
+      "productID" : "com.snooze_pay.balance.499",
+      "referenceName" : "Balance 499 ₽",
+      "type" : "Consumable"
+    },
+    {
+      "displayPrice" : "999.00",
+      "familyShareable" : false,
+      "internalID" : "2E2A8654-503F-4A93-96DC-7FD1320FA101",
+      "localizations" : [
+        {
+          "description" : "Пополнение баланса на 999 ₽",
+          "displayName" : "Пополнение 999 ₽",
+          "locale" : "ru"
+        }
+      ],
+      "productID" : "com.snooze_pay.balance.999",
+      "referenceName" : "Balance 999 ₽",
+      "type" : "Consumable"
+    }
+  ],
+  "settings" : {
+    "_applicationInternalID" : "snoozepay.local.test",
+    "_developerTeamID" : "8ZKDC782V4",
+    "_failTransactionsEnabled" : false,
+    "_askToBuyEnabled" : false,
+    "_billingIssuesEnabled" : false,
+    "_billingGracePeriodEnabled" : false,
+    "_storeKitErrors" : [
+
+    ]
+  },
+  "subscriptionGroups" : [
+
+  ],
+  "version" : {
+    "major" : 3,
+    "minor" : 0
+  }
+}

--- a/SnoozePay/SnoozePay.xcodeproj/xcshareddata/xcschemes/SnoozePay.xcscheme
+++ b/SnoozePay/SnoozePay.xcodeproj/xcshareddata/xcschemes/SnoozePay.xcscheme
@@ -70,6 +70,9 @@
             ReferencedContainer = "container:SnoozePay.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <StoreKitConfigurationFileReference
+         identifier = "../../../SnoozePay.storekit">
+      </StoreKitConfigurationFileReference>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/docs/IAP.md
+++ b/docs/IAP.md
@@ -1,0 +1,65 @@
+# IAP / пополнение баланса — StoreKit
+
+Пополнение баланса в SnoozePay идёт через **In-App Purchase (StoreKit 2)**, а не через
+Apple Pay (PassKit). Apple требует продавать внутреннюю валюту приложения только через IAP;
+настоящий Apple Pay для цифрового баланса использовать нельзя. В UI бренд «Apple Pay» убран
+в нейтральное «Пополнить» (`AlarmFiringViewController+NoBalance.swift`), но под капотом —
+`StoreKitService.purchase()` → `StoreKit.Transaction`.
+
+## Локальное тестирование без оплаченного Apple Developer (#195)
+
+В репозитории лежит `SnoozePay/SnoozePay.storekit` — локальный StoreKit Configuration File.
+Он привязан к **Run-action** схемы `SnoozePay` (`Edit Scheme → Run → Options → StoreKit
+Configuration`). Это даёт полный IAP-флоу в симуляторе без App Store Connect, без sandbox-
+аккаунтов и без оплаченного аккаунта.
+
+### Продукты (5 consumable)
+
+ID — источник истины — это константы `StoreKitService.productIDs` / `productAmounts`:
+
+| productID | Сумма зачисления |
+|-----------|------------------|
+| `com.snooze_pay.balance.49`  | 49 ₽  |
+| `com.snooze_pay.balance.149` | 149 ₽ |
+| `com.snooze_pay.balance.299` | 299 ₽ |
+| `com.snooze_pay.balance.499` | 499 ₽ |
+| `com.snooze_pay.balance.999` | 999 ₽ |
+
+> ⚠️ При изменении ID/сумм в `.storekit` — синхронно править `StoreKitService.swift`
+> (и наоборот). Расхождение → продукт не загрузится / зачислится не та сумма.
+
+### Тест-action оставлен БЕЗ StoreKit Configuration
+
+Намеренно: `NoBalanceTopUpUITests` тапает «Пополнить» и рассчитывает на fallback-ветку
+`noBalanceApplePayTapped` (когда `StoreKitService.products` пуст → прямой
+`BalanceService.topUp`). Если повесить `.storekit` на Test-action, тап откроет
+StoreKit-лист подтверждения, который XCUITest не закроет → тест упадёт. CI (`xcodebuild test`)
+гоняет Test-action, поэтому остаётся на fallback и проходит.
+
+### Ручная матрица проверок (выполнять в Xcode на симуляторе)
+
+`Debug → StoreKit → Manage Transactions` + `Editor`:
+
+- [ ] Покупка → баланс растёт в UserDefaults (`user_balance`)
+- [ ] Restore Purchases — для Consumable не дублирует кредиты
+- [ ] Ask-to-Buy (`Editor → Enable Ask To Buy`) → `purchasePendingNotification`, кредит после approve
+- [ ] Отказ пользователя в диалоге → баланс не меняется
+- [ ] Прерванная покупка → `Transaction.updates` досылает после возобновления
+- [ ] Refund (`Editor → Refund Transaction`) — обрабатывается, баланс не уходит в минус
+- [ ] Failed transaction (`Editor → Fail Transactions`) → `purchaseFailedNotification` + алерт
+
+> Эта матрица интерактивная (Xcode Transaction Manager) и не воспроизводится headless-
+> тулзами CI/агента — её прогоняет PM в Xcode.
+
+## Миграция на App Store (после оплаты Apple Developer $99/год)
+
+1. Создать те же 5 продуктов в **App Store Connect** с теми же `productID` (Consumable).
+2. Цены/локализации — как в `.storekit` (49/149/299/499/999 ₽).
+3. Переключить схему: `Run → Options → StoreKit Configuration → None`.
+4. Sandbox-тестирование через TestFlight + sandbox Apple ID.
+5. Бандл-ID и подпись — зона PM (см. CLAUDE.md «No-touch zones»).
+
+## Android (отдельная задача)
+
+Моковая `BillingRepository` для разработки → реальная Play Billing после оплаты Console ($25).
+Вне scope #195.


### PR DESCRIPTION
## Что сделано
Позволяет полностью протестировать IAP-флоу пополнения в симуляторе **без оплаченного Apple Developer аккаунта и без App Store Connect**.

- **`SnoozePay/SnoozePay.storekit`** — 5 consumable-продуктов с ID из `StoreKitService` (`com.snooze_pay.balance.{49,149,299,499,999}`, суммы 1:1 с `productAmounts`), RU-локализации. Лежит вне синхронизированной папки исходников → **pbxproj не тронут**.
- **Привязка к схеме** — `StoreKitConfigurationFileReference` в **Run-action** `SnoozePay.xcscheme`. Намеренно НЕ на Test-action: иначе тап «Пополнить» в `NoBalanceTopUpUITests` откроет StoreKit-лист (XCUITest не закроет) и тест упадёт; CI гоняет Test-action → остаётся на fallback-ветке.
- **`docs/IAP.md`** — IAP vs Apple Pay, сетап локального тестирования, ручная матрица транзакций, чеклист миграции на App Store Connect.

Логика `StoreKitService` не менялась (per AC). ID взяты из констант кода, а не из устаревших `topup_*` в теле issue.

## Тесты
- build_sim: ✅ succeeded
- swiftlint: ✅ (нет Swift-изменений — только .storekit JSON / .xcscheme / .md)
- JSON `.storekit`: ✅ валиден

## ⚠️ Требует ручной проверки PM в Xcode (не воспроизводимо headless)
AC раздел 3 — интерактивная матрица через `Debug → StoreKit → Manage Transactions`:
- [ ] Покупка → баланс растёт · Restore (не дублирует consumable) · Ask-to-Buy · отказ · прерванная · Refund · Failed transaction
- [ ] Подтвердить, что конфиг реально подхватывается схемой (продукты грузятся)

**Merge — за тобой**, после прогона матрицы в Xcode. Также: правка `.xcscheme` — если no-touch-хук её режет, нужен `pm-override`.

## Связано
- #364 — баланс не переживает переустановку (отдельный стратегический вопрос, не входит в #195).

Fixes #195