### PR TITLE
[ui] Create alarm: example hint in name placeholder (#344)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/NameCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/NameCell.swift
@@ -16,11 +16,12 @@ final class NameCell: UITableViewCell {
         field.font = AppTypography.h3
         field.textColor = AppColors.fg1
         field.translatesAutoresizingMaskIntoConstraints = false
-        // Large attributed placeholder ("Название", #231) tinted with the
-        // disabled foreground role so the field still reads as empty without
-        // a label.
+        // Large attributed placeholder (#231) tinted with the disabled
+        // foreground role so the field still reads as empty without a label.
+        // The «· напр. Будни» example hint matches the prototype (screen 08,
+        // #344) — it nudges the user toward a short, recognisable name.
         field.attributedPlaceholder = NSAttributedString(
-            string: "Название",
+            string: "Название · напр. Будни",
             attributes: [
                 .font: AppTypography.h3,
                 .foregroundColor: AppColors.fg4


### PR DESCRIPTION
## Что сделано
Плейсхолдер поля имени в создании будильника был «Название»; прототип (экран 08) — «Название · напр. Будни» с примером-подсказкой. Обновил attributed-placeholder в `NameCell`.

## Тесты
- build_sim: ✅
- swiftlint: ✅ (0)
- `CreateAlarmUITests` печатает в поле по accessibility id и НЕ ассертит placeholder → не ломается.

## Приёмка #344
- [x] Плейсхолдер имени сверён с прототипом (добавлен пример)

Fixes #344