### PR TITLE
[audio] AlarmKit: custom firing screen + device-bug fixes (#379, #381, #382, #383)

### DIFF
--- a/SnoozePay/SnoozePay/AppDelegate.swift
+++ b/SnoozePay/SnoozePay/AppDelegate.swift
@@ -51,6 +51,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Handle notification responses
         UNUserNotificationCenter.current().delegate = self
 
+        // Watch AlarmKit's alerting stream so an alarm that fires while the app
+        // is in the foreground mounts our custom firing screen on top of the
+        // system alert (#379). No-op on iOS < 26 / when AlarmKit is absent.
+        AlarmKitAlertObserver.shared.start()
+
         // Reclaim orphaned custom-theme JPEGs (#357): re-picking a photo or
         // deleting a `.custom`-themed alarm leaves its image on disk forever.
         // Sweep off the main thread against the live alarm set — only files no
@@ -348,35 +353,13 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             return
         }
 
+        // The window/VC walk + full-screen present (and the stacking-alarm
+        // swap) live in `AlarmFiringPresenter` so the AlarmKit paths (#379)
+        // share them verbatim. Keep the hop to the main queue here: the
+        // notification delegate already runs on main, but `willPresent` may
+        // race a not-yet-attached window on cold launch.
         DispatchQueue.main.async {
-            let firingVC = AlarmFiringViewController(alarm: alarm, snoozeCount: payload.snoozeCount)
-            firingVC.modalPresentationStyle = .fullScreen
-
-            // Find the topmost presented view controller to avoid "already presenting" issues
-            guard
-                let windowScene = UIApplication.shared.connectedScenes
-                    .compactMap({ $0 as? UIWindowScene })
-                    .first,
-                let rootVC = windowScene.windows.first?.rootViewController
-            else {
-                AppLogger.appDelegate.error("no window scene, stopping audio")
-                AudioService.shared.stopAlarmSound()
-                return
-            }
-
-            var topVC = rootVC
-            while let presented = topVC.presentedViewController {
-                // If an alarm firing screen is already showing, dismiss it first
-                if presented is AlarmFiringViewController {
-                    presented.dismiss(animated: false) {
-                        topVC.present(firingVC, animated: false)
-                    }
-                    return
-                }
-                topVC = presented
-            }
-
-            topVC.present(firingVC, animated: false)
+            AlarmFiringPresenter.shared.present(alarm: alarm, snoozeCount: payload.snoozeCount)
         }
     }
 

--- a/SnoozePay/SnoozePay/SceneDelegate.swift
+++ b/SnoozePay/SnoozePay/SceneDelegate.swift
@@ -56,6 +56,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let nextRoot = makeNextRootViewController()
         UIView.transition(with: window, duration: 0.3, options: .transitionCrossDissolve) {
             window.rootViewController = nextRoot
+        } completion: { _ in
+            // Cold launch by an AlarmKit alarm tap: the firing screen was
+            // deferred while only the splash existed (swapping the root would
+            // tear a screen presented over the splash back down). Now the real
+            // root is mounted, mount the deferred firing screen (#382).
+            AlarmFiringPresenter.shared.flushPendingPresentation()
         }
     }
 
@@ -205,6 +211,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         tabBar.layer.cornerRadius = AppRadius.xl
         tabBar.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
         tabBar.layer.masksToBounds = true
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Flush any AlarmKit firing screen deferred while the scene wasn't yet
+        // active (#382): tapping an AlarmKit alarm button runs the intent before
+        // the window exists, so `AlarmFiringPresenter` records the alarm as
+        // pending and mounts it here once a root view controller is attached.
+        AlarmFiringPresenter.shared.flushPendingPresentation()
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {

--- a/SnoozePay/SnoozePay/Services/AlarmFiringPresenter.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmFiringPresenter.swift
@@ -23,19 +23,93 @@ import os
 @MainActor
 final class AlarmFiringPresenter {
 
-    static let shared = AlarmFiringPresenter()
+    static let shared = AlarmFiringPresenter(alarmRepository: .shared)
 
     private let alarmRepository: AlarmRepository
 
+    /// An alarm an AlarmKit alert button (or the alerting observer) asked us to
+    /// present but which we couldn't mount yet because no foreground window/root
+    /// existed: the system runs the intent before the scene is active, and on a
+    /// cold launch the splash → tab-bar root only mounts ~200 ms later. Recorded
+    /// by `requestPresentation(alarmID:)` and flushed by
+    /// `flushPendingPresentation()` once the scene becomes active, so the firing
+    /// screen survives both a warm-foreground race and a cold start (#382).
+    /// `private(set)` so tests can assert the deferred id without poking the
+    /// internals through reflection.
+    private(set) var pendingAlarmID: UUID?
+
+    /// `true` when the real app root (not the launch splash) is mounted and the
+    /// firing screen can be presented. Seam so the pending-present retry (#382)
+    /// is unit-testable without a UIKit window; production reads the live scene.
+    var isRootReady: () -> Bool = { AlarmFiringPresenter.isLaunchRootReady() }
+
+    /// Mounts the firing screen for `alarmID`, returning `false` only when there
+    /// was no window to present on (the retry signal). Seam so the pending /
+    /// flush logic is unit-testable without standing up the VC hierarchy;
+    /// production points at the real `present(alarmID:snoozeCount:)`.
+    lazy var mount: (UUID, Int) -> Bool = { [weak self] alarmID, snoozeCount in
+        self?.present(alarmID: alarmID, snoozeCount: snoozeCount) ?? false
+    }
+
+    // Explicit (no defaulted-argument) init: a `= .shared` default on a
+    // `@MainActor` init is evaluated in the *caller's* isolation and trips a
+    // "main actor-isolated static property can not be referenced from a
+    // nonisolated context" warning at the `static let shared` initializer (#382).
     #if DEBUG
-    init(alarmRepository: AlarmRepository = .shared) {
+    init(alarmRepository: AlarmRepository) {
         self.alarmRepository = alarmRepository
     }
     #else
-    private init(alarmRepository: AlarmRepository = .shared) {
+    private init(alarmRepository: AlarmRepository) {
         self.alarmRepository = alarmRepository
     }
     #endif
+
+    // MARK: - Pending-present entry point (#382)
+
+    /// Request the firing screen for `alarmID` from a context that may run
+    /// before any foreground window exists — the AlarmKit alert buttons
+    /// (`AlarmKitActionRouter`, whose intents set `openAppWhenRun`) and the
+    /// alerting observer. Records the id as pending and attempts an immediate
+    /// present; if no scene/root is attached yet (cold launch, or the foreground
+    /// transition hasn't completed) the present is a no-op and the recorded id
+    /// is flushed later by `flushPendingPresentation()` from
+    /// `SceneDelegate.sceneDidBecomeActive`. This is what makes tapping an
+    /// AlarmKit alarm actually open the app *and* land on our screen (#382) —
+    /// presenting directly in the intent's `perform()` lost the race and the
+    /// screen never appeared.
+    func requestPresentation(alarmID: UUID, snoozeCount: Int = 0) {
+        pendingAlarmID = alarmID
+        attemptPendingPresentation(snoozeCount: snoozeCount)
+    }
+
+    /// Mount any deferred firing screen now that the scene is active. Called
+    /// from `SceneDelegate.sceneDidBecomeActive` (and after the splash → root
+    /// transition completes). Clears the pending id only once the present
+    /// actually lands so a still-too-early flush keeps retrying on the next
+    /// activation. No-op when nothing is pending.
+    func flushPendingPresentation() {
+        attemptPendingPresentation()
+    }
+
+    /// Try to mount the pending firing screen, but only once the *real* app
+    /// root (tab bar / onboarding) is up — not the transient splash. Presenting
+    /// over the splash would have the screen torn down the instant the splash
+    /// swaps the window's root, so we keep the id pending until the launch
+    /// transition completes and re-attempt then. Clears the pending id only
+    /// after a successful present (#382).
+    private func attemptPendingPresentation(snoozeCount: Int = 0) {
+        guard let alarmID = pendingAlarmID else { return }
+        guard isRootReady() else {
+            AppLogger.appDelegate.notice(
+                "firing-present: launch root not ready — deferring alarm \(alarmID, privacy: .private)"
+            )
+            return
+        }
+        if mount(alarmID, snoozeCount) {
+            pendingAlarmID = nil
+        }
+    }
 
     // MARK: - Entry points
 
@@ -44,7 +118,13 @@ final class AlarmFiringPresenter {
     /// (#379) which only carry the id. A missing / corrupt alarm is logged and
     /// the audio is silenced so the user is never left with a sounding alarm
     /// and no screen — mirroring `AppDelegate.presentAlarmFiringScreen`.
-    func present(alarmID: UUID, snoozeCount: Int = 0) {
+    ///
+    /// Returns `true` when a firing screen was mounted (or the alarm was
+    /// resolved-but-missing, a terminal outcome that must not be retried), and
+    /// `false` only when there was no window to present on — the single signal
+    /// the pending-present retry (#382) keys off.
+    @discardableResult
+    func present(alarmID: UUID, snoozeCount: Int = 0) -> Bool {
         let alarm: Alarm?
         do {
             alarm = try alarmRepository.fetchChecked(id: alarmID)
@@ -54,31 +134,36 @@ final class AlarmFiringPresenter {
                 "firing-present: fetch failed for \(alarmID, privacy: .private): \(errorDesc, privacy: .public)"
             )
             AudioService.shared.stopAlarmSound()
-            return
+            return true
         }
         guard let alarm else {
             AppLogger.appDelegate.error(
                 "firing-present: alarm \(alarmID, privacy: .private) not found — stopping audio"
             )
             AudioService.shared.stopAlarmSound()
-            return
+            return true
         }
-        present(alarm: alarm, snoozeCount: snoozeCount)
+        return present(alarm: alarm, snoozeCount: snoozeCount)
     }
 
     /// Present the firing screen for an already-resolved alarm. The single
     /// place that builds + mounts `AlarmFiringViewController`, so every trigger
     /// source shares the "dismiss any stale firing screen first, then present
     /// full-screen on the topmost VC" behaviour.
-    func present(alarm: Alarm, snoozeCount: Int = 0) {
-        let firingVC = AlarmFiringViewController(alarm: alarm, snoozeCount: snoozeCount)
-        firingVC.modalPresentationStyle = .fullScreen
-
+    ///
+    /// Returns `false` when no foreground window exists yet (cold-launch race)
+    /// so the AlarmKit pending-present (#382) knows to retry on scene-active;
+    /// `true` once the present has been issued.
+    @discardableResult
+    func present(alarm: Alarm, snoozeCount: Int = 0) -> Bool {
         guard let topVC = Self.topViewController() else {
             AppLogger.appDelegate.error("firing-present: no window scene, stopping audio")
             AudioService.shared.stopAlarmSound()
-            return
+            return false
         }
+
+        let firingVC = AlarmFiringViewController(alarm: alarm, snoozeCount: snoozeCount)
+        firingVC.modalPresentationStyle = .fullScreen
 
         // If an alarm firing screen is already showing, swap it for this one so
         // a stacking alarm (or a re-entry from a different trigger source for
@@ -87,13 +172,32 @@ final class AlarmFiringPresenter {
             presentedFiring.dismiss(animated: false) {
                 Self.topViewController()?.present(firingVC, animated: false)
             }
-            return
+            return true
         }
 
         topVC.present(firingVC, animated: false)
+        return true
     }
 
     // MARK: - Hierarchy walk
+
+    /// `true` once the active window scene's root is the *real* app UI rather
+    /// than the transient launch splash. The pending-present retry (#382) gates
+    /// on this so a deferred firing screen isn't mounted over the splash only to
+    /// be torn down when the splash swaps the window's root. Returns `false`
+    /// when no scene/window is attached yet (cold-launch race) or the splash is
+    /// still showing.
+    private static func isLaunchRootReady() -> Bool {
+        guard
+            let windowScene = UIApplication.shared.connectedScenes
+                .compactMap({ $0 as? UIWindowScene })
+                .first,
+            let rootVC = windowScene.windows.first?.rootViewController
+        else {
+            return false
+        }
+        return !(rootVC is SplashViewController)
+    }
 
     /// Topmost presented VC of the active foreground window scene, or `nil`
     /// when no scene/window is attached yet (cold-launch race).

--- a/SnoozePay/SnoozePay/Services/AlarmFiringPresenter.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmFiringPresenter.swift
@@ -1,0 +1,126 @@
+import UIKit
+import os
+
+/// Presents the app's custom alarm-firing screen (`AlarmFiringViewController`)
+/// for a given alarm. Extracted from `AppDelegate` so the SAME presentation
+/// path serves every trigger source without duplication:
+///
+///   * notification banner tap / foreground delivery (`AppDelegate`, the
+///     original caller — routes through `present(payload:)`),
+///   * AlarmKit alert Stop / Snooze buttons (`AlarmKitActionRouter`, #379),
+///   * AlarmKit foreground alerting updates (`AlarmKitAlertObserver`, #379).
+///
+/// The AlarmKit paths only know an `alarmID` (the system replays the intent /
+/// the `alarmUpdates` stream yields `Alarm` structs keyed by id), so the
+/// entry point resolves the alarm from `AlarmRepository` and builds a
+/// zero-snooze firing screen. The notification path keeps its richer payload
+/// (snoozeCount, volume) via `present(payload:)`.
+///
+/// `@MainActor`-isolated because it walks the UIKit view-controller hierarchy
+/// and presents a VC — the same isolation the callers (`AppDelegate`
+/// notification delegate, AppIntent `perform()`, the alarmUpdates `Task`) run
+/// under.
+@MainActor
+final class AlarmFiringPresenter {
+
+    static let shared = AlarmFiringPresenter()
+
+    private let alarmRepository: AlarmRepository
+
+    #if DEBUG
+    init(alarmRepository: AlarmRepository = .shared) {
+        self.alarmRepository = alarmRepository
+    }
+    #else
+    private init(alarmRepository: AlarmRepository = .shared) {
+        self.alarmRepository = alarmRepository
+    }
+    #endif
+
+    // MARK: - Entry points
+
+    /// Present the firing screen for the alarm identified by `alarmID`,
+    /// resolving its model from the repository. Used by the AlarmKit paths
+    /// (#379) which only carry the id. A missing / corrupt alarm is logged and
+    /// the audio is silenced so the user is never left with a sounding alarm
+    /// and no screen — mirroring `AppDelegate.presentAlarmFiringScreen`.
+    func present(alarmID: UUID, snoozeCount: Int = 0) {
+        let alarm: Alarm?
+        do {
+            alarm = try alarmRepository.fetchChecked(id: alarmID)
+        } catch {
+            let errorDesc = String(describing: error)
+            AppLogger.appDelegate.error(
+                "firing-present: fetch failed for \(alarmID, privacy: .private): \(errorDesc, privacy: .public)"
+            )
+            AudioService.shared.stopAlarmSound()
+            return
+        }
+        guard let alarm else {
+            AppLogger.appDelegate.error(
+                "firing-present: alarm \(alarmID, privacy: .private) not found — stopping audio"
+            )
+            AudioService.shared.stopAlarmSound()
+            return
+        }
+        present(alarm: alarm, snoozeCount: snoozeCount)
+    }
+
+    /// Present the firing screen for an already-resolved alarm. The single
+    /// place that builds + mounts `AlarmFiringViewController`, so every trigger
+    /// source shares the "dismiss any stale firing screen first, then present
+    /// full-screen on the topmost VC" behaviour.
+    func present(alarm: Alarm, snoozeCount: Int = 0) {
+        let firingVC = AlarmFiringViewController(alarm: alarm, snoozeCount: snoozeCount)
+        firingVC.modalPresentationStyle = .fullScreen
+
+        guard let topVC = Self.topViewController() else {
+            AppLogger.appDelegate.error("firing-present: no window scene, stopping audio")
+            AudioService.shared.stopAlarmSound()
+            return
+        }
+
+        // If an alarm firing screen is already showing, swap it for this one so
+        // a stacking alarm (or a re-entry from a different trigger source for
+        // the same firing) doesn't trip "already presenting".
+        if let presentedFiring = Self.presentedFiringScreen(from: topVC) {
+            presentedFiring.dismiss(animated: false) {
+                Self.topViewController()?.present(firingVC, animated: false)
+            }
+            return
+        }
+
+        topVC.present(firingVC, animated: false)
+    }
+
+    // MARK: - Hierarchy walk
+
+    /// Topmost presented VC of the active foreground window scene, or `nil`
+    /// when no scene/window is attached yet (cold-launch race).
+    private static func topViewController() -> UIViewController? {
+        guard
+            let windowScene = UIApplication.shared.connectedScenes
+                .compactMap({ $0 as? UIWindowScene })
+                .first,
+            let rootVC = windowScene.windows.first?.rootViewController
+        else {
+            return nil
+        }
+        var topVC = rootVC
+        while let presented = topVC.presentedViewController {
+            topVC = presented
+        }
+        return topVC
+    }
+
+    /// Returns the currently-presented `AlarmFiringViewController` anywhere up
+    /// the presentation chain rooted at `topVC`, if one is on screen.
+    private static func presentedFiringScreen(from topVC: UIViewController) -> UIViewController? {
+        var vc: UIViewController? = topVC
+        while let current = vc {
+            if current is AlarmFiringViewController { return current }
+            vc = current.presentingViewController
+        }
+        return nil
+    }
+}

--- a/SnoozePay/SnoozePay/Services/AlarmKitAlertObserver.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmKitAlertObserver.swift
@@ -38,7 +38,10 @@ protocol AlertingAlarmStream {
 @MainActor
 final class AlarmKitAlertObserver {
 
-    static let shared = AlarmKitAlertObserver()
+    static let shared = AlarmKitAlertObserver(
+        stream: AlarmKitAlertObserver.makeDefaultStream(),
+        onAlerting: { AlarmFiringPresenter.shared.requestPresentation(alarmID: $0) }
+    )
 
     private let stream: AlertingAlarmStream?
     /// Closure invoked with each newly-alerting alarm ID. Injectable so tests
@@ -54,18 +57,25 @@ final class AlarmKitAlertObserver {
 
     private var task: Task<Void, Never>?
 
+    // Explicit (no defaulted-argument) inits: `static let shared` is a
+    // main-actor-isolated initializer, so it supplies the production stream +
+    // presenter closure directly. A defaulted `= makeDefaultStream()` /
+    // `= { … present }` would force the helper to be `nonisolated` (and then
+    // calling the main-actor `AlarmManagerAlertingStream.init` from it warns —
+    // every type is `@MainActor` by default under SWIFT_DEFAULT_ACTOR_ISOLATION,
+    // #382).
     #if DEBUG
     init(
-        stream: AlertingAlarmStream? = AlarmKitAlertObserver.makeDefaultStream(),
-        onAlerting: @escaping @MainActor (UUID) -> Void = { AlarmFiringPresenter.shared.present(alarmID: $0) }
+        stream: AlertingAlarmStream?,
+        onAlerting: @escaping @MainActor (UUID) -> Void
     ) {
         self.stream = stream
         self.onAlerting = onAlerting
     }
     #else
     private init(
-        stream: AlertingAlarmStream? = AlarmKitAlertObserver.makeDefaultStream(),
-        onAlerting: @escaping @MainActor (UUID) -> Void = { AlarmFiringPresenter.shared.present(alarmID: $0) }
+        stream: AlertingAlarmStream?,
+        onAlerting: @escaping @MainActor (UUID) -> Void
     ) {
         self.stream = stream
         self.onAlerting = onAlerting
@@ -73,9 +83,8 @@ final class AlarmKitAlertObserver {
     #endif
 
     /// Build the production stream when AlarmKit is available on this OS, else
-    /// `nil` (iOS < 26 — there are no AlarmKit alarms to observe). `nonisolated`
-    /// so it can be evaluated as a default argument outside the main actor.
-    private nonisolated static func makeDefaultStream() -> AlertingAlarmStream? {
+    /// `nil` (iOS < 26 — there are no AlarmKit alarms to observe).
+    private static func makeDefaultStream() -> AlertingAlarmStream? {
         #if canImport(AlarmKit)
         if #available(iOS 26.0, *) {
             return AlarmManagerAlertingStream()
@@ -90,10 +99,12 @@ final class AlarmKitAlertObserver {
     func start() {
         guard task == nil, let stream else { return }
         AppLogger.scheduler.info("AlarmKit alert observer started")
+        // The Task inherits this main-actor context, so `handle` (main-actor,
+        // synchronous) is called without an actor hop — no `await` needed (#382).
         task = Task { [weak self] in
             for await alertingIDs in stream.alertingAlarmIDs() {
                 guard let self else { return }
-                await self.handle(alertingIDs: alertingIDs)
+                self.handle(alertingIDs: alertingIDs)
             }
         }
     }

--- a/SnoozePay/SnoozePay/Services/AlarmKitAlertObserver.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmKitAlertObserver.swift
@@ -1,0 +1,149 @@
+import Foundation
+import os
+#if canImport(AlarmKit)
+import AlarmKit
+#endif
+
+// MARK: - #379: foreground custom firing screen for AlarmKit alarms
+//
+// When an AlarmKit alarm fires while the app is already in the foreground (or
+// while it becomes active during the alert window) iOS still owns the system
+// alert presentation, but our app process is alive and able to mount its own
+// UI on top of its own window. `AlarmManager.shared.alarmUpdates` is an
+// `AsyncSequence<[Alarm], Never>` that yields the full alarm set on every
+// state change; an alarm in `.alerting` state is one that is currently
+// ringing. We watch that stream and present `AlarmFiringViewController` for
+// each newly-alerting alarm, de-duplicating so a repeated snapshot (the stream
+// re-emits the whole array) doesn't re-present the same firing.
+//
+// We do NOT and cannot suppress the system lock-screen alert — that's an iOS
+// limitation documented in #379. This only adds our screen on the foreground
+// app window; it's the AlarmKit analogue of `AppDelegate.willPresent` for the
+// notification backend.
+
+/// Source of currently-alerting alarm IDs. Protocol seam so the observer's
+/// dedup + present logic is unit-testable without a live `AlarmManager` (which
+/// needs an iOS-26 device + authorization). The production conformer wraps
+/// `AlarmManager.shared.alarmUpdates`; tests feed a hand-built stream.
+protocol AlertingAlarmStream {
+    /// An async stream of the *set* of alarm IDs currently in the alerting
+    /// state, re-emitted whenever AlarmKit reports any alarm state change.
+    func alertingAlarmIDs() -> AsyncStream<Set<UUID>>
+}
+
+/// Observes alerting AlarmKit alarms and presents the app's custom firing
+/// screen for each one as it begins ringing. Framework-free at the type level
+/// (only `UUID` in its API) so the test target compiles on any host; the
+/// `AlarmManager`-backed stream is the only iOS-26-gated surface.
+@MainActor
+final class AlarmKitAlertObserver {
+
+    static let shared = AlarmKitAlertObserver()
+
+    private let stream: AlertingAlarmStream?
+    /// Closure invoked with each newly-alerting alarm ID. Injectable so tests
+    /// can capture presentations; production presents the firing screen.
+    /// `@MainActor` because the only caller (`handle`) is main-actor isolated
+    /// and the production closure presents a VC.
+    private let onAlerting: @MainActor (UUID) -> Void
+
+    /// Alarm IDs we've already presented for this alerting episode. Cleared as
+    /// an alarm leaves the alerting set so a later re-fire of the same alarm
+    /// presents again.
+    private var presentedAlertingIDs: Set<UUID> = []
+
+    private var task: Task<Void, Never>?
+
+    #if DEBUG
+    init(
+        stream: AlertingAlarmStream? = AlarmKitAlertObserver.makeDefaultStream(),
+        onAlerting: @escaping @MainActor (UUID) -> Void = { AlarmFiringPresenter.shared.present(alarmID: $0) }
+    ) {
+        self.stream = stream
+        self.onAlerting = onAlerting
+    }
+    #else
+    private init(
+        stream: AlertingAlarmStream? = AlarmKitAlertObserver.makeDefaultStream(),
+        onAlerting: @escaping @MainActor (UUID) -> Void = { AlarmFiringPresenter.shared.present(alarmID: $0) }
+    ) {
+        self.stream = stream
+        self.onAlerting = onAlerting
+    }
+    #endif
+
+    /// Build the production stream when AlarmKit is available on this OS, else
+    /// `nil` (iOS < 26 — there are no AlarmKit alarms to observe). `nonisolated`
+    /// so it can be evaluated as a default argument outside the main actor.
+    private nonisolated static func makeDefaultStream() -> AlertingAlarmStream? {
+        #if canImport(AlarmKit)
+        if #available(iOS 26.0, *) {
+            return AlarmManagerAlertingStream()
+        }
+        #endif
+        return nil
+    }
+
+    /// Begin observing. Idempotent — a second call while already running is a
+    /// no-op so AppDelegate / SceneDelegate can both arm it without
+    /// coordinating. No-op when there's no stream (iOS < 26).
+    func start() {
+        guard task == nil, let stream else { return }
+        AppLogger.scheduler.info("AlarmKit alert observer started")
+        task = Task { [weak self] in
+            for await alertingIDs in stream.alertingAlarmIDs() {
+                guard let self else { return }
+                await self.handle(alertingIDs: alertingIDs)
+            }
+        }
+    }
+
+    /// Stop observing and reset dedup state.
+    func stop() {
+        task?.cancel()
+        task = nil
+        presentedAlertingIDs.removeAll()
+    }
+
+    /// Diff the latest alerting set against what we've already presented:
+    /// present each newly-alerting alarm exactly once, and forget alarms that
+    /// have stopped alerting so a future re-fire presents again. Internal so
+    /// tests can drive it directly with synthetic snapshots.
+    func handle(alertingIDs: Set<UUID>) {
+        // Drop IDs that are no longer alerting so they can re-present later.
+        presentedAlertingIDs.formIntersection(alertingIDs)
+
+        let newlyAlerting = alertingIDs.subtracting(presentedAlertingIDs)
+        for alarmID in newlyAlerting {
+            presentedAlertingIDs.insert(alarmID)
+            AppLogger.scheduler.notice(
+                "AlarmKit foreground alerting alarm=\(alarmID, privacy: .private) — presenting firing screen"
+            )
+            onAlerting(alarmID)
+        }
+    }
+}
+
+#if canImport(AlarmKit)
+
+/// Production `AlertingAlarmStream` over `AlarmManager.shared.alarmUpdates`.
+/// Maps each `[Alarm]` snapshot to the set of ids whose `state == .alerting`.
+@available(iOS 26.0, *)
+private struct AlarmManagerAlertingStream: AlertingAlarmStream {
+    func alertingAlarmIDs() -> AsyncStream<Set<UUID>> {
+        AsyncStream { continuation in
+            let task = Task {
+                for await alarms in AlarmManager.shared.alarmUpdates {
+                    let alerting = Set(
+                        alarms.filter { $0.state == .alerting }.map(\.id)
+                    )
+                    continuation.yield(alerting)
+                }
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+}
+
+#endif

--- a/SnoozePay/SnoozePay/Services/AlarmKitIntents.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmKitIntents.swift
@@ -4,7 +4,7 @@ import os
 import AppIntents
 #endif
 
-// MARK: - AlarmKit alert button intents (#377)
+// MARK: - AlarmKit alert button intents (#377, routing reworked in #379)
 //
 // AlarmKit (iOS 26+, Strategy A) does NOT use UNNotificationAction-style action
 // identifiers routed through the UNUserNotificationCenter delegate. Instead the
@@ -15,17 +15,18 @@ import AppIntents
 // runs the corresponding intent's `perform()` in our app process — even while
 // the device is locked.
 //
-// These two intents are the AlarmKit analogue of the
-// `DISMISS_ACTION` / `SNOOZE_ACTION` notification actions handled in
-// `AppDelegate.userNotificationCenter(_:didReceive:)`:
-//   * `StopAlarmIntent`   → stop ringing, record the wake day (no charge).
-//   * `SnoozeAlarmIntent`  → charge the (progressive) penalty, reschedule via
-//                            `AlarmFiringCoordinator`, re-arm the snooze alarm.
+// #379: both intents now set `openAppWhenRun`, so tapping either button
+// foregrounds the app and routes to our custom firing screen
+// (`AlarmFiringViewController`) for that alarm via `AlarmKitActionRouter` —
+// rather than charging / dismissing silently from the lock-screen context.
+// The in-app firing screen owns the actual stop / paid-snooze flow, so the
+// charge / reschedule logic is NOT duplicated in the intents. Both carry the
+// alarm UUID as a plain string parameter so the system can persist + replay
+// them; the router resolves the alarm from `AlarmRepository` when presenting.
 //
-// Both carry the alarm UUID as a plain string parameter so the system can
-// persist + replay them, and both resolve the alarm from `AlarmRepository`
-// rather than trusting any payload state — the repository is the single source
-// of truth for penalty / snooze settings (mirrors the notification path).
+// NOTE: iOS does not allow replacing the system alert at fire time on a locked
+// screen with our own UIView — that presentation stays system-owned. Our screen
+// only appears once the app is brought to the foreground (#379 scope).
 
 #if canImport(AppIntents)
 
@@ -33,6 +34,13 @@ import AppIntents
 struct StopAlarmIntent: LiveActivityIntent {
 
     static let title: LocalizedStringResource = "Выключить будильник"
+
+    /// Bring the app to the foreground when the system runs this intent so the
+    /// router can present our custom firing screen (#379). Without this the
+    /// intent silences the alarm but the user never sees our screen — the
+    /// issue's whole point is to route an alarm-open to the in-app flow rather
+    /// than only dismissing the system UI.
+    static let openAppWhenRun: Bool = true
 
     /// UUID string of the alarm whose AlarmKit alert this button belongs to.
     /// Stored as a string because `IntentParameter` does not support `UUID`
@@ -57,6 +65,10 @@ struct SnoozeAlarmIntent: LiveActivityIntent {
 
     static let title: LocalizedStringResource = "Поспать ещё"
 
+    /// Open the app so the paid-snooze flow runs in our firing screen (#379)
+    /// rather than charging silently from the lock screen. See `StopAlarmIntent`.
+    static let openAppWhenRun: Bool = true
+
     @Parameter(title: "Alarm ID")
     var alarmID: String
 
@@ -75,28 +87,51 @@ struct SnoozeAlarmIntent: LiveActivityIntent {
 #endif
 
 /// Shared, framework-free router for AlarmKit alert-button actions. Extracted
-/// from the intents so the business logic (charge + reschedule + wake-event)
-/// is unit-testable without standing up AppIntents / AlarmKit — the intents
-/// are thin shells whose only job is to forward to this type.
+/// from the intents so the routing decision is unit-testable without standing
+/// up AppIntents / AlarmKit — the intents are thin shells whose only job is to
+/// forward to this type.
 ///
 /// Always available (no `@available` gate) so the test target and the
 /// `< iOS 26` build can reference it; the intents that call it are the
 /// iOS-26-gated surface.
 ///
-/// `@MainActor`-isolated: every action it performs touches a UI-adjacent
-/// singleton (`AudioService`, `AlarmScheduler`, `WakeEventStore`,
-/// `AlarmFiringCoordinator`), and the AppIntent `perform()` that drives it is
-/// itself main-actor isolated — keeping the router on the main actor avoids
-/// cross-actor hops and the Swift-6 isolation diagnostics they raise.
+/// ## #379 — route an alarm-open into our custom firing screen
+///
+/// Both alert buttons set `openAppWhenRun`, so the system foregrounds the app
+/// before running `perform()`. Rather than charging / dismissing from the
+/// lock-screen context, the router silences the system alarm UI and then hands
+/// off to `AlarmFiringPresenter`, which mounts our `AlarmFiringViewController`
+/// for that alarm. The in-app firing screen owns the actual stop / paid-snooze
+/// flow (via `AlarmFiringViewModel` → `AlarmFiringCoordinator`), so the charge
+/// / refund logic is NOT duplicated here — the lock-screen button can't tell
+/// us the live snoozeCount or run an Apple-Pay top-up anyway.
+///
+/// `@MainActor`-isolated: it silences `AudioService`, stops the system alarm
+/// via `AlarmScheduler`, and presents a VC through `AlarmFiringPresenter` —
+/// all main-actor surfaces, matching the main-actor `perform()` that drives it.
 @MainActor
 final class AlarmKitActionRouter {
 
     static let shared = AlarmKitActionRouter()
 
-    private init() {}
+    /// Seam so a test can observe which alarmID the router asked to present
+    /// without standing up the UIKit hierarchy. Defaults to the real presenter.
+    var present: (UUID) -> Void = { alarmID in
+        AlarmFiringPresenter.shared.present(alarmID: alarmID)
+    }
 
-    /// Stop the ringing alarm: silence audio + record the wake day. No charge —
-    /// mirrors the `DISMISS_ACTION` branch in `AppDelegate.didReceive`.
+    #if DEBUG
+    init() {}
+    #else
+    private init() {}
+    #endif
+
+    /// Stop button on the system alert. Silence audio, dismiss the system alarm
+    /// UI, then open our firing screen so the user confirms the wake in-app
+    /// (the in-app dismiss records the wake day, mirroring the notification
+    /// `DISMISS_ACTION` semantics). The screen is the single owner of the wake
+    /// event so a Stop that the user then changes their mind on (snoozes
+    /// in-app) isn't double-counted.
     func handleStop(alarmIDString: String) {
         guard let alarmID = UUID(uuidString: alarmIDString) else {
             AppLogger.scheduler.error(
@@ -106,14 +141,17 @@ final class AlarmKitActionRouter {
         }
         AppLogger.scheduler.notice("AlarmKit stop alarm=\(alarmID, privacy: .private)")
         AudioService.shared.stopAlarmSound()
-        WakeEventStore.shared.recordWake()
         // Stop the AlarmKit alert itself so the system stops the alarm UI.
         AlarmScheduler.shared.stopSystemAlarm(alarmID)
+        present(alarmID)
     }
 
-    /// Snooze the ringing alarm: charge the penalty + reschedule. Routed
-    /// through the same `AlarmFiringCoordinator` the notification path uses so
-    /// the paid-snooze / refund-on-failure semantics stay identical (#377).
+    /// Snooze button on the system alert. Silence the system alarm UI, then
+    /// open our firing screen so the *paid* snooze (−X ₽, progressive penalty,
+    /// Apple-Pay top-up on insufficient balance) runs through the in-app flow
+    /// — the same path the notification banner takes. The charge therefore
+    /// happens exactly once, in the screen, never from the lock-screen button
+    /// (which can't surface a balance error or a top-up sheet).
     func handleSnooze(alarmIDString: String) async {
         guard let alarmID = UUID(uuidString: alarmIDString) else {
             AppLogger.scheduler.error(
@@ -124,28 +162,6 @@ final class AlarmKitActionRouter {
         AppLogger.scheduler.notice("AlarmKit snooze alarm=\(alarmID, privacy: .private)")
         AudioService.shared.stopAlarmSound()
         AlarmScheduler.shared.stopSystemAlarm(alarmID)
-
-        // Reuse the notification-path payload contract so the coordinator's
-        // charge / progressive-penalty / refund logic is shared verbatim. The
-        // coordinator re-reads the alarm from the repository, so a minimal
-        // payload (id + current snoozeCount) is enough — but we still need the
-        // alarm's penalty settings to build a complete payload, so resolve it.
-        guard let alarm = AlarmRepository.shared.fetch(id: alarmID) else {
-            AppLogger.scheduler.notice(
-                "AlarmKit snooze: alarm \(alarmID, privacy: .private) not found — skipping"
-            )
-            return
-        }
-        // AlarmKit owns its own snooze counter via repeated alerts; we start at
-        // the alarm's base penalty (snoozeCount 0 → coordinator increments to 1).
-        let payload = AlarmNotificationPayload(alarm: alarm, snoozeCount: 0)
-        await withCheckedContinuation { continuation in
-            AlarmFiringCoordinator.shared.handleSnooze(userInfo: payload.asUserInfo()) { outcome in
-                AppLogger.scheduler.info(
-                    "AlarmKit snooze outcome=\(String(describing: outcome), privacy: .public)"
-                )
-                continuation.resume()
-            }
-        }
+        present(alarmID)
     }
 }

--- a/SnoozePay/SnoozePay/Services/AlarmKitIntents.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmKitIntents.swift
@@ -15,14 +15,32 @@ import AppIntents
 // runs the corresponding intent's `perform()` in our app process — even while
 // the device is locked.
 //
-// #379: both intents now set `openAppWhenRun`, so tapping either button
-// foregrounds the app and routes to our custom firing screen
+// #379: both intents set `openAppWhenRun`, so tapping either *button* on the
+// system alert foregrounds the app and routes to our custom firing screen
 // (`AlarmFiringViewController`) for that alarm via `AlarmKitActionRouter` —
 // rather than charging / dismissing silently from the lock-screen context.
 // The in-app firing screen owns the actual stop / paid-snooze flow, so the
 // charge / reschedule logic is NOT duplicated in the intents. Both carry the
 // alarm UUID as a plain string parameter so the system can persist + replay
 // them; the router resolves the alarm from `AlarmRepository` when presenting.
+//
+// #382: presenting our screen directly inside `perform()` lost a window race —
+// `openAppWhenRun` foregrounds the app, but `perform()` runs *before* the scene
+// is active (and on a cold launch the splash → tab-bar root mounts ~200 ms
+// later), so the present silently no-op'd and the user only ever saw the app
+// background. The router now hands the alarm id to
+// `AlarmFiringPresenter.requestPresentation`, which records it as *pending* and
+// flushes it from `SceneDelegate.sceneDidBecomeActive`. The presentation
+// therefore survives both the warm-foreground race and a cold start.
+//
+// What `openAppWhenRun` can / cannot do (verified against the public AlarmKit /
+// AppIntents surface, iOS 26): it reliably foregrounds the app when the user
+// taps a *button* (Stop / Snooze) whose `LiveActivityIntent` we own. The public
+// API does NOT expose a way to attach an intent to a tap on the *body* of the
+// system alert / Dynamic Island — that gesture is system-owned and is not
+// guaranteed to run our intent. So the supported "tap to open our screen" path
+// is the alert's buttons; tapping the body alone may not route. Both buttons
+// are wired, so any deliberate user action on the alarm opens the app.
 //
 // NOTE: iOS does not allow replacing the system alert at fire time on a locked
 // screen with our own UIView — that presentation stays system-owned. Our screen
@@ -115,9 +133,13 @@ final class AlarmKitActionRouter {
     static let shared = AlarmKitActionRouter()
 
     /// Seam so a test can observe which alarmID the router asked to present
-    /// without standing up the UIKit hierarchy. Defaults to the real presenter.
+    /// without standing up the UIKit hierarchy. Defaults to the real presenter's
+    /// *pending-present* entry point: the system runs the intent before the
+    /// scene is active (and may cold-launch the app), so presenting directly
+    /// here loses the window race and the screen never appears (#382).
+    /// `requestPresentation` records the id and retries on scene-active.
     var present: (UUID) -> Void = { alarmID in
-        AlarmFiringPresenter.shared.present(alarmID: alarmID)
+        AlarmFiringPresenter.shared.requestPresentation(alarmID: alarmID)
     }
 
     #if DEBUG

--- a/SnoozePay/SnoozePay/Services/AlarmKitScheduler.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmKitScheduler.swift
@@ -44,6 +44,14 @@ protocol AlarmKitScheduling: AnyObject {
     /// disabled alarm is the caller's responsibility.
     func schedule(_ alarm: Alarm) throws
 
+    /// Reschedule `alarm` as a one-shot AlarmKit system alarm that re-fires at
+    /// `fireDate` (the snooze re-ring), `.never` recurrence. Reuses the alarm's
+    /// id so the snooze replaces the just-stopped firing (#383). Throws when
+    /// AlarmKit rejects the request. Kept distinct from `schedule(_:)` because a
+    /// snooze fires at an arbitrary wall-clock time (now + snoozeMinutes), not at
+    /// the alarm's configured time-of-day.
+    func scheduleSnooze(_ alarm: Alarm, fireDate: Date) throws
+
     /// Cancel the system alarm for `alarmID` (pending — not yet alerting).
     func cancel(_ alarmID: UUID)
 
@@ -129,6 +137,27 @@ final class AlarmKitScheduler: AlarmKitScheduling {
         }
     }
 
+    func scheduleSnooze(_ alarm: Alarm, fireDate: Date) throws {
+        let configuration = try Self.makeSnoozeConfiguration(for: alarm, fireDate: fireDate)
+        // Reuse the alarm's id so the snooze replaces the just-stopped firing —
+        // a fresh id would leave the original armed for its next recurrence AND
+        // arm a snooze, double-ringing. Fire-and-log mirrors `schedule(_:)` so
+        // the synchronous contract holds.
+        Task {
+            do {
+                _ = try await manager.schedule(id: alarm.id, configuration: configuration)
+                AppLogger.scheduler.info(
+                    "AlarmKit snooze scheduled alarm=\(alarm.id, privacy: .private)"
+                )
+            } catch {
+                let desc = error.localizedDescription
+                AppLogger.scheduler.error(
+                    "AlarmKit snooze schedule failed alarm=\(alarm.id, privacy: .private): \(desc, privacy: .public)"
+                )
+            }
+        }
+    }
+
     func cancel(_ alarmID: UUID) {
         do {
             try manager.cancel(id: alarmID)
@@ -176,6 +205,42 @@ final class AlarmKitScheduler: AlarmKitScheduling {
             secondaryIntent: SnoozeAlarmIntent(alarmID: alarm.id),
             sound: alarmSound(for: alarm)
         )
+    }
+
+    /// Build the AlarmKit configuration for a snooze re-fire: same presentation /
+    /// intents / sound as the original alarm, but a one-shot schedule pinned to
+    /// `fireDate`'s hour/minute (`.never` recurrence) so it rings once at
+    /// now + snoozeMinutes instead of the alarm's configured time-of-day (#383).
+    static func makeSnoozeConfiguration(
+        for alarm: Alarm,
+        fireDate: Date
+    ) throws -> AlarmManager.AlarmConfiguration<SnoozePayAlarmMetadata> {
+        let schedule = makeSnoozeSchedule(fireDate: fireDate)
+        let presentation = makePresentation(for: alarm)
+        let attributes = AlarmAttributes<SnoozePayAlarmMetadata>(
+            presentation: presentation,
+            metadata: SnoozePayAlarmMetadata(),
+            tintColor: Color.orange
+        )
+        return AlarmManager.AlarmConfiguration.alarm(
+            schedule: schedule,
+            attributes: attributes,
+            stopIntent: StopAlarmIntent(alarmID: alarm.id),
+            secondaryIntent: SnoozeAlarmIntent(alarmID: alarm.id),
+            sound: alarmSound(for: alarm)
+        )
+    }
+
+    /// One-shot relative schedule pinned to `fireDate`'s hour/minute. AlarmKit's
+    /// relative schedule fires at the next occurrence of that time-of-day; for a
+    /// snooze (always < 1h ahead) that next occurrence is the snooze re-ring.
+    nonisolated static func makeSnoozeSchedule(fireDate: Date) -> AlarmKit.Alarm.Schedule {
+        let components = Calendar.current.dateComponents([.hour, .minute], from: fireDate)
+        let time = AlarmKit.Alarm.Schedule.Relative.Time(
+            hour: components.hour ?? 0,
+            minute: components.minute ?? 0
+        )
+        return .relative(.init(time: time, repeats: .never))
     }
 
     /// Map the app's hour/minute + Monday-first repeat-day indices to an

--- a/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
@@ -130,12 +130,16 @@ final class AlarmScheduler: AlarmScheduling {
     /// iOS-26-vs-fallback branching can be exercised on any host OS.
     private let alarmKitScheduler: AlarmKitScheduling?
 
-    /// Whether the AlarmKit (Strategy A) path should be used for this call.
+    /// Whether the AlarmKit (Strategy A) path is active for this app/device.
     /// True only when running on iOS 26+, a backend is wired, AND the user has
     /// authorized AlarmKit. Otherwise we fall through to the notification
     /// fallback so a denied / undetermined AlarmKit grant never leaves the user
-    /// without any alarm.
-    private var usesAlarmKit: Bool {
+    /// without any alarm. `internal` (#383) so the firing screen can mirror the
+    /// scheduler's backend choice — on the AlarmKit path the system owns the
+    /// alarm sound and the snooze re-fires as a system alarm, so the in-app
+    /// screen must NOT start its own `AudioService` and must dismiss (rather than
+    /// run the in-place notification snooze countdown) after a snooze.
+    var usesAlarmKit: Bool {
         guard #available(iOS 26.0, *), let alarmKitScheduler else { return false }
         return alarmKitScheduler.isAuthorized
     }
@@ -361,6 +365,38 @@ final class AlarmScheduler: AlarmScheduling {
         snoozeCount: Int,
         completion: ((Result<Void, SchedulingError>) -> Void)? = nil
     ) {
+        // Strategy A (#383): on iOS 26+ with AlarmKit authorized, the snooze must
+        // re-fire as a real system alarm — not a notification — to match the
+        // original firing and keep piercing silent mode / Focus. Stop the
+        // currently-alerting system alarm first (the in-app firing screen also
+        // silences its audio), then reschedule the same id as a one-shot relative
+        // alarm at now + snoozeMinutes. A synchronous reschedule failure (config
+        // build) falls through to the notification path so the user is never left
+        // without a re-ring. Below iOS 26 (Strategy B) the notification burst
+        // below is unchanged.
+        if #available(iOS 26.0, *), usesAlarmKit, let alarmKitScheduler {
+            let fireDate = Self.scheduledFireDate(now: Date(), snoozeMinutes: alarm.snoozeMinutes)
+            do {
+                alarmKitScheduler.stop(alarm.id)
+                try alarmKitScheduler.scheduleSnooze(alarm, fireDate: fireDate)
+                AppLogger.scheduler.info(
+                    "scheduled snooze via AlarmKit (Strategy A) alarm=\(alarm.id, privacy: .private)"
+                )
+                completion?(.success(()))
+                return
+            } catch {
+                let desc = error.localizedDescription
+                let alarmID = alarm.id
+                AppLogger.scheduler.error(
+                    """
+                    AlarmKit snooze schedule failed alarm=\(alarmID, privacy: .private): \
+                    \(desc, privacy: .public) — fallback
+                    """
+                )
+                // fall through to the notification path below
+            }
+        }
+
         let content = makeContent(for: alarm, snoozeCount: snoozeCount)
 
         let fireDate = Self.scheduledFireDate(now: Date(), snoozeMinutes: alarm.snoozeMinutes)

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+ViewLifecycle.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+ViewLifecycle.swift
@@ -71,6 +71,15 @@ extension AlarmFiringViewController {
     // MARK: Actions
 
     func snoozeTapped() {
+        // On the AlarmKit (Strategy A) path the snooze re-fires as a REAL system
+        // alarm (the scheduler stops the current one and reschedules via
+        // AlarmKit), so this screen must close — its job is done and the system
+        // owns the next ring (#383). The in-place "отложено" countdown is a
+        // Strategy-B affordance for the notification path, where the in-app
+        // screen is the sound source and stays up. We capture the flag up front
+        // because `viewModel.snooze` is the same call on both paths.
+        let usesAlarmKit = viewModel.usesAlarmKit
+
         // scheduleCompletion surfaces a notification-center failure (revoked
         // permission, 64-pending-limit, malformed trigger) so the user
         // doesn't pay for a snooze that will never re-fire (#127 finding).
@@ -94,14 +103,42 @@ extension AlarmFiringViewController {
                 self.presentSnoozeRefundFailedAlert(error: error)
             }
         }
-        // Foreground snooze (#226): instead of dismissing, transition the live
-        // firing screen into the "отложено" state in place — countdown to the
-        // next ring, zZ badge, progressive ladder. At countdown zero the active
-        // firing UI restores. `viewModel.snooze` already bumped `snoozeCount`
-        // and fired `onStateChanged → updateUI`, so the balance pill / ladder
-        // reflect the charge before we render the snoozed chrome.
-        if success {
-            enterSnoozedState()
+
+        guard success else { return }
+
+        if usesAlarmKit {
+            // System alarm rescheduled — silence any in-app audio (a no-op on
+            // this path since we never started it, but keeps the stop-on-handoff
+            // contract) and dismiss the firing screen.
+            dismissAfterAlarmKitSnooze()
+            return
+        }
+
+        // Foreground snooze (#226), notification path: instead of dismissing,
+        // transition the live firing screen into the "отложено" state in place —
+        // countdown to the next ring, zZ badge, progressive ladder. At countdown
+        // zero the active firing UI restores. `viewModel.snooze` already bumped
+        // `snoozeCount` and fired `onStateChanged → updateUI`, so the balance
+        // pill / ladder reflect the charge before we render the snoozed chrome.
+        enterSnoozedState()
+    }
+
+    /// Close the firing screen after an AlarmKit snooze (#383). The next ring is
+    /// a real system alarm: the scheduler already stopped the currently-alerting
+    /// alarm and rescheduled the snooze under the same id, so we must NOT call
+    /// `stopSystemAlarm` again here — that would cancel the freshly-armed snooze.
+    /// We only silence any in-app audio (guarded by the per-alarm owner check,
+    /// mirroring `viewDidDisappear`; a no-op on this path since we never started
+    /// it) and dismiss. `viewDidDisappear` re-runs the same guarded stop, so the
+    /// audio teardown is idempotent.
+    private func dismissAfterAlarmKitSnooze() {
+        if AudioService.shared.currentAlarmID == viewModel.alarm.id {
+            AudioService.shared.stopAlarmSound()
+        }
+        if let presenter = presentingViewController {
+            presenter.dismiss(animated: true)
+        } else {
+            dismiss(animated: true)
         }
     }
 

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController.swift
@@ -316,15 +316,22 @@ class AlarmFiringViewController: UIViewController {
         startClockTicker()
         startGlowBreathing()
 
-        // Pass `alarmID` so a stacking-replace race does not silence the next
-        // alarm when this VC's `viewDidDisappear` fires. Volume + fade-in
-        // honour the per-alarm settings.
-        AudioService.shared.startAlarmSound(
-            soundID: viewModel.alarm.soundID,
-            alarmID: viewModel.alarm.id,
-            volume: viewModel.alarm.volume,
-            fadeIn: viewModel.alarm.volumeFadeIn
-        )
+        // On the AlarmKit (Strategy A) path the SYSTEM owns the alarm sound (a
+        // real system alarm that pierces silent mode); the lock-screen button
+        // that opened this screen already silenced it. Starting our own
+        // `AudioService` here would double up the sound (#383). On the
+        // notification (Strategy B) path the in-app screen IS the sound source,
+        // so it starts audio as before. Pass `alarmID` so a stacking-replace race
+        // does not silence the next alarm when this VC's `viewDidDisappear` fires.
+        // Volume + fade-in honour the per-alarm settings.
+        if !viewModel.usesAlarmKit {
+            AudioService.shared.startAlarmSound(
+                soundID: viewModel.alarm.soundID,
+                alarmID: viewModel.alarm.id,
+                volume: viewModel.alarm.volume,
+                fadeIn: viewModel.alarm.volumeFadeIn
+            )
+        }
 
         // Initial transition may have happened synchronously inside
         // `startAlarmSound` before our observer is wired — sync now.

--- a/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
@@ -117,6 +117,15 @@ final class AlarmFiringViewModel {
 
     var alarmName: String { alarm.name }
 
+    /// `true` when this firing runs on the AlarmKit (Strategy A) backend — iOS
+    /// 26+ with AlarmKit authorized (#383). On that path the SYSTEM owns the
+    /// alarm sound (the in-app screen must not start its own `AudioService`) and
+    /// a snooze re-fires as a real system alarm, so the firing screen DISMISSES
+    /// after a snooze rather than running the in-place notification-snooze
+    /// countdown (which is a Strategy-B-only affordance). Below iOS 26 this is
+    /// `false` and the existing notification behaviour is unchanged.
+    var usesAlarmKit: Bool { scheduler.usesAlarmKit }
+
     /// Amount charged by the MOST RECENT snooze — the rung the user just paid
     /// for. `snooze()` bumps `snoozeCount` before this reads, so it equals
     /// `penalty(forSnoozeCount: snoozeCount)`. Drives the fly-up «−N ₽» in the

--- a/SnoozePay/SnoozePayTests/AlarmFiringSnoozeAlarmKitTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmFiringSnoozeAlarmKitTests.swift
@@ -1,0 +1,163 @@
+import XCTest
+import UserNotifications
+@testable import SnoozePay
+
+/// #383 — the in-app snooze on the AlarmKit (Strategy A, iOS 26+) path must:
+///   • charge the penalty exactly once,
+///   • reschedule the snooze through AlarmKit (a real system alarm) and NOT as
+///     a notification (Strategy B),
+///   • surface `usesAlarmKit == true` so the firing screen dismisses (rather
+///     than running the in-place notification-snooze countdown) and skips its
+///     own `AudioService` (the system owns the sound).
+///
+/// The screen-level stop/dismiss/audio behaviour lives in the VC; here we pin
+/// the model + scheduler seam that drives it, since those are the testable
+/// non-UI surfaces. Routes through the injectable `AlarmKitScheduling` /
+/// `NotificationScheduling` seams so the iOS-26 path is exercisable from the
+/// branching logic on any host (the AlarmKit branch itself is iOS-26 gated).
+final class AlarmFiringSnoozeAlarmKitTests: XCTestCase {
+
+    private func makeAlarm(penalty: Double = 50) -> Alarm {
+        Alarm(snoozeMinutes: 9, penaltyAmount: penalty)
+    }
+
+    // MARK: - usesAlarmKit plumbing
+
+    func testUsesAlarmKit_authorizedBackend_isTrue() throws {
+        guard #available(iOS 26.0, *) else { throw XCTSkip("AlarmKit branch is iOS 26+") }
+        let scheduler = AlarmScheduler(
+            notificationCenter: SnoozeRecordingCenter(),
+            alarmKit: SnoozeMockAlarmKit(authorized: true)
+        )
+        let vm = AlarmFiringViewModel(
+            alarm: makeAlarm(),
+            balanceService: SnoozeStubBalance(balanceValue: 500),
+            scheduler: scheduler
+        )
+        XCTAssertTrue(vm.usesAlarmKit, "Authorized AlarmKit backend must surface usesAlarmKit == true")
+    }
+
+    func testUsesAlarmKit_noBackend_isFalse() {
+        let scheduler = AlarmScheduler(notificationCenter: SnoozeRecordingCenter(), alarmKit: nil)
+        let vm = AlarmFiringViewModel(
+            alarm: makeAlarm(),
+            balanceService: SnoozeStubBalance(balanceValue: 500),
+            scheduler: scheduler
+        )
+        XCTAssertFalse(vm.usesAlarmKit, "Without an AlarmKit backend the path stays Strategy B")
+    }
+
+    // MARK: - Snooze on the AlarmKit path
+
+    /// A successful AlarmKit snooze charges once and reschedules via AlarmKit
+    /// (stop-then-reschedule), never a notification.
+    func testSnooze_alarmKitPath_chargesOnceAndReschedulesViaAlarmKit() throws {
+        guard #available(iOS 26.0, *) else { throw XCTSkip("AlarmKit branch is iOS 26+") }
+        let alarmKit = SnoozeMockAlarmKit(authorized: true)
+        let center = SnoozeRecordingCenter()
+        let scheduler = AlarmScheduler(notificationCenter: center, alarmKit: alarmKit)
+        let billing = SnoozeStubBalance(balanceValue: 500)
+        let alarm = makeAlarm(penalty: 50)
+        let vm = AlarmFiringViewModel(alarm: alarm, balanceService: billing, scheduler: scheduler)
+
+        let exp = expectation(description: "snooze outcome")
+        var outcome: AlarmFiringViewModel.SnoozeScheduleOutcome?
+        let charged = vm.snooze { outcome = $0; exp.fulfill() }
+        wait(for: [exp], timeout: 2.0)
+
+        XCTAssertTrue(charged, "Snooze charges when the balance covers the penalty")
+        XCTAssertEqual(billing.chargeCalls, [50], "The penalty must be charged exactly once")
+        XCTAssertTrue(billing.topUpCalls.isEmpty, "No refund on a successful AlarmKit snooze")
+        XCTAssertEqual(outcome, .scheduled)
+        XCTAssertEqual(alarmKit.snoozedIDs, [alarm.id], "Snooze must reschedule via AlarmKit")
+        XCTAssertEqual(alarmKit.stoppedIDs, [alarm.id], "The ringing alarm must be stopped on snooze")
+        XCTAssertTrue(center.addedRequests.isEmpty, "AlarmKit snooze must not register a notification")
+        XCTAssertEqual(vm.snoozeCount, 1)
+    }
+
+    /// At zero balance the AlarmKit snooze takes no money and does not snooze —
+    /// the #381 top-up guard is unchanged on this path (no charge, no negative).
+    func testSnooze_alarmKitPath_zeroBalance_takesNoMoney() throws {
+        guard #available(iOS 26.0, *) else { throw XCTSkip("AlarmKit branch is iOS 26+") }
+        let alarmKit = SnoozeMockAlarmKit(authorized: true)
+        let scheduler = AlarmScheduler(notificationCenter: SnoozeRecordingCenter(), alarmKit: alarmKit)
+        let billing = SnoozeStubBalance(balanceValue: 0)
+        let vm = AlarmFiringViewModel(alarm: makeAlarm(penalty: 50), balanceService: billing, scheduler: scheduler)
+
+        let result = vm.snooze()
+
+        XCTAssertFalse(result, "A paid snooze at 0 ₽ must not proceed")
+        XCTAssertTrue(billing.chargeCalls.isEmpty, "Nothing is charged when the balance can't cover it")
+        XCTAssertTrue(alarmKit.snoozedIDs.isEmpty, "No reschedule when the snooze is refused")
+        XCTAssertEqual(vm.snoozeCount, 0)
+    }
+}
+
+// MARK: - Test doubles
+
+private final class SnoozeMockAlarmKit: AlarmKitScheduling {
+    private let authorized: Bool
+    private(set) var scheduledIDs: [UUID] = []
+    private(set) var snoozedIDs: [UUID] = []
+    private(set) var stoppedIDs: [UUID] = []
+    private(set) var cancelledIDs: [UUID] = []
+
+    init(authorized: Bool) { self.authorized = authorized }
+
+    var isAuthorized: Bool { authorized }
+    func requestAuthorization(completion: @escaping (Bool) -> Void) { completion(authorized) }
+    func schedule(_ alarm: Alarm) throws { scheduledIDs.append(alarm.id) }
+    func scheduleSnooze(_ alarm: Alarm, fireDate: Date) throws { snoozedIDs.append(alarm.id) }
+    func cancel(_ alarmID: UUID) { cancelledIDs.append(alarmID) }
+    func stop(_ alarmID: UUID) { stoppedIDs.append(alarmID) }
+}
+
+private final class SnoozeStubBalance: AlarmFiringBalancing {
+    private(set) var balance: Double
+    private(set) var chargeCalls: [Double] = []
+    private(set) var topUpCalls: [Double] = []
+
+    init(balanceValue: Double) { self.balance = balanceValue }
+
+    func canAfford(_ amount: Double) -> Bool { balance >= amount }
+
+    @discardableResult
+    func charge(amount: Double, alarmID: UUID?) -> Bool {
+        chargeCalls.append(amount)
+        guard balance >= amount else { return false }
+        balance -= amount
+        return true
+    }
+
+    @discardableResult
+    func topUp(amount: Double, refundsTransactionID: UUID?) -> Bool {
+        topUpCalls.append(amount)
+        balance += amount
+        return true
+    }
+}
+
+private final class SnoozeRecordingCenter: NotificationScheduling {
+    private(set) var addedRequests: [UNNotificationRequest] = []
+
+    func add(_ request: UNNotificationRequest, withCompletionHandler completion: ((Error?) -> Void)?) {
+        addedRequests.append(request)
+        completion?(nil)
+    }
+    func getPendingNotificationRequests(completionHandler: @escaping ([UNNotificationRequest]) -> Void) {
+        completionHandler([])
+    }
+    func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {}
+    func removeDeliveredNotifications(withIdentifiers identifiers: [String]) {}
+    func getDeliveredNotifications(completionHandler: @escaping ([UNNotification]) -> Void) {
+        completionHandler([])
+    }
+    func setNotificationCategories(_ categories: Set<UNNotificationCategory>) {}
+    func removeAllPendingNotificationRequests() {}
+    func requestAuthorization(
+        options: UNAuthorizationOptions,
+        completionHandler: @escaping (Bool, Error?) -> Void
+    ) {
+        completionHandler(true, nil)
+    }
+}

--- a/SnoozePay/SnoozePayTests/AlarmFiringViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmFiringViewModelTests.swift
@@ -80,6 +80,27 @@ final class AlarmFiringViewModelIOS011Tests: XCTestCase {
         XCTAssertFalse(result, "Snooze should fail when balance is penalty - 1")
     }
 
+    /// #381: with a zero balance the paid snooze must take *no* money and *not*
+    /// snooze — the balance stays at 0 (never negative) and the snooze count is
+    /// untouched. The user is instead routed to the Apple Pay top-up (the VC's
+    /// no-balance state), and the actual snooze only runs after a successful
+    /// top-up flips `canSnooze` true. This is the in-app guard the AlarmKit
+    /// lock-screen Snooze button now relies on (it only opens the app; it never
+    /// charges), so a −50 ₽ button at 0 ₽ can't snooze for free or go negative.
+    func testSnooze_atZeroBalance_takesNoMoneyAndDoesNotSnooze() {
+        setBalance(0)
+        let alarm = makeAlarm(penalty: 50)
+        let vm = AlarmFiringViewModel(alarm: alarm, snoozeCount: 0)
+
+        let result = vm.snooze()
+
+        XCTAssertFalse(result, "A paid snooze at 0 ₽ must not proceed")
+        XCTAssertFalse(vm.canSnooze, "0 ₽ cannot afford a −50 ₽ snooze")
+        XCTAssertEqual(vm.snoozeCount, 0, "snoozeCount must not advance on a refused snooze")
+        XCTAssertEqual(BalanceService.shared.balance, 0, accuracy: 0.001,
+                       "Balance must stay at 0 — never deducted, never negative")
+    }
+
     // MARK: - Snooze count
 
     func testSnooze_incrementsSnoozeCount() {

--- a/SnoozePay/SnoozePayTests/AlarmKitFiringRoutingTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmKitFiringRoutingTests.swift
@@ -111,4 +111,100 @@ final class AlarmKitFiringRoutingTests: XCTestCase {
 
         XCTAssertEqual(presentedCount, 0)
     }
+
+    // MARK: - AlarmFiringPresenter pending-present (#382)
+
+    /// Builds a presenter with injectable readiness + mount seams so the
+    /// pending-present logic is exercised without a UIKit window.
+    private func makePresenter(
+        rootReady: @escaping () -> Bool,
+        mounted: @escaping (UUID) -> Bool
+    ) -> AlarmFiringPresenter {
+        let presenter = AlarmFiringPresenter(alarmRepository: .shared)
+        presenter.isRootReady = rootReady
+        presenter.mount = { alarmID, _ in mounted(alarmID) }
+        return presenter
+    }
+
+    /// When no window is ready yet, a request records the alarm as pending and
+    /// mounts nothing — the screen must survive until the scene becomes active.
+    func testPresenter_requestBeforeWindow_defersAndKeepsPending() {
+        var mountedIDs: [UUID] = []
+        let presenter = makePresenter(rootReady: { false }, mounted: { id in
+            mountedIDs.append(id); return true
+        })
+        let id = UUID()
+
+        presenter.requestPresentation(alarmID: id)
+
+        XCTAssertTrue(mountedIDs.isEmpty, "Must not mount before the root is ready")
+        XCTAssertEqual(presenter.pendingAlarmID, id,
+                       "The alarm must stay pending until the scene is active")
+    }
+
+    /// A flush once the root is ready mounts the deferred alarm and clears the
+    /// pending id — the cold-launch / scene-active recovery path.
+    func testPresenter_flushAfterWindowReady_mountsAndClearsPending() {
+        var rootReady = false
+        var mountedIDs: [UUID] = []
+        let presenter = makePresenter(rootReady: { rootReady }, mounted: { id in
+            mountedIDs.append(id); return true
+        })
+        let id = UUID()
+
+        presenter.requestPresentation(alarmID: id) // deferred (no root)
+        rootReady = true
+        presenter.flushPendingPresentation()        // scene became active
+
+        XCTAssertEqual(mountedIDs, [id], "Flush must mount the deferred alarm once")
+        XCTAssertNil(presenter.pendingAlarmID, "Pending must clear after a successful mount")
+    }
+
+    /// A flush that still finds no window keeps the alarm pending so a later
+    /// activation re-attempts — it must not silently drop the firing screen.
+    func testPresenter_flushWhileStillNotReady_keepsPending() {
+        var mountedIDs: [UUID] = []
+        let presenter = makePresenter(rootReady: { false }, mounted: { id in
+            mountedIDs.append(id); return true
+        })
+        let id = UUID()
+
+        presenter.requestPresentation(alarmID: id)
+        presenter.flushPendingPresentation() // still no root
+
+        XCTAssertTrue(mountedIDs.isEmpty)
+        XCTAssertEqual(presenter.pendingAlarmID, id)
+    }
+
+    /// A mount that reports "no window" (returns false) even though the root
+    /// gate passed keeps the alarm pending for the next flush — the window-race
+    /// belt-and-suspenders.
+    func testPresenter_mountReportsNoWindow_keepsPending() {
+        var attempts = 0
+        let presenter = makePresenter(rootReady: { true }, mounted: { _ in
+            attempts += 1; return false
+        })
+        let id = UUID()
+
+        presenter.requestPresentation(alarmID: id)
+
+        XCTAssertEqual(attempts, 1, "Should attempt the mount when the root is ready")
+        XCTAssertEqual(presenter.pendingAlarmID, id,
+                       "A failed mount must keep the alarm pending")
+    }
+
+    /// A warm request (window already ready) mounts immediately and never
+    /// records a pending id.
+    func testPresenter_requestWithWindowReady_mountsImmediately() {
+        var mountedIDs: [UUID] = []
+        let presenter = makePresenter(rootReady: { true }, mounted: { id in
+            mountedIDs.append(id); return true
+        })
+        let id = UUID()
+
+        presenter.requestPresentation(alarmID: id)
+
+        XCTAssertEqual(mountedIDs, [id])
+        XCTAssertNil(presenter.pendingAlarmID)
+    }
 }

--- a/SnoozePay/SnoozePayTests/AlarmKitFiringRoutingTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmKitFiringRoutingTests.swift
@@ -1,0 +1,114 @@
+import XCTest
+@testable import SnoozePay
+
+/// Unit tests for the #379 routing surface: AlarmKit alert buttons and the
+/// foreground `alarmUpdates` observer both funnel an alarm-open into our custom
+/// firing screen via an injectable presentation seam — verified here without a
+/// live `AlarmManager` / UIKit hierarchy.
+@MainActor
+final class AlarmKitFiringRoutingTests: XCTestCase {
+
+    // MARK: - AlarmKitActionRouter
+
+    /// Stop button presents the firing screen for the alarm's id.
+    func testRouterStop_presentsFiringScreenForAlarmID() {
+        let router = AlarmKitActionRouter()
+        var presented: [UUID] = []
+        router.present = { presented.append($0) }
+        let id = UUID()
+
+        router.handleStop(alarmIDString: id.uuidString)
+
+        XCTAssertEqual(presented, [id],
+                       "Stop must route the alarm-open to our firing screen")
+    }
+
+    /// Snooze button presents the firing screen for the alarm's id (the paid
+    /// snooze itself runs in-app, not from the lock-screen button).
+    func testRouterSnooze_presentsFiringScreenForAlarmID() async {
+        let router = AlarmKitActionRouter()
+        var presented: [UUID] = []
+        router.present = { presented.append($0) }
+        let id = UUID()
+
+        await router.handleSnooze(alarmIDString: id.uuidString)
+
+        XCTAssertEqual(presented, [id],
+                       "Snooze must route the alarm-open to our firing screen")
+    }
+
+    /// A malformed alarmID is rejected without presenting anything.
+    func testRouterStop_malformedID_doesNotPresent() {
+        let router = AlarmKitActionRouter()
+        var presented: [UUID] = []
+        router.present = { presented.append($0) }
+
+        router.handleStop(alarmIDString: "not-a-uuid")
+
+        XCTAssertTrue(presented.isEmpty, "Malformed id must not present a screen")
+    }
+
+    func testRouterSnooze_malformedID_doesNotPresent() async {
+        let router = AlarmKitActionRouter()
+        var presented: [UUID] = []
+        router.present = { presented.append($0) }
+
+        await router.handleSnooze(alarmIDString: "")
+
+        XCTAssertTrue(presented.isEmpty, "Malformed id must not present a screen")
+    }
+
+    // MARK: - AlarmKitAlertObserver dedup
+
+    /// A newly-alerting alarm presents exactly once even though the stream
+    /// re-emits the same snapshot on every state change.
+    func testObserver_presentsEachAlertingAlarmOnce() {
+        var presented: [UUID] = []
+        let observer = AlarmKitAlertObserver(stream: nil, onAlerting: { presented.append($0) })
+        let alarmA = UUID()
+
+        observer.handle(alertingIDs: [alarmA])
+        observer.handle(alertingIDs: [alarmA]) // repeated snapshot
+        observer.handle(alertingIDs: [alarmA])
+
+        XCTAssertEqual(presented, [alarmA],
+                       "A still-alerting alarm must not re-present on repeated snapshots")
+    }
+
+    /// An alarm that stops alerting and later fires again presents twice.
+    func testObserver_reFiringAfterStop_presentsAgain() {
+        var presented: [UUID] = []
+        let observer = AlarmKitAlertObserver(stream: nil, onAlerting: { presented.append($0) })
+        let alarmA = UUID()
+
+        observer.handle(alertingIDs: [alarmA]) // first fire
+        observer.handle(alertingIDs: [])       // stopped
+        observer.handle(alertingIDs: [alarmA]) // re-fire
+
+        XCTAssertEqual(presented, [alarmA, alarmA],
+                       "Re-firing after the alarm stopped must present again")
+    }
+
+    /// Multiple simultaneously-alerting alarms each present once.
+    func testObserver_multipleAlerting_presentEachOnce() {
+        var presented: Set<UUID> = []
+        let observer = AlarmKitAlertObserver(stream: nil, onAlerting: { presented.insert($0) })
+        let alarmA = UUID()
+        let alarmB = UUID()
+
+        observer.handle(alertingIDs: [alarmA, alarmB])
+        observer.handle(alertingIDs: [alarmA, alarmB])
+
+        XCTAssertEqual(presented, [alarmA, alarmB])
+    }
+
+    /// An empty alerting set presents nothing.
+    func testObserver_emptySet_presentsNothing() {
+        var presentedCount = 0
+        let observer = AlarmKitAlertObserver(stream: nil, onAlerting: { _ in presentedCount += 1 })
+
+        observer.handle(alertingIDs: [])
+
+        XCTAssertEqual(presentedCount, 0)
+    }
+}

--- a/SnoozePay/SnoozePayTests/AlarmKitSchedulerTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmKitSchedulerTests.swift
@@ -94,6 +94,89 @@ final class AlarmKitSchedulerTests: XCTestCase {
         XCTAssertTrue(center.addedRequests.isEmpty)
     }
 
+    // MARK: - Snooze routing (#383)
+
+    /// On the AlarmKit path a snooze must reschedule a real system alarm (NOT a
+    /// notification) and must stop the currently-alerting alarm *before*
+    /// rescheduling, so the ringing stops and the snooze re-arms cleanly.
+    func testScheduleSnooze_authorizedAlarmKit_stopsThenReschedulesViaAlarmKit() throws {
+        guard #available(iOS 26.0, *) else {
+            throw XCTSkip("AlarmKit branch only runs on iOS 26+")
+        }
+        let alarmKit = MockAlarmKitScheduler(authorized: true)
+        let center = RecordingCenter()
+        let scheduler = AlarmScheduler(notificationCenter: center, alarmKit: alarmKit)
+        let alarm = AppAlarm(penaltyAmount: 50)
+
+        let exp = expectation(description: "snooze completes")
+        scheduler.scheduleSnooze(for: alarm, snoozeCount: 1) { result in
+            if case .failure = result { XCTFail("expected success on AlarmKit snooze path") }
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 2.0)
+
+        XCTAssertEqual(alarmKit.snoozedIDs, [alarm.id],
+                       "Authorized AlarmKit must receive the snooze reschedule")
+        XCTAssertEqual(alarmKit.stoppedIDs, [alarm.id],
+                       "The currently-alerting alarm must be stopped on snooze")
+        XCTAssertEqual(alarmKit.callLog, ["stop", "scheduleSnooze"],
+                       "Stop must run BEFORE the reschedule so the alarm stops ringing")
+        XCTAssertTrue(center.addedRequests.isEmpty,
+                      "Strategy A snooze must not also register a notification (Strategy B)")
+    }
+
+    /// The AlarmKit snooze re-fire date is now + the alarm's snoozeMinutes.
+    func testScheduleSnooze_authorizedAlarmKit_fireDateIsNowPlusSnoozeMinutes() throws {
+        guard #available(iOS 26.0, *) else {
+            throw XCTSkip("AlarmKit branch only runs on iOS 26+")
+        }
+        let alarmKit = MockAlarmKitScheduler(authorized: true)
+        let scheduler = AlarmScheduler(notificationCenter: RecordingCenter(), alarmKit: alarmKit)
+        let alarm = AppAlarm(snoozeMinutes: 9, penaltyAmount: 50)
+
+        let before = Date()
+        let exp = expectation(description: "snooze completes")
+        scheduler.scheduleSnooze(for: alarm, snoozeCount: 1) { _ in exp.fulfill() }
+        wait(for: [exp], timeout: 2.0)
+        let after = Date()
+
+        let fireDate = try XCTUnwrap(alarmKit.snoozeFireDates.first)
+        XCTAssertGreaterThanOrEqual(fireDate.timeIntervalSince(before), 9 * 60 - 1)
+        XCTAssertLessThanOrEqual(fireDate.timeIntervalSince(after), 9 * 60 + 1)
+    }
+
+    /// On the notification fallback (AlarmKit unauthorized) the snooze stays a
+    /// notification (Strategy B) — the existing behaviour must not regress.
+    func testScheduleSnooze_unauthorizedAlarmKit_fallsBackToNotification() throws {
+        guard #available(iOS 26.0, *) else {
+            throw XCTSkip("AlarmKit branch only runs on iOS 26+")
+        }
+        let alarmKit = MockAlarmKitScheduler(authorized: false)
+        let center = RecordingCenter()
+        let scheduler = AlarmScheduler(notificationCenter: center, alarmKit: alarmKit)
+
+        let exp = expectation(description: "snooze completes")
+        scheduler.scheduleSnooze(for: AppAlarm(penaltyAmount: 50), snoozeCount: 1) { _ in exp.fulfill() }
+        wait(for: [exp], timeout: 2.0)
+
+        XCTAssertTrue(alarmKit.snoozedIDs.isEmpty, "Unauthorized AlarmKit must not reschedule a system snooze")
+        XCTAssertFalse(center.addedRequests.isEmpty, "Fallback must register the notification snooze")
+    }
+
+    /// With no AlarmKit backend (iOS < 26 shape) the snooze is a notification —
+    /// the pre-#383 behaviour, unchanged.
+    func testScheduleSnooze_noAlarmKitBackend_usesNotificationFallback() {
+        let center = RecordingCenter()
+        let scheduler = AlarmScheduler(notificationCenter: center, alarmKit: nil)
+
+        let exp = expectation(description: "snooze completes")
+        scheduler.scheduleSnooze(for: AppAlarm(penaltyAmount: 50), snoozeCount: 1) { _ in exp.fulfill() }
+        wait(for: [exp], timeout: 2.0)
+
+        XCTAssertFalse(center.addedRequests.isEmpty,
+                       "Without AlarmKit the notification snooze fallback must still register")
+    }
+
     // MARK: - Cancel + stop forward to AlarmKit
 
     func testCancel_forwardsToAlarmKitBackend() throws {
@@ -213,9 +296,14 @@ final class AlarmKitSchedulerTests: XCTestCase {
 private final class MockAlarmKitScheduler: AlarmKitScheduling {
     private let authorized: Bool
     private(set) var scheduledIDs: [UUID] = []
+    private(set) var snoozedIDs: [UUID] = []
+    private(set) var snoozeFireDates: [Date] = []
     private(set) var cancelledIDs: [UUID] = []
     private(set) var stoppedIDs: [UUID] = []
     private(set) var authorizationRequests = 0
+    /// Ordered log of every mutating call so #383 can assert the snooze stops
+    /// the alerting alarm BEFORE rescheduling.
+    private(set) var callLog: [String] = []
 
     init(authorized: Bool) { self.authorized = authorized }
 
@@ -228,14 +316,23 @@ private final class MockAlarmKitScheduler: AlarmKitScheduling {
 
     func schedule(_ alarm: AppAlarm) throws {
         scheduledIDs.append(alarm.id)
+        callLog.append("schedule")
+    }
+
+    func scheduleSnooze(_ alarm: AppAlarm, fireDate: Date) throws {
+        snoozedIDs.append(alarm.id)
+        snoozeFireDates.append(fireDate)
+        callLog.append("scheduleSnooze")
     }
 
     func cancel(_ alarmID: UUID) {
         cancelledIDs.append(alarmID)
+        callLog.append("cancel")
     }
 
     func stop(_ alarmID: UUID) {
         stoppedIDs.append(alarmID)
+        callLog.append("stop")
     }
 }
 


### PR DESCRIPTION
## Что и зачем

Консолидированный перенос оставшейся AlarmKit-работы с локальной device-ветки `feature/IOS-374` на чистую базу `design-refresh` (поверх уже смердженного #378 / Strategy A). Заменяет закрытый стек-PR #380.

### #379 — наш экран срабатывания при открытии из будильника
`AlarmKitActionRouter` + `AlarmFiringPresenter` (pending-present pattern) + `AlarmKitAlertObserver` (observe `AlarmManager.alarmUpdates`). Кнопки системного алерта (`openAppWhenRun`) открывают приложение и показывают наш `AlarmFiringViewController`. (iOS не даёт заменить системный lock-screen алерт — только показ нашего экрана при foreground.)

### #382 — тап не открывал приложение
Презентация прямо в `perform()` теряла window-гонку (scene ещё не active / cold launch). Теперь id запоминается как pending и флашится из `SceneDelegate.sceneDidBecomeActive` — переживает и warm-гонку, и cold start.

### #381 — платный снуз при балансе 0 ₽
Кнопка снуза на низком балансе уводит в Apple Pay top-up через in-app flow, а не списывает с нуля.

### #383 — снуз не глушил звонок / экран не закрывался / снуз пересоздавался как уведомление
Снуз на iOS 26 теперь: глушит AlarmKit-алерт, пересоздаёт через AlarmKit (а не Strategy B уведомление), закрывает экран.

## Проверка
- ✅ Clean build (sim) — зелёный
- ✅ Тесты: `AlarmKitFiringRoutingTests`, `AlarmFiringSnoozeAlarmKitTests` (логика роутера/снуза покрыта)
- ✅ Verified на устройстве (iOS 26): тап открывает приложение, снуз глушит звонок и закрывает экран

## Контекст
Закрывает по смыслу #379, #381, #382, #383 (закрыть руками после merge — интеграционная ветка, auto-close только на main). Superseded PR #380 (закрыт автоматически при merge #378).

🤖 Generated with [Claude Code](https://claude.com/claude-code)