### PR TITLE
[ui] Render balance gradient mask at on-screen font scale (#397)

### DIFF
--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPBalanceCard.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPBalanceCard.swift
@@ -206,6 +206,21 @@ final class SPBalanceCard: UIView {
             guard let attributed = valueLabel.attributedText?.mutableCopy() as? NSMutableAttributedString else {
                 return
             }
+            // `valueLabel.adjustsFontSizeToFitWidth` may have shrunk the glyphs
+            // below the 56pt `moneyXl` baked into the attributed string. The
+            // attributed copy still carries the original (large) font, so
+            // drawing it verbatim renders 56pt glyphs into the smaller, shrunk
+            // `textBounds` — the mask then overflows / clips the right-hand
+            // digits and the `₽`. Re-font every run at the effective on-screen
+            // scale so the mask matches what the label actually paints.
+            let scale = Self.effectiveFontScale(
+                for: attributed,
+                fitting: textBounds.width,
+                minimumScaleFactor: valueLabel.minimumScaleFactor
+            )
+            if scale < 1 {
+                Self.scaleFonts(in: attributed, by: scale)
+            }
             attributed.addAttribute(
                 .foregroundColor,
                 value: UIColor.white,
@@ -220,6 +235,47 @@ final class SPBalanceCard: UIView {
         // Hide the underlying label colour so we don't double-stack glyph
         // outlines (label paints fg1, gradient paints money tones).
         valueLabel.textColor = .clear
+    }
+
+    // MARK: - Auto-shrink mask alignment
+
+    /// Compute the scale factor `adjustsFontSizeToFitWidth` would apply to fit
+    /// `attributed` (rendered at its baked-in fonts) into `availableWidth`.
+    ///
+    /// Mirrors UIKit's single-line shrink heuristic: if the natural text width
+    /// already fits, returns `1`; otherwise returns `availableWidth / naturalWidth`
+    /// clamped to `minimumScaleFactor` (UIKit never shrinks below the floor,
+    /// it clips instead — so the mask must match that clamped size, not the
+    /// raw ratio). A pure function so the geometry is unit-testable without a
+    /// live label / layout pass.
+    static func effectiveFontScale(
+        for attributed: NSAttributedString,
+        fitting availableWidth: CGFloat,
+        minimumScaleFactor: CGFloat
+    ) -> CGFloat {
+        guard availableWidth > 0, attributed.length > 0 else { return 1 }
+        let naturalWidth = attributed.size().width
+        guard naturalWidth > availableWidth else { return 1 }
+        let ratio = availableWidth / naturalWidth
+        let floor = minimumScaleFactor > 0 ? minimumScaleFactor : ratio
+        return max(ratio, floor)
+    }
+
+    /// Re-font every run of `attributed` in place at `scale × pointSize`,
+    /// preserving each run's traits / weight (digits stay mono, the separator
+    /// stays proportional). Used to align the gradient mask with the shrunk
+    /// on-screen glyphs.
+    static func scaleFonts(in attributed: NSMutableAttributedString, by scale: CGFloat) {
+        guard scale > 0, scale != 1 else { return }
+        let full = NSRange(location: 0, length: attributed.length)
+        attributed.enumerateAttribute(.font, in: full, options: []) { value, range, _ in
+            guard let font = value as? UIFont else { return }
+            attributed.addAttribute(
+                .font,
+                value: font.withSize(font.pointSize * scale),
+                range: range
+            )
+        }
     }
 
     private func renderDelta(_ delta: Decimal) -> NSAttributedString {

--- a/SnoozePay/SnoozePayTests/SPBalanceCardGradientMaskTests.swift
+++ b/SnoozePay/SnoozePayTests/SPBalanceCardGradientMaskTests.swift
@@ -1,0 +1,88 @@
+import UIKit
+import XCTest
+@testable import SnoozePay
+
+/// Tests for the balance-card gradient mask alignment under auto-shrink (#397).
+///
+/// `SPBalanceCard.valueLabel` shrinks wide balances via `adjustsFontSizeToFitWidth`,
+/// but the gradient clip-mask is rendered from the attributed string whose font
+/// is baked at 56pt `moneyXl`. Drawing 56pt glyphs into the shrunk bounds let the
+/// right-hand digits / `₽` fall outside the mask. `effectiveFontScale` mirrors
+/// UIKit's shrink heuristic so the mask re-fonts to the on-screen size — the pure
+/// geometry is pinned here.
+final class SPBalanceCardGradientMaskTests: XCTestCase {
+
+    private func attributed(_ string: String, size: CGFloat) -> NSAttributedString {
+        NSAttributedString(string: string, attributes: [.font: UIFont.systemFont(ofSize: size)])
+    }
+
+    func testScale_isOneWhenTextFits() {
+        let text = attributed("12 345 ₽", size: 56)
+        let natural = text.size().width
+        let scale = SPBalanceCard.effectiveFontScale(
+            for: text, fitting: natural + 50, minimumScaleFactor: 0.75
+        )
+        XCTAssertEqual(scale, 1, "Text that already fits is not shrunk")
+    }
+
+    func testScale_isOneWhenExactlyFits() {
+        let text = attributed("12 345 ₽", size: 56)
+        let natural = text.size().width
+        let scale = SPBalanceCard.effectiveFontScale(
+            for: text, fitting: natural, minimumScaleFactor: 0.75
+        )
+        XCTAssertEqual(scale, 1, "Text at the exact width edge is not shrunk")
+    }
+
+    func testScale_shrinksProportionallyWhenTooWide() {
+        let text = attributed("1 234 567 ₽", size: 56)
+        let natural = text.size().width
+        let available = natural * 0.85   // needs ~0.85x to fit, above the floor
+        let scale = SPBalanceCard.effectiveFontScale(
+            for: text, fitting: available, minimumScaleFactor: 0.75
+        )
+        XCTAssertEqual(scale, 0.85, accuracy: 0.001,
+                       "Above the floor the scale tracks availableWidth / naturalWidth")
+    }
+
+    func testScale_clampsToMinimumScaleFactor() {
+        let text = attributed("1 234 567 ₽", size: 56)
+        let natural = text.size().width
+        let available = natural * 0.5    // would need 0.5x, below the 0.75 floor
+        let scale = SPBalanceCard.effectiveFontScale(
+            for: text, fitting: available, minimumScaleFactor: 0.75
+        )
+        XCTAssertEqual(scale, 0.75, accuracy: 0.001,
+                       "UIKit clamps at minimumScaleFactor and clips beyond it")
+    }
+
+    func testScale_isOneForZeroWidth() {
+        let text = attributed("12 345 ₽", size: 56)
+        XCTAssertEqual(
+            SPBalanceCard.effectiveFontScale(for: text, fitting: 0, minimumScaleFactor: 0.75),
+            1, "Zero available width is a no-op (layout not resolved yet)"
+        )
+    }
+
+    func testScaleFonts_multipliesEveryRunPointSize() {
+        let combined = NSMutableAttributedString(
+            string: "12 ", attributes: [.font: UIFont.systemFont(ofSize: 56)]
+        )
+        combined.append(NSAttributedString(string: "₽", attributes: [.font: UIFont.systemFont(ofSize: 40)]))
+
+        SPBalanceCard.scaleFonts(in: combined, by: 0.5)
+
+        var sizes: [CGFloat] = []
+        combined.enumerateAttribute(.font, in: NSRange(location: 0, length: combined.length), options: []) { value, _, _ in
+            if let font = value as? UIFont { sizes.append(font.pointSize) }
+        }
+        XCTAssertEqual(sizes, [28, 20], "Each run keeps its own font, scaled uniformly")
+    }
+
+    func testScaleFonts_isNoopAtUnitScale() {
+        let text = NSMutableAttributedString(string: "12 345 ₽", attributes: [.font: UIFont.systemFont(ofSize: 56)])
+        SPBalanceCard.scaleFonts(in: text, by: 1)
+        let font = text.attribute(.font, at: 0, effectiveRange: nil) as? UIFont
+        XCTAssertEqual(font?.pointSize, 56, "Unit scale leaves fonts untouched")
+    }
+}


### PR DESCRIPTION
Fixes #397

## Что сделано
- `applyValueGradient()` строил clip-маску из attributed-строки с захардкоженным 56pt `moneyXl`. При `adjustsFontSizeToFitWidth` лейбл сжимает глифы, но маска рисовала 56pt в уже сжатый `textBounds` — правые цифры и `₽` теряли градиент / обрезались.
- Добавлена чистая функция `effectiveFontScale(for:fitting:minimumScaleFactor:)` — повторяет single-line shrink-эвристику UIKit: 1.0 если влезает, иначе `availableWidth/naturalWidth` с клампом по `minimumScaleFactor` (0.75).
- `scaleFonts(in:by:)` перешрифтовывает каждый run копии attributed-строки на эффективный scale перед отрисовкой маски — маска совпадает с тем, что реально рисует лейбл. Несжатый путь (scale == 1) не затронут.

## Verify
- ✅ swiftlint: 0 errors
- ✅ xcodebuild build-for-testing: exit 0 (iphonesimulator, generic destination)
- ✅ Юнит-тесты на чистую геометрию: `SPBalanceCardGradientMaskTests` (fit / exact-edge / shrink / clamp-to-floor / zero-width / per-run scaling)

## Acceptance
- [x] Большой баланс (7+ знаков) — маска перешрифтована на on-screen scale, покрывает все цифры и `₽`
- [x] Обычный (несжатый) баланс не регрессирует — фикс gated за `scale < 1`