### PR TITLE
[ui] Edit-mode nav buttons: Отмена / Сохранить (#351)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
@@ -109,31 +109,44 @@ final class CreateAlarmViewController: UIViewController {
     // MARK: - Setup
 
     private func setupNavigationBar() {
-        // V2 nav bar — left X close chip, centered caps title, right `Готово`
-        // SPButton(.money, .sm). The UIKit navigation bar still owns layout
-        // (we keep `title` set on viewDidLoad for accessibility), but the
-        // left/right items are custom views so the brand styling sticks.
-        // Matches `SPScreensV2.jsx` lines 496-502.
-        let closeButton = UIButton(type: .system)
-        closeButton.setImage(
-            UIImage(systemName: "xmark")?.withConfiguration(
-                UIImage.SymbolConfiguration(pointSize: 16, weight: .semibold)
-            ),
-            for: .normal
-        )
-        closeButton.tintColor = AppColors.fg1
-        closeButton.backgroundColor = AppColors.whiteOverlay06
-        closeButton.layer.cornerRadius = 18
-        closeButton.layer.masksToBounds = true
-        closeButton.translatesAutoresizingMaskIntoConstraints = false
-        closeButton.widthAnchor.constraint(equalToConstant: 36).isActive = true
-        closeButton.heightAnchor.constraint(equalToConstant: 36).isActive = true
-        closeButton.addTarget(self, action: #selector(cancelTapped), for: .touchUpInside)
-        closeButton.accessibilityLabel = "Закрыть"
-        navigationItem.leftBarButtonItem = UIBarButtonItem(customView: closeButton)
+        // V2 nav bar. Two modes differ by design (SPMore2.jsx `AlarmEdit`
+        // artboard 10 vs `SPScreensV2.jsx` lines 496-502):
+        //   • create — left X close chip, right `Готово` money button
+        //   • edit   — left `Отмена` quiet button, right `Сохранить` money button
+        // The UIKit navigation bar still owns layout (we keep `title` set on
+        // viewDidLoad for accessibility), but the left/right items are custom
+        // views so the brand styling sticks.
+        if viewModel.isEditing {
+            let cancelButton = SPButton(
+                title: "Отмена",
+                variant: .quiet,
+                size: .sm
+            )
+            cancelButton.accessibilityIdentifier = "createAlarm.cancelButton"
+            cancelButton.addTarget(self, action: #selector(cancelTapped), for: .touchUpInside)
+            navigationItem.leftBarButtonItem = UIBarButtonItem(customView: cancelButton)
+        } else {
+            let closeButton = UIButton(type: .system)
+            closeButton.setImage(
+                UIImage(systemName: "xmark")?.withConfiguration(
+                    UIImage.SymbolConfiguration(pointSize: 16, weight: .semibold)
+                ),
+                for: .normal
+            )
+            closeButton.tintColor = AppColors.fg1
+            closeButton.backgroundColor = AppColors.whiteOverlay06
+            closeButton.layer.cornerRadius = 18
+            closeButton.layer.masksToBounds = true
+            closeButton.translatesAutoresizingMaskIntoConstraints = false
+            closeButton.widthAnchor.constraint(equalToConstant: 36).isActive = true
+            closeButton.heightAnchor.constraint(equalToConstant: 36).isActive = true
+            closeButton.addTarget(self, action: #selector(cancelTapped), for: .touchUpInside)
+            closeButton.accessibilityLabel = "Закрыть"
+            navigationItem.leftBarButtonItem = UIBarButtonItem(customView: closeButton)
+        }
 
         let saveButton = SPButton(
-            title: "Готово",
+            title: viewModel.isEditing ? "Сохранить" : "Готово",
             variant: .money,
             size: .sm
         )


### PR DESCRIPTION
## Что сделано
Экран редактирования будильника теперь использует подписи кнопок по дизайну (SPMore2.jsx `AlarmEdit`, artboard `10-alarm-edit`):
- **edit**: слева `SPButton(.quiet, .sm)` «Отмена», справа `SPButton(.money, .sm)` «Сохранить».
- **create**: без изменений — X-чип слева + «Готово» справа (SPScreensV2.jsx:496-502).

Ветвление по `viewModel.isEditing` в `setupNavigationBar()`. Селекторы (`cancelTapped`/`saveTapped`) и `accessibilityIdentifier=createAlarm.saveButton` сохранены; кнопке отмены добавлен `createAlarm.cancelButton`.

## Тесты
- build_sim: ✅ SUCCEEDED
- swiftlint: ✅ 0 violations
- Чистый UI без новой логики (ветвление подписей) — юнит-тесты не требуются.

## Визуальная верификация
(screenshot-vs-Figma gate временно отключён — UI проверит PM интерактивно)

Fixes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)