### PR TITLE
[fix] Anchor snooze countdown to stored tap moment + hide no-balance during snooze (#396, #398)

### DIFF
--- a/SnoozePay/SnoozePay/Utilities/UITourLauncher.swift
+++ b/SnoozePay/SnoozePay/Utilities/UITourLauncher.swift
@@ -182,13 +182,12 @@ enum UITourLauncher {
     }
 
     /// The firing-screen sample, anchored to the CURRENT time rather than a
-    /// fixed 07:30. A firing alarm is, by definition, ringing *now* — and the
-    /// snoozed-state countdown derives the next ring from the alarm's HH:MM on
-    /// today (`AlarmFiringViewModel.nextRingDate`). With a fixed 07:30 time the
-    /// snooze target lands in the past whenever the tour runs later in the day,
-    /// so `secondsUntilNextRing == 0` and the snoozed chrome never installs.
-    /// Pinning the time to now keeps the snooze countdown positive — both for
-    /// realistic screenshots and for the e2e firing→snooze→wake UI test.
+    /// fixed 07:30. A firing alarm is, by definition, ringing *now*. The
+    /// snoozed-state countdown now anchors to the snooze-tap moment
+    /// (`AlarmFiringViewModel.nextRingDate` = tap + snoozeMinutes, issue #396),
+    /// so the countdown stays positive regardless of the alarm's HH:MM — but a
+    /// now-anchored time still keeps the firing clock and "ringing now" framing
+    /// realistic for screenshots and the e2e firing→snooze→wake UI test.
     private static func firingSampleAlarm() -> Alarm {
         Alarm(
             time: Date(),

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+NoBalance.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+NoBalance.swift
@@ -226,6 +226,11 @@ extension AlarmFiringViewController {
     /// external top-ups also flip the state).
     func refreshNoBalanceVisibility() {
         let needsNoBalance = !viewModel.canSnooze
+        // #398: while the snoozed countdown owns the screen, never surface the
+        // no-balance stack — even if a mid-snooze balance notification re-runs
+        // this pass with `canSnooze == false`. `exitSnoozedState` re-calls this
+        // after clearing the flag, so the stack returns correctly on teardown.
+        let showNoBalanceStack = needsNoBalance && !isSnoozedStateActive
         // Refresh the disabled card's hint + price each pass so progressive
         // alarms show the correct disabled value even after snoozeCount has
         // bumped the next penalty.
@@ -236,8 +241,8 @@ extension AlarmFiringViewController {
                 hint: "Недостаточно средств"
             )
         }
-        noBalanceContainer?.isHidden = !needsNoBalance
-        noBalanceCenterBlock?.isHidden = !needsNoBalance
+        noBalanceContainer?.isHidden = !showNoBalanceStack
+        noBalanceCenterBlock?.isHidden = !showNoBalanceStack
         // Drained background + red glow + neutral clock + accent wake-border.
         applyDrainedAtmosphere(needsNoBalance)
         // Hide the normal-state group when the no-balance stack takes over.

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Snoozed.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmFiringViewController+Snoozed.swift
@@ -55,6 +55,11 @@ extension AlarmFiringViewController {
         // only toggles the clock/eyebrow/badge, not the name. Without this the
         // active firing UI returns with a stale "отложено до …" label (#226 QA).
         nameLabel.text = viewModel.heroTitle
+        // #398: `showSnoozedChrome(true)` force-hid the no-balance stack so it
+        // wouldn't overlap the countdown. Re-evaluate affordability now — if the
+        // snooze left the wallet empty, the "Баланса не осталось" stack returns
+        // for the restored active state; if still solvent it stays hidden.
+        refreshNoBalanceVisibility()
     }
 
     /// Invalidate the countdown timer on teardown — mirrors the `clockTimer`
@@ -135,6 +140,19 @@ extension AlarmFiringViewController {
 
         let showLadder = snoozed && viewModel.isProgressiveActive
         snoozedCenterStack?.isHidden = !showLadder
+
+        if snoozed {
+            // #398: a snooze that drains the balance below the next penalty has
+            // already run `refreshNoBalanceVisibility()` (via `updateUI`), which
+            // unhid the "Баланса не осталось" stack. Force it hidden so the
+            // countdown owns the screen — the two must never overlap. Exit
+            // restores it via `refreshNoBalanceVisibility()` (see `exitSnoozedState`).
+            noBalanceContainer?.isHidden = true
+            noBalanceCenterBlock?.isHidden = true
+        }
+        // On `false` (teardown) we do NOT unhide here: `exitSnoozedState` calls
+        // `refreshNoBalanceVisibility()` so the stack returns only when actually
+        // unaffordable — unconditionally showing it would flash it for solvent users.
     }
 
     // MARK: - Refresh (text + ladder + accents)
@@ -143,9 +161,10 @@ extension AlarmFiringViewController {
     /// name suffix, countdown label, progressive pill copy and the ladder rungs.
     func refreshSnoozedChrome() {
         guard isSnoozedStateActive else { return }
-        let now = Date()
-        nameLabel.text = viewModel.snoozedHeroTitle(after: now)
-        updateCountdownLabel(now: now)
+        // Hero suffix reads the FIXED snooze target (anchor + snoozeMinutes), not
+        // a per-tick clock, so "отложено до 07:06" stays put across ticks (#396).
+        nameLabel.text = viewModel.snoozedHeroTitle()
+        updateCountdownLabel(now: Date())
 
         guard viewModel.isProgressiveActive else { return }
         snoozedProgressivePill?.text =

--- a/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
@@ -182,19 +182,20 @@ final class AlarmFiringViewModel {
         }
     }
 
-    /// Wall-clock `Date` of the next ring after the current snooze — the
-    /// alarm's time-of-day shifted forward `snoozeMinutes × snoozeCount`
-    /// minutes, anchored to `reference`'s calendar day. Pure (takes `now` +
-    /// `calendar`) so the countdown maths is testable without the system clock.
+    /// Wall-clock `Date` of the next ring after the current snooze — `reference`
+    /// (the moment the user tapped «Поспать ещё») shifted forward exactly one
+    /// `snoozeMinutes` interval. This mirrors `AlarmScheduler.scheduledFireDate`,
+    /// which registers the snooze trigger at `now + snoozeMinutes` regardless of
+    /// `snoozeCount`. Anchoring to the tap moment (not the alarm's time-of-day ×
+    /// snoozeCount) keeps the in-app countdown aligned with the real re-ring even
+    /// when the user snoozes minutes after the alarm fires (issue #396): a 07:00
+    /// alarm snoozed at 07:12 counts down to 07:17, not the long-past 07:05.
+    /// Pure (takes `reference` + `calendar`) so the countdown maths is testable
+    /// without the system clock; `calendar` is retained for call-site symmetry
+    /// with the time-of-day formatters even though the interval add is
+    /// calendar-independent.
     func nextRingDate(after reference: Date, calendar: Calendar = .current) -> Date {
-        let timeParts = calendar.dateComponents([.hour, .minute], from: alarm.time)
-        let base = calendar.date(
-            bySettingHour: timeParts.hour ?? 0,
-            minute: timeParts.minute ?? 0,
-            second: 0,
-            of: reference
-        ) ?? reference
-        return base.addingTimeInterval(TimeInterval(alarm.snoozeMinutes * snoozeCount * 60))
+        AlarmScheduler.scheduledFireDate(now: reference, snoozeMinutes: alarm.snoozeMinutes)
     }
 
     /// `HH:mm` label of the next ring — "отложено до 07:05" / status-bar time.

--- a/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmFiringViewModel.swift
@@ -39,6 +39,16 @@ final class AlarmFiringViewModel {
     let alarm: Alarm
     private(set) var snoozeCount: Int
 
+    /// Wall-clock moment the user last tapped «Поспать ещё», captured ONCE per
+    /// snooze in `snooze()`. The snoozed countdown anchors its target to this
+    /// FIXED instant (`snoozeAnchor + snoozeMinutes`) so the live countdown
+    /// ticks down against a moving `now` and actually reaches `0` (issue #396).
+    /// It must equal what the scheduler arms — `AlarmScheduler.scheduledFireDate`
+    /// = tap moment + snoozeMinutes — so the in-app countdown and the real
+    /// re-ring agree even when the user snoozes minutes after the alarm fired.
+    /// `nil` before the first snooze (the active firing UI shows no countdown).
+    private(set) var snoozeAnchor: Date?
+
     // MARK: - Callbacks
 
     var onStateChanged: (() -> Void)?
@@ -48,6 +58,7 @@ final class AlarmFiringViewModel {
     init(
         alarm: Alarm,
         snoozeCount: Int = 0,
+        snoozeAnchor: Date? = nil,
         balanceService: AlarmFiringBalancing = BalanceService.shared,
         alarmRepository: AlarmRepository = .shared,
         scheduler: AlarmScheduler = .shared,
@@ -55,6 +66,7 @@ final class AlarmFiringViewModel {
     ) {
         self.alarm = alarm
         self.snoozeCount = snoozeCount
+        self.snoozeAnchor = snoozeAnchor
         self.balanceService = balanceService
         self.alarmRepository = alarmRepository
         self.scheduler = scheduler
@@ -182,42 +194,49 @@ final class AlarmFiringViewModel {
         }
     }
 
-    /// Wall-clock `Date` of the next ring after the current snooze — `reference`
-    /// (the moment the user tapped «Поспать ещё») shifted forward exactly one
-    /// `snoozeMinutes` interval. This mirrors `AlarmScheduler.scheduledFireDate`,
-    /// which registers the snooze trigger at `now + snoozeMinutes` regardless of
-    /// `snoozeCount`. Anchoring to the tap moment (not the alarm's time-of-day ×
-    /// snoozeCount) keeps the in-app countdown aligned with the real re-ring even
-    /// when the user snoozes minutes after the alarm fires (issue #396): a 07:00
-    /// alarm snoozed at 07:12 counts down to 07:17, not the long-past 07:05.
-    /// Pure (takes `reference` + `calendar`) so the countdown maths is testable
-    /// without the system clock; `calendar` is retained for call-site symmetry
-    /// with the time-of-day formatters even though the interval add is
-    /// calendar-independent.
-    func nextRingDate(after reference: Date, calendar: Calendar = .current) -> Date {
-        AlarmScheduler.scheduledFireDate(now: reference, snoozeMinutes: alarm.snoozeMinutes)
+    /// Wall-clock `Date` of the next ring after the current snooze — the FIXED
+    /// `anchor` (the moment the user tapped «Поспать ещё», stored once in
+    /// `snooze()`) shifted forward exactly one `snoozeMinutes` interval. This
+    /// mirrors `AlarmScheduler.scheduledFireDate`, which arms the snooze trigger
+    /// at `tap + snoozeMinutes` regardless of `snoozeCount`. Anchoring to the
+    /// FIXED tap moment (not the per-tick clock and not the alarm's time-of-day ×
+    /// snoozeCount) is what lets the live countdown decrement: the target is
+    /// constant while `now` moves, so `secondsUntilNextRing(from:)` falls to `0`
+    /// and the chrome tears down. A 07:00 alarm snoozed at 07:12 counts down to
+    /// 07:17, not the long-past 07:05 (issue #396). The default `anchor`
+    /// (`snoozeAnchor`, the stored tap moment) is used by production call sites;
+    /// tests pin it explicitly. Returns `nil` before the first snooze.
+    func nextRingDate(anchor: Date? = nil) -> Date? {
+        guard let tap = anchor ?? snoozeAnchor else { return nil }
+        return AlarmScheduler.scheduledFireDate(now: tap, snoozeMinutes: alarm.snoozeMinutes)
     }
 
     /// `HH:mm` label of the next ring — "отложено до 07:05" / status-bar time.
-    func nextRingTimeText(after reference: Date, calendar: Calendar = .current) -> String {
-        AlarmFiringTimeFormatter.string(from: nextRingDate(after: reference, calendar: calendar))
+    /// Empty before the first snooze (no anchor → no target).
+    func nextRingTimeText(anchor: Date? = nil) -> String {
+        guard let target = nextRingDate(anchor: anchor) else { return "" }
+        return AlarmFiringTimeFormatter.string(from: target)
     }
 
     /// Hero name + next-ring suffix shown in the snoozed state, e.g.
     /// "Будни · отложено до 07:05". Degrades to "отложено до …" when the alarm
     /// has no name, so the row never renders a dangling "·".
-    func snoozedHeroTitle(after reference: Date, calendar: Calendar = .current) -> String {
-        let time = nextRingTimeText(after: reference, calendar: calendar)
+    func snoozedHeroTitle(anchor: Date? = nil) -> String {
+        let time = nextRingTimeText(anchor: anchor)
         let name = alarm.name.trimmingCharacters(in: .whitespacesAndNewlines)
         let suffix = "отложено до \(time)"
         return name.isEmpty ? suffix : "\(name) · \(suffix)"
     }
 
-    /// Remaining seconds until the next ring (never negative). Used by the live
-    /// countdown; at `0` the firing screen restores the active state.
-    func secondsUntilNextRing(from reference: Date, calendar: Calendar = .current) -> Int {
-        let target = nextRingDate(after: reference, calendar: calendar)
-        return max(0, Int(target.timeIntervalSince(reference).rounded()))
+    /// Remaining seconds until the next ring (never negative), measured from the
+    /// FIXED snooze target (`snoozeAnchor + snoozeMinutes`) to the MOVING `now`.
+    /// Because the target is fixed while `now` advances, the value decrements
+    /// every tick and reaches `0` at the re-ring — which is when the firing
+    /// screen restores the active state. `0` when there is no anchor yet (no
+    /// snooze taken) so the snoozed chrome never installs prematurely.
+    func secondsUntilNextRing(from now: Date, anchor: Date? = nil) -> Int {
+        guard let target = nextRingDate(anchor: anchor) else { return 0 }
+        return max(0, Int(target.timeIntervalSince(now).rounded()))
     }
 
     /// `mm:ss` countdown label clamped at `00:00`. Static so the formatting is
@@ -275,6 +294,12 @@ final class AlarmFiringViewModel {
         ) else { return false }
 
         snoozeCount += 1
+        // Pin the tap moment ONCE so the live countdown target stays fixed while
+        // `now` advances (issue #396). Mirrors the instant the scheduler arms the
+        // trigger at (`scheduledFireDate(now: Date(), …)`) so the in-app countdown
+        // and the real re-ring agree. Re-tapping snooze re-anchors to the new tap,
+        // matching the freshly-armed trigger.
+        snoozeAnchor = Date()
         scheduler.scheduleSnooze(for: alarm, snoozeCount: snoozeCount) { [weak self] result in
             self?.handleScheduleResult(
                 result,

--- a/SnoozePay/SnoozePayTests/AlarmFiringSnoozedStateTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmFiringSnoozedStateTests.swift
@@ -43,29 +43,38 @@ final class AlarmFiringSnoozedStateTests: XCTestCase {
     }
 
     // MARK: - Next-ring time
+    //
+    // The next ring anchors to the snooze-TAP moment (`reference`), not the
+    // alarm's time-of-day × snoozeCount (issue #396). This mirrors
+    // `AlarmScheduler.scheduledFireDate`, which registers the snooze trigger at
+    // `now + snoozeMinutes` regardless of `snoozeCount`. So the next-ring time is
+    // always `reference + snoozeMinutes` — independent of how many snoozes have
+    // accrued or how long after the alarm the user finally tapped snooze.
 
-    func testNextRingTime_firstSnooze_shiftsByOneInterval() {
+    func testNextRingTime_firstSnooze_shiftsByOneIntervalFromTap() {
         let vm = AlarmFiringViewModel(alarm: makeAlarm(snoozeMinutes: 5), snoozeCount: 1)
+        // Tapped at 07:01 → next ring 07:06 (tap + 5min), NOT 07:05 (alarm + 5).
         let text = vm.nextRingTimeText(after: reference(hour: 7, minute: 1))
-        XCTAssertEqual(text, "07:05", "07:00 + 5min × 1 snooze = 07:05")
+        XCTAssertEqual(text, "07:06", "07:01 tap + 5min = 07:06")
     }
 
-    func testNextRingTime_thirdSnooze_accumulates() {
+    func testNextRingTime_thirdSnooze_stillOneIntervalFromTap() {
         let vm = AlarmFiringViewModel(alarm: makeAlarm(snoozeMinutes: 5), snoozeCount: 3)
+        // The interval does not accumulate with snoozeCount — each tap re-anchors.
         let text = vm.nextRingTimeText(after: reference(hour: 7, minute: 11))
-        XCTAssertEqual(text, "07:15", "07:00 + 5min × 3 snoozes = 07:15")
+        XCTAssertEqual(text, "07:16", "07:11 tap + 5min = 07:16, regardless of snoozeCount")
     }
 
     func testNextRingTime_customInterval() {
         let vm = AlarmFiringViewModel(alarm: makeAlarm(snoozeMinutes: 9), snoozeCount: 2)
         let text = vm.nextRingTimeText(after: reference(hour: 7, minute: 10))
-        XCTAssertEqual(text, "07:18", "07:00 + 9min × 2 snoozes = 07:18")
+        XCTAssertEqual(text, "07:19", "07:10 tap + 9min = 07:19")
     }
 
     func testSnoozedHeroTitle_includesNameAndNextRing() {
         let vm = AlarmFiringViewModel(alarm: makeAlarm(snoozeMinutes: 5), snoozeCount: 1)
         let title = vm.snoozedHeroTitle(after: reference(hour: 7, minute: 1))
-        XCTAssertEqual(title, "Будни · отложено до 07:05")
+        XCTAssertEqual(title, "Будни · отложено до 07:06")
     }
 
     func testSnoozedHeroTitle_blankNameDropsSeparator() {
@@ -73,22 +82,36 @@ final class AlarmFiringSnoozedStateTests: XCTestCase {
         let renamed = alarm.with(name: "   ")
         let vm = AlarmFiringViewModel(alarm: renamed, snoozeCount: 1)
         let title = vm.snoozedHeroTitle(after: reference(hour: 7, minute: 1))
-        XCTAssertEqual(title, "отложено до 07:05", "Whitespace name must not leave a dangling «·»")
+        XCTAssertEqual(title, "отложено до 07:06", "Whitespace name must not leave a dangling «·»")
     }
 
     // MARK: - Countdown
 
     func testSecondsUntilNextRing_countsRemainder() {
         let vm = AlarmFiringViewModel(alarm: makeAlarm(snoozeMinutes: 5), snoozeCount: 1)
-        // Next ring 07:05; now 07:00:37 → 4min 23s = 263s.
-        let now = reference(hour: 7, minute: 0).addingTimeInterval(37)
-        XCTAssertEqual(vm.secondsUntilNextRing(from: now), 263)
+        // Tapped at 07:00:00; next ring tap + 5min = 07:05:00 → 300s.
+        let now = reference(hour: 7, minute: 0)
+        XCTAssertEqual(vm.secondsUntilNextRing(from: now), 300)
+    }
+
+    /// Issue #396 regression: snoozing well AFTER the alarm rang must still yield
+    /// a positive countdown ≈ snoozeMinutes. Under the old time-of-day anchoring a
+    /// 07:00 alarm snoozed at 07:12 pointed at the long-past 07:05 → clamped to 0,
+    /// so the snoozed chrome never installed and the countdown was dead.
+    func testSecondsUntilNextRing_lateSnooze_isPositiveOneInterval() {
+        let vm = AlarmFiringViewModel(alarm: makeAlarm(snoozeMinutes: 5), snoozeCount: 1)
+        // Alarm fired 07:00, user dawdles, taps snooze at 07:12.
+        let tap = reference(hour: 7, minute: 12)
+        let seconds = vm.secondsUntilNextRing(from: tap)
+        XCTAssertEqual(seconds, 5 * 60, "Late snooze still counts a full interval from the tap")
+        XCTAssertGreaterThan(seconds, 0, "Snoozed chrome must install — countdown is positive")
     }
 
     func testSecondsUntilNextRing_clampsAtZeroPastRing() {
         let vm = AlarmFiringViewModel(alarm: makeAlarm(snoozeMinutes: 5), snoozeCount: 1)
-        // Past the 07:05 next ring — never negative.
-        XCTAssertEqual(vm.secondsUntilNextRing(from: reference(hour: 7, minute: 10)), 0)
+        // 6 minutes after the 07:00 tap — past the tap + 5min ring; never negative.
+        let now = reference(hour: 7, minute: 0).addingTimeInterval(6 * 60)
+        XCTAssertEqual(vm.secondsUntilNextRing(from: now), 0)
     }
 
     func testCountdownText_formatsMinutesSeconds() {

--- a/SnoozePay/SnoozePayTests/AlarmFiringSnoozedStateTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmFiringSnoozedStateTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import UserNotifications
 @testable import SnoozePay
 
 /// Coverage for the snoozed firing state (#226) — the pure VM logic that drives
@@ -44,74 +45,142 @@ final class AlarmFiringSnoozedStateTests: XCTestCase {
 
     // MARK: - Next-ring time
     //
-    // The next ring anchors to the snooze-TAP moment (`reference`), not the
-    // alarm's time-of-day × snoozeCount (issue #396). This mirrors
-    // `AlarmScheduler.scheduledFireDate`, which registers the snooze trigger at
-    // `now + snoozeMinutes` regardless of `snoozeCount`. So the next-ring time is
-    // always `reference + snoozeMinutes` — independent of how many snoozes have
+    // The next ring anchors to the FIXED snooze-TAP moment (`snoozeAnchor`), not
+    // the alarm's time-of-day × snoozeCount (issue #396). This mirrors
+    // `AlarmScheduler.scheduledFireDate`, which arms the snooze trigger at
+    // `tap + snoozeMinutes` regardless of `snoozeCount`. So the next-ring time is
+    // always `anchor + snoozeMinutes` — independent of how many snoozes have
     // accrued or how long after the alarm the user finally tapped snooze.
 
     func testNextRingTime_firstSnooze_shiftsByOneIntervalFromTap() {
-        let vm = AlarmFiringViewModel(alarm: makeAlarm(snoozeMinutes: 5), snoozeCount: 1)
         // Tapped at 07:01 → next ring 07:06 (tap + 5min), NOT 07:05 (alarm + 5).
-        let text = vm.nextRingTimeText(after: reference(hour: 7, minute: 1))
-        XCTAssertEqual(text, "07:06", "07:01 tap + 5min = 07:06")
+        let vm = AlarmFiringViewModel(
+            alarm: makeAlarm(snoozeMinutes: 5),
+            snoozeCount: 1,
+            snoozeAnchor: reference(hour: 7, minute: 1)
+        )
+        XCTAssertEqual(vm.nextRingTimeText(), "07:06", "07:01 tap + 5min = 07:06")
     }
 
     func testNextRingTime_thirdSnooze_stillOneIntervalFromTap() {
-        let vm = AlarmFiringViewModel(alarm: makeAlarm(snoozeMinutes: 5), snoozeCount: 3)
         // The interval does not accumulate with snoozeCount — each tap re-anchors.
-        let text = vm.nextRingTimeText(after: reference(hour: 7, minute: 11))
-        XCTAssertEqual(text, "07:16", "07:11 tap + 5min = 07:16, regardless of snoozeCount")
+        let vm = AlarmFiringViewModel(
+            alarm: makeAlarm(snoozeMinutes: 5),
+            snoozeCount: 3,
+            snoozeAnchor: reference(hour: 7, minute: 11)
+        )
+        XCTAssertEqual(vm.nextRingTimeText(), "07:16", "07:11 tap + 5min = 07:16, regardless of snoozeCount")
     }
 
     func testNextRingTime_customInterval() {
-        let vm = AlarmFiringViewModel(alarm: makeAlarm(snoozeMinutes: 9), snoozeCount: 2)
-        let text = vm.nextRingTimeText(after: reference(hour: 7, minute: 10))
-        XCTAssertEqual(text, "07:19", "07:10 tap + 9min = 07:19")
+        let vm = AlarmFiringViewModel(
+            alarm: makeAlarm(snoozeMinutes: 9),
+            snoozeCount: 2,
+            snoozeAnchor: reference(hour: 7, minute: 10)
+        )
+        XCTAssertEqual(vm.nextRingTimeText(), "07:19", "07:10 tap + 9min = 07:19")
+    }
+
+    func testNextRingTime_noAnchor_isEmpty() {
+        let vm = AlarmFiringViewModel(alarm: makeAlarm(snoozeMinutes: 5), snoozeCount: 0)
+        XCTAssertEqual(vm.nextRingTimeText(), "", "Before the first snooze there is no anchored ring")
+        XCTAssertNil(vm.nextRingDate(), "No anchor → no target date")
     }
 
     func testSnoozedHeroTitle_includesNameAndNextRing() {
-        let vm = AlarmFiringViewModel(alarm: makeAlarm(snoozeMinutes: 5), snoozeCount: 1)
-        let title = vm.snoozedHeroTitle(after: reference(hour: 7, minute: 1))
-        XCTAssertEqual(title, "Будни · отложено до 07:06")
+        let vm = AlarmFiringViewModel(
+            alarm: makeAlarm(snoozeMinutes: 5),
+            snoozeCount: 1,
+            snoozeAnchor: reference(hour: 7, minute: 1)
+        )
+        XCTAssertEqual(vm.snoozedHeroTitle(), "Будни · отложено до 07:06")
     }
 
     func testSnoozedHeroTitle_blankNameDropsSeparator() {
-        let alarm = makeAlarm(snoozeMinutes: 5)
-        let renamed = alarm.with(name: "   ")
-        let vm = AlarmFiringViewModel(alarm: renamed, snoozeCount: 1)
-        let title = vm.snoozedHeroTitle(after: reference(hour: 7, minute: 1))
-        XCTAssertEqual(title, "отложено до 07:06", "Whitespace name must not leave a dangling «·»")
+        let alarm = makeAlarm(snoozeMinutes: 5).with(name: "   ")
+        let vm = AlarmFiringViewModel(
+            alarm: alarm,
+            snoozeCount: 1,
+            snoozeAnchor: reference(hour: 7, minute: 1)
+        )
+        XCTAssertEqual(vm.snoozedHeroTitle(), "отложено до 07:06", "Whitespace name must not leave a dangling «·»")
     }
 
     // MARK: - Countdown
+    //
+    // The countdown subtracts the MOVING `now` from the FIXED target
+    // (`snoozeAnchor + snoozeMinutes`), so it decrements every tick and reaches
+    // `0` at the re-ring (issue #396). The previous attempt computed the target
+    // from the per-call `now`, freezing the countdown at a constant.
 
-    func testSecondsUntilNextRing_countsRemainder() {
-        let vm = AlarmFiringViewModel(alarm: makeAlarm(snoozeMinutes: 5), snoozeCount: 1)
-        // Tapped at 07:00:00; next ring tap + 5min = 07:05:00 → 300s.
-        let now = reference(hour: 7, minute: 0)
-        XCTAssertEqual(vm.secondsUntilNextRing(from: now), 300)
+    func testSecondsUntilNextRing_atTap_isFullInterval() {
+        // Anchor 07:00, query at the same instant → the full 5-min interval.
+        let anchor = reference(hour: 7, minute: 0)
+        let vm = AlarmFiringViewModel(
+            alarm: makeAlarm(snoozeMinutes: 5),
+            snoozeCount: 1,
+            snoozeAnchor: anchor
+        )
+        XCTAssertEqual(vm.secondsUntilNextRing(from: anchor), 300)
+    }
+
+    /// The countdown must actually TICK DOWN as `now` advances against the fixed
+    /// target — the regression the previous attempt introduced (constant 300s).
+    func testSecondsUntilNextRing_decrementsAsNowAdvances() {
+        let anchor = reference(hour: 7, minute: 0)
+        let vm = AlarmFiringViewModel(
+            alarm: makeAlarm(snoozeMinutes: 5),
+            snoozeCount: 1,
+            snoozeAnchor: anchor
+        )
+        // Anchor 07:00, target 07:05. now=07:01 → 240s, now=07:04 → 60s.
+        XCTAssertEqual(vm.secondsUntilNextRing(from: anchor.addingTimeInterval(60)), 240)
+        XCTAssertEqual(vm.secondsUntilNextRing(from: anchor.addingTimeInterval(4 * 60)), 60)
+        XCTAssertGreaterThan(
+            vm.secondsUntilNextRing(from: anchor.addingTimeInterval(60)),
+            vm.secondsUntilNextRing(from: anchor.addingTimeInterval(4 * 60)),
+            "A later now must yield fewer remaining seconds — the countdown decrements"
+        )
     }
 
     /// Issue #396 regression: snoozing well AFTER the alarm rang must still yield
-    /// a positive countdown ≈ snoozeMinutes. Under the old time-of-day anchoring a
-    /// 07:00 alarm snoozed at 07:12 pointed at the long-past 07:05 → clamped to 0,
-    /// so the snoozed chrome never installed and the countdown was dead.
-    func testSecondsUntilNextRing_lateSnooze_isPositiveOneInterval() {
-        let vm = AlarmFiringViewModel(alarm: makeAlarm(snoozeMinutes: 5), snoozeCount: 1)
+    /// a positive countdown that then ticks to 0. Under the old time-of-day
+    /// anchoring a 07:00 alarm snoozed at 07:12 pointed at the long-past 07:05 →
+    /// clamped to 0, so the snoozed chrome never installed and the countdown was
+    /// dead. With the tap anchor the target is 07:17 and the countdown is live.
+    func testSecondsUntilNextRing_lateSnooze_isPositiveThenReachesZero() {
         // Alarm fired 07:00, user dawdles, taps snooze at 07:12.
         let tap = reference(hour: 7, minute: 12)
-        let seconds = vm.secondsUntilNextRing(from: tap)
-        XCTAssertEqual(seconds, 5 * 60, "Late snooze still counts a full interval from the tap")
-        XCTAssertGreaterThan(seconds, 0, "Snoozed chrome must install — countdown is positive")
+        let vm = AlarmFiringViewModel(
+            alarm: makeAlarm(snoozeMinutes: 5),
+            snoozeCount: 1,
+            snoozeAnchor: tap
+        )
+        // At the tap the chrome installs (positive countdown to 07:17).
+        XCTAssertEqual(vm.secondsUntilNextRing(from: tap), 5 * 60,
+                       "Late snooze still counts a full interval from the tap")
+        XCTAssertEqual(vm.nextRingTimeText(), "07:17", "07:12 tap + 5min = 07:17")
+        // Six minutes later (07:18) the target has passed → countdown is 0, so the
+        // ticker fires `exitSnoozedState()`.
+        XCTAssertEqual(vm.secondsUntilNextRing(from: tap.addingTimeInterval(6 * 60)), 0,
+                       "Past the target the live countdown reaches 0 — exitSnoozedState fires")
     }
 
     func testSecondsUntilNextRing_clampsAtZeroPastRing() {
-        let vm = AlarmFiringViewModel(alarm: makeAlarm(snoozeMinutes: 5), snoozeCount: 1)
+        let anchor = reference(hour: 7, minute: 0)
+        let vm = AlarmFiringViewModel(
+            alarm: makeAlarm(snoozeMinutes: 5),
+            snoozeCount: 1,
+            snoozeAnchor: anchor
+        )
         // 6 minutes after the 07:00 tap — past the tap + 5min ring; never negative.
-        let now = reference(hour: 7, minute: 0).addingTimeInterval(6 * 60)
-        XCTAssertEqual(vm.secondsUntilNextRing(from: now), 0)
+        XCTAssertEqual(vm.secondsUntilNextRing(from: anchor.addingTimeInterval(6 * 60)), 0)
+    }
+
+    func testSecondsUntilNextRing_noAnchor_isZero() {
+        let vm = AlarmFiringViewModel(alarm: makeAlarm(snoozeMinutes: 5), snoozeCount: 0)
+        XCTAssertEqual(vm.secondsUntilNextRing(from: Date()), 0,
+                       "No snooze taken → no countdown, so the snoozed chrome never installs")
     }
 
     func testCountdownText_formatsMinutesSeconds() {
@@ -175,5 +244,147 @@ final class AlarmFiringSnoozedStateTests: XCTestCase {
     func testLastChargeAmount_flatWhenNotProgressive() {
         let vm = AlarmFiringViewModel(alarm: makeAlarm(penalty: 50, progressive: false), snoozeCount: 3)
         XCTAssertEqual(vm.lastChargeAmount, 50, "Flat penalty alarms charge the base each time")
+    }
+
+    // MARK: - Stored tap anchor (#396)
+    //
+    // `snooze()` must pin the anchor ONCE at the tap so the countdown target is
+    // fixed (decrementing countdown). Re-tapping snooze must re-anchor to the new
+    // tap — matching the freshly-armed scheduler trigger.
+
+    func testSnooze_setsAnchorAndProducesLiveCountdown() {
+        let billing = SnoozedStubBalance(balanceValue: 1000)
+        let vm = AlarmFiringViewModel(
+            alarm: makeAlarm(snoozeMinutes: 5),
+            balanceService: billing,
+            scheduler: AlarmScheduler(notificationCenter: SilentNotificationCenter())
+        )
+        XCTAssertNil(vm.snoozeAnchor, "No anchor before the first snooze")
+
+        let before = Date()
+        XCTAssertTrue(vm.snooze())
+        let after = Date()
+
+        let anchor = try? XCTUnwrap(vm.snoozeAnchor)
+        XCTAssertNotNil(anchor, "snooze() pins the tap moment")
+        if let anchor {
+            XCTAssertGreaterThanOrEqual(anchor.timeIntervalSince1970, before.timeIntervalSince1970)
+            XCTAssertLessThanOrEqual(anchor.timeIntervalSince1970, after.timeIntervalSince1970)
+            // Countdown measured from the fixed target ticks down toward 0.
+            let atTap = vm.secondsUntilNextRing(from: anchor)
+            let later = vm.secondsUntilNextRing(from: anchor.addingTimeInterval(120))
+            XCTAssertEqual(atTap, 300)
+            XCTAssertEqual(later, 180, "Countdown decrements as now advances against the fixed target")
+        }
+    }
+
+    func testSnooze_reTapReAnchorsToLatestTap() {
+        let billing = SnoozedStubBalance(balanceValue: 1000)
+        let vm = AlarmFiringViewModel(
+            alarm: makeAlarm(snoozeMinutes: 5),
+            balanceService: billing,
+            scheduler: AlarmScheduler(notificationCenter: SilentNotificationCenter())
+        )
+        XCTAssertTrue(vm.snooze())
+        let firstAnchor = vm.snoozeAnchor
+        // Second snooze re-anchors — its target is a fresh interval from the new tap.
+        XCTAssertTrue(vm.snooze())
+        let secondAnchor = vm.snoozeAnchor
+        XCTAssertNotNil(firstAnchor)
+        XCTAssertNotNil(secondAnchor)
+        if let first = firstAnchor, let second = secondAnchor {
+            XCTAssertGreaterThanOrEqual(second.timeIntervalSince1970, first.timeIntervalSince1970,
+                                        "Re-tapping snooze re-anchors to the later tap moment")
+        }
+    }
+
+    // MARK: - No-balance / countdown mutual exclusion (#398)
+    //
+    // When a snooze drains the wallet below the next penalty the firing screen
+    // must show EITHER the live countdown OR the "Баланса не осталось" stack,
+    // never both. The VC fold hides the no-balance stack while the snoozed chrome
+    // is up; this VM-level test guarantees the precondition the fold relies on —
+    // a draining snooze still yields a positive countdown so the chrome installs
+    // (which is what triggers hiding the no-balance stack).
+
+    func testSnooze_draining_stillYieldsPositiveCountdown_soChromeOwnsScreen() {
+        // Wallet covers exactly one 50₽ snooze, then goes empty.
+        let billing = SnoozedStubBalance(balanceValue: 50)
+        let vm = AlarmFiringViewModel(
+            alarm: makeAlarm(penalty: 50, snoozeMinutes: 5),
+            balanceService: billing,
+            scheduler: AlarmScheduler(notificationCenter: SilentNotificationCenter())
+        )
+        XCTAssertTrue(vm.canSnooze, "Pre-snooze the wallet covers the penalty")
+
+        XCTAssertTrue(vm.snooze())
+
+        // Post-snooze the wallet is empty → the no-balance state would normally show.
+        XCTAssertFalse(vm.canSnooze, "Snooze drained the wallet below the next penalty")
+        // …but the snooze ALSO armed a live countdown, so the snoozed chrome
+        // installs and (per the fold) hides the no-balance stack: exactly one of
+        // the two is on screen, never both.
+        let anchor = vm.snoozeAnchor
+        XCTAssertNotNil(anchor)
+        if let anchor {
+            XCTAssertGreaterThan(vm.secondsUntilNextRing(from: anchor), 0,
+                                 "A draining snooze still installs the countdown chrome, which owns the screen")
+        }
+    }
+}
+
+// MARK: - Test doubles
+
+/// Minimal `AlarmFiringBalancing` for the snoozed-state tests — charges drain a
+/// running balance so a snooze can flip `canSnooze` to `false` (the #398
+/// drain-to-empty scenario) without touching `UserDefaults`.
+private final class SnoozedStubBalance: AlarmFiringBalancing {
+    private(set) var balance: Double
+    init(balanceValue: Double) { balance = balanceValue }
+
+    func canAfford(_ amount: Double) -> Bool { balance >= amount }
+
+    func chargeWithReceipt(amount: Double, alarmID: UUID?) -> Transaction? {
+        guard balance >= amount else { return nil }
+        balance -= amount
+        return Transaction(type: .charge, amount: amount, alarmID: alarmID?.uuidString)
+    }
+
+    @discardableResult
+    func topUp(amount: Double, refundsTransactionID: UUID?) -> Bool {
+        balance += amount
+        return true
+    }
+}
+
+/// `NotificationScheduling` stub that accepts every `add` so `scheduleSnooze`
+/// resolves successfully — the snoozed-state tests only care about the VM's
+/// anchor/countdown maths, not the trigger registration.
+private final class SilentNotificationCenter: NotificationScheduling {
+    func add(
+        _ request: UNNotificationRequest,
+        withCompletionHandler completion: ((Error?) -> Void)?
+    ) {
+        completion?(nil)
+    }
+    func getPendingNotificationRequests(
+        completionHandler: @escaping ([UNNotificationRequest]) -> Void
+    ) {
+        completionHandler([])
+    }
+    func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {}
+    func removeDeliveredNotifications(withIdentifiers identifiers: [String]) {}
+    func getDeliveredNotifications(
+        completionHandler: @escaping ([UNNotification]) -> Void
+    ) {
+        completionHandler([])
+    }
+    func setNotificationCategories(_ categories: Set<UNNotificationCategory>) {}
+    func removeAllPendingNotificationRequests() {}
+    func requestAuthorization(
+        options: UNAuthorizationOptions,
+        completionHandler: @escaping (Bool, Error?) -> Void
+    ) {
+        completionHandler(true, nil)
     }
 }


### PR DESCRIPTION
Fixes #396
Fixes #398

## Проблема

**#396** — `secondsUntilNextRing` морозил живой отсчёт. Предыдущая попытка делала `nextRingDate(after: reference) = reference + snoozeMinutes` от per-call `reference`, поэтому `secondsUntilNextRing(from: now)` всегда давал константу `snoozeMinutes×60` (target ре-анкорился на тот же `now`) → отсчёт не убывал, не доходил до 0, `exitSnoozedState()` не срабатывал, `testSecondsUntilNextRing_clampsAtZeroPastRing` краснел на CI.

**#398** — при снузе в ноль баланса `refreshNoBalanceVisibility()` показывал стек «Баланса не осталось», а `showSnoozedChrome(true)` его не прятал → часы-отсчёт и no-balance блок накладывались.

## Что сделано

- **Сохранённый tap-anchor.** В `AlarmFiringViewModel` добавлен `private(set) var snoozeAnchor: Date?`, выставляется ОДИН раз в `snooze()` = `Date()` (момент тапа, совпадает с тем, что арм-ит `AlarmScheduler.scheduledFireDate`). `nextRingDate` теперь = `anchor + snoozeMinutes` от ФИКСИРОВАННОГО якоря, а `secondsUntilNextRing(from: now)` вычитает ДВИЖУЩИЙСЯ `now` из фиксированного target → отсчёт убывает и доходит до 0. Ре-тап снуза ре-анкорится на новый тап (как свежий триггер планировщика).
- `nextRingDate`/`nextRingTimeText`/`snoozedHeroTitle`/`secondsUntilNextRing` читают сохранённый якорь по умолчанию (тесты пиннят явно); до первого снуза якоря нет → `secondsUntilNextRing == 0`, chrome не ставится преждевременно.
- **Fold #398.** `showSnoozedChrome(true)` дополнительно прячет `noBalanceContainer`/`noBalanceCenterBlock` пока активен отсчёт; `exitSnoozedState` восстанавливает через `refreshNoBalanceVisibility()` — отсчёт и no-balance стек больше не накладываются (видно ровно одно).

## Тесты (`AlarmFiringSnoozedStateTests`)
- Поздний снуз → положительный отсчёт, затем доходит до 0 (07:12 тап → 07:17 цель → 0 в 07:18).
- Отсчёт УБЫВАЕТ по мере роста `now` против фиксированного target (240s → 60s).
- `snooze()` ставит якорь; ре-тап ре-анкорится на поздний тап.
- Drain-to-empty снуз всё равно ставит положительный отсчёт → chrome владеет экраном (precondition фолда #398).
- Нет якоря → `secondsUntilNextRing == 0`, `nextRingTimeText == ""`.

## Verify
- ✅ swiftlint: 0 violations, 0 serious (own files)
- ✅ xcodebuild build-for-testing: exit 0, 0 errors (app + test target, iphonesimulator)