### PR TITLE
[fix] Referral input: preserve caret on mid-string edits (#412)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController+Referral.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController+Referral.swift
@@ -168,17 +168,62 @@ extension SettingsViewController: UITextFieldDelegate {
     /// displayed always matches what `applyFriendCode` will see post-
     /// normalisation. Without the cap nothing prevents pasting a 30-char
     /// blob that would later fail validation with no visible cause.
+    ///
+    /// We always return `false` and rewrite the text ourselves (the uppercase
+    /// transform means the rendered string differs from the raw replacement),
+    /// but we recompute the caret offset and restore it via
+    /// `selectedTextRange` so mid-string edits and backspaces don't jump the
+    /// caret to the end. The transform itself lives in `ReferralCodeInput`
+    /// so it can be unit-tested without a live `UITextField`.
     public func textField(
         _ textField: UITextField,
         shouldChangeCharactersIn range: NSRange,
         replacementString string: String
     ) -> Bool {
         let current = textField.text ?? ""
-        guard let swiftRange = Range(range, in: current) else { return false }
-        let proposed = current.replacingCharacters(in: swiftRange, with: string).uppercased()
-        if proposed.count > 6 { return false }
-        textField.text = proposed
+        guard let result = ReferralCodeInput.transform(
+            current: current,
+            replacing: range,
+            with: string
+        ) else { return false }
+
+        textField.text = result.text
+        // Map the UTF-16 caret offset back onto a live text position. Clamp to
+        // the document end in case the transform produced a shorter string.
+        let offset = min(result.caretOffset, (result.text as NSString).length)
+        if let position = textField.position(from: textField.beginningOfDocument, offset: offset) {
+            textField.selectedTextRange = textField.textRange(from: position, to: position)
+        }
         return false
+    }
+}
+
+// MARK: - ReferralCodeInput (pure transform)
+
+/// Pure, UI-free transform behind the referral input's `shouldChangeCharactersIn`
+/// delegate hook. Extracted so the uppercase + 6-char-cap + caret math can be
+/// unit-tested without instantiating a `UITextField`.
+enum ReferralCodeInput {
+
+    /// Result of applying an edit: the new field text plus where the caret
+    /// should land, expressed as a UTF-16 offset from the start of the string.
+    struct Result: Equatable {
+        let text: String
+        let caretOffset: Int
+    }
+
+    /// Applies the replacement, uppercases the whole value, and rejects (returns
+    /// `nil`) any edit that would push the result past 6 characters. On accept,
+    /// the caret offset is the original range start plus the length of the
+    /// inserted (uppercased) text — i.e. it follows what the user just typed,
+    /// even mid-string.
+    static func transform(current: String, replacing range: NSRange, with string: String) -> Result? {
+        guard let swiftRange = Range(range, in: current) else { return nil }
+        let proposed = current.replacingCharacters(in: swiftRange, with: string).uppercased()
+        if proposed.count > 6 { return nil }
+        let insertedLength = (string.uppercased() as NSString).length
+        let caretOffset = range.location + insertedLength
+        return Result(text: proposed, caretOffset: caretOffset)
     }
 }
 

--- a/SnoozePay/SnoozePayTests/ReferralCodeInputTests.swift
+++ b/SnoozePay/SnoozePayTests/ReferralCodeInputTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import SnoozePay
+
+/// Coverage for the referral input's pure transform (#412). The delegate hook
+/// `textField(_:shouldChangeCharactersIn:)` always returns `false` and rewrites
+/// the text, so the caret offset has to be recomputed by hand — these tests
+/// lock the uppercase + 6-char-cap behaviour and the caret math that keeps
+/// mid-string edits from jumping to the end.
+final class ReferralCodeInputTests: XCTestCase {
+
+    private func transform(_ current: String, _ range: NSRange, _ string: String) -> ReferralCodeInput.Result? {
+        ReferralCodeInput.transform(current: current, replacing: range, with: string)
+    }
+
+    // MARK: - Uppercase + append
+
+    func testAppendingLowercase_uppercasesAndAdvancesCaret() {
+        let result = transform("AB", NSRange(location: 2, length: 0), "c")
+        XCTAssertEqual(result, .init(text: "ABC", caretOffset: 3))
+    }
+
+    func testAppendingToEmpty_uppercases() {
+        let result = transform("", NSRange(location: 0, length: 0), "x")
+        XCTAssertEqual(result, .init(text: "X", caretOffset: 1))
+    }
+
+    // MARK: - 6-char cap
+
+    func testEditFillingToSixChars_isAccepted() {
+        let result = transform("ABCDE", NSRange(location: 5, length: 0), "f")
+        XCTAssertEqual(result, .init(text: "ABCDEF", caretOffset: 6))
+    }
+
+    func testEditExceedingSixChars_isRejected() {
+        XCTAssertNil(transform("ABCDEF", NSRange(location: 6, length: 0), "G"))
+    }
+
+    func testPastingPastSixChars_isRejected() {
+        XCTAssertNil(transform("", NSRange(location: 0, length: 0), "ABCDEFG"))
+    }
+
+    func testPastingExactlySixChars_isAccepted() {
+        let result = transform("", NSRange(location: 0, length: 0), "abcdef")
+        XCTAssertEqual(result, .init(text: "ABCDEF", caretOffset: 6))
+    }
+
+    // MARK: - Mid-string edits (the bug)
+
+    func testInsertingMidString_keepsCaretAfterInsertion() {
+        // "AC" with caret between A and C, type "B" -> "ABC", caret after B (offset 2)
+        let result = transform("AC", NSRange(location: 1, length: 0), "b")
+        XCTAssertEqual(result, .init(text: "ABC", caretOffset: 2))
+    }
+
+    func testBackspaceMidString_keepsCaretAtDeletionPoint() {
+        // "ABC", delete the "B" (range location 1, length 1) -> "AC", caret at offset 1
+        let result = transform("ABC", NSRange(location: 1, length: 1), "")
+        XCTAssertEqual(result, .init(text: "AC", caretOffset: 1))
+    }
+
+    func testReplacingSelectionMidString_advancesByInsertedLength() {
+        // "AXYZ B", select "XYZ" (loc 1 len 3), type "12" -> "A12 B", caret after "12" (offset 3)
+        let result = transform("AXYZB", NSRange(location: 1, length: 3), "12")
+        XCTAssertEqual(result, .init(text: "A12B", caretOffset: 3))
+    }
+}


### PR DESCRIPTION
Fixes #412

## Что сделано
- Делегат `textField(_:shouldChangeCharactersIn:)` теперь восстанавливает каретку через `selectedTextRange` после переписывания текста — правка/бэкспейс в середине кода больше не прыгает в конец.
- Логика трансформации (uppercase + cap 6) вынесена в чистый `ReferralCodeInput.transform` — тестируется без живого `UITextField`, поведение uppercase + 6-char-cap сохранено.
- Добавлен `ReferralCodeInputTests` (9 кейсов: append, cap, mid-string insert/backspace/replace).

## Verify
- ✅ swiftlint: 0 violations (own files)
- ✅ xcodebuild build-for-testing: exit 0, 0 errors
- ✅ unit-тесты добавлены (ReferralCodeInputTests, filesystem-synced target — без правки pbxproj)

🤖 Generated with [Claude Code](https://claude.com/claude-code)