### PR TITLE
[audio] AlarmKit Strategy A — real alarm that rings in silent mode (#377)

### DIFF
--- a/SnoozePay/SnoozePay/Info.plist
+++ b/SnoozePay/SnoozePay/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAlarmKitUsageDescription</key>
+	<string>SnoozePay использует будильники, чтобы будить вас вовремя — даже в беззвучном режиме.</string>
 	<key>NSCriticalAlertUsageDescription</key>
 	<string>SnoozePay использует критические уведомления для срабатывания будильника даже в режиме «Не беспокоить» и при выключенном звуке.</string>
 	<key>UIBackgroundModes</key>

--- a/SnoozePay/SnoozePay/Services/AlarmKitIntents.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmKitIntents.swift
@@ -1,0 +1,151 @@
+import Foundation
+import os
+#if canImport(AppIntents)
+import AppIntents
+#endif
+
+// MARK: - AlarmKit alert button intents (#377)
+//
+// AlarmKit (iOS 26+, Strategy A) does NOT use UNNotificationAction-style action
+// identifiers routed through the UNUserNotificationCenter delegate. Instead the
+// system-rendered full-screen alert's buttons are wired to `LiveActivityIntent`
+// instances handed to `AlarmManager` at schedule time
+// (`AlarmConfiguration.stopIntent` / `.secondaryIntent`). When the user taps a
+// button on the lock-screen / Dynamic-Island alarm presentation, the system
+// runs the corresponding intent's `perform()` in our app process — even while
+// the device is locked.
+//
+// These two intents are the AlarmKit analogue of the
+// `DISMISS_ACTION` / `SNOOZE_ACTION` notification actions handled in
+// `AppDelegate.userNotificationCenter(_:didReceive:)`:
+//   * `StopAlarmIntent`   → stop ringing, record the wake day (no charge).
+//   * `SnoozeAlarmIntent`  → charge the (progressive) penalty, reschedule via
+//                            `AlarmFiringCoordinator`, re-arm the snooze alarm.
+//
+// Both carry the alarm UUID as a plain string parameter so the system can
+// persist + replay them, and both resolve the alarm from `AlarmRepository`
+// rather than trusting any payload state — the repository is the single source
+// of truth for penalty / snooze settings (mirrors the notification path).
+
+#if canImport(AppIntents)
+
+@available(iOS 26.0, *)
+struct StopAlarmIntent: LiveActivityIntent {
+
+    static let title: LocalizedStringResource = "Выключить будильник"
+
+    /// UUID string of the alarm whose AlarmKit alert this button belongs to.
+    /// Stored as a string because `IntentParameter` does not support `UUID`
+    /// directly and the system serialises the intent for later replay.
+    @Parameter(title: "Alarm ID")
+    var alarmID: String
+
+    init() {}
+
+    init(alarmID: UUID) {
+        self.alarmID = alarmID.uuidString
+    }
+
+    func perform() async throws -> some IntentResult {
+        await AlarmKitActionRouter.shared.handleStop(alarmIDString: alarmID)
+        return .result()
+    }
+}
+
+@available(iOS 26.0, *)
+struct SnoozeAlarmIntent: LiveActivityIntent {
+
+    static let title: LocalizedStringResource = "Поспать ещё"
+
+    @Parameter(title: "Alarm ID")
+    var alarmID: String
+
+    init() {}
+
+    init(alarmID: UUID) {
+        self.alarmID = alarmID.uuidString
+    }
+
+    func perform() async throws -> some IntentResult {
+        await AlarmKitActionRouter.shared.handleSnooze(alarmIDString: alarmID)
+        return .result()
+    }
+}
+
+#endif
+
+/// Shared, framework-free router for AlarmKit alert-button actions. Extracted
+/// from the intents so the business logic (charge + reschedule + wake-event)
+/// is unit-testable without standing up AppIntents / AlarmKit — the intents
+/// are thin shells whose only job is to forward to this type.
+///
+/// Always available (no `@available` gate) so the test target and the
+/// `< iOS 26` build can reference it; the intents that call it are the
+/// iOS-26-gated surface.
+///
+/// `@MainActor`-isolated: every action it performs touches a UI-adjacent
+/// singleton (`AudioService`, `AlarmScheduler`, `WakeEventStore`,
+/// `AlarmFiringCoordinator`), and the AppIntent `perform()` that drives it is
+/// itself main-actor isolated — keeping the router on the main actor avoids
+/// cross-actor hops and the Swift-6 isolation diagnostics they raise.
+@MainActor
+final class AlarmKitActionRouter {
+
+    static let shared = AlarmKitActionRouter()
+
+    private init() {}
+
+    /// Stop the ringing alarm: silence audio + record the wake day. No charge —
+    /// mirrors the `DISMISS_ACTION` branch in `AppDelegate.didReceive`.
+    func handleStop(alarmIDString: String) {
+        guard let alarmID = UUID(uuidString: alarmIDString) else {
+            AppLogger.scheduler.error(
+                "AlarmKit stop: malformed alarmID \(alarmIDString, privacy: .public)"
+            )
+            return
+        }
+        AppLogger.scheduler.notice("AlarmKit stop alarm=\(alarmID, privacy: .private)")
+        AudioService.shared.stopAlarmSound()
+        WakeEventStore.shared.recordWake()
+        // Stop the AlarmKit alert itself so the system stops the alarm UI.
+        AlarmScheduler.shared.stopSystemAlarm(alarmID)
+    }
+
+    /// Snooze the ringing alarm: charge the penalty + reschedule. Routed
+    /// through the same `AlarmFiringCoordinator` the notification path uses so
+    /// the paid-snooze / refund-on-failure semantics stay identical (#377).
+    func handleSnooze(alarmIDString: String) async {
+        guard let alarmID = UUID(uuidString: alarmIDString) else {
+            AppLogger.scheduler.error(
+                "AlarmKit snooze: malformed alarmID \(alarmIDString, privacy: .public)"
+            )
+            return
+        }
+        AppLogger.scheduler.notice("AlarmKit snooze alarm=\(alarmID, privacy: .private)")
+        AudioService.shared.stopAlarmSound()
+        AlarmScheduler.shared.stopSystemAlarm(alarmID)
+
+        // Reuse the notification-path payload contract so the coordinator's
+        // charge / progressive-penalty / refund logic is shared verbatim. The
+        // coordinator re-reads the alarm from the repository, so a minimal
+        // payload (id + current snoozeCount) is enough — but we still need the
+        // alarm's penalty settings to build a complete payload, so resolve it.
+        guard let alarm = AlarmRepository.shared.fetch(id: alarmID) else {
+            AppLogger.scheduler.notice(
+                "AlarmKit snooze: alarm \(alarmID, privacy: .private) not found — skipping"
+            )
+            return
+        }
+        // AlarmKit owns its own snooze counter via repeated alerts; we start at
+        // the alarm's base penalty (snoozeCount 0 → coordinator increments to 1).
+        let payload = AlarmNotificationPayload(alarm: alarm, snoozeCount: 0)
+        await withCheckedContinuation { continuation in
+            AlarmFiringCoordinator.shared.handleSnooze(userInfo: payload.asUserInfo()) { outcome in
+                AppLogger.scheduler.info(
+                    "AlarmKit snooze outcome=\(String(describing: outcome), privacy: .public)"
+                )
+                continuation.resume()
+            }
+        }
+    }
+}

--- a/SnoozePay/SnoozePay/Services/AlarmKitScheduler.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmKitScheduler.swift
@@ -1,0 +1,245 @@
+import Foundation
+import os
+#if canImport(AlarmKit)
+import ActivityKit
+import AlarmKit
+import AppIntents
+import SwiftUI
+#endif
+
+// MARK: - Strategy A: AlarmKit (#377)
+//
+// `docs/SPEC.md` §3.2.1 defines Strategy A — a real system-level alarm via the
+// AlarmKit framework (iOS 26+). Unlike a `UNUserNotificationCenter` notification
+// (Strategy B, the fallback), an AlarmKit alarm rings continuously, pierces
+// silent mode and Focus/DND, and shows a full-screen alert on the lock screen —
+// exactly like Clock.app — WITHOUT the Critical Alerts entitlement (which is
+// not approved on the Personal team).
+//
+// This file owns the AlarmKit wrapper. `AlarmScheduler` (Strategy B) decides at
+// runtime which backend to use: AlarmKit on iOS 26+, the existing notification
+// scheduler below it.
+
+/// Backend-agnostic seam over the AlarmKit `AlarmManager`. Extracted as a
+/// protocol — exactly like `NotificationScheduling` for `UNUserNotificationCenter`
+/// — so unit tests can substitute a mock and verify the iOS-26-vs-fallback
+/// branching in `AlarmScheduler` without standing up the real `AlarmManager`
+/// (which requires a live iOS 26 device, user authorization, and a registered
+/// AppIntent surface).
+///
+/// Deliberately uses ONLY framework-free types (`Alarm`, `UUID`, `Bool`) in its
+/// signatures so the protocol — and the tests that mock it — compile on every
+/// iOS version. The concrete `AlarmKitScheduler` is the only `@available(iOS 26)`
+/// surface.
+protocol AlarmKitScheduling: AnyObject {
+    /// Whether AlarmKit reports the user has authorized scheduling alarms.
+    var isAuthorized: Bool { get }
+
+    /// Request AlarmKit authorization. Completes with `true` when authorized.
+    /// Idempotent — AlarmKit returns the cached state once decided.
+    func requestAuthorization(completion: @escaping (Bool) -> Void)
+
+    /// Schedule (or replace) the system alarm for `alarm`. Throws when AlarmKit
+    /// rejects the request (limit reached, not authorized). A no-op for a
+    /// disabled alarm is the caller's responsibility.
+    func schedule(_ alarm: Alarm) throws
+
+    /// Cancel the system alarm for `alarmID` (pending — not yet alerting).
+    func cancel(_ alarmID: UUID)
+
+    /// Stop a currently-alerting system alarm (user tapped stop / snooze).
+    func stop(_ alarmID: UUID)
+}
+
+#if canImport(AlarmKit)
+
+/// Empty metadata payload. AlarmKit requires the generic `AlarmAttributes` to
+/// carry an `AlarmMetadata`; we don't need custom Live Activity data for the
+/// core scheduling path (Live Activity / Dynamic Island presentation is
+/// explicitly out of scope for #377), so a marker struct satisfies the
+/// constraint without shipping unused UI.
+@available(iOS 26.0, *)
+struct SnoozePayAlarmMetadata: AlarmMetadata {
+    init() {}
+}
+
+/// Concrete AlarmKit backend. Translates the app's `Alarm` model into an
+/// `AlarmManager.AlarmConfiguration` and drives schedule / cancel / stop +
+/// authorization. Wires the system alert's stop / snooze buttons to
+/// `StopAlarmIntent` / `SnoozeAlarmIntent` so a lock-screen tap routes back
+/// into the shared charge / reschedule logic (`AlarmKitActionRouter`).
+@available(iOS 26.0, *)
+final class AlarmKitScheduler: AlarmKitScheduling {
+
+    private let manager = AlarmManager.shared
+
+    var isAuthorized: Bool {
+        manager.authorizationState == .authorized
+    }
+
+    func requestAuthorization(completion: @escaping (Bool) -> Void) {
+        // Already decided? Report synchronously without re-prompting.
+        switch manager.authorizationState {
+        case .authorized:
+            completion(true)
+            return
+        case .denied:
+            completion(false)
+            return
+        case .notDetermined:
+            break
+        @unknown default:
+            break
+        }
+
+        Task {
+            do {
+                let state = try await manager.requestAuthorization()
+                AppLogger.scheduler.notice(
+                    "AlarmKit authorization resolved=\(String(describing: state), privacy: .public)"
+                )
+                await MainActor.run { completion(state == .authorized) }
+            } catch {
+                AppLogger.scheduler.error(
+                    "AlarmKit authorization failed: \(error.localizedDescription, privacy: .public)"
+                )
+                await MainActor.run { completion(false) }
+            }
+        }
+    }
+
+    func schedule(_ alarm: Alarm) throws {
+        let configuration = try Self.makeConfiguration(for: alarm)
+        // `schedule(id:configuration:)` is async; we fire-and-log so the
+        // synchronous `AlarmScheduling` contract (used by `AlarmRepository`)
+        // is preserved. Errors that surface before the await (config build)
+        // are thrown to the caller; post-await failures are logged.
+        Task {
+            do {
+                _ = try await manager.schedule(id: alarm.id, configuration: configuration)
+                AppLogger.scheduler.info(
+                    "AlarmKit scheduled alarm=\(alarm.id, privacy: .private)"
+                )
+            } catch {
+                let desc = error.localizedDescription
+                AppLogger.scheduler.error(
+                    "AlarmKit schedule failed alarm=\(alarm.id, privacy: .private): \(desc, privacy: .public)"
+                )
+            }
+        }
+    }
+
+    func cancel(_ alarmID: UUID) {
+        do {
+            try manager.cancel(id: alarmID)
+            AppLogger.scheduler.info("AlarmKit cancelled alarm=\(alarmID, privacy: .private)")
+        } catch {
+            // A not-found cancel is benign (alarm already fired / never armed
+            // on this backend) — log at info, never crash the caller.
+            let desc = error.localizedDescription
+            AppLogger.scheduler.info(
+                "AlarmKit cancel no-op alarm=\(alarmID, privacy: .private): \(desc, privacy: .public)"
+            )
+        }
+    }
+
+    func stop(_ alarmID: UUID) {
+        do {
+            try manager.stop(id: alarmID)
+        } catch {
+            let desc = error.localizedDescription
+            AppLogger.scheduler.info(
+                "AlarmKit stop no-op alarm=\(alarmID, privacy: .private): \(desc, privacy: .public)"
+            )
+        }
+    }
+
+    // MARK: - Configuration mapping
+
+    /// Build the AlarmKit configuration for an alarm: schedule (relative time
+    /// + weekly recurrence), the full-screen alert presentation (title + stop /
+    /// snooze buttons), the stop / snooze intents, and the alarm sound.
+    static func makeConfiguration(
+        for alarm: Alarm
+    ) throws -> AlarmManager.AlarmConfiguration<SnoozePayAlarmMetadata> {
+        let schedule = makeSchedule(for: alarm)
+        let presentation = makePresentation(for: alarm)
+        let attributes = AlarmAttributes<SnoozePayAlarmMetadata>(
+            presentation: presentation,
+            metadata: SnoozePayAlarmMetadata(),
+            tintColor: Color.orange
+        )
+        return AlarmManager.AlarmConfiguration.alarm(
+            schedule: schedule,
+            attributes: attributes,
+            stopIntent: StopAlarmIntent(alarmID: alarm.id),
+            secondaryIntent: SnoozeAlarmIntent(alarmID: alarm.id),
+            sound: alarmSound(for: alarm)
+        )
+    }
+
+    /// Map the app's hour/minute + Monday-first repeat-day indices to an
+    /// AlarmKit relative schedule. A non-repeating alarm uses `.never`
+    /// recurrence so it fires once at the next occurrence of the time.
+    nonisolated static func makeSchedule(for alarm: Alarm) -> AlarmKit.Alarm.Schedule {
+        let components = Calendar.current.dateComponents([.hour, .minute], from: alarm.time)
+        let time = AlarmKit.Alarm.Schedule.Relative.Time(
+            hour: components.hour ?? 0,
+            minute: components.minute ?? 0
+        )
+        let recurrence: AlarmKit.Alarm.Schedule.Relative.Recurrence
+        if alarm.repeatDays.isEmpty || alarm.repeatMode != .weekly {
+            recurrence = .never
+        } else {
+            recurrence = .weekly(alarm.repeatDays.compactMap { weekday(forMondayFirstIndex: $0) })
+        }
+        return .relative(.init(time: time, repeats: recurrence))
+    }
+
+    /// Convert a Monday-first 0...6 index (the app's `repeatDays` convention)
+    /// to a `Locale.Weekday`. Returns `nil` for out-of-range input so a corrupt
+    /// index is dropped rather than crashing — `repeatDays` is already filtered
+    /// to 0...6 at the model boundary (#207), so this is belt-and-suspenders.
+    nonisolated static func weekday(forMondayFirstIndex index: Int) -> Locale.Weekday? {
+        switch index {
+        case 0: return .monday
+        case 1: return .tuesday
+        case 2: return .wednesday
+        case 3: return .thursday
+        case 4: return .friday
+        case 5: return .saturday
+        case 6: return .sunday
+        default: return nil
+        }
+    }
+
+    /// Build the full-screen alert presentation. The primary (stop) button is
+    /// driven by `stopIntent`; the secondary (snooze) button shows the paid
+    /// snooze cost and is driven by `secondaryIntent`.
+    private static func makePresentation(for alarm: Alarm) -> AlarmPresentation {
+        let snoozeTitle: LocalizedStringResource =
+            "Поспать ещё (−\(MoneyFormatter.string(alarm.penalty(forSnoozeCount: 1))))"
+        let snoozeButton = AlarmButton(
+            text: snoozeTitle,
+            textColor: .white,
+            systemImageName: "zzz"
+        )
+        let alert = AlarmPresentation.Alert(
+            title: LocalizedStringResource(stringLiteral: alarm.name),
+            secondaryButton: snoozeButton,
+            secondaryButtonBehavior: .custom
+        )
+        return AlarmPresentation(alert: alert)
+    }
+
+    /// Resolve the alarm's sound to an AlarmKit alert sound. Falls back to the
+    /// system default when the bundled file can't be located.
+    private static func alarmSound(for alarm: Alarm) -> ActivityKit.AlertConfiguration.AlertSound {
+        if let fileName = AlarmScheduler.shared.alarmSoundFileName(for: alarm.soundID) {
+            return .named(fileName)
+        }
+        return .default
+    }
+}
+
+#endif

--- a/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
@@ -44,10 +44,23 @@ protocol AlarmScheduling: AnyObject {
     func cancel(_ alarmID: UUID)
 }
 
-/// Handles scheduling and cancelling alarms.
-/// Uses UNUserNotificationCenter (iOS 18+) as the scheduling backend.
-/// On iOS 26+ with AlarmKit, the system alarm engine takes over — this service
-/// manages the notification fallback and snooze rescheduling.
+/// Handles scheduling and cancelling alarms across two backends (`docs/SPEC.md`
+/// §3.2.1):
+///
+/// - **Strategy A — AlarmKit (iOS 26+).** On iOS 26 and later, alarms are
+///   scheduled through `AlarmKitScheduler` (the `AlarmManager` wrapper). This
+///   is a real system alarm: it rings continuously, pierces silent mode and
+///   Focus/DND, and shows a full-screen lock-screen alert — like Clock.app —
+///   without the (unapproved) Critical Alerts entitlement. Stop / snooze
+///   buttons on the system alert route back through `AlarmKitActionRouter`.
+/// - **Strategy B — UNUserNotificationCenter (fallback, all versions).** Below
+///   iOS 26 (or if AlarmKit scheduling fails / is unauthorized) the alarm is a
+///   `.timeSensitive` notification with the lock-screen fallback burst (#19).
+///   This is the only backend that ran before #377.
+///
+/// The two paths share `AlarmFiringCoordinator` for paid-snooze charging and
+/// refund-on-failure, so the wallet semantics are identical regardless of
+/// backend.
 final class AlarmScheduler: AlarmScheduling {
 
     static let shared = AlarmScheduler()
@@ -111,6 +124,22 @@ final class AlarmScheduler: AlarmScheduling {
 
     private let notificationCenter: NotificationScheduling
 
+    /// Strategy A backend (#377). Non-nil only on iOS 26+ where AlarmKit is
+    /// available; `nil` on earlier OSes so every call site naturally falls
+    /// through to the notification path. Injectable for tests so the
+    /// iOS-26-vs-fallback branching can be exercised on any host OS.
+    private let alarmKitScheduler: AlarmKitScheduling?
+
+    /// Whether the AlarmKit (Strategy A) path should be used for this call.
+    /// True only when running on iOS 26+, a backend is wired, AND the user has
+    /// authorized AlarmKit. Otherwise we fall through to the notification
+    /// fallback so a denied / undetermined AlarmKit grant never leaves the user
+    /// without any alarm.
+    private var usesAlarmKit: Bool {
+        guard #available(iOS 26.0, *), let alarmKitScheduler else { return false }
+        return alarmKitScheduler.isAuthorized
+    }
+
     // Notification category and action IDs
     private let categoryID = "ALARM_CATEGORY"
     private let dismissActionID = "DISMISS_ACTION"
@@ -139,17 +168,54 @@ final class AlarmScheduler: AlarmScheduling {
 
     private init() {
         self.notificationCenter = UNUserNotificationCenter.current()
+        // Wire the AlarmKit backend on iOS 26+; leave nil below so every call
+        // site falls through to the notification fallback (Strategy B).
+        if #available(iOS 26.0, *) {
+            self.alarmKitScheduler = AlarmKitScheduler()
+        } else {
+            self.alarmKitScheduler = nil
+        }
     }
 
-    /// Test-only initializer that swaps the notification-center seam.
-    /// Production code MUST use `AlarmScheduler.shared` (see `singleton`).
-    init(notificationCenter: NotificationScheduling) {
+    /// Test-only initializer that swaps the notification-center seam and,
+    /// optionally, the AlarmKit backend. Production code MUST use
+    /// `AlarmScheduler.shared` (see `singleton`). Passing an `alarmKit` mock
+    /// lets tests drive the Strategy-A path on any host OS.
+    init(
+        notificationCenter: NotificationScheduling,
+        alarmKit: AlarmKitScheduling? = nil
+    ) {
         self.notificationCenter = notificationCenter
+        self.alarmKitScheduler = alarmKit
     }
 
     // MARK: - Permission
 
+    /// Request AlarmKit (Strategy A) authorization on iOS 26+. No-op on earlier
+    /// OSes / when no backend is wired. Completes with the resolved grant.
+    /// Called alongside the notification permission request so the onboarding /
+    /// first-enable flow primes both backends (#377).
+    func requestAlarmKitAuthorization(completion: @escaping (Bool) -> Void) {
+        guard #available(iOS 26.0, *), let alarmKitScheduler else {
+            completion(false)
+            return
+        }
+        alarmKitScheduler.requestAuthorization(completion: completion)
+    }
+
     func requestPermission(completion: @escaping (Bool) -> Void) {
+        // On iOS 26+ prime AlarmKit authorization first (Strategy A). Its grant
+        // does not gate the notification request — we always also request
+        // notifications so the Strategy-B fallback stays available if AlarmKit
+        // is denied. The result reported to the caller is the NOTIFICATION
+        // grant, preserving the existing PermissionsViewController contract.
+        if #available(iOS 26.0, *), let alarmKitScheduler {
+            alarmKitScheduler.requestAuthorization { granted in
+                AppLogger.scheduler.notice(
+                    "AlarmKit authorization granted=\(granted, privacy: .public)"
+                )
+            }
+        }
         // Request critical alerts if entitled, fall back to standard alerts otherwise.
         // Always log the resolved state so QA can tell if we're on the degraded
         // (no critical-alert) path even when standard permission succeeds.
@@ -223,6 +289,28 @@ final class AlarmScheduler: AlarmScheduling {
         guard alarm.enabled else {
             completion?(.success(()))
             return
+        }
+
+        // Strategy A (#377): on iOS 26+ with AlarmKit authorized, schedule a
+        // real system alarm. If AlarmKit rejects the request synchronously
+        // (e.g. limit reached) we fall through to the notification fallback so
+        // the user is never left without an alarm.
+        if #available(iOS 26.0, *), usesAlarmKit, let alarmKitScheduler {
+            do {
+                try alarmKitScheduler.schedule(alarm)
+                AppLogger.scheduler.info(
+                    "scheduled via AlarmKit (Strategy A) alarm=\(alarm.id, privacy: .private)"
+                )
+                completion?(.success(()))
+                return
+            } catch {
+                let desc = error.localizedDescription
+                let alarmID = alarm.id
+                AppLogger.scheduler.error(
+                    "AlarmKit schedule failed alarm=\(alarmID, privacy: .private): \(desc, privacy: .public) — fallback"
+                )
+                // fall through to the notification path below
+            }
         }
 
         let content = makeContent(for: alarm, snoozeCount: 0)
@@ -408,6 +496,15 @@ final class AlarmScheduler: AlarmScheduling {
     /// label list — this prevents regressions like IOS-070 where a one-off (`once`) alarm
     /// kept ringing after deletion because its identifier was missing from the cancel set.
     func cancel(_ alarmID: UUID) {
+        // Strategy A (#377): also cancel the AlarmKit system alarm. Always
+        // attempt it on iOS 26+ regardless of `usesAlarmKit` so an alarm
+        // scheduled while authorized is still cancellable if authorization
+        // later changed. The notification sweep below runs unconditionally
+        // because an alarm may have been scheduled via either backend.
+        if #available(iOS 26.0, *), let alarmKitScheduler {
+            alarmKitScheduler.cancel(alarmID)
+        }
+
         let prefix = notificationIDPrefix(for: alarmID)
         let snoozeID = snoozeNotificationID(for: alarmID)
         // Match the snooze identifier itself AND its fallback-burst follow-ups
@@ -496,6 +593,16 @@ final class AlarmScheduler: AlarmScheduling {
 
     func cancelAll() {
         notificationCenter.removeAllPendingNotificationRequests()
+    }
+
+    /// Stop a currently-alerting AlarmKit (Strategy A) system alarm — invoked
+    /// from `AlarmKitActionRouter` when the user taps stop / snooze on the
+    /// system alert. No-op on iOS < 26 / when no AlarmKit backend is wired
+    /// (the notification path stops audio via `AudioService` instead). (#377)
+    func stopSystemAlarm(_ alarmID: UUID) {
+        if #available(iOS 26.0, *), let alarmKitScheduler {
+            alarmKitScheduler.stop(alarmID)
+        }
     }
 
     // MARK: - Private helpers

--- a/SnoozePay/SnoozePayTests/AlarmKitSchedulerTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmKitSchedulerTests.swift
@@ -1,0 +1,275 @@
+import XCTest
+import UserNotifications
+import AlarmKit
+@testable import SnoozePay
+
+// `import AlarmKit` brings `AlarmKit.Alarm` into scope, which collides with the
+// app's `SnoozePay.Alarm` model. We need both: the AlarmKit `Schedule` /
+// `Recurrence` enums for pattern-matching the mapping output, and the app model
+// to build test fixtures. `AppAlarm` disambiguates the app model so every
+// fixture / mock signature is unambiguous.
+private typealias AppAlarm = SnoozePay.Alarm
+
+/// Unit tests for the AlarmKit (Strategy A) integration in `AlarmScheduler`
+/// (#377). Covers the iOS-26-vs-notification-fallback branching through the
+/// injectable `AlarmKitScheduling` seam, plus the `Alarm` → AlarmKit config
+/// mapping. The branching tests run on any host because they exercise the
+/// `AlarmScheduling` API; the config-mapping tests are gated to iOS 26.
+final class AlarmKitSchedulerTests: XCTestCase {
+
+    // MARK: - Branching: schedule routes to the right backend
+
+    /// When AlarmKit is authorized (Strategy A), `schedule` must hand the alarm
+    /// to the AlarmKit backend and NOT register any notification request.
+    func testSchedule_authorizedAlarmKit_routesToAlarmKitNotNotifications() throws {
+        guard #available(iOS 26.0, *) else {
+            throw XCTSkip("AlarmKit branch only runs on iOS 26+")
+        }
+        let alarmKit = MockAlarmKitScheduler(authorized: true)
+        let center = RecordingCenter()
+        let scheduler = AlarmScheduler(notificationCenter: center, alarmKit: alarmKit)
+
+        let exp = expectation(description: "schedule completes")
+        scheduler.schedule(AppAlarm(penaltyAmount: 50)) { result in
+            if case .failure = result { XCTFail("expected success on AlarmKit path") }
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 2.0)
+
+        XCTAssertEqual(alarmKit.scheduledIDs.count, 1,
+                       "Authorized AlarmKit must receive the schedule call")
+        XCTAssertTrue(center.addedRequests.isEmpty,
+                      "Strategy A must not also register a notification (Strategy B)")
+    }
+
+    /// When AlarmKit is present but NOT authorized, `schedule` must fall back to
+    /// the notification path so the user is never left without an alarm.
+    func testSchedule_unauthorizedAlarmKit_fallsBackToNotifications() throws {
+        guard #available(iOS 26.0, *) else {
+            throw XCTSkip("AlarmKit branch only runs on iOS 26+")
+        }
+        let alarmKit = MockAlarmKitScheduler(authorized: false)
+        let center = RecordingCenter()
+        let scheduler = AlarmScheduler(notificationCenter: center, alarmKit: alarmKit)
+
+        let exp = expectation(description: "schedule completes")
+        scheduler.schedule(AppAlarm(penaltyAmount: 50)) { _ in exp.fulfill() }
+        wait(for: [exp], timeout: 2.0)
+
+        XCTAssertTrue(alarmKit.scheduledIDs.isEmpty,
+                      "Unauthorized AlarmKit must not be used")
+        XCTAssertFalse(center.addedRequests.isEmpty,
+                       "Fallback must register at least one notification (Strategy B)")
+    }
+
+    /// With no AlarmKit backend wired (the pre-#377 / iOS < 26 shape), behaviour
+    /// is unchanged: the alarm is scheduled via notifications.
+    func testSchedule_noAlarmKitBackend_usesNotificationFallback() {
+        let center = RecordingCenter()
+        let scheduler = AlarmScheduler(notificationCenter: center, alarmKit: nil)
+
+        let exp = expectation(description: "schedule completes")
+        scheduler.schedule(AppAlarm(penaltyAmount: 50)) { _ in exp.fulfill() }
+        wait(for: [exp], timeout: 2.0)
+
+        XCTAssertFalse(center.addedRequests.isEmpty,
+                       "Without AlarmKit the notification fallback must still schedule")
+    }
+
+    /// A disabled alarm short-circuits on every backend — no AlarmKit schedule,
+    /// no notification add.
+    func testSchedule_disabledAlarm_isNoOpOnBothBackends() throws {
+        guard #available(iOS 26.0, *) else {
+            throw XCTSkip("AlarmKit branch only runs on iOS 26+")
+        }
+        let alarmKit = MockAlarmKitScheduler(authorized: true)
+        let center = RecordingCenter()
+        let scheduler = AlarmScheduler(notificationCenter: center, alarmKit: alarmKit)
+
+        let exp = expectation(description: "schedule completes")
+        scheduler.schedule(AppAlarm(penaltyAmount: 50, enabled: false)) { _ in exp.fulfill() }
+        wait(for: [exp], timeout: 2.0)
+
+        XCTAssertTrue(alarmKit.scheduledIDs.isEmpty)
+        XCTAssertTrue(center.addedRequests.isEmpty)
+    }
+
+    // MARK: - Cancel + stop forward to AlarmKit
+
+    func testCancel_forwardsToAlarmKitBackend() throws {
+        guard #available(iOS 26.0, *) else {
+            throw XCTSkip("AlarmKit branch only runs on iOS 26+")
+        }
+        let alarmKit = MockAlarmKitScheduler(authorized: true)
+        let scheduler = AlarmScheduler(notificationCenter: RecordingCenter(), alarmKit: alarmKit)
+        let id = UUID()
+
+        scheduler.cancel(id)
+
+        XCTAssertEqual(alarmKit.cancelledIDs, [id],
+                       "cancel(_:) must also cancel the AlarmKit system alarm")
+    }
+
+    func testStopSystemAlarm_forwardsToAlarmKitBackend() throws {
+        guard #available(iOS 26.0, *) else {
+            throw XCTSkip("AlarmKit branch only runs on iOS 26+")
+        }
+        let alarmKit = MockAlarmKitScheduler(authorized: true)
+        let scheduler = AlarmScheduler(notificationCenter: RecordingCenter(), alarmKit: alarmKit)
+        let id = UUID()
+
+        scheduler.stopSystemAlarm(id)
+
+        XCTAssertEqual(alarmKit.stoppedIDs, [id])
+    }
+
+    func testStopSystemAlarm_noBackend_isNoOp() {
+        // No crash when no AlarmKit backend exists (iOS < 26 / fallback shape).
+        let scheduler = AlarmScheduler(notificationCenter: RecordingCenter(), alarmKit: nil)
+        scheduler.stopSystemAlarm(UUID())
+    }
+
+    // MARK: - Authorization request
+
+    func testRequestAlarmKitAuthorization_forwardsGrant() throws {
+        guard #available(iOS 26.0, *) else {
+            throw XCTSkip("AlarmKit branch only runs on iOS 26+")
+        }
+        let alarmKit = MockAlarmKitScheduler(authorized: true)
+        let scheduler = AlarmScheduler(notificationCenter: RecordingCenter(), alarmKit: alarmKit)
+
+        let exp = expectation(description: "authorization resolves")
+        scheduler.requestAlarmKitAuthorization { granted in
+            XCTAssertTrue(granted)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 2.0)
+        XCTAssertEqual(alarmKit.authorizationRequests, 1)
+    }
+
+    func testRequestAlarmKitAuthorization_noBackend_completesFalse() {
+        let scheduler = AlarmScheduler(notificationCenter: RecordingCenter(), alarmKit: nil)
+        let exp = expectation(description: "completes")
+        scheduler.requestAlarmKitAuthorization { granted in
+            XCTAssertFalse(granted, "No backend → cannot be authorized")
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 2.0)
+    }
+
+    // MARK: - Config mapping (iOS 26 only)
+
+    func testMakeSchedule_weeklyAlarm_mapsRepeatDaysToWeekdays() throws {
+        guard #available(iOS 26.0, *) else {
+            throw XCTSkip("AlarmKit types require iOS 26+")
+        }
+        // Monday (0) + Sunday (6) selected, weekly mode.
+        let alarm = AppAlarm(repeatDays: [0, 6], penaltyAmount: 50, repeatMode: .weekly)
+        let schedule = AlarmKitScheduler.makeSchedule(for: alarm)
+
+        guard case let .relative(relative) = schedule,
+              case let .weekly(days) = relative.repeats else {
+            return XCTFail("Weekly alarm must map to a relative weekly schedule")
+        }
+        XCTAssertTrue(days.contains(.monday))
+        XCTAssertTrue(days.contains(.sunday))
+        XCTAssertEqual(days.count, 2)
+    }
+
+    func testMakeSchedule_oneShotAlarm_usesNeverRecurrence() throws {
+        guard #available(iOS 26.0, *) else {
+            throw XCTSkip("AlarmKit types require iOS 26+")
+        }
+        let alarm = AppAlarm(repeatDays: [], penaltyAmount: 50)
+        let schedule = AlarmKitScheduler.makeSchedule(for: alarm)
+
+        guard case let .relative(relative) = schedule,
+              case .never = relative.repeats else {
+            return XCTFail("One-shot alarm must use .never recurrence")
+        }
+    }
+
+    func testWeekdayMapping_coversAllSevenIndices() throws {
+        guard #available(iOS 26.0, *) else {
+            throw XCTSkip("AlarmKit types require iOS 26+")
+        }
+        let expected: [Int: Locale.Weekday] = [
+            0: .monday, 1: .tuesday, 2: .wednesday, 3: .thursday,
+            4: .friday, 5: .saturday, 6: .sunday
+        ]
+        for (index, weekday) in expected {
+            XCTAssertEqual(AlarmKitScheduler.weekday(forMondayFirstIndex: index), weekday)
+        }
+        XCTAssertNil(AlarmKitScheduler.weekday(forMondayFirstIndex: 7),
+                     "Out-of-range index is dropped, not crashed")
+    }
+}
+
+// MARK: - Test doubles
+
+/// Records the calls `AlarmScheduler` makes against its AlarmKit seam so the
+/// Strategy-A-vs-fallback branching can be asserted on any host OS. Mirrors the
+/// `PermissionStubCenter` pattern from `AlarmSchedulerTests`.
+private final class MockAlarmKitScheduler: AlarmKitScheduling {
+    private let authorized: Bool
+    private(set) var scheduledIDs: [UUID] = []
+    private(set) var cancelledIDs: [UUID] = []
+    private(set) var stoppedIDs: [UUID] = []
+    private(set) var authorizationRequests = 0
+
+    init(authorized: Bool) { self.authorized = authorized }
+
+    var isAuthorized: Bool { authorized }
+
+    func requestAuthorization(completion: @escaping (Bool) -> Void) {
+        authorizationRequests += 1
+        completion(authorized)
+    }
+
+    func schedule(_ alarm: AppAlarm) throws {
+        scheduledIDs.append(alarm.id)
+    }
+
+    func cancel(_ alarmID: UUID) {
+        cancelledIDs.append(alarmID)
+    }
+
+    func stop(_ alarmID: UUID) {
+        stoppedIDs.append(alarmID)
+    }
+}
+
+/// `NotificationScheduling` double that records every `add` so the fallback
+/// path can be observed. Completes async members with empty results so the
+/// pre-flight 64-pending check resolves deterministically.
+private final class RecordingCenter: NotificationScheduling {
+    private(set) var addedRequests: [UNNotificationRequest] = []
+
+    func add(
+        _ request: UNNotificationRequest,
+        withCompletionHandler completion: ((Error?) -> Void)?
+    ) {
+        addedRequests.append(request)
+        completion?(nil)
+    }
+    func getPendingNotificationRequests(
+        completionHandler: @escaping ([UNNotificationRequest]) -> Void
+    ) {
+        completionHandler([])
+    }
+    func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {}
+    func removeDeliveredNotifications(withIdentifiers identifiers: [String]) {}
+    func getDeliveredNotifications(
+        completionHandler: @escaping ([UNNotification]) -> Void
+    ) {
+        completionHandler([])
+    }
+    func setNotificationCategories(_ categories: Set<UNNotificationCategory>) {}
+    func removeAllPendingNotificationRequests() {}
+    func requestAuthorization(
+        options: UNAuthorizationOptions,
+        completionHandler: @escaping (Bool, Error?) -> Void
+    ) {
+        completionHandler(true, nil)
+    }
+}


### PR DESCRIPTION
Fixes #377

## Что сделано

Реализована **Стратегия A (AlarmKit, iOS 26+)** из `docs/SPEC.md` §3.2.1 — настоящий системный будильник, который звонит непрерывно даже в беззвучном режиме и Focus/DND, с полноэкранным алертом на Lock Screen (как Clock.app), БЕЗ Critical Alerts entitlement.

- **NEW `Services/AlarmKitScheduler.swift`** — обёртка над `AlarmManager` (`@available(iOS 26.0, *)`): `requestAuthorization`, `schedule`/`cancel`/`stop`, маппинг `Alarm` → `AlarmManager.AlarmConfiguration` (relative schedule + weekly recurrence из Monday-first индексов, alert presentation со stop/snooze кнопками, alarm sound). Тестируемый через новый `AlarmKitScheduling` protocol (по образцу `NotificationScheduling`).
- **NEW `Services/AlarmKitIntents.swift`** — `StopAlarmIntent` / `SnoozeAlarmIntent` (`LiveActivityIntent`), которыми AlarmKit вызывает действия с системного алерта. Оба форвардят в `@MainActor AlarmKitActionRouter`, который переиспользует тот же `AlarmFiringCoordinator` что и notification-путь → платный снуз (−X ₽) и refund-on-failure идентичны.
- **`Services/AlarmScheduler.swift`** — интеграция как Стратегия A: на iOS 26+ при авторизованном AlarmKit `schedule`/`cancel`/`stopSystemAlarm` идут через AlarmKit; иначе — существующий UNUserNotificationCenter-фолбэк (Стратегия B) БЕЗ изменений поведения. `requestPermission` дополнительно праймит AlarmKit-авторизацию на iOS 26+ (затрагивает onboarding через `PermissionsViewController`, который вызывает `requestPermission`). **Поправлен ложный комментарий** в шапке файла на честный.
- **NEW тесты** `AlarmKitSchedulerTests.swift` — ветвление iOS26-vs-фолбэк через мок `AlarmKitScheduling` (authorized → AlarmKit, no notification; unauthorized/nil → notification fallback), cancel/stop форвардинг, authorization, маппинг schedule/weekday. Существующие `AlarmScheduler*Tests` не тронуты.

OUT OF SCOPE (как в issue): Live Activity / Dynamic Island / Apple Watch презентации.

## ⚠️ NO-TOUCH EXCEPTION

Этот PR **трогает `SnoozePay/SnoozePay/Info.plist`** — добавляет ключ:
```
<key>NSAlarmKitUsageDescription</key>
<string>SnoozePay использует будильники, чтобы будить вас вовремя — даже в беззвучном режиме.</string>
```
Без него AlarmKit-авторизация падает в рантайме. **Одобрено PM 2026-06-24** как разрешённое исключение для этой задачи. No-touch-хук заблокирует авто-мердж → **нужен ручной merge через pm-override path**. (`project.pbxproj` НЕ тронут — проект использует `PBXFileSystemSynchronizedRootGroup`, новые файлы подхватываются автоматически.)

## Verify

- ✅ swiftlint: 0 errors (только pre-existing line_length warnings + 1 type_body_length warning от роста AlarmScheduler)
- ✅ build_sim (clean): SUCCEEDED, 0 warnings/0 errors (simulator: iPhone 17 Pro Max, iOS 26.5) — AlarmKit компилируется
- ✅ build-for-testing: TEST BUILD SUCCEEDED, новый тест-файл включён в таргет и компилируется
- ⏭️ test_sim/screenshot: пропущены (отключены по процессу)

🤖 Generated with [Claude Code](https://claude.com/claude-code)