### PR TITLE
[fix] Onboarding: resolve page state on no-momentum drag end (#408)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Onboarding/OnboardingViewController.swift
@@ -406,8 +406,27 @@ final class OnboardingViewController: UIViewController {
 
 extension OnboardingViewController: UIScrollViewDelegate {
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-        let page = Int(round(scrollView.contentOffset.x / scrollView.bounds.width))
+        settlePagerState(for: scrollView)
+    }
+
+    /// A slow drag released without momentum settles here (`decelerate == false`)
+    /// and never reaches `scrollViewDidEndDecelerating`. Resolve the page so the
+    /// dot-row, glow, "Позже" link and primary CTA stay in sync. (#408)
+    func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        guard !decelerate else { return }
+        settlePagerState(for: scrollView)
+    }
+
+    private func settlePagerState(for scrollView: UIScrollView) {
+        let page = Self.resolvePage(offsetX: scrollView.contentOffset.x, width: scrollView.bounds.width)
         pageControl.currentPage = page
         updatePagerState(forPage: page)
+    }
+
+    /// Pure page-index resolution from a horizontal content offset. Static and
+    /// side-effect-free so it can be unit-tested without a live scroll view.
+    static func resolvePage(offsetX: CGFloat, width: CGFloat) -> Int {
+        guard width > 0 else { return 0 }
+        return Int(round(offsetX / width))
     }
 }

--- a/SnoozePay/SnoozePayTests/OnboardingTests.swift
+++ b/SnoozePay/SnoozePayTests/OnboardingTests.swift
@@ -95,4 +95,21 @@ final class OnboardingTests: XCTestCase {
         let title = vc.skipButton.configuration?.attributedTitle.map { String($0.characters) }
         XCTAssertEqual(title, "Пропустить")
     }
+
+    // MARK: - Pager page resolution (#408)
+
+    func testResolvePage_settlesToNearestPage() {
+        let width: CGFloat = 390
+
+        XCTAssertEqual(OnboardingViewController.resolvePage(offsetX: 0, width: width), 0)
+        // Slow drag releasing just past the midpoint of page 3 rounds to page 2,
+        // the case scrollViewDidEndDragging(decelerate: false) must now cover.
+        XCTAssertEqual(OnboardingViewController.resolvePage(offsetX: width * 2 - 10, width: width), 2)
+        XCTAssertEqual(OnboardingViewController.resolvePage(offsetX: width * 2, width: width), 2)
+    }
+
+    func testResolvePage_zeroWidthIsSafe() {
+        // Before layout the scroll view has zero width — must not divide by zero.
+        XCTAssertEqual(OnboardingViewController.resolvePage(offsetX: 100, width: 0), 0)
+    }
 }


### PR DESCRIPTION
Fixes #408

## Что сделано
- Реализован `scrollViewDidEndDragging(_:willDecelerate:)` — медленный свайп без инерции (`decelerate == false`) теперь резолвит страницу и зовёт `updatePagerState`, как и `scrollViewDidEndDecelerating`. На стр.3 CTA становится «Пополнить», dot-row/glow/«Позже» актуализируются, а `primaryTapped` читает корректный `pageControl.currentPage`.
- Извлечён чистый статический хелпер `resolvePage(offsetX:width:)` (с guard от деления на ноль), общий для обоих делегатов, покрыт unit-тестами.

## Verify
- ✅ swiftlint: 0 violations (own files)
- ✅ xcodebuild build-for-testing: exit 0 (CODE_SIGNING_ALLOWED=NO)
- 🔁 test_sim отключён по policy — добавлены unit-тесты `testResolvePage_*` в OnboardingTests