### PR TITLE
[ui] Penalty field: dismissible numberPad + commit on editing-end (#410)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/PenaltyCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/PenaltyCell.swift
@@ -62,6 +62,19 @@ final class PenaltyCell: UITableViewCell {
         return field
     }()
 
+    /// «Готово» toolbar above the numberPad — the pad has no return key, so this
+    /// is the explicit dismissal path (#410). Complements the table's
+    /// interactive drag-to-dismiss.
+    private lazy var accessoryToolbar: UIToolbar = {
+        let toolbar = UIToolbar()
+        toolbar.sizeToFit()
+        let spacer = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+        let done = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(doneTapped))
+        done.accessibilityIdentifier = "createAlarm.penaltyDone"
+        toolbar.items = [spacer, done]
+        return toolbar
+    }()
+
     /// Trailing ₽ in the same mono amber as the number.
     private let suffixLabel: UILabel = {
         let label = UILabel()
@@ -133,6 +146,7 @@ final class PenaltyCell: UITableViewCell {
         backgroundColor = AppColors.bg1
         selectionStyle = .none
 
+        amountField.inputAccessoryView = accessoryToolbar
         amountField.addTarget(self, action: #selector(amountEditingChanged), for: .editingChanged)
         amountField.addTarget(self, action: #selector(amountEditingEnded), for: .editingDidEnd)
 
@@ -201,29 +215,40 @@ final class PenaltyCell: UITableViewCell {
         return value
     }
 
+    /// Live keystroke handler — updates ONLY the cell's own appearance (helper
+    /// flag + chip highlight). It does NOT commit to the model: typing "100"
+    /// must not push 1→10→100 and flicker the preset chips / progressive chain
+    /// downstream (#410). The commit happens once on `.editingDidEnd`.
     @objc private func amountEditingChanged() {
         guard let value = validatedAmount() else {
-            // Invalid mid-edit — flag it, but keep the last valid amount staged
-            // so the model isn't fed a bad price.
             setHelper(visible: true)
             return
         }
         setHelper(visible: false)
         currentAmount = Double(value)
+        refreshAppearance()
+    }
+
+    @objc private func amountEditingEnded() {
+        guard let value = validatedAmount() else {
+            // Left blank / invalid — revert to the last valid amount.
+            amountField.text = String(Int(lastValidAmount))
+            currentAmount = lastValidAmount
+            setHelper(visible: false)
+            refreshAppearance()
+            return
+        }
+        setHelper(visible: false)
+        currentAmount = Double(value)
+        // Commit only the final value once editing ends.
+        guard abs(lastValidAmount - currentAmount) >= .ulpOfOne else { return }
         lastValidAmount = currentAmount
         refreshAppearance()
         onValueChanged?(currentAmount)
     }
 
-    @objc private func amountEditingEnded() {
-        guard validatedAmount() == nil else {
-            setHelper(visible: false)
-            return
-        }
-        // Left blank / invalid — revert to the last valid amount.
-        amountField.text = String(Int(lastValidAmount))
-        setHelper(visible: false)
-        refreshAppearance()
+    @objc private func doneTapped() {
+        amountField.resignFirstResponder()
     }
 
     private func setHelper(visible: Bool) {

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
@@ -174,6 +174,10 @@ final class CreateAlarmViewController: UIViewController {
         view.addSubview(tableView)
         tableView.delegate = self
         tableView.dataSource = self
+        // The penalty field uses a `.numberPad` keyboard (no return key), so a
+        // drag over the form dismisses it — otherwise it would cover the cards
+        // below with no way out but Save/Cancel (#410).
+        tableView.keyboardDismissMode = .interactive
         registerSectionCells(in: tableView)
 
         // Pin to safe area on top so the first section's "ПОВТОР" header is

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/CreateAlarmViewController.swift
@@ -240,6 +240,11 @@ final class CreateAlarmViewController: UIViewController {
     }
 
     @objc private func saveTapped() {
+        // Commit any focused field first: the penalty `.numberPad` commits its
+        // value on `editingDidEnd` (#410), and tapping the nav-bar Save button
+        // does not blur the field on its own — without this, a value typed and
+        // saved without dismissing the keyboard would be silently dropped.
+        view.endEditing(true)
         // Cells push state into the view-model live via callbacks, so save just
         // forwards the current snapshot to the repository.
         // The async overload waits on `AlarmScheduler.schedule` to resolve so


### PR DESCRIPTION
Fixes #410

## Что сделано
- **Закрытие numberPad-клавиатуры (p2):** добавлен `tableView.keyboardDismissMode = .interactive` в `CreateAlarmViewController.setupTableView` (свайп по форме) + «Готово» `inputAccessoryView`-тулбар на поле цены (у numberPad нет return-кнопки). Раньше клавиатура висела и перекрывала карточки ниже.
- **Flicker чипов/цепочки (p3):** `onValueChanged` теперь коммитится только на `.editingDidEnd`, а не на каждый `.editingChanged`. Ввод «100» больше не пушит 1→10→100 в модель и не моргает preset-чипами / progressive-цепочкой. Live-keystroke остаётся локальным (helper-флаг + подсветка чипов в самой ячейке).

## Verify
- ✅ swiftlint: 0 violations (PenaltyCell.swift, CreateAlarmViewController.swift)
- ✅ xcodebuild build-for-testing: EXIT=0, 0 errors (sim, CODE_SIGNING_ALLOWED=NO)
- ⚪ test_sim / screenshot / qa: disabled per current policy; UI-верификация вручную PM/QA

## Acceptance
- [x] Цифровую клавиатуру цены можно закрыть (свайп / «Готово»)
- [x] Ввод многозначной цены не моргает чипами/цепочкой до завершения

🤖 Generated with [Claude Code](https://claude.com/claude-code)