### PR TITLE
[fix] StoreKit: gate demo top-up fallback behind DEBUG (#385)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+NoBalance.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+NoBalance.swift
@@ -306,14 +306,23 @@ extension AlarmFiringViewController {
             return
         }
 
-        // Product list hasn't loaded yet — fall back to a direct top-up.
+        // Product list hasn't loaded yet.
+        #if DEBUG
+        // DEBUG/simulator: credit locally so the flow stays testable.
         AppLogger.storeKit.notice(
-            "noBalanceApplePayTapped: product \(productID, privacy: .public) not loaded — fallback to topUp"
+            "noBalanceApplePayTapped: product \(productID, privacy: .public) not loaded — DEBUG fallback to topUp"
         )
         let amount = Double(Self.noBalanceDisplayAmount)
         if BalanceService.shared.topUp(amount: amount) {
             return
         }
+        #else
+        // Release: never credit without a real StoreKit transaction —
+        // fall through to reset + the failure alert below.
+        AppLogger.storeKit.error(
+            "noBalanceApplePayTapped: product \(productID, privacy: .public) not loaded — purchase unavailable (no local credit in release)"
+        )
+        #endif
         noBalancePurchaseInFlight = false
         applePayNoBalanceButton?.isEnabled = true
         presentNoBalancePurchaseFailureAlert(

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/FiringTopUpBottomSheetViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/FiringTopUpBottomSheetViewController.swift
@@ -583,8 +583,11 @@ extension FiringTopUpBottomSheetViewController {
             }
         } else {
             let pid = preset.productID
+            #if DEBUG
+            // DEBUG/simulator without a loaded StoreKit catalogue: credit
+            // locally so the flow stays testable without ASC products.
             AppLogger.storeKit.notice(
-                "FiringTopUpSheet: product \(pid, privacy: .public) not loaded — falling back to BalanceService.topUp"
+                "FiringTopUpSheet: product \(pid, privacy: .public) not loaded — DEBUG fallback to BalanceService.topUp"
             )
             let amount = Double(preset.amount)
             if BalanceService.shared.topUp(amount: amount) {
@@ -592,6 +595,13 @@ extension FiringTopUpBottomSheetViewController {
             } else {
                 handlePurchaseFailure(message: StoreKitService.ledgerLockedFailureMessage)
             }
+            #else
+            // Release: never credit without a real StoreKit transaction.
+            AppLogger.storeKit.error(
+                "FiringTopUpSheet: product \(pid, privacy: .public) not loaded — purchase unavailable (no local credit in release)"
+            )
+            handlePurchaseFailure(message: "Не удалось загрузить пакеты пополнения. Попробуйте позже.")
+            #endif
         }
     }
 

--- a/SnoozePay/SnoozePay/ViewControllers/Wallet/DepositBottomSheetViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Wallet/DepositBottomSheetViewController.swift
@@ -363,14 +363,27 @@ final class DepositBottomSheetViewController: UIViewController {
             }
         } else {
             let pid = preset.productID
+            #if DEBUG
+            // DEBUG/simulator without a loaded StoreKit catalogue: credit
+            // locally so the flow stays testable without ASC products.
             AppLogger.storeKit.notice(
-                "DepositSheet: product \(pid, privacy: .public) not loaded — falling back to BalanceService.topUp"
+                "DepositSheet: product \(pid, privacy: .public) not loaded — DEBUG fallback to BalanceService.topUp"
             )
             if BalanceService.shared.topUp(amount: Double(preset.amount)) {
                 handlePurchaseSuccess(amount: preset.amount)
             } else {
                 handlePurchaseFailure(message: StoreKitService.ledgerLockedFailureMessage)
             }
+            #else
+            // Release: NEVER credit balance without a real StoreKit
+            // transaction. An empty product list (inactive Paid Apps /
+            // unpropagated SKU / offline) must surface as an error, not as
+            // free balance.
+            AppLogger.storeKit.error(
+                "DepositSheet: product \(pid, privacy: .public) not loaded — purchase unavailable (no local credit in release)"
+            )
+            handlePurchaseFailure(message: "Не удалось загрузить пакеты пополнения. Попробуйте позже.")
+            #endif
         }
     }
 


### PR DESCRIPTION
## Проблема
Локальный demo-фолбэк (`BalanceService.topUp` при пустом StoreKit-каталоге) не был огорожен компиляцией. В **release** это значило: если продукты не загрузились (неактивный Paid Apps, непропагированный SKU, офлайн) — любой тап «Пополнить» давал **бесплатное начисление баланса**. Утечка выручки.

## Фикс
Все три точки пополнения огорожены `#if DEBUG`:
- `DepositBottomSheetViewController` (кошелёк)
- `FiringTopUpBottomSheetViewController` (срабатывание)
- `AlarmFiringViewController+NoBalance` (Apple Pay при нулевом балансе)

В **release** при пустом каталоге — ошибка загрузки, начисления НЕТ. В **DEBUG** демо-кредит сохранён (тестируемость без ASC).

## Проверка
- ✅ Debug build (sim) — зелёный
- ✅ **Release build** (`xcodebuild -configuration Release`) — зелёный (проверка `#else`-веток)
- ✅ SwiftLint — 0 errors
- Тестом release-путь не покрыть (тест-таргет компилируется в DEBUG); проверено сборкой Release + инспекцией.

Fixes #385 (закрыть руками после merge — интеграционная ветка).

🤖 Generated with [Claude Code](https://claude.com/claude-code)