### PR TITLE
[ui] Settings: refresh visible card shadows on live theme switch (#420)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsViewController.swift
@@ -174,6 +174,10 @@ class SettingsViewController: UIViewController {
         default: theme = .system
         }
         themeService.setTheme(theme)
+        // Theme flips overrideUserInterfaceStyle live, but already-displayed rows
+        // baked their mode-specific shadow + (light-only) ambient layer in
+        // willDisplay. Reload so willDisplay re-runs styleAsCardRow for visible rows.
+        tableView.reloadData()
     }
 }
 


### PR DESCRIPTION
Fixes #420

## Что сделано
- В `handleThemeSegmentChange` после `themeService.setTheme` добавлен `tableView.reloadData()`.
- Это перевызывает `willDisplay` для видимых строк → `styleAsCardRow` перезапекает mode-specific тень и (light-only) ambient-слой под новую тему.
- Правка только в `SettingsViewController.swift`; `UIView+CardStyle.swift` не тронут (чтобы не пересекаться с другими задачами).

## Verify
- ✅ swiftlint: 0 errors (own file)
- ✅ xcodebuild build-for-testing: exit 0, 0 errors (iphonesimulator)
- ⏭️ test_sim / screenshot / qa: disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)