### PR TITLE
[ui] Alarms list: drop leading zero on the hour (#343)

### DIFF
--- a/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
@@ -447,12 +447,16 @@ final class AlarmsListViewModel {
     // MARK: - Helpers for cell display
 
     /// Cached formatter — avoids ~1ms per-call allocation that adds up in lists.
-    /// Locale fixed to `en_US_POSIX` so the 24-hour format `HH:mm` is honoured
-    /// regardless of the user's region (some locales otherwise render `7:00 AM`).
+    /// Locale fixed to `en_US_POSIX` so the 24-hour format is honoured regardless
+    /// of the user's region (some locales otherwise render `7:00 AM`).
+    ///
+    /// The list cells use `H:mm` — hour WITHOUT a leading zero ("7:30", "19:05")
+    /// to match the prototype (artboard 06); the create/edit time picker keeps
+    /// the padded `HH:mm` form (`TimePickerCell`). See #343.
     private static let timeFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "HH:mm"
+        formatter.dateFormat = "H:mm"
         return formatter
     }()
 


### PR DESCRIPTION
## Что сделано
Ячейки списка будильников показывали «07:30» (ведущий ноль у часа), а прототип (artboard 06) — «7:30». Пикер создания/редактирования при этом сохраняет padded «07:00» (`TimePickerCell`).

Сменил формат **только списочного** кэш-форматтера `AlarmsListViewModel.timeFormatter` с `"HH:mm"` на `"H:mm"` (по-прежнему 24-часовой через `en_US_POSIX`, «19:05» не меняется).

## Тесты
- build_sim: ✅ (полный ребилд)
- swiftlint: ✅ (0)
- Ни один unit-тест не ассертит формат `alarmTimeString` (только пустую строку для невалидного индекса) — ничего не ломается.

## Приёмка #343
- [x] Формат часа в ячейке списка сверён с прототипом (убран ведущий ноль)

Fixes #343