### PR TITLE
[fix] Link foreground snooze refund to its charge for stats exclusion (#366)

### DIFF
--- a/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
@@ -263,12 +263,24 @@ final class AlarmFiringViewModel {
         // Capture the penalty for this snooze BEFORE bumping the count so the
         // refund (if the schedule fails) returns the exact amount charged.
         let penalty = currentPenalty
-        let charged = balanceService.charge(amount: penalty, alarmID: alarm.id)
-        guard charged else { return false }
+        // `chargeWithReceipt` surfaces the persisted charge transaction so a
+        // later refund can link back to it via `refundsTransactionID` (issue
+        // #366). Without that link the foreground refund offsets the balance
+        // but the original charge still inflates snooze stats / streak, the
+        // exact bug #133 fixed for the notification-action path only.
+        guard let chargeTransaction = balanceService.chargeWithReceipt(
+            amount: penalty,
+            alarmID: alarm.id
+        ) else { return false }
 
         snoozeCount += 1
         scheduler.scheduleSnooze(for: alarm, snoozeCount: snoozeCount) { [weak self] result in
-            self?.handleScheduleResult(result, penalty: penalty, completion: scheduleCompletion)
+            self?.handleScheduleResult(
+                result,
+                penalty: penalty,
+                chargeTransactionID: chargeTransaction.id,
+                completion: scheduleCompletion
+            )
         }
         onStateChanged?()
         return true
@@ -280,6 +292,7 @@ final class AlarmFiringViewModel {
     private func handleScheduleResult(
         _ result: Result<Void, AlarmScheduler.SchedulingError>,
         penalty: Double,
+        chargeTransactionID: UUID,
         completion: ((SnoozeScheduleOutcome) -> Void)?
     ) {
         switch result {
@@ -288,8 +301,13 @@ final class AlarmFiringViewModel {
         case .failure(let error):
             // Refund via `topUp` (an offsetting ledger entry) rather than
             // mutating storage directly, so transaction history shows both the
-            // charge and the refund and stats stay auditable.
-            let refunded = balanceService.topUp(amount: penalty, refundsTransactionID: nil)
+            // charge and the refund and stats stay auditable. Link the refund
+            // to the original charge so `realCharges(from:)` excludes the
+            // reversed snooze from stats / streak (issue #366 / #133).
+            let refunded = balanceService.topUp(
+                amount: penalty,
+                refundsTransactionID: chargeTransactionID
+            )
             let desc = error.errorDescription ?? error.localizedDescription
             if refunded {
                 AppLogger.ui.error(
@@ -351,12 +369,15 @@ final class AlarmFiringViewModel {
 protocol AlarmFiringBalancing: AnyObject {
     var balance: Double { get }
     func canAfford(_ amount: Double) -> Bool
-    @discardableResult func charge(amount: Double, alarmID: UUID?) -> Bool
+    /// Charges the penalty and returns the persisted charge `Transaction` (or
+    /// `nil` on insufficient funds / locked ledger). The returned `id` lets the
+    /// foreground snooze path link an offsetting refund back to this charge via
+    /// `topUp(amount:refundsTransactionID:)` so a reversed snooze is excluded
+    /// from stats — closing the gap #133 left on the foreground path (#366).
+    func chargeWithReceipt(amount: Double, alarmID: UUID?) -> Transaction?
     /// `refundsTransactionID` links a refund to the charge it offsets so the
-    /// charge is excluded from snooze stats (issue #133). The foreground snooze
-    /// path passes `nil` — `charge(amount:alarmID:)` doesn't surface the charge
-    /// transaction id yet (tracked separately); the notification-action path in
-    /// `AlarmFiringCoordinator` supplies it.
+    /// charge is excluded from snooze stats (issue #133). Both the foreground
+    /// snooze path and the notification-action path now supply it (#366).
     @discardableResult func topUp(amount: Double, refundsTransactionID: UUID?) -> Bool
 }
 

--- a/SnoozePay/SnoozePayTests/AlarmFiringSnoozeAlarmKitTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmFiringSnoozeAlarmKitTests.swift
@@ -121,12 +121,11 @@ private final class SnoozeStubBalance: AlarmFiringBalancing {
 
     func canAfford(_ amount: Double) -> Bool { balance >= amount }
 
-    @discardableResult
-    func charge(amount: Double, alarmID: UUID?) -> Bool {
+    func chargeWithReceipt(amount: Double, alarmID: UUID?) -> Transaction? {
         chargeCalls.append(amount)
-        guard balance >= amount else { return false }
+        guard balance >= amount else { return nil }
         balance -= amount
-        return true
+        return Transaction(type: .charge, amount: amount, alarmID: alarmID?.uuidString)
     }
 
     @discardableResult

--- a/SnoozePay/SnoozePayTests/AlarmFiringSnoozeRefundTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmFiringSnoozeRefundTests.swift
@@ -122,6 +122,48 @@ final class AlarmFiringSnoozeRefundTests: XCTestCase {
         XCTAssertEqual(billing.chargeCalls, [50], "The penalty was charged before scheduling")
     }
 
+    // MARK: - Refund linkage (#366)
+
+    func testForegroundSnooze_scheduleFails_refundLinksToChargeTransaction() {
+        let billing = StubFiringBalance(balanceValue: 200, chargeResult: true, topUpResult: true)
+
+        let vm = AlarmFiringViewModel(
+            alarm: makeAlarm(penalty: 50),
+            balanceService: billing,
+            scheduler: makeFailingScheduler()
+        )
+
+        let exp = expectation(description: "schedule outcome")
+        vm.snooze { _ in exp.fulfill() }
+        wait(for: [exp], timeout: 10)
+
+        XCTAssertEqual(billing.topUpRefundLinks, [billing.lastChargeID],
+                       "Foreground refund must link to the charge it offsets (#366)")
+        XCTAssertNotNil(billing.lastChargeID)
+    }
+
+    /// End-to-end: a failed foreground snooze must NOT count toward snooze stats,
+    /// because the refund links to the charge so `realCharges(from:)` drops it.
+    func testForegroundSnooze_scheduleFails_chargeExcludedFromRealCharges() {
+        let repo = TransactionRepository(defaults: defaults)
+        let balance = BalanceService(defaults: defaults, transactionRepository: repo)
+        balance.topUp(amount: 200)
+
+        let vm = AlarmFiringViewModel(
+            alarm: makeAlarm(penalty: 50),
+            balanceService: balance,
+            scheduler: makeFailingScheduler()
+        )
+
+        let exp = expectation(description: "schedule outcome")
+        vm.snooze { _ in exp.fulfill() }
+        wait(for: [exp], timeout: 10)
+
+        let realCharges = TransactionRepository.realCharges(from: repo.fetchAll())
+        XCTAssertTrue(realCharges.isEmpty,
+                      "A refunded foreground snooze must be excluded from real charges (#366)")
+    }
+
     // MARK: - Success path
 
     func testForegroundSnooze_scheduleSucceeds_reportsScheduledNoRefund() {
@@ -157,6 +199,12 @@ private final class StubFiringBalance: AlarmFiringBalancing {
     private let topUpResult: Bool
     private(set) var chargeCalls: [Double] = []
     private(set) var topUpCalls: [Double] = []
+    /// The id minted for the most recent successful `chargeWithReceipt`, so a
+    /// test can assert the refund linked back to it (issue #366).
+    private(set) var lastChargeID: UUID?
+    /// Captures the `refundsTransactionID` passed to each `topUp` so a test can
+    /// assert the foreground refund links to the charge instead of `nil`.
+    private(set) var topUpRefundLinks: [UUID?] = []
 
     init(balanceValue: Double, chargeResult: Bool, topUpResult: Bool) {
         self.balance = balanceValue
@@ -166,17 +214,19 @@ private final class StubFiringBalance: AlarmFiringBalancing {
 
     func canAfford(_ amount: Double) -> Bool { balance >= amount }
 
-    @discardableResult
-    func charge(amount: Double, alarmID: UUID?) -> Bool {
+    func chargeWithReceipt(amount: Double, alarmID: UUID?) -> Transaction? {
         chargeCalls.append(amount)
-        guard chargeResult else { return false }
+        guard chargeResult else { return nil }
         balance -= amount
-        return true
+        let transaction = Transaction(type: .charge, amount: amount, alarmID: alarmID?.uuidString)
+        lastChargeID = transaction.id
+        return transaction
     }
 
     @discardableResult
     func topUp(amount: Double, refundsTransactionID: UUID?) -> Bool {
         topUpCalls.append(amount)
+        topUpRefundLinks.append(refundsTransactionID)
         guard topUpResult else { return false }
         balance += amount
         return true


### PR DESCRIPTION
Fixes #366

## Что сделано
- `AlarmFiringViewModel.snooze` теперь чарджит через `chargeWithReceipt(...)`, сохраняет `transaction.id` и передаёт его как `refundsTransactionID` в рефанд при провале планировщика — раньше foreground-путь рефандил с `nil`, и списание всё равно засчитывалось в статистике/серии (escape из исключения #133).
- Расширен protocol `AlarmFiringBalancing`: `charge(amount:alarmID:)` → `chargeWithReceipt(amount:alarmID:) -> Transaction?`, зеркаля нотификейшн-путь в `AlarmFiringCoordinator`.
- `StubFiringBalance` обновлён под новый seam; добавлены тесты на линковку рефанда к чарджу и end-to-end проверку, что зарефанженный foreground-снуз исключается из `TransactionRepository.realCharges(from:)`.

## Verify
- swiftlint: 0 errors (изменённые файлы)
- build_sim (clean): SUCCEEDED, 0 warnings/errors (simulator: iPhone 17 Pro Max)
- test_sim: отключён в этом ране (запустит CI / QA); добавлены unit-тесты в `AlarmFiringSnoozeRefundTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)