### PR TITLE
[test] Lock progressive ×N multiplier pill (#349 already implemented)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmCell.swift
@@ -211,7 +211,8 @@ final class AlarmCell: UITableViewCell {
     // MARK: - Configure
 
     /// Configure the row's content. Inputs:
-    /// - `time`: pre-formatted "HH:mm".
+    /// - `time`: pre-formatted clock string, e.g. "7:30" (the list uses the
+    ///   unpadded `H:mm` form — see `AlarmsListViewModel.timeFormatter`).
     /// - `daysCaps`: caps string for the top-left ("БУДНИ · ПН–ПТ" /
     ///   "ВЫХОДНЫЕ" / "ПН, ВТ, СР").
     /// - `priceText`: e.g. "50 ₽".

--- a/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
@@ -114,6 +114,32 @@ final class AlarmsListViewModelTests: XCTestCase {
         XCTAssertEqual(penalty, "▲ ПОСПАТЬ ЕЩЁ: −1\u{00A0}000\u{202F}₽")
     }
 
+    // MARK: - alarmMultiplierText(at:)
+
+    /// Progressive-scale alarms surface a «×2» pill in the list card so the
+    /// user sees the price escalates per snooze (#349 — the cell already
+    /// renders it via `AlarmCell.configure(multiplier:)`). Locks the value so
+    /// it can't silently regress to `nil`.
+    func testAlarmMultiplierText_progressiveAlarm_showsMultiplier() {
+        repo.save(Alarm(penaltyAmount: 100, progressiveScale: true))
+
+        let vm = makeViewModel()
+        vm.loadData()
+
+        XCTAssertEqual(vm.alarmMultiplierText(at: 0), "×2")
+    }
+
+    /// Flat-penalty alarms have no multiplier pill — the pill must stay hidden
+    /// so a non-progressive card doesn't imply escalation.
+    func testAlarmMultiplierText_nonProgressiveAlarm_isNil() {
+        repo.save(Alarm(penaltyAmount: 50, progressiveScale: false))
+
+        let vm = makeViewModel()
+        vm.loadData()
+
+        XCTAssertNil(vm.alarmMultiplierText(at: 0))
+    }
+
     // MARK: - Safe index handling
 
     func testAlarmTimeString_emptyAlarmsReturnsEmptyString() {
@@ -122,6 +148,7 @@ final class AlarmsListViewModelTests: XCTestCase {
         XCTAssertEqual(vm.alarmTimeString(at: 0), "")
         XCTAssertEqual(vm.alarmDetail(at: 0), "")
         XCTAssertEqual(vm.alarmPenaltyString(at: 0), "")
+        XCTAssertNil(vm.alarmMultiplierText(at: 0))
     }
 
     func testFormattedBalance_containsRubleSign() {


### PR DESCRIPTION
## Что выяснилось
#349 (design-аудит 2026-06-15) — **false-positive**. Пилюля множителя «×2» прогрессивной цены **уже реализована** и провязана:
- `Alarm.progressiveScale` + `penalty(forSnoozeCount:)` (удвоение, #218);
- `AlarmsListViewModel.alarmMultiplierText` → «×2» для прогрессивных будильников;
- `AlarmCell.configure(multiplier:)` рисует pain-tone пилюлю с trend-up иконкой (#223);
- call-site списка передаёт множитель.

Аудит не увидел пилюлю, т.к. экран `-uitour alarms` без `-uitour-seed` показывает пустой список (а seed как раз содержит прогрессивный будильник «Спортзал…»).

## Что сделано
`alarmMultiplierText` не имел unit-теста — добавил regression-покрытие (прогрессивный → «×2», плоский → nil, безопасный индекс → nil), чтобы поведение #349 не регрессировало молча. Заодно поправил устаревший doc-комментарий в `AlarmCell` («HH:mm» → unpadded «7:30», флагнули на #368).

## Тесты
- test_sim (новые 2): ✅ passed
- swiftlint: ✅ (0 serious; pre-existing function_parameter_count warning на `configure` — не из этого изменения, CI без --strict)

## Приёмка #349
- [x] У прогрессивных будильников в ячейке видна пилюля ×N (уже было; теперь под тестом)

Fixes #349