### PR TITLE
[fix] Guard Deposit sheet against double-present (#389)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmsListViewController.swift
@@ -351,6 +351,8 @@ class AlarmsListViewController: UIViewController {
         // Single amount-picker surface (#281): the Alarms «Пополнить» opens the
         // same Deposit sheet as the Wallet tab — the legacy TopUpViewController
         // is retired.
+        // Guard against double-present from a fast double-tap (#389).
+        guard presentedViewController == nil else { return }
         present(DepositBottomSheetViewController(), animated: true)
     }
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletViewController.swift
@@ -195,6 +195,8 @@ final class WalletViewController: UIViewController {
     // MARK: - Navigation
 
     @objc private func presentDepositSheet() {
+        // Guard against double-present from a fast double-tap (#389).
+        guard presentedViewController == nil else { return }
         let sheet = DepositBottomSheetViewController()
         present(sheet, animated: true)
     }


### PR DESCRIPTION
Fixes #389

## Что сделано
- Добавлен гард `guard presentedViewController == nil else { return }` перед презентацией `DepositBottomSheetViewController` во всех точках входа:
  - `AlarmsListViewController.presentTopUp()` (главный экран «Пополнить»)
  - `WalletViewController.presentDepositSheet()` (кошелёк «Пополнить»)
- Быстрый двойной тап теперь открывает ровно один шит, без UIKit-warning «already presenting».

## Verify
- ✅ swiftlint: 0 violations в затронутых файлах
- ✅ build: clean build (fresh derivedDataPath) — BUILD SUCCEEDED, simulator iPhone 17 Pro Max (iOS 26.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)