### PR TITLE
[fix] AudioService: paused state + interruption recovery + un-pause stacked alarms (#374)

### DIFF
--- a/SnoozePay/SnoozePay/Services/AudioService.swift
+++ b/SnoozePay/SnoozePay/Services/AudioService.swift
@@ -75,6 +75,19 @@ final class AudioService {
     /// Queue-confined backing storage for `currentAlarmID`.
     private var _currentAlarmID: UUID?
 
+    /// Queue-confined. `true` while the looped player is paused but the session
+    /// is still owned — either the top-up sheet paused it (#141) or a system
+    /// interruption did (#374). `_state` stays `.playing` throughout (the
+    /// session is ours and a resume must succeed without re-asking), so this
+    /// flag is what distinguishes "audible right now" from "owned but silent".
+    private var _isPaused = false
+
+    /// Queue-confined. `true` when the current pause was caused by an
+    /// `AVAudioSession` interruption (call/Siri) and should therefore
+    /// auto-resume when the interruption ends — as opposed to a top-up pause,
+    /// which only resumes via `resumeAlarmSound()` (#374).
+    private var _interrupted = false
+
     /// Current playback state. Thread-safe snapshot read (#202).
     var state: AudioPlaybackState { queue.sync { _state } }
 
@@ -95,9 +108,27 @@ final class AudioService {
 
     /// Backwards-compatible boolean. `true` only when actually playing real audio.
     /// Retained so existing callers (AppDelegate guards, tests) keep working.
+    /// Note: stays `true` across a pause/interruption (the session is still
+    /// owned) — use `isPaused` to tell whether sound is *audible right now*.
     var isPlaying: Bool { state == .playing }
 
-    private init() {}
+    /// `true` while owned audio is paused (top-up sheet #141 or interruption
+    /// #374). Callers that need "is sound actually audible" check
+    /// `isPlaying && !isPaused`. Thread-safe snapshot read.
+    var isPaused: Bool { queue.sync { _isPaused } }
+
+    private init() {
+        // Resume the alarm after a phone call / Siri interruption — for an
+        // alarm a permanent silence is a failed wake, so we re-activate and
+        // restart rather than waiting for the user (#374). The singleton lives
+        // for the app's lifetime, so the observer never needs removal.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleAudioInterruption(_:)),
+            name: AVAudioSession.interruptionNotification,
+            object: nil
+        )
+    }
 
     // MARK: - Audio Session
 
@@ -191,6 +222,10 @@ final class AudioService {
             return
         }
 
+        // Fresh start always begins audible; clear any stale pause/interrupt
+        // bookkeeping (defensive — we only reach here from `.stopped`).
+        _isPaused = false
+        _interrupted = false
         audioPlayer = player
         configurePlayerVolume(player, target: volume, fadeIn: fadeIn)
 
@@ -224,6 +259,15 @@ final class AudioService {
     /// stays under SwiftLint's `function_body_length` cap (#182).
     /// Must only be called from `queue`.
     private func handleStartWhileNonStopped(alarmID: UUID?) {
+        // If the session is paused (top-up sheet open #141, or mid-interruption
+        // #374) a newly firing alarm would otherwise stay silent until the
+        // top-up auto-resume — un-pause now so the incoming alarm is immediately
+        // audible on the already-owned session, consistent with #116's
+        // "audio is already ringing, just hand over ownership" philosophy.
+        if _isPaused {
+            resumePlaybackLocked()
+        }
+
         // We're already playing — but the *caller* may be a new alarm taking
         // over (stacking-replace path #116). Update ownership so the previous
         // VC's `viewDidDisappear` correctly recognises the session no longer
@@ -301,6 +345,8 @@ final class AudioService {
             stopVibration()
             deactivateAudioSession()
             _currentAlarmID = nil
+            _isPaused = false
+            _interrupted = false
             _state = .stopped
         }
     }
@@ -327,6 +373,7 @@ final class AudioService {
             guard _state == .playing else { return }
             audioPlayer?.pause()
             stopVibration()
+            _isPaused = true
         }
     }
 
@@ -335,16 +382,81 @@ final class AudioService {
     /// dismiss path can call it without checking pause state first.
     func resumeAlarmSound() {
         queue.sync {
-            guard _state == .playing, let player = audioPlayer else { return }
-            // `play()` returns false only if the queue refuses — which on a paused
-            // looping player should not happen unless the session was deactivated
-            // out-of-band. Log so a regression where pause/resume gets out of sync
-            // (e.g. interrupted by another app's audio) is diagnosable.
-            if !player.play() {
-                AppLogger.audio.error("resumeAlarmSound: AVAudioPlayer.play() returned false")
-            }
-            startVibration()
+            guard _state == .playing, audioPlayer != nil else { return }
+            resumePlaybackLocked()
+            _interrupted = false
         }
+    }
+
+    /// Resume the paused looped player + vibration. Must only be called from
+    /// `queue` with `audioPlayer != nil`. Clears `_isPaused`. Shared by
+    /// `resumeAlarmSound()` (#141), the stacking-replace un-pause (#116/#374)
+    /// and interruption recovery (#374).
+    private func resumePlaybackLocked() {
+        guard let player = audioPlayer else { return }
+        // `play()` returns false only if the queue refuses — which on a paused
+        // looping player should not happen unless the session was deactivated
+        // out-of-band. Log so a regression where pause/resume gets out of sync
+        // (e.g. interrupted by another app's audio) is diagnosable.
+        if !player.play() {
+            AppLogger.audio.error("resumePlaybackLocked: AVAudioPlayer.play() returned false")
+        }
+        startVibration()
+        _isPaused = false
+    }
+
+    // MARK: - Interruptions
+
+    /// React to an `AVAudioSession` interruption (incoming call, Siri, another
+    /// app grabbing audio). On `.began` iOS has already paused our player, so we
+    /// mirror that into our own state and stop the vibration timer (otherwise it
+    /// keeps buzzing with no sound). On `.ended` we re-activate the session and
+    /// resume — an alarm that stays silent after a call is a failed wake (#374).
+    @objc private func handleAudioInterruption(_ notification: Notification) {
+        guard
+            let info = notification.userInfo,
+            let raw = info[AVAudioSessionInterruptionTypeKey] as? UInt,
+            let type = AVAudioSession.InterruptionType(rawValue: raw)
+        else { return }
+
+        queue.sync {
+            switch type {
+            case .began:
+                // Only act on an active, not-already-paused alarm. If a top-up
+                // pause is already in effect we leave it to `resumeAlarmSound()`.
+                guard _state == .playing, !_isPaused else { return }
+                audioPlayer?.pause()
+                stopVibration()
+                _isPaused = true
+                _interrupted = true
+            case .ended:
+                guard _interrupted else { return }
+                _interrupted = false
+                resumeAfterInterruptionLocked()
+            @unknown default:
+                break
+            }
+        }
+    }
+
+    /// Re-activate the audio session (the system deactivated it during the
+    /// interruption) and resume playback. Must only be called from `queue`.
+    private func resumeAfterInterruptionLocked() {
+        guard _state == .playing, audioPlayer != nil else { return }
+        do {
+            try configureAudioSession()
+        } catch {
+            // Session could not be reclaimed (another app holds it). Surface the
+            // explicit fallback so the firing UI can warn the user rather than
+            // showing a "ringing" screen with no sound.
+            AppLogger.audio.error(
+                "failed to reactivate audio session after interruption: \(error.localizedDescription, privacy: .public)"
+            )
+            _isPaused = false
+            _state = .silentBecauseConfigFailed
+            return
+        }
+        resumePlaybackLocked()
     }
 
     // MARK: - Vibration

--- a/SnoozePay/SnoozePayTests/AudioServiceTests.swift
+++ b/SnoozePay/SnoozePayTests/AudioServiceTests.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import XCTest
 @testable import SnoozePay
 
@@ -329,5 +330,115 @@ final class AudioServiceTests: XCTestCase {
 
         service.stopAlarmSound()
         XCTAssertEqual(service.state, .stopped)
+    }
+
+    // MARK: - Pause / interruption state (#374)
+
+    /// Post a synthetic `AVAudioSession` interruption so the service's observer
+    /// runs its handler. The handler hops the serial queue with `queue.sync`,
+    /// and `NotificationCenter.post` delivers synchronously on this thread, so
+    /// the service state is fully settled when `post` returns.
+    private func postInterruption(_ type: AVAudioSession.InterruptionType) {
+        NotificationCenter.default.post(
+            name: AVAudioSession.interruptionNotification,
+            object: AVAudioSession.sharedInstance(),
+            userInfo: [AVAudioSessionInterruptionTypeKey: type.rawValue]
+        )
+    }
+
+    /// `pauseAlarmSound()` must flip `isPaused` while keeping `.playing`
+    /// (session ownership intact, #141); `resumeAlarmSound()` clears it.
+    func testPauseResume_togglesIsPaused() {
+        let service = AudioService.shared
+        service.stopAlarmSound()
+        service.startAlarmSound(soundID: "nonexistent_test_sound", alarmID: UUID())
+        XCTAssertTrue(service.isPlaying)
+        XCTAssertFalse(service.isPaused)
+
+        service.pauseAlarmSound()
+        XCTAssertTrue(service.isPaused, "pause must mark the session as not audible")
+        XCTAssertEqual(service.state, .playing, "pause keeps .playing (session owned)")
+
+        service.resumeAlarmSound()
+        XCTAssertFalse(service.isPaused, "resume must clear the paused flag")
+        XCTAssertEqual(service.state, .playing)
+
+        service.stopAlarmSound()
+        XCTAssertFalse(service.isPaused)
+    }
+
+    /// #374 facet 2 — a new alarm firing while the session is paused (top-up
+    /// sheet open) must un-pause so it is immediately audible, not silent until
+    /// the 60s auto-resume. Ownership still transfers to the new alarm (#116).
+    func testStartWhilePaused_unPausesAndTransfersOwnership() {
+        let service = AudioService.shared
+        service.stopAlarmSound()
+
+        let alarmA = UUID()
+        let alarmB = UUID()
+        service.startAlarmSound(soundID: "tone_a", alarmID: alarmA)
+        service.pauseAlarmSound()
+        XCTAssertTrue(service.isPaused)
+
+        // Alarm B fires into the paused session.
+        service.startAlarmSound(soundID: "tone_b", alarmID: alarmB)
+        XCTAssertFalse(service.isPaused, "a new alarm must un-pause the session so it rings")
+        XCTAssertEqual(service.currentAlarmID, alarmB, "ownership transfers to the new alarm (#116)")
+        XCTAssertTrue(service.isPlaying)
+
+        service.stopAlarmSound()
+    }
+
+    /// #374 facet 1 — an interruption (call/Siri) pauses the alarm; when it ends
+    /// the alarm must resume (a permanently silent alarm is a failed wake).
+    func testInterruption_pausesOnBeganAndResumesOnEnded() {
+        let service = AudioService.shared
+        service.stopAlarmSound()
+        service.startAlarmSound(soundID: "nonexistent_test_sound", alarmID: UUID())
+        XCTAssertFalse(service.isPaused)
+
+        postInterruption(.began)
+        XCTAssertTrue(service.isPaused, "interruption .began must pause the alarm")
+        XCTAssertEqual(service.state, .playing, "session is still owned across the interruption")
+
+        postInterruption(.ended)
+        XCTAssertFalse(service.isPaused, "interruption .ended must auto-resume the alarm")
+        XCTAssertEqual(service.state, .playing)
+
+        service.stopAlarmSound()
+    }
+
+    /// An `.ended` with no preceding `.began` (we were never interrupted) must
+    /// be a no-op rather than spuriously toggling state.
+    func testInterruptionEnded_withoutBegan_isNoOp() {
+        let service = AudioService.shared
+        service.stopAlarmSound()
+        service.startAlarmSound(soundID: "nonexistent_test_sound", alarmID: UUID())
+
+        postInterruption(.ended)
+        XCTAssertFalse(service.isPaused)
+        XCTAssertEqual(service.state, .playing)
+
+        service.stopAlarmSound()
+    }
+
+    /// A system interruption that arrives while a top-up pause (#141) is already
+    /// in effect must not hijack the pause: `.ended` must NOT auto-resume,
+    /// leaving the manual `resumeAlarmSound()` in control.
+    func testInterruption_duringTopUpPause_doesNotAutoResume() {
+        let service = AudioService.shared
+        service.stopAlarmSound()
+        service.startAlarmSound(soundID: "nonexistent_test_sound", alarmID: UUID())
+        service.pauseAlarmSound()          // top-up pause
+        XCTAssertTrue(service.isPaused)
+
+        postInterruption(.began)           // guarded out (already paused)
+        postInterruption(.ended)           // must not auto-resume the top-up pause
+        XCTAssertTrue(service.isPaused, "top-up pause must survive an interruption cycle")
+
+        service.resumeAlarmSound()
+        XCTAssertFalse(service.isPaused)
+
+        service.stopAlarmSound()
     }
 }


### PR DESCRIPTION
## Что сделано
Закрывает два реальных сценария, где `AudioService` сообщал `.playing`, пока звук фактически молчал (audit-finding):

**Facet 1 — обработка прерываний AVAudioSession.** Раньше не было ни одного наблюдателя `interruptionNotification`: входящий звонок/Siri ставил `AVAudioPlayer` на паузу, iOS не возобновлял его, а будильник оставался немым (при этом таймер вибрации продолжал тикать). Добавлен observer: на `.began` — пауза + остановка вибрации; на `.ended` — реактивация сессии и возобновление (немой будильник = провал подъёма, поэтому возобновляем независимо от `.shouldResume`).

**Facet 2 — пауза при стэкинге.** Если первый будильник на паузе (открыта top-up-шторка #141) и срабатывает второй, `handleStartWhileNonStopped` лишь передавал владение и оставлял плеер на паузе → тишина до 60s авто-resume. Теперь сначала снимаем паузу, чтобы новый будильник был слышен сразу.

### Подход
Вместо нового кейса `.paused` в enum (сломал бы контракт «`.playing` сохраняется» из #141 и всех наблюдателей `stateChangedNotification`) добавлены два queue-confined флага `_isPaused`/`_interrupted` и публичный `isPaused`. Контракт `isPlaying`/`state` не меняется — вызывающие, которым нужно «звучит ли прямо сейчас», используют `isPlaying && !isPaused`. Это вариант, который сам же рекомендовал type-design-агент.

## Тесты
- build_sim: ✅ SUCCEEDED
- test_sim (локально): ✅ **19/19 AudioServiceTests passed** (6 новых + 13 существующих)
- swiftlint: ✅ 0 violations в тест-файле
- Новые тесты: `testPauseResume_togglesIsPaused`, `testStartWhilePaused_unPausesAndTransfersOwnership`, `testInterruption_pausesOnBeganAndResumesOnEnded`, `testInterruptionEnded_withoutBegan_isNoOp`, `testInterruption_duringTopUpPause_doesNotAutoResume`

## Заметки для ревью / PM
- ⚠️ **file_length warning**: `AudioService.swift` 393 → 505 строк (soft-cap 400). Вынос interruption-кода в extension-файл потребовал бы снять `private` с queue-confined состояния (регрессия инкапсуляции #202), поэтому оставил в файле. CI non-strict — не блокирует. Возможный follow-up: рефактор после #182-паттерна, если PM захочет.
- ⚠️ **Device-verification gap**: реальное поведение прерывания звонком невозможно проверить в unit-тестах (только синтетическая нотификация) и на симуляторе; qa-tester/device-тесты отключены. Логику покрыл детерминированными тестами через `isPaused`, но финальную проверку «звонок во время будильника → возобновился» стоит сделать на устройстве.

Fixes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)