### PR TITLE
[audio] Reactivate session on resume after interruption + fix _interrupted reset (#395)

### DIFF
--- a/SnoozePay/SnoozePay/Services/AudioService.swift
+++ b/SnoozePay/SnoozePay/Services/AudioService.swift
@@ -75,6 +75,16 @@ final class AudioService {
     /// Queue-confined backing storage for `currentAlarmID`.
     private var _currentAlarmID: UUID?
 
+    /// Queue-confined count of successful `configureAudioSession()` activations.
+    /// Exposed (`@testable`) so unit tests can assert that a resume path actually
+    /// reclaims the session before `play()` (#395) — the activation itself can't
+    /// be observed in the simulator, but the call count proves the code path ran.
+    private var _sessionActivationCount = 0
+
+    /// Test-only snapshot of how many times the audio session was (re)activated.
+    /// Thread-safe read; see `_sessionActivationCount`.
+    var sessionActivationCount: Int { queue.sync { _sessionActivationCount } }
+
     /// Queue-confined. `true` while the looped player is paused but the session
     /// is still owned — either the top-up sheet paused it (#141) or a system
     /// interruption did (#374). `_state` stays `.playing` throughout (the
@@ -140,6 +150,8 @@ final class AudioService {
         let session = AVAudioSession.sharedInstance()
         try session.setCategory(.playback, options: [.duckOthers])
         try session.setActive(true, options: [])
+        // Only counted on success (a throw skips this) — see `sessionActivationCount`.
+        _sessionActivationCount += 1
     }
 
     /// Deactivate the audio session when alarm is stopped.
@@ -380,24 +392,45 @@ final class AudioService {
     /// Resume playback + vibration after `pauseAlarmSound()`. No-op if no
     /// player exists (state != .playing). Idempotent so the bottom sheet's
     /// dismiss path can call it without checking pause state first.
+    ///
+    /// Does NOT touch `_interrupted`: a top-up resume must not cancel an
+    /// in-flight system-interruption recovery (#395). Clearing `_interrupted`
+    /// is owned exclusively by the `.ended` branch of `handleAudioInterruption`.
     func resumeAlarmSound() {
         queue.sync {
             guard _state == .playing, audioPlayer != nil else { return }
             resumePlaybackLocked()
-            _interrupted = false
         }
     }
 
     /// Resume the paused looped player + vibration. Must only be called from
     /// `queue` with `audioPlayer != nil`. Clears `_isPaused`. Shared by
     /// `resumeAlarmSound()` (#141), the stacking-replace un-pause (#116/#374)
-    /// and interruption recovery (#374).
+    /// and interruption recovery (#374/#395).
+    ///
+    /// Re-activates the audio session before `play()`. A top-up pause that
+    /// overlaps a system interruption (#395) leaves the session *deactivated*
+    /// by iOS — calling `play()` against a dead session yields silence with no
+    /// error, a failed wake. So every resume path reclaims the session first,
+    /// falling back to `.silentBecauseConfigFailed` if another app holds it.
     private func resumePlaybackLocked() {
         guard let player = audioPlayer else { return }
+        do {
+            try configureAudioSession()
+        } catch {
+            // Session could not be reclaimed (another app owns it). Surface the
+            // explicit fallback so the firing UI warns the user instead of
+            // showing a "ringing" screen with no sound.
+            AppLogger.audio.error(
+                "resumePlaybackLocked: session reactivate failed: \(error.localizedDescription, privacy: .public)"
+            )
+            _isPaused = false
+            _state = .silentBecauseConfigFailed
+            return
+        }
         // `play()` returns false only if the queue refuses — which on a paused
-        // looping player should not happen unless the session was deactivated
-        // out-of-band. Log so a regression where pause/resume gets out of sync
-        // (e.g. interrupted by another app's audio) is diagnosable.
+        // looping player should not happen once the session is active again.
+        // Log so a residual desync is diagnosable.
         if !player.play() {
             AppLogger.audio.error("resumePlaybackLocked: AVAudioPlayer.play() returned false")
         }
@@ -432,31 +465,14 @@ final class AudioService {
             case .ended:
                 guard _interrupted else { return }
                 _interrupted = false
-                resumeAfterInterruptionLocked()
+                // `resumePlaybackLocked` reactivates the session the system
+                // tore down during the interruption before `play()` (#395).
+                guard _state == .playing, audioPlayer != nil else { return }
+                resumePlaybackLocked()
             @unknown default:
                 break
             }
         }
-    }
-
-    /// Re-activate the audio session (the system deactivated it during the
-    /// interruption) and resume playback. Must only be called from `queue`.
-    private func resumeAfterInterruptionLocked() {
-        guard _state == .playing, audioPlayer != nil else { return }
-        do {
-            try configureAudioSession()
-        } catch {
-            // Session could not be reclaimed (another app holds it). Surface the
-            // explicit fallback so the firing UI can warn the user rather than
-            // showing a "ringing" screen with no sound.
-            AppLogger.audio.error(
-                "failed to reactivate audio session after interruption: \(error.localizedDescription, privacy: .public)"
-            )
-            _isPaused = false
-            _state = .silentBecauseConfigFailed
-            return
-        }
-        resumePlaybackLocked()
     }
 
     // MARK: - Vibration

--- a/SnoozePay/SnoozePayTests/AudioServiceTests.swift
+++ b/SnoozePay/SnoozePayTests/AudioServiceTests.swift
@@ -441,4 +441,108 @@ final class AudioServiceTests: XCTestCase {
 
         service.stopAlarmSound()
     }
+
+    // MARK: - Session reactivation on resume (#395)
+
+    /// #395 facet 1 — every resume must reclaim the audio session before
+    /// `play()`. iOS deactivates the session during an interruption; a
+    /// `play()` against a dead session is silent with no error (a failed wake).
+    /// `sessionActivationCount` increasing on resume proves the reactivation
+    /// path actually ran.
+    func testResumeAlarmSound_reactivatesSession() {
+        let service = AudioService.shared
+        service.stopAlarmSound()
+        service.startAlarmSound(soundID: "nonexistent_test_sound", alarmID: UUID())
+        let afterStart = service.sessionActivationCount
+
+        service.pauseAlarmSound()
+        service.resumeAlarmSound()
+        XCTAssertEqual(
+            service.sessionActivationCount, afterStart + 1,
+            "resumeAlarmSound must reactivate the session (it may be dead after an interruption, #395)"
+        )
+        XCTAssertFalse(service.isPaused)
+        XCTAssertEqual(service.state, .playing)
+
+        service.stopAlarmSound()
+    }
+
+    /// #395 core scenario — a top-up pause (#141) overlaps an incoming call.
+    /// The `.began` is guarded out because `_isPaused` is already set, so iOS
+    /// silently tears the session down. When the top-up sheet dismisses,
+    /// `resumeAlarmSound()` must reactivate the session — otherwise the alarm
+    /// plays against a dead session and the user never wakes.
+    func testTopUpPauseThenInterruption_resumeReactivatesSession() {
+        let service = AudioService.shared
+        service.stopAlarmSound()
+        service.startAlarmSound(soundID: "nonexistent_test_sound", alarmID: UUID())
+
+        service.pauseAlarmSound()          // top-up sheet opens
+        postInterruption(.began)           // call arrives, guarded out, session torn down
+        XCTAssertTrue(service.isPaused, "top-up pause stays in effect through the interruption")
+
+        let beforeResume = service.sessionActivationCount
+        service.resumeAlarmSound()         // sheet dismisses
+        XCTAssertEqual(
+            service.sessionActivationCount, beforeResume + 1,
+            "resume after a top-up-pause+interruption must reclaim the dead session (#395)"
+        )
+        XCTAssertFalse(service.isPaused)
+        XCTAssertEqual(service.state, .playing)
+
+        service.stopAlarmSound()
+    }
+
+    /// #395 facet 2 — `resumeAlarmSound()` must NOT clear `_interrupted`. If a
+    /// real interruption is active and a top-up resume fires concurrently, the
+    /// old code reset `_interrupted=false`, so the later `.ended` no-op'd and
+    /// the alarm never auto-resumed. Here the un-pause via stacking-replace
+    /// (which calls the same resume path) must leave the pending interruption's
+    /// `.ended` recovery intact.
+    func testConcurrentResume_doesNotDropPendingInterruption() {
+        let service = AudioService.shared
+        service.stopAlarmSound()
+        service.startAlarmSound(soundID: "nonexistent_test_sound", alarmID: UUID())
+
+        postInterruption(.began)           // real interruption → _interrupted = true
+        XCTAssertTrue(service.isPaused)
+
+        // A racing manual resume (e.g. top-up dismiss) must not cancel the
+        // pending interruption recovery.
+        service.resumeAlarmSound()
+        XCTAssertFalse(service.isPaused, "manual resume un-pauses")
+
+        // The interruption still ends — recovery must run rather than no-op,
+        // proving `_interrupted` survived the manual resume.
+        let beforeEnded = service.sessionActivationCount
+        postInterruption(.ended)
+        XCTAssertEqual(
+            service.sessionActivationCount, beforeEnded + 1,
+            "interruption .ended must still reactivate — _interrupted must survive a concurrent resume (#395)"
+        )
+        XCTAssertEqual(service.state, .playing)
+
+        service.stopAlarmSound()
+    }
+
+    /// Interruption began/ended round-trip must reactivate the session on
+    /// `.ended` (#395) — the original #374 path, now routed through
+    /// `resumePlaybackLocked`.
+    func testInterruptionEnded_reactivatesSession() {
+        let service = AudioService.shared
+        service.stopAlarmSound()
+        service.startAlarmSound(soundID: "nonexistent_test_sound", alarmID: UUID())
+
+        postInterruption(.began)
+        let beforeEnded = service.sessionActivationCount
+        postInterruption(.ended)
+        XCTAssertEqual(
+            service.sessionActivationCount, beforeEnded + 1,
+            "interruption .ended must reclaim the session iOS tore down (#395)"
+        )
+        XCTAssertFalse(service.isPaused)
+        XCTAssertEqual(service.state, .playing)
+
+        service.stopAlarmSound()
+    }
 }


### PR DESCRIPTION
Fixes #395

## Что сделано
- `resumePlaybackLocked()` теперь реактивирует аудиосессию через `configureAudioSession()` перед `play()` на **всех** resume-путях (top-up #141, stacking-replace #116, interruption #374). Раньше это делал только `resumeAfterInterruptionLocked`; top-up resume против деактивированной системой сессии давал тишину (провал пробуждения). При неудаче реактивации — fallback на `.silentBecauseConfigFailed`, как раньше в interruption-пути.
- `resumeAlarmSound()` больше **не** сбрасывает `_interrupted` безусловно. Очистка флага теперь принадлежит исключительно ветке `.ended` в `handleAudioInterruption`, поэтому конкурентный top-up resume не ломает авто-резюм после звонка.
- `resumeAfterInterruptionLocked` удалён — его логика свернулась в обновлённый `resumePlaybackLocked` (дедупликация реактивации сессии).
- Добавлен queue-confined `sessionActivationCount` (`@testable`) — счётчик успешных активаций сессии, чтобы юнит-тесты могли подтвердить, что resume реально проходит путь реактивации (саму сессию в симуляторе не проверить).

## Verify
- ✅ swiftlint: 0 serious (остались 3 pre-existing line_length warning не в моих строках)
- ✅ xcodebuild build-for-testing (app + tests): EXIT=0, no errors
- Новые тесты в `AudioServiceTests.swift`:
  - `testResumeAlarmSound_reactivatesSession` — resume реактивирует сессию
  - `testTopUpPauseThenInterruption_resumeReactivatesSession` — core scenario #395: top-up пауза + звонок → resume реклеймит мёртвую сессию
  - `testConcurrentResume_doesNotDropPendingInterruption` — конкурентный resume не теряет `_interrupted`, `.ended` всё ещё авто-резюмит
  - `testInterruptionEnded_reactivatesSession` — round-trip began/ended реактивирует на `.ended`

🤖 Generated with [Claude Code](https://claude.com/claude-code)