### PR TITLE
[fix] AlarmKit snooze: preserve weekly recurrence + absolute fireDate (#394)

### DIFF
--- a/SnoozePay/SnoozePay/Services/AlarmKitScheduler.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmKitScheduler.swift
@@ -44,12 +44,15 @@ protocol AlarmKitScheduling: AnyObject {
     /// disabled alarm is the caller's responsibility.
     func schedule(_ alarm: Alarm) throws
 
-    /// Reschedule `alarm` as a one-shot AlarmKit system alarm that re-fires at
-    /// `fireDate` (the snooze re-ring), `.never` recurrence. Reuses the alarm's
-    /// id so the snooze replaces the just-stopped firing (#383). Throws when
-    /// AlarmKit rejects the request. Kept distinct from `schedule(_:)` because a
-    /// snooze fires at an arbitrary wall-clock time (now + snoozeMinutes), not at
-    /// the alarm's configured time-of-day.
+    /// Reschedule `alarm` as a one-shot AlarmKit system alarm that re-fires once
+    /// at `fireDate` (the snooze re-ring), no recurrence. Scheduled under a
+    /// SEPARATE snooze id (not `alarm.id`) so a repeating (`.weekly`) original is
+    /// left armed for its future occurrences — replacing `alarm.id` would
+    /// overwrite the weekly schedule with a one-shot and the alarm would never
+    /// ring on its weekdays again (#394). Throws when AlarmKit rejects the
+    /// request. Kept distinct from `schedule(_:)` because a snooze fires at an
+    /// arbitrary wall-clock time (now + snoozeMinutes), not at the alarm's
+    /// configured time-of-day.
     func scheduleSnooze(_ alarm: Alarm, fireDate: Date) throws
 
     /// Cancel the system alarm for `alarmID` (pending — not yet alerting).
@@ -139,13 +142,17 @@ final class AlarmKitScheduler: AlarmKitScheduling {
 
     func scheduleSnooze(_ alarm: Alarm, fireDate: Date) throws {
         let configuration = try Self.makeSnoozeConfiguration(for: alarm, fireDate: fireDate)
-        // Reuse the alarm's id so the snooze replaces the just-stopped firing —
-        // a fresh id would leave the original armed for its next recurrence AND
-        // arm a snooze, double-ringing. Fire-and-log mirrors `schedule(_:)` so
-        // the synchronous contract holds.
+        // Schedule under a SEPARATE, deterministic snooze id — NOT `alarm.id`.
+        // Replacing `alarm.id` would overwrite a `.weekly` original with this
+        // one-shot snooze, permanently dropping the recurrence (#394). The
+        // caller stops the currently-alerting `alarm.id` before this (#383), so
+        // the original weekly stays armed for its next weekday while the snooze
+        // rings once. Fire-and-log mirrors `schedule(_:)` so the synchronous
+        // contract holds.
+        let snoozeID = Self.snoozeID(for: alarm.id)
         Task {
             do {
-                _ = try await manager.schedule(id: alarm.id, configuration: configuration)
+                _ = try await manager.schedule(id: snoozeID, configuration: configuration)
                 AppLogger.scheduler.info(
                     "AlarmKit snooze scheduled alarm=\(alarm.id, privacy: .private)"
                 )
@@ -159,26 +166,41 @@ final class AlarmKitScheduler: AlarmKitScheduling {
     }
 
     func cancel(_ alarmID: UUID) {
+        // Cancel both the alarm and any pending snooze re-ring scheduled under
+        // its separate snooze id (#394) — otherwise a cancelled alarm could
+        // still fire its outstanding snooze.
+        cancelOne(alarmID)
+        cancelOne(Self.snoozeID(for: alarmID))
+    }
+
+    private func cancelOne(_ id: UUID) {
         do {
-            try manager.cancel(id: alarmID)
-            AppLogger.scheduler.info("AlarmKit cancelled alarm=\(alarmID, privacy: .private)")
+            try manager.cancel(id: id)
+            AppLogger.scheduler.info("AlarmKit cancelled alarm=\(id, privacy: .private)")
         } catch {
             // A not-found cancel is benign (alarm already fired / never armed
             // on this backend) — log at info, never crash the caller.
             let desc = error.localizedDescription
             AppLogger.scheduler.info(
-                "AlarmKit cancel no-op alarm=\(alarmID, privacy: .private): \(desc, privacy: .public)"
+                "AlarmKit cancel no-op alarm=\(id, privacy: .private): \(desc, privacy: .public)"
             )
         }
     }
 
     func stop(_ alarmID: UUID) {
+        // Stop both the alarm and any alerting snooze under its snooze id (#394)
+        // so a "stop" from the lock screen silences whichever is ringing.
+        stopOne(alarmID)
+        stopOne(Self.snoozeID(for: alarmID))
+    }
+
+    private func stopOne(_ id: UUID) {
         do {
-            try manager.stop(id: alarmID)
+            try manager.stop(id: id)
         } catch {
             let desc = error.localizedDescription
             AppLogger.scheduler.info(
-                "AlarmKit stop no-op alarm=\(alarmID, privacy: .private): \(desc, privacy: .public)"
+                "AlarmKit stop no-op alarm=\(id, privacy: .private): \(desc, privacy: .public)"
             )
         }
     }
@@ -208,8 +230,8 @@ final class AlarmKitScheduler: AlarmKitScheduling {
     }
 
     /// Build the AlarmKit configuration for a snooze re-fire: same presentation /
-    /// intents / sound as the original alarm, but a one-shot schedule pinned to
-    /// `fireDate`'s hour/minute (`.never` recurrence) so it rings once at
+    /// intents / sound as the original alarm, but a one-shot `.fixed` schedule
+    /// pinned to the absolute `fireDate` so it rings exactly once at
     /// now + snoozeMinutes instead of the alarm's configured time-of-day (#383).
     static func makeSnoozeConfiguration(
         for alarm: Alarm,
@@ -231,16 +253,29 @@ final class AlarmKitScheduler: AlarmKitScheduling {
         )
     }
 
-    /// One-shot relative schedule pinned to `fireDate`'s hour/minute. AlarmKit's
-    /// relative schedule fires at the next occurrence of that time-of-day; for a
-    /// snooze (always < 1h ahead) that next occurrence is the snooze re-ring.
+    /// One-shot schedule pinned to the ABSOLUTE `fireDate`. Uses `.fixed` rather
+    /// than a relative hour/minute schedule: a relative schedule drops seconds
+    /// and fires at the *next* occurrence of that hh:mm, so a snooze planned at
+    /// 07:00:30 for +1min (07:01:30) would round to 07:01 — already in the past
+    /// this minute — and AlarmKit would take *tomorrow's* 07:01, ~24h away
+    /// (#394). `.fixed` rings once at the exact instant, no truncation. (#383)
     nonisolated static func makeSnoozeSchedule(fireDate: Date) -> AlarmKit.Alarm.Schedule {
-        let components = Calendar.current.dateComponents([.hour, .minute], from: fireDate)
-        let time = AlarmKit.Alarm.Schedule.Relative.Time(
-            hour: components.hour ?? 0,
-            minute: components.minute ?? 0
-        )
-        return .relative(.init(time: time, repeats: .never))
+        .fixed(fireDate)
+    }
+
+    /// Deterministic, distinct snooze id derived from the alarm id (#394). The
+    /// AlarmKit snooze re-ring is scheduled under THIS id, not `alarm.id`, so a
+    /// `.weekly` original keeps its recurrence instead of being overwritten by a
+    /// one-shot. Derived by XOR-ing a fixed namespace into the id's bytes so the
+    /// mapping is stable (same alarm → same snooze id) and reversibly cancelable
+    /// without persisting any extra state.
+    nonisolated static func snoozeID(for alarmID: UUID) -> UUID {
+        var bytes = alarmID.uuid
+        // Flip the high byte with a fixed marker so the snooze id can never
+        // collide with the original alarm id (or any other alarm's id, since the
+        // remaining 120 bits stay unique).
+        bytes.0 ^= 0x53 // 'S' for Snooze
+        return UUID(uuid: bytes)
     }
 
     /// Map the app's hour/minute + Monday-first repeat-day indices to an

--- a/SnoozePay/SnoozePay/Services/AlarmKitScheduler.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmKitScheduler.swift
@@ -49,11 +49,23 @@ protocol AlarmKitScheduling: AnyObject {
     /// SEPARATE snooze id (not `alarm.id`) so a repeating (`.weekly`) original is
     /// left armed for its future occurrences — replacing `alarm.id` would
     /// overwrite the weekly schedule with a one-shot and the alarm would never
-    /// ring on its weekdays again (#394). Throws when AlarmKit rejects the
-    /// request. Kept distinct from `schedule(_:)` because a snooze fires at an
-    /// arbitrary wall-clock time (now + snoozeMinutes), not at the alarm's
-    /// configured time-of-day.
-    func scheduleSnooze(_ alarm: Alarm, fireDate: Date) throws
+    /// ring on its weekdays again (#394). Kept distinct from `schedule(_:)`
+    /// because a snooze fires at an arbitrary wall-clock time (now +
+    /// snoozeMinutes), not at the alarm's configured time-of-day.
+    ///
+    /// Completion-based — NOT a synchronous `throws` — because the actual
+    /// AlarmKit `schedule` is `async`: a synchronous API would have to report
+    /// success before the await resolves, so an async rejection (alarm limit,
+    /// revoked auth, backend reject) would be swallowed while the caller has
+    /// already charged the snooze penalty and stopped the original — nothing
+    /// would ring (#394 Finding 1). `completion` fires with `.success` ONLY after
+    /// the await succeeds, and `.failure` on any (sync config or async schedule)
+    /// error so the caller can arm the notification-burst fallback instead.
+    func scheduleSnooze(
+        _ alarm: Alarm,
+        fireDate: Date,
+        completion: @escaping (Result<Void, Error>) -> Void
+    )
 
     /// Cancel the system alarm for `alarmID` (pending — not yet alerting).
     func cancel(_ alarmID: UUID)
@@ -140,27 +152,52 @@ final class AlarmKitScheduler: AlarmKitScheduling {
         }
     }
 
-    func scheduleSnooze(_ alarm: Alarm, fireDate: Date) throws {
-        let configuration = try Self.makeSnoozeConfiguration(for: alarm, fireDate: fireDate)
+    func scheduleSnooze(
+        _ alarm: Alarm,
+        fireDate: Date,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
         // Schedule under a SEPARATE, deterministic snooze id — NOT `alarm.id`.
         // Replacing `alarm.id` would overwrite a `.weekly` original with this
         // one-shot snooze, permanently dropping the recurrence (#394). The
         // caller stops the currently-alerting `alarm.id` before this (#383), so
         // the original weekly stays armed for its next weekday while the snooze
-        // rings once. Fire-and-log mirrors `schedule(_:)` so the synchronous
-        // contract holds.
+        // rings once.
+        let configuration: AlarmManager.AlarmConfiguration<SnoozePayAlarmMetadata>
+        do {
+            configuration = try Self.makeSnoozeConfiguration(for: alarm, fireDate: fireDate)
+        } catch {
+            // Synchronous config-build failure — report immediately so the
+            // caller arms the notification fallback (#394 Finding 1).
+            let desc = error.localizedDescription
+            AppLogger.scheduler.error(
+                "AlarmKit snooze config failed alarm=\(alarm.id, privacy: .private): \(desc, privacy: .public)"
+            )
+            completion(.failure(error))
+            return
+        }
         let snoozeID = Self.snoozeID(for: alarm.id)
+        let alarmID = alarm.id
+        // Report success/failure ONLY after the async schedule resolves, on the
+        // main actor (the caller charges the penalty / arms the fallback off
+        // this result). A swallowed async error here would mean the penalty was
+        // charged but nothing re-rings (#394 Finding 1).
         Task {
             do {
                 _ = try await manager.schedule(id: snoozeID, configuration: configuration)
                 AppLogger.scheduler.info(
-                    "AlarmKit snooze scheduled alarm=\(alarm.id, privacy: .private)"
+                    "AlarmKit snooze scheduled alarm=\(alarmID, privacy: .private)"
                 )
+                await MainActor.run { completion(.success(())) }
             } catch {
                 let desc = error.localizedDescription
                 AppLogger.scheduler.error(
-                    "AlarmKit snooze schedule failed alarm=\(alarm.id, privacy: .private): \(desc, privacy: .public)"
+                    """
+                    AlarmKit snooze schedule failed alarm=\(alarmID, privacy: .private): \
+                    \(desc, privacy: .public) — fallback
+                    """
                 )
+                await MainActor.run { completion(.failure(error)) }
             }
         }
     }
@@ -259,8 +296,35 @@ final class AlarmKitScheduler: AlarmKitScheduling {
     /// 07:00:30 for +1min (07:01:30) would round to 07:01 — already in the past
     /// this minute — and AlarmKit would take *tomorrow's* 07:01, ~24h away
     /// (#394). `.fixed` rings once at the exact instant, no truncation. (#383)
+    ///
+    /// `fireDate` is captured by the caller *before* the async schedule await, so
+    /// under latency it can already be in the past; a `.fixed` schedule with a
+    /// past instant silently never fires (#394 Finding 2). Floor it strictly into
+    /// the future first.
     nonisolated static func makeSnoozeSchedule(fireDate: Date) -> AlarmKit.Alarm.Schedule {
-        .fixed(fireDate)
+        .fixed(flooredSnoozeFireDate(fireDate, now: Date()))
+    }
+
+    /// Smallest gap a snooze `fireDate` must keep ahead of `now`; at or under
+    /// this we treat it as effectively-past and bump forward so `.fixed` always
+    /// fires.
+    static let pastDateFloorBuffer: TimeInterval = 2
+
+    /// Clamp a snooze `fireDate` strictly into the future. If `fireDate` is at or
+    /// before `now + pastDateFloorBuffer` (latency ate the gap), return
+    /// `now + pastDateFloorBuffer` and `.notice`-log the bump; otherwise pass it
+    /// through unchanged. Pure + `now`-injectable so the floor is unit-testable
+    /// (#394 Finding 2).
+    nonisolated static func flooredSnoozeFireDate(_ fireDate: Date, now: Date) -> Date {
+        let floor = now.addingTimeInterval(pastDateFloorBuffer)
+        guard fireDate <= floor else { return fireDate }
+        AppLogger.scheduler.notice(
+            """
+            AlarmKit snooze fireDate in past/too-soon — \
+            bumped forward to now+\(pastDateFloorBuffer, privacy: .public)s
+            """
+        )
+        return floor
     }
 
     /// Deterministic, distinct snooze id derived from the alarm id (#394). The

--- a/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
@@ -369,34 +369,63 @@ final class AlarmScheduler: AlarmScheduling {
         // re-fire as a real system alarm — not a notification — to match the
         // original firing and keep piercing silent mode / Focus. Stop the
         // currently-alerting system alarm first (the in-app firing screen also
-        // silences its audio), then reschedule the same id as a one-shot relative
-        // alarm at now + snoozeMinutes. A synchronous reschedule failure (config
-        // build) falls through to the notification path so the user is never left
-        // without a re-ring. Below iOS 26 (Strategy B) the notification burst
-        // below is unchanged.
+        // silences its audio), then reschedule (under a separate snooze id, #394)
+        // a one-shot `.fixed` alarm at now + snoozeMinutes.
+        //
+        // The AlarmKit `schedule` is async: we report `.success` ONLY after that
+        // await resolves, and on ANY failure (sync config build OR async reject —
+        // alarm limit, revoked auth, backend reject) we arm the notification
+        // burst below instead. A success reported before the await could leave
+        // the penalty charged with nothing re-ringing (#394 Finding 1). Below
+        // iOS 26 (Strategy B) the notification burst is the only path.
         if #available(iOS 26.0, *), usesAlarmKit, let alarmKitScheduler {
             let fireDate = Self.scheduledFireDate(now: Date(), snoozeMinutes: alarm.snoozeMinutes)
-            do {
-                alarmKitScheduler.stop(alarm.id)
-                try alarmKitScheduler.scheduleSnooze(alarm, fireDate: fireDate)
-                AppLogger.scheduler.info(
-                    "scheduled snooze via AlarmKit (Strategy A) alarm=\(alarm.id, privacy: .private)"
-                )
-                completion?(.success(()))
-                return
-            } catch {
-                let desc = error.localizedDescription
-                let alarmID = alarm.id
-                AppLogger.scheduler.error(
-                    """
-                    AlarmKit snooze schedule failed alarm=\(alarmID, privacy: .private): \
-                    \(desc, privacy: .public) — fallback
-                    """
-                )
-                // fall through to the notification path below
+            alarmKitScheduler.stop(alarm.id)
+            alarmKitScheduler.scheduleSnooze(alarm, fireDate: fireDate) { [weak self] result in
+                switch result {
+                case .success:
+                    AppLogger.scheduler.info(
+                        "scheduled snooze via AlarmKit (Strategy A) alarm=\(alarm.id, privacy: .private)"
+                    )
+                    completion?(.success(()))
+                case .failure(let error):
+                    let desc = error.localizedDescription
+                    AppLogger.scheduler.error(
+                        """
+                        AlarmKit snooze schedule failed alarm=\(alarm.id, privacy: .private): \
+                        \(desc, privacy: .public) — arming notification fallback
+                        """
+                    )
+                    guard let self else {
+                        // Scheduler gone before the async result — report a typed
+                        // failure so the penalty is refunded, never a phantom
+                        // success with no re-ring (#199 / #394).
+                        completion?(.failure(.cancelled))
+                        return
+                    }
+                    self.scheduleSnoozeNotification(
+                        for: alarm,
+                        snoozeCount: snoozeCount,
+                        completion: completion
+                    )
+                }
             }
+            return
         }
 
+        scheduleSnoozeNotification(for: alarm, snoozeCount: snoozeCount, completion: completion)
+    }
+
+    /// Strategy B (fallback) snooze: a `.timeSensitive` notification at
+    /// now + snoozeMinutes plus the lock-screen insistence burst (#19). Used
+    /// below iOS 26 and as the re-ring fallback when the AlarmKit system snooze
+    /// fails to schedule (#394 Finding 1) so the user is never left without a
+    /// re-ring after the penalty is charged.
+    private func scheduleSnoozeNotification(
+        for alarm: Alarm,
+        snoozeCount: Int,
+        completion: ((Result<Void, SchedulingError>) -> Void)?
+    ) {
         let content = makeContent(for: alarm, snoozeCount: snoozeCount)
 
         let fireDate = Self.scheduledFireDate(now: Date(), snoozeMinutes: alarm.snoozeMinutes)

--- a/SnoozePay/SnoozePayTests/AlarmFiringSnoozeAlarmKitTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmFiringSnoozeAlarmKitTests.swift
@@ -107,7 +107,14 @@ private final class SnoozeMockAlarmKit: AlarmKitScheduling {
     var isAuthorized: Bool { authorized }
     func requestAuthorization(completion: @escaping (Bool) -> Void) { completion(authorized) }
     func schedule(_ alarm: Alarm) throws { scheduledIDs.append(alarm.id) }
-    func scheduleSnooze(_ alarm: Alarm, fireDate: Date) throws { snoozedIDs.append(alarm.id) }
+    func scheduleSnooze(
+        _ alarm: Alarm,
+        fireDate: Date,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
+        snoozedIDs.append(alarm.id)
+        completion(.success(()))
+    }
     func cancel(_ alarmID: UUID) { cancelledIDs.append(alarmID) }
     func stop(_ alarmID: UUID) { stoppedIDs.append(alarmID) }
 }

--- a/SnoozePay/SnoozePayTests/AlarmKitSchedulerTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmKitSchedulerTests.swift
@@ -177,6 +177,81 @@ final class AlarmKitSchedulerTests: XCTestCase {
                        "Without AlarmKit the notification snooze fallback must still register")
     }
 
+    /// #394 Finding 1: when the AlarmKit system snooze fails to schedule
+    /// asynchronously (alarm limit, revoked auth, backend reject), the caller
+    /// MUST arm the notification-burst fallback so a re-ring still exists — the
+    /// penalty was already charged and the original already stopped, so a
+    /// swallowed failure would leave the user with nothing ringing.
+    func testScheduleSnooze_alarmKitAsyncFailure_armsNotificationFallback() throws {
+        guard #available(iOS 26.0, *) else {
+            throw XCTSkip("AlarmKit branch only runs on iOS 26+")
+        }
+        let alarmKit = MockAlarmKitScheduler(authorized: true, failSnooze: true)
+        let center = RecordingCenter()
+        let scheduler = AlarmScheduler(notificationCenter: center, alarmKit: alarmKit)
+        let alarm = AppAlarm(penaltyAmount: 50)
+
+        let exp = expectation(description: "snooze completes")
+        var reportedResult: Result<Void, AlarmScheduler.SchedulingError>?
+        scheduler.scheduleSnooze(for: alarm, snoozeCount: 1) { result in
+            reportedResult = result
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 2.0)
+
+        XCTAssertEqual(alarmKit.snoozedIDs, [alarm.id],
+                       "AlarmKit snooze must have been attempted before failing over")
+        XCTAssertFalse(center.addedRequests.isEmpty,
+                       "On async AlarmKit failure the notification re-ring fallback MUST be armed")
+        if case .success = reportedResult {
+            // Fallback notification landed → reporting success is correct: a
+            // re-ring exists. The regression we guard against is success with
+            // NO notification armed (covered by the addedRequests assertion).
+        } else {
+            XCTFail("With the notification fallback armed the snooze should report success")
+        }
+    }
+
+    // MARK: - Past-date floor (#394 Finding 2)
+
+    /// `.fixed` with a past instant silently never fires. A `fireDate` captured
+    /// before the async schedule await can land in the past under latency; the
+    /// floor must bump it strictly forward instead of passing the past instant
+    /// straight through.
+    func testMakeSnoozeSchedule_pastFireDate_isFlooredForward() throws {
+        guard #available(iOS 26.0, *) else {
+            throw XCTSkip("AlarmKit types require iOS 26+")
+        }
+        let now = Date()
+        // A fireDate already in the past (latency ate the snooze gap).
+        let pastDate = now.addingTimeInterval(-30)
+        let floored = AlarmKitScheduler.flooredSnoozeFireDate(pastDate, now: now)
+
+        XCTAssertGreaterThan(floored, now,
+                             "A past fireDate must be bumped strictly into the future, not passed through")
+        XCTAssertEqual(floored.timeIntervalSince(now),
+                       AlarmKitScheduler.pastDateFloorBuffer, accuracy: 0.001,
+                       "Floored snooze must land exactly at now + buffer")
+    }
+
+    /// A comfortably-future fireDate is passed through unchanged — the floor only
+    /// engages when latency would otherwise push `.fixed` into the past.
+    func testMakeSnoozeSchedule_futureFireDate_isUnchanged() throws {
+        guard #available(iOS 26.0, *) else {
+            throw XCTSkip("AlarmKit types require iOS 26+")
+        }
+        let now = Date()
+        let future = now.addingTimeInterval(9 * 60)
+        XCTAssertEqual(AlarmKitScheduler.flooredSnoozeFireDate(future, now: now), future,
+                       "A future fireDate must not be altered by the floor")
+
+        // And the public schedule entry point yields a .fixed at that instant.
+        guard case let .fixed(date) = AlarmKitScheduler.makeSnoozeSchedule(fireDate: future) else {
+            return XCTFail("Snooze must use an absolute .fixed schedule")
+        }
+        XCTAssertEqual(date.timeIntervalSince(future), 0, accuracy: 1)
+    }
+
     // MARK: - Cancel + stop forward to AlarmKit
 
     func testCancel_forwardsToAlarmKitBackend() throws {
@@ -372,7 +447,13 @@ final class AlarmKitSchedulerTests: XCTestCase {
 /// Strategy-A-vs-fallback branching can be asserted on any host OS. Mirrors the
 /// `PermissionStubCenter` pattern from `AlarmSchedulerTests`.
 private final class MockAlarmKitScheduler: AlarmKitScheduling {
+    struct SnoozeScheduleError: Error {}
+
     private let authorized: Bool
+    /// When `true`, `scheduleSnooze` reports `.failure` via its completion (after
+    /// still recording the call) — models an async AlarmKit reject so the caller
+    /// must arm the notification fallback instead (#394 Finding 1).
+    private let failSnooze: Bool
     private(set) var scheduledIDs: [UUID] = []
     private(set) var snoozedIDs: [UUID] = []
     private(set) var snoozeFireDates: [Date] = []
@@ -383,7 +464,10 @@ private final class MockAlarmKitScheduler: AlarmKitScheduling {
     /// the alerting alarm BEFORE rescheduling.
     private(set) var callLog: [String] = []
 
-    init(authorized: Bool) { self.authorized = authorized }
+    init(authorized: Bool, failSnooze: Bool = false) {
+        self.authorized = authorized
+        self.failSnooze = failSnooze
+    }
 
     var isAuthorized: Bool { authorized }
 
@@ -397,10 +481,15 @@ private final class MockAlarmKitScheduler: AlarmKitScheduling {
         callLog.append("schedule")
     }
 
-    func scheduleSnooze(_ alarm: AppAlarm, fireDate: Date) throws {
+    func scheduleSnooze(
+        _ alarm: AppAlarm,
+        fireDate: Date,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
         snoozedIDs.append(alarm.id)
         snoozeFireDates.append(fireDate)
         callLog.append("scheduleSnooze")
+        completion(failSnooze ? .failure(SnoozeScheduleError()) : .success(()))
     }
 
     func cancel(_ alarmID: UUID) {

--- a/SnoozePay/SnoozePayTests/AlarmKitSchedulerTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmKitSchedulerTests.swift
@@ -356,7 +356,11 @@ final class AlarmKitSchedulerTests: XCTestCase {
         guard #available(iOS 26.0, *) else {
             throw XCTSkip("AlarmKit types require iOS 26+")
         }
-        let fireDate = Date(timeIntervalSince1970: 1_700_000_030) // :30s — non-zero seconds
+        // Far-future instant with non-zero seconds (2100-01-01 00:00:30 UTC): it is
+        // well beyond `now + floor buffer`, so the past-date floor (#394 Finding 2)
+        // does NOT engage and `.fixed` must echo the exact fireDate, proving seconds
+        // are preserved (not truncated to hh:mm).
+        let fireDate = Date(timeIntervalSince1970: 4_102_444_830)
         let schedule = AlarmKitScheduler.makeSnoozeSchedule(fireDate: fireDate)
 
         guard case let .fixed(date) = schedule else {

--- a/SnoozePay/SnoozePayTests/AlarmKitSchedulerTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmKitSchedulerTests.swift
@@ -272,6 +272,84 @@ final class AlarmKitSchedulerTests: XCTestCase {
         }
     }
 
+    // MARK: - Snooze schedule + id (#394)
+
+    /// The snooze schedule must be an ABSOLUTE `.fixed` schedule pinned to the
+    /// exact fireDate — NOT a relative hh:mm schedule that drops seconds and can
+    /// roll over to the next day. Regression guard for the ~24h drift (#394).
+    func testMakeSnoozeSchedule_usesFixedAbsoluteDate_notRelative() throws {
+        guard #available(iOS 26.0, *) else {
+            throw XCTSkip("AlarmKit types require iOS 26+")
+        }
+        let fireDate = Date(timeIntervalSince1970: 1_700_000_030) // :30s — non-zero seconds
+        let schedule = AlarmKitScheduler.makeSnoozeSchedule(fireDate: fireDate)
+
+        guard case let .fixed(date) = schedule else {
+            return XCTFail("Snooze must use an absolute .fixed schedule, not .relative")
+        }
+        XCTAssertEqual(date, fireDate,
+                       "The snooze must fire at the exact fireDate, seconds preserved")
+    }
+
+    /// A short snooze planned at a non-zero-seconds instant must fire ≈ now + N,
+    /// never ~24h later. Exercises the boundary the relative-schedule bug failed:
+    /// 07:00:30 + 1min = 07:01:30, which a seconds-truncating relative schedule
+    /// would round to 07:01 (already past) and push to tomorrow (#394).
+    func testMakeSnoozeSchedule_shortSnoozeFiresWithinTheMinute_notNextDay() throws {
+        guard #available(iOS 26.0, *) else {
+            throw XCTSkip("AlarmKit types require iOS 26+")
+        }
+        let now = Date()
+        let fireDate = now.addingTimeInterval(60) // +1 minute
+        let schedule = AlarmKitScheduler.makeSnoozeSchedule(fireDate: fireDate)
+
+        guard case let .fixed(date) = schedule else {
+            return XCTFail("Snooze must use an absolute .fixed schedule")
+        }
+        let delta = date.timeIntervalSince(now)
+        XCTAssertEqual(delta, 60, accuracy: 1,
+                       "Snooze must fire ~1 min out, not ~24h (86400s) later")
+        XCTAssertLessThan(delta, 3600, "A snooze must never land hours/days away")
+    }
+
+    /// The snooze is scheduled under a SEPARATE id derived from the alarm id, so
+    /// a `.weekly` original is never overwritten by the one-shot snooze and keeps
+    /// ringing on its weekdays (#394). The derived id must be stable and distinct.
+    func testSnoozeID_isDistinctFromAlarmIDButDeterministic() throws {
+        guard #available(iOS 26.0, *) else {
+            throw XCTSkip("AlarmKit types require iOS 26+")
+        }
+        let alarmID = UUID()
+        let snoozeID = AlarmKitScheduler.snoozeID(for: alarmID)
+
+        XCTAssertNotEqual(snoozeID, alarmID,
+                          "Snooze must use a different id so the weekly original survives")
+        XCTAssertEqual(snoozeID, AlarmKitScheduler.snoozeID(for: alarmID),
+                       "Derivation must be deterministic — same alarm → same snooze id")
+        // Distinct alarms map to distinct snooze ids (no collisions).
+        XCTAssertNotEqual(AlarmKitScheduler.snoozeID(for: alarmID),
+                          AlarmKitScheduler.snoozeID(for: UUID()))
+    }
+
+    /// End-to-end mapping guard for #394 part 1: a weekly alarm's MAIN schedule
+    /// (`makeSchedule`) still carries its weekly recurrence — the snooze path
+    /// (which targets the separate snooze id) cannot touch it. The original
+    /// alarm keeps ringing on its configured weekdays after a snooze.
+    func testWeeklyAlarm_mainScheduleKeepsRecurrence_independentOfSnooze() throws {
+        guard #available(iOS 26.0, *) else {
+            throw XCTSkip("AlarmKit types require iOS 26+")
+        }
+        let alarm = AppAlarm(repeatDays: [0, 2, 4], penaltyAmount: 50, repeatMode: .weekly)
+        // Snooze targets a different id, so the alarm's own schedule is untouched.
+        XCTAssertNotEqual(AlarmKitScheduler.snoozeID(for: alarm.id), alarm.id)
+
+        guard case let .relative(relative) = AlarmKitScheduler.makeSchedule(for: alarm),
+              case let .weekly(days) = relative.repeats else {
+            return XCTFail("Weekly alarm must keep its weekly recurrence")
+        }
+        XCTAssertEqual(Set(days), [.monday, .wednesday, .friday])
+    }
+
     func testWeekdayMapping_coversAllSevenIndices() throws {
         guard #available(iOS 26.0, *) else {
             throw XCTSkip("AlarmKit types require iOS 26+")


### PR DESCRIPTION
Fixes #394

## Что сделано
Две связанные ошибки снуза в `AlarmKitScheduler.swift` (Strategy A), сверены с notification-путём (Strategy B) в `AlarmScheduler.swift`:

1. **Weekly-повтор больше не стирается.** Снуз планировался под тем же `alarm.id` → AlarmKit заменял `.weekly`-расписание одноразовым one-shot, и будильник переставал звонить по будням. Теперь снуз планируется под отдельным детерминированным snooze-id (`snoozeID(for:)`, derived из alarm.id), оригинал с `.weekly` остаётся армированным. `cancel`/`stop` теперь сметают и основной, и snooze-id.
2. **Снуз больше не уезжает на ~24ч.** `makeSnoozeSchedule` резал `fireDate` до hh:mm (`.relative .never`) → при потере секунд AlarmKit брал завтрашние hh:mm. Заменено на `.fixed(fireDate)` — абсолютная дата, ровно один раз, без усечения.

## Тесты (SnoozePayTests/AlarmKitSchedulerTests.swift)
- `testMakeSnoozeSchedule_usesFixedAbsoluteDate_notRelative` — снуз = `.fixed`, секунды сохранены.
- `testMakeSnoozeSchedule_shortSnoozeFiresWithinTheMinute_notNextDay` — снуз на +1мин даёт fireDate ≈ now+60s, не +86400s.
- `testSnoozeID_isDistinctFromAlarmIDButDeterministic` — snooze-id ≠ alarm-id, стабилен, без коллизий.
- `testWeeklyAlarm_mainScheduleKeepsRecurrence_independentOfSnooze` — основное расписание сохраняет weekly, снуз его не трогает.

## Verify
- ✅ swiftlint: 0 violations (изменённые файлы)
- ✅ xcodebuild build-for-testing (app + test target, iphonesimulator): exit 0, 0 errors
- ⚠️ NO-TOUCH не затронуты (entitlements / Info.plist / pbxproj signing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)