### PR TITLE
[ui] SPAmountPreset: fix secondary label truncation (single-line shrink) (#399)

### DIFF
--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPAmountPreset.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPAmountPreset.swift
@@ -160,13 +160,15 @@ final class SPAmountPreset: UIControl {
         labelView.font = AppTypography.meta
         labelView.textColor = AppColors.fg3
         labelView.textAlignment = .center
-        // The "≈ N откладываний" hint is too wide for a 3-column tile on one
-        // line (it truncated to "≈ 1 откладыва…"). Wrap to two lines and let
-        // the font shrink a touch as a backstop so the full word is always
-        // visible regardless of count/plural form.
-        labelView.numberOfLines = 2
+        // The "≈ N откладываний" hint is too wide for a 3-column tile (it
+        // truncated to "≈ 1 откладыва…"). Keep it on a single line and shrink
+        // the font as a backstop so the full word is always visible regardless
+        // of count/plural form. `adjustsFontSizeToFitWidth` is honoured only for
+        // single-line labels — pairing it with numberOfLines=2 silently disabled
+        // the shrink and let the longest form ellipsise.
+        labelView.numberOfLines = 1
         labelView.adjustsFontSizeToFitWidth = true
-        labelView.minimumScaleFactor = 0.8
+        labelView.minimumScaleFactor = 0.7
 
         stack.translatesAutoresizingMaskIntoConstraints = false
         stack.axis = .vertical


### PR DESCRIPTION
Fixes #399

## Что сделано
- `labelView` в `SPAmountPreset` сочетал `numberOfLines = 2` с `adjustsFontSizeToFitWidth = true`. UIKit чтит `adjustsFontSizeToFitWidth` только для однострочных лейблов — при multi-line shrink-backstop молча отключался, и самый длинный «≈ N откладываний» обрезался эллипсисом.
- Перешёл на вариант (a): `numberOfLines = 1` + `adjustsFontSizeToFitWidth = true` + `minimumScaleFactor = 0.7`. Теперь самый длинный вторичный текст («≈ 20 откладываний», max-SKU 999 ₽ при 50 ₽/откладывание) ужимается шрифтом и виден полностью на самом узком 3-колоночном пресете — без эллипсиса.
- Без новых magic insets: padding/spacing остаются на существующих design-system токенах.

## Verify
- ✅ swiftlint: 0 errors (1 pre-existing `function_body_length` warning в `configure()`, не мой код)
- ✅ xcodebuild build-for-testing (generic iOS Simulator, CODE_SIGNING_ALLOWED=NO): exit 0, 0 errors
- Тесты: чистый UI-фикс, sizing-логика остаётся в `DepositPresets` (уже unit-tested) — нового helper не вводил, существующие тесты не трогал

🤖 Generated with [Claude Code](https://claude.com/claude-code)