### PR TITLE
[fix] IAP payment: real product loading + aligned product IDs + deposit-badge polish

### DIFF
--- a/SnoozePay/SnoozePay/Services/StoreKitService.swift
+++ b/SnoozePay/SnoozePay/Services/StoreKitService.swift
@@ -179,6 +179,17 @@ final class StoreKitService {
         do {
             let loaded = try await Product.products(for: Set(StoreKitService.productIDs))
             products = loaded.sorted { $0.price < $1.price }
+            // `Product.products(for:)` returns the *available* subset and does
+            // NOT throw when an ID is simply unavailable (e.g. the Paid Apps
+            // agreement isn't active, or the SKU hasn't propagated yet) — it
+            // just omits it. Log found/missing so a silent empty result is
+            // diagnosable instead of looking like the call never ran.
+            let missing = Set(StoreKitService.productIDs)
+                .subtracting(loaded.map(\.id))
+                .sorted()
+            AppLogger.storeKit.notice(
+                "loaded \(loaded.count)/\(StoreKitService.productIDs.count) products; missing: \(missing.joined(separator: ", "), privacy: .public)"
+            )
             postProductsLoaded(products)
         } catch {
             AppLogger.storeKit.error("product load failed: \(error.localizedDescription, privacy: .public)")

--- a/SnoozePay/SnoozePay/Services/StoreKitService.swift
+++ b/SnoozePay/SnoozePay/Services/StoreKitService.swift
@@ -27,20 +27,20 @@ final class StoreKitService {
 
     // Product IDs — must match App Store Connect configuration
     static let productIDs = [
-        "com.snooze_pay.balance.49",
-        "com.snooze_pay.balance.149",
-        "com.snooze_pay.balance.299",
-        "com.snooze_pay.balance.499",
-        "com.snooze_pay.balance.999"
+        "io.mobilife.snoozepay.balance.49",
+        "io.mobilife.snoozepay.balance.149",
+        "io.mobilife.snoozepay.balance.299",
+        "io.mobilife.snoozepay.balance.499",
+        "io.mobilife.snoozepay.balance.999"
     ]
 
     // Corresponding RUB amounts to credit
     static let productAmounts: [String: Double] = [
-        "com.snooze_pay.balance.49": 49,
-        "com.snooze_pay.balance.149": 149,
-        "com.snooze_pay.balance.299": 299,
-        "com.snooze_pay.balance.499": 499,
-        "com.snooze_pay.balance.999": 999
+        "io.mobilife.snoozepay.balance.49": 49,
+        "io.mobilife.snoozepay.balance.149": 149,
+        "io.mobilife.snoozepay.balance.299": 299,
+        "io.mobilife.snoozepay.balance.499": 499,
+        "io.mobilife.snoozepay.balance.999": 999
     ]
 
     // MARK: - Notification names

--- a/SnoozePay/SnoozePay/Services/StoreKitService.swift
+++ b/SnoozePay/SnoozePay/Services/StoreKitService.swift
@@ -126,6 +126,12 @@ final class StoreKitService {
         self.notificationPoster = UNUserNotificationCenter.current()
         self.defaults = .standard
         transactionListener = Self.makeTransactionListener()
+        // Fetch the StoreKit catalogue at startup. Without this the `products`
+        // array stays empty for the whole session and every top-up path falls
+        // back to the (DEBUG-only intended) local credit — the purchase sheet
+        // never reaches real StoreKit. `_ = StoreKitService.shared` in
+        // AppDelegate triggers this init, so the load kicks off at launch.
+        Task { await loadProducts() }
     }
 
     /// Test-only initializer. Injects the notification + storage seams and skips

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+NoBalance.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+NoBalance.swift
@@ -24,7 +24,7 @@ extension AlarmFiringViewController {
 
     /// SKU resolved by the no-balance Apple Pay tap. Targets the 499 ₽ tier;
     /// the 500 ₽ SKU doesn't exist in App Store Connect (lineup is PM's #240).
-    static var noBalanceProductID: String { "com.snooze_pay.balance.499" }
+    static var noBalanceProductID: String { "io.mobilife.snoozepay.balance.499" }
 
     /// Display amount (₽) for the no-balance Apple Pay button title. Derived
     /// from the catalogue amount of `noBalanceProductID` so the rendered number

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
@@ -185,7 +185,7 @@ class AlarmFiringViewController: UIViewController {
     var noBalanceSnoozeCard: SPSnoozePrice?
 
     /// Apple Pay 500 ₽ primary CTA. Single-tap purchase via StoreKitService
-    /// (SKU `com.snooze_pay.balance.499`); falls back to direct
+    /// (SKU `io.mobilife.snoozepay.balance.499`); falls back to direct
     /// `BalanceService.topUp` when the StoreKit product list hasn't loaded
     /// yet (test / debug paths) so the wallet still credits end-to-end.
     var applePayNoBalanceButton: SPButton?

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/FiringTopUpBottomSheetViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/FiringTopUpBottomSheetViewController.swift
@@ -66,15 +66,15 @@ final class FiringTopUpBottomSheetViewController: UIViewController {
     /// (#297). Labels / hints follow `SPTopUp.jsx:106-108`.
     static let defaultPresets: [Preset] = [
         Preset(
-            productID: "com.snooze_pay.balance.149",
+            productID: "io.mobilife.snoozepay.balance.149",
             label: "+1 откладывание", hint: "ровно на сейчас", popular: false
         ),
         Preset(
-            productID: "com.snooze_pay.balance.499",
+            productID: "io.mobilife.snoozepay.balance.499",
             label: "+несколько", hint: "на пару дней", popular: true
         ),
         Preset(
-            productID: "com.snooze_pay.balance.999",
+            productID: "io.mobilife.snoozepay.balance.999",
             label: "+неделя", hint: "забыть про баланс", popular: false
         )
     ].compactMap { $0 }

--- a/SnoozePay/SnoozePay/ViewControllers/Wallet/DepositPresets.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Wallet/DepositPresets.swift
@@ -28,7 +28,7 @@ enum DepositPresets {
         DepositPreset(
             amount: amount,
             label: snoozeCountLabel(forAmount: amount),
-            productID: "com.snooze_pay.balance.\(amount)",
+            productID: "io.mobilife.snoozepay.balance.\(amount)",
             popular: amount == 149
         )
     }

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPAmountPreset.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPAmountPreset.swift
@@ -44,7 +44,11 @@ final class SPAmountPreset: UIControl {
     private let labelView = UILabel()
     private let popularBadge = InsetLabel(insets: UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10))
     /// Money-gradient backing for the «Популярно» badge (`.sp-preset__pop`
-    /// fills with `--sp-grad-money`). Inserted behind the badge label.
+    /// fills with `--sp-grad-money`). Lives in `popularBackground` *behind* the
+    /// label — a `UILabel` draws its text as the layer's own content, which
+    /// composites below any sublayer, so a gradient inserted into the label's
+    /// own layer painted over the text (badge showed an empty green pill).
+    private let popularBackground = UIView()
     private let popularGradient = CAGradientLayer()
     private let stack = UIStackView()
 
@@ -73,6 +77,7 @@ final class SPAmountPreset: UIControl {
         isSelected = selected
         applySelectionState(animated: false)
         popularBadge.isHidden = !popular
+        popularBackground.isHidden = !popular
         addTarget(self, action: #selector(handleTap), for: .touchUpInside)
         // iOS 17 deprecated `traitCollectionDidChange(_:)` — register a
         // closure-based observer when available; the legacy override below
@@ -99,8 +104,8 @@ final class SPAmountPreset: UIControl {
             roundedRect: bounds,
             cornerRadius: AppRadius.md
         ).cgPath
-        // Keep the «Популярно» gradient backing matched to the badge bounds.
-        popularGradient.frame = popularBadge.bounds
+        // Keep the «Популярно» gradient backing matched to its backing view.
+        popularGradient.frame = popularBackground.bounds
     }
 
     @available(iOS, deprecated: 17.0, message: "Replaced by registerForTraitChanges; kept for iOS 15/16.")
@@ -145,6 +150,13 @@ final class SPAmountPreset: UIControl {
         labelView.font = AppTypography.meta
         labelView.textColor = AppColors.fg3
         labelView.textAlignment = .center
+        // The "≈ N откладываний" hint is too wide for a 3-column tile on one
+        // line (it truncated to "≈ 1 откладыва…"). Wrap to two lines and let
+        // the font shrink a touch as a backstop so the full word is always
+        // visible regardless of count/plural form.
+        labelView.numberOfLines = 2
+        labelView.adjustsFontSizeToFitWidth = true
+        labelView.minimumScaleFactor = 0.8
 
         stack.translatesAutoresizingMaskIntoConstraints = false
         stack.axis = .vertical
@@ -168,17 +180,23 @@ final class SPAmountPreset: UIControl {
             ]
         )
         popularBadge.textAlignment = .center
-        // Inset the text via layoutMargins-style padding using contentInset on
-        // a label isn't supported, so pad with leading/trailing constraints on
-        // a hugging label below; the gradient backs the whole badge bounds.
+        popularBadge.backgroundColor = .clear
+
+        // Gradient backing view — sits strictly *behind* the label so the text
+        // composites on top (see `popularBackground` doc). The label keeps a
+        // clear background and hugs its text via `InsetLabel`'s 10pt insets;
+        // the backing is pinned to the label's bounds.
+        popularBackground.translatesAutoresizingMaskIntoConstraints = false
+        popularBackground.isUserInteractionEnabled = false
         popularGradient.colors = SPSupport.moneyGradientColors
         popularGradient.locations = SPSupport.moneyGradientLocations
         popularGradient.startPoint = SPSupport.gradientStart
         popularGradient.endPoint = SPSupport.gradientEnd
-        popularGradient.cornerRadius = 10
-        popularBadge.layer.insertSublayer(popularGradient, at: 0)
-        popularBadge.layer.cornerRadius = 10
-        popularBadge.layer.masksToBounds = true
+        popularGradient.cornerRadius = 11
+        popularBackground.layer.insertSublayer(popularGradient, at: 0)
+        popularBackground.layer.cornerRadius = 11
+        popularBackground.layer.masksToBounds = true
+        addSubview(popularBackground)
         addSubview(popularBadge)
 
         NSLayoutConstraint.activate([
@@ -191,7 +209,12 @@ final class SPAmountPreset: UIControl {
 
             popularBadge.centerXAnchor.constraint(equalTo: centerXAnchor),
             popularBadge.centerYAnchor.constraint(equalTo: topAnchor),
-            popularBadge.heightAnchor.constraint(equalToConstant: 22)
+            popularBadge.heightAnchor.constraint(equalToConstant: 22),
+
+            popularBackground.leadingAnchor.constraint(equalTo: popularBadge.leadingAnchor),
+            popularBackground.trailingAnchor.constraint(equalTo: popularBadge.trailingAnchor),
+            popularBackground.topAnchor.constraint(equalTo: popularBadge.topAnchor),
+            popularBackground.bottomAnchor.constraint(equalTo: popularBadge.bottomAnchor)
         ])
     }
 

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPAmountPreset.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPAmountPreset.swift
@@ -176,7 +176,10 @@ final class SPAmountPreset: UIControl {
             attributes: [
                 .font: AppTypography.caps,
                 .kern: AppTypography.capsKerning,
-                .foregroundColor: AppColors.fgOnMoney
+                // White reads with even contrast across the whole money
+                // gradient — the dark `fgOnMoney` ink vanished on the gradient's
+                // darker (#0B7A56) end and made the badge look empty.
+                .foregroundColor: UIColor.white
             ]
         )
         popularBadge.textAlignment = .center
@@ -188,6 +191,9 @@ final class SPAmountPreset: UIControl {
         // the backing is pinned to the label's bounds.
         popularBackground.translatesAutoresizingMaskIntoConstraints = false
         popularBackground.isUserInteractionEnabled = false
+        // Solid opaque fill under the gradient — guarantees the badge never
+        // shows through even before the gradient layer lays out its frame.
+        popularBackground.backgroundColor = AppColors.money500
         popularGradient.colors = SPSupport.moneyGradientColors
         popularGradient.locations = SPSupport.moneyGradientLocations
         popularGradient.startPoint = SPSupport.gradientStart

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPAmountPreset.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPAmountPreset.swift
@@ -51,6 +51,11 @@ final class SPAmountPreset: UIControl {
     private let popularBackground = UIView()
     private let popularGradient = CAGradientLayer()
     private let stack = UIStackView()
+    /// Tile outline drawn as a *sublayer* rather than `layer.borderWidth`: a
+    /// CALayer border renders above all sublayers, so the real border painted
+    /// a line straight across the «Популярно» badge that floats on the top
+    /// edge. As a sublayer (inserted below the badge) the badge covers it.
+    private let borderLayer = CALayer()
 
     // MARK: - Init
 
@@ -98,6 +103,8 @@ final class SPAmountPreset: UIControl {
     override func layoutSubviews() {
         super.layoutSubviews()
         layer.cornerRadius = AppRadius.md     // 16pt — matches sp-r-md
+        borderLayer.frame = bounds
+        borderLayer.cornerRadius = AppRadius.md
         // Outer ring is faked via shadow when selected — pre-rasterise the
         // path so it tracks the rounded corners cleanly.
         layer.shadowPath = UIBezierPath(
@@ -139,7 +146,10 @@ final class SPAmountPreset: UIControl {
         backgroundColor = AppColors.bg1
         layer.cornerRadius = AppRadius.md
         layer.masksToBounds = false
-        layer.borderWidth = 1.5
+        // Border as a bottom sublayer (not `layer.borderWidth`) so it draws
+        // *below* the badge — see `borderLayer`.
+        borderLayer.borderWidth = 1.5
+        layer.insertSublayer(borderLayer, at: 0)
 
         valueLabel.translatesAutoresizingMaskIntoConstraints = false
         valueLabel.font = Self.valueFont
@@ -234,7 +244,7 @@ final class SPAmountPreset: UIControl {
                 // `rgba(46,219,159,…)`), a hair brighter than money500, so the
                 // selected fill/ring pop against the surface.
                 self.backgroundColor = AppColors.money400.withAlphaComponent(0.10)
-                self.layer.borderColor = AppColors.money400.cgColor
+                self.borderLayer.borderColor = AppColors.money400.cgColor
                 // Tight selection ring: 4pt radius / 0.10 opacity reads as a
                 // crisp brand outline rather than a diffuse glow that bled
                 // into adjacent presets at radius 8 / opacity 0.18.
@@ -245,7 +255,7 @@ final class SPAmountPreset: UIControl {
                 self.layer.masksToBounds = false
             } else {
                 self.backgroundColor = AppColors.bg1
-                self.layer.borderColor = AppColors.stroke1
+                self.borderLayer.borderColor = AppColors.stroke1
                     .resolvedColor(with: self.traitCollection).cgColor
                 self.layer.shadowOpacity = 0
             }

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPAmountPreset.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPAmountPreset.swift
@@ -198,7 +198,10 @@ final class SPAmountPreset: UIControl {
         popularGradient.locations = SPSupport.moneyGradientLocations
         popularGradient.startPoint = SPSupport.gradientStart
         popularGradient.endPoint = SPSupport.gradientEnd
-        popularGradient.cornerRadius = 11
+        // No corner radius on the gradient itself — the backing view's
+        // `masksToBounds` does all the rounding. Two independently-rounded
+        // layers misaligned by a sub-pixel, exposing a hairline of the solid
+        // fill at the corners (read as a faint border around the badge).
         popularBackground.layer.insertSublayer(popularGradient, at: 0)
         popularBackground.layer.cornerRadius = 11
         popularBackground.layer.masksToBounds = true

--- a/SnoozePay/SnoozePayTests/DepositPresetsTests.swift
+++ b/SnoozePay/SnoozePayTests/DepositPresetsTests.swift
@@ -17,7 +17,7 @@ final class DepositPresetsTests: XCTestCase {
                 StoreKitService.productIDs.contains(preset.productID),
                 "Preset \(preset.amount) ₽ points at unknown SKU \(preset.productID)"
             )
-            XCTAssertEqual(preset.productID, "com.snooze_pay.balance.\(preset.amount)")
+            XCTAssertEqual(preset.productID, "io.mobilife.snoozepay.balance.\(preset.amount)")
         }
     }
 
@@ -32,7 +32,7 @@ final class DepositPresetsTests: XCTestCase {
     }
 
     func testPresetForAmount_returnsMatchingPreset() {
-        XCTAssertEqual(DepositPresets.preset(forAmount: 499)?.productID, "com.snooze_pay.balance.499")
+        XCTAssertEqual(DepositPresets.preset(forAmount: 499)?.productID, "io.mobilife.snoozepay.balance.499")
         XCTAssertNil(DepositPresets.preset(forAmount: 500))
     }
 

--- a/SnoozePay/SnoozePayTests/StoreKitServiceTests.swift
+++ b/SnoozePay/SnoozePayTests/StoreKitServiceTests.swift
@@ -292,7 +292,7 @@ final class StoreKitServiceTests: XCTestCase {
 
     func testCreditAmount_knownProduct_returnsCatalogueAmount() {
         XCTAssertEqual(
-            StoreKitService.creditAmount(for: "com.snooze_pay.balance.299", fallbackPrice: 999),
+            StoreKitService.creditAmount(for: "io.mobilife.snoozepay.balance.299", fallbackPrice: 999),
             299,
             "known SKU must credit the catalogue amount, ignoring any fallback price"
         )
@@ -303,14 +303,14 @@ final class StoreKitServiceTests: XCTestCase {
         // The caller's `amount > 0` gate then refuses to finish. (Logging side
         // effect is asserted indirectly: the path is exercised.)
         XCTAssertEqual(
-            StoreKitService.creditAmount(for: "com.snooze_pay.balance.unknown", fallbackPrice: nil),
+            StoreKitService.creditAmount(for: "io.mobilife.snoozepay.balance.unknown", fallbackPrice: nil),
             0
         )
     }
 
     func testCreditAmount_unknownProductWithFallback_usesFallback() {
         XCTAssertEqual(
-            StoreKitService.creditAmount(for: "com.snooze_pay.balance.unknown", fallbackPrice: 199),
+            StoreKitService.creditAmount(for: "io.mobilife.snoozepay.balance.unknown", fallbackPrice: 199),
             199,
             "an unmapped SKU with a resolved StoreKit price still credits that price"
         )

--- a/SnoozePay/SnoozePayTests/TopUpDisplayAmountTests.swift
+++ b/SnoozePay/SnoozePayTests/TopUpDisplayAmountTests.swift
@@ -66,7 +66,7 @@ final class TopUpDisplayAmountTests: XCTestCase {
     /// this is what prevents a rounded literal from ever being displayed again.
     func testPresetInit_rejectsUnknownSKU() {
         let preset = FiringTopUpBottomSheetViewController.Preset(
-            productID: "com.snooze_pay.balance.does_not_exist",
+            productID: "io.mobilife.snoozepay.balance.does_not_exist",
             label: "fake",
             hint: "fake",
             popular: false
@@ -80,8 +80,8 @@ final class TopUpDisplayAmountTests: XCTestCase {
         let presets = FiringTopUpBottomSheetViewController.defaultPresets
         let popular = presets.first(where: { $0.popular })
         XCTAssertNotNil(popular)
-        XCTAssertEqual(popular?.productID, "com.snooze_pay.balance.499")
-        XCTAssertEqual(popular?.amount, StoreKitService.catalogAmount(for: "com.snooze_pay.balance.499"))
+        XCTAssertEqual(popular?.productID, "io.mobilife.snoozepay.balance.499")
+        XCTAssertEqual(popular?.amount, StoreKitService.catalogAmount(for: "io.mobilife.snoozepay.balance.499"))
     }
 
     // MARK: - No-balance CTA
@@ -115,7 +115,7 @@ final class TopUpDisplayAmountTests: XCTestCase {
         for (productID, amount) in StoreKitService.productAmounts {
             XCTAssertEqual(StoreKitService.catalogAmount(for: productID), Int(amount))
         }
-        XCTAssertNil(StoreKitService.catalogAmount(for: "com.snooze_pay.balance.unknown"))
+        XCTAssertNil(StoreKitService.catalogAmount(for: "io.mobilife.snoozepay.balance.unknown"))
     }
 
     /// With no products loaded (test environment), `displayAmount(for:)` falls


### PR DESCRIPTION
## Что и зачем

Чистый перенос работы по оплате с локальной device-ветки (без no-touch signing-коммита и без AlarmKit-коммитов, которые уже в PR #378/#380).

### 1. Root-cause фикс: StoreKit `loadProducts()` никогда не вызывался
`loadProducts()` был определён, но **не имел ни одного call-site** во всём проекте. Массив `products` оставался пустым всю сессию, и **каждый** путь пополнения молча падал в локальный demo-кредит (`BalanceService.topUp`) — настоящий StoreKit-лист покупки был недостижим. На устройстве это выглядело как «мгновенный успех» без sandbox.
→ Запускаем загрузку каталога в `private init()` (триггерится `_ = StoreKitService.shared` в AppDelegate).
→ Добавлен диагностический лог `loaded X/N products; missing: …` — пустой ответ Apple (неактивный Paid Apps / непропагированный SKU) больше не выглядит как «вызов не сработал».

### 2. Выравнивание product ID под bundle namespace
`com.snooze_pay.balance.*` → `io.mobilife.snoozepay.balance.*` (совпадает с bundle `io.mobilife.SnoozePay`). Сделано до релиза, пока product ID ещё можно менять. Код + тесты.

### 3. Полировка бейджа «Популярно» (deposit preset)
- Градиент вынесен в backing-view позади лейбла (был сабслоем в `UILabel` → перекрывал текст, бейдж выглядел пустой зелёной пилюлей).
- Текст белый, заливка непрозрачная.
- Рамка тайла рисуется отдельным сублоем, а не `layer.borderWidth` (тот рендерится поверх сабвью и чертил линию через бейдж).
- Подпись «≈ N откладываний» переносится на 2 строки + авто-шринк — больше не обрезается в узком 3-колоночном тайле.

## Проверка
- ✅ Clean build (sim) — зелёный
- ✅ SwiftLint — 0 errors в затронутых файлах
- ✅ Бейдж и подписи verified на устройстве (iOS 26)
- ⚠️ Реальный sandbox end-to-end (#384) пока не verifiable — ждёт активации Paid Applications agreement (PM/Account Holder)

## Контекст (НЕ авто-закрывать — интеграционная ветка)
Связано с #384 (sandbox-тест IAP) и #385 (огородить demo-фолбэк DEBUG — отдельный фикс, не в этом PR). Закрывать issues руками после merge в main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)