### PR TITLE
[ui] AlarmCell: reset card chrome on reuse + accessibility (#418)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/AlarmCell.swift
@@ -195,6 +195,17 @@ final class AlarmCell: UITableViewCell {
             pillsStack.trailingAnchor.constraint(lessThanOrEqualTo: cardView.trailingAnchor, constant: -pad),
             pillsStack.bottomAnchor.constraint(equalTo: cardView.bottomAnchor, constant: -pad)
         ])
+
+        // Accessibility: VoiceOver would otherwise read the card's labels as
+        // disconnected fragments ("07:00", "50 ₽", "×2"). Make the cell an
+        // a11y container exposing exactly two elements — the card (a composed
+        // summary label, updated in `configure`) and the toggle (a UISwitch,
+        // which carries native on/off value + activation for free).
+        isAccessibilityElement = false
+        accessibilityElements = [cardView, toggleSwitch]
+        cardView.isAccessibilityElement = true
+        cardView.accessibilityTraits = .summaryElement
+        toggleSwitch.accessibilityLabel = "Будильник"
     }
 
     override func prepareForReuse() {
@@ -206,6 +217,17 @@ final class AlarmCell: UITableViewCell {
             pillsStack.removeArrangedSubview(view)
             view.removeFromSuperview()
         }
+        // Reset card chrome to a known (enabled) state. `applyCardChrome` only
+        // *adds* the ambient `shadow-1` sublayer in its disabled branch, and
+        // `layoutSubviews` re-installs it whenever `isEnabledTone` is false —
+        // so a recycled cell whose previous alarm was disabled would paint the
+        // stale ambient shadow / disabled tone for one layout pass before the
+        // controller re-calls `configure`. Drop the ambient layer and reset the
+        // tracked tone so the cell starts every reuse from the enabled recipe.
+        cardView.layer.sublayers?
+            .first { $0.name == AppShadow.ambientShadow1LayerName }?
+            .removeFromSuperlayer()
+        isEnabledTone = true
     }
 
     // MARK: - Configure
@@ -250,6 +272,54 @@ final class AlarmCell: UITableViewCell {
         toggleSwitch.isOn = enabled
         applyEnabledTone(enabled)
         rebuildPills(price: priceText, multiplier: multiplier, soundName: soundName, enabled: enabled)
+
+        // Compose the VoiceOver summary from the same fields and refresh the
+        // toggle's value so the row reads as one coherent control pair.
+        cardView.accessibilityLabel = Self.accessibilityLabel(
+            time: time,
+            daysCaps: daysCaps,
+            priceText: priceText,
+            multiplier: multiplier,
+            soundName: soundName
+        )
+        toggleSwitch.accessibilityValue = enabled ? "включён" : "выключен"
+    }
+
+    /// Build the composed VoiceOver label for a card from its display fields,
+    /// e.g. "Будильник 07:00, будни Пн–Пт, 50 ₽, ×2, Soft Dawn". Pure so it
+    /// can be unit-tested without instantiating a cell. `daysCaps` arrives
+    /// upper-cased for the visual caps row; VoiceOver reads sentence-case more
+    /// naturally, so it's lowered with a capital first letter.
+    static func accessibilityLabel(
+        time: String,
+        daysCaps: String,
+        priceText: String,
+        multiplier: String?,
+        soundName: String?
+    ) -> String {
+        var parts: [String] = ["Будильник \(time)"]
+
+        let days = sentenceCased(daysCaps)
+        if !days.isEmpty { parts.append(days) }
+
+        let price = priceText.trimmingCharacters(in: .whitespaces)
+        if !price.isEmpty { parts.append(price) }
+
+        if let multiplier = multiplier?.trimmingCharacters(in: .whitespaces), !multiplier.isEmpty {
+            parts.append(multiplier)
+        }
+        if let soundName = soundName?.trimmingCharacters(in: .whitespaces), !soundName.isEmpty {
+            parts.append(soundName)
+        }
+        return parts.joined(separator: ", ")
+    }
+
+    /// Lower-case a caps string and re-capitalise its first letter so VoiceOver
+    /// reads "Будни · Пн–Пт" instead of spelling out the all-caps form.
+    private static func sentenceCased(_ caps: String) -> String {
+        let trimmed = caps.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let first = trimmed.first else { return "" }
+        return first.uppercased() + trimmed.dropFirst().lowercased()
     }
 
     /// Legacy-style call site preserved for migration. Forwards to the
@@ -378,6 +448,7 @@ final class AlarmCell: UITableViewCell {
     @objc private func toggleSwitchChanged() {
         let isOn = toggleSwitch.isOn
         applyEnabledTone(isOn)
+        toggleSwitch.accessibilityValue = isOn ? "включён" : "выключен"
         // Recolour the caps + pill set to track the new tone.
         if let attributed = capsLabel.attributedText?.string {
             capsLabel.attributedText = NSAttributedString(

--- a/SnoozePay/SnoozePay/Views/DesignSystem/SPSwitch.swift
+++ b/SnoozePay/SnoozePay/Views/DesignSystem/SPSwitch.swift
@@ -9,16 +9,31 @@ import UIKit
 /// Subclassing (rather than a factory) keeps the type information attached
 /// to call sites: a screen that exposes `let pushToggle = SPSwitch()` makes
 /// the brand intent obvious in code review.
+///
+/// Accessibility: because this is a real `UISwitch`, VoiceOver gets the native
+/// `.button`/switch trait, the on/off value and double-tap activation for free
+/// — there's nothing custom to re-implement. What it can't infer is *which*
+/// setting the toggle controls, so every call site is responsible for setting a
+/// context `accessibilityLabel` (e.g. the alarm card sets "Будильник"). We seed
+/// a neutral fallback here so a switch that's never given one isn't announced
+/// as an anonymous control.
 final class SPSwitch: UISwitch {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
         applyBrandTint()
+        seedAccessibility()
     }
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         applyBrandTint()
+        seedAccessibility()
+    }
+
+    private func seedAccessibility() {
+        // Neutral fallback label; call sites override with a contextual one.
+        accessibilityLabel = "Переключатель"
     }
 
     private func applyBrandTint() {

--- a/SnoozePay/SnoozePayTests/AlarmCellAccessibilityTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmCellAccessibilityTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import SnoozePay
+
+/// Tests for the composed VoiceOver label `AlarmCell` builds from its display
+/// fields (#418). Without this the screen reader announced "07:00", "50 ₽",
+/// "×2" as disconnected fragments; the helper joins them into one sentence so
+/// the card reads as a single coherent control.
+final class AlarmCellAccessibilityTests: XCTestCase {
+
+    func testFullLabelComposesAllParts() {
+        let label = AlarmCell.accessibilityLabel(
+            time: "07:00",
+            daysCaps: "БУДНИ · ПН–ПТ",
+            priceText: "50 ₽",
+            multiplier: "×2",
+            soundName: "Soft Dawn"
+        )
+        XCTAssertEqual(label, "Будильник 07:00, Будни · пн–пт, 50 ₽, ×2, Soft Dawn")
+    }
+
+    func testMinimalLabelDropsOptionalParts() {
+        let label = AlarmCell.accessibilityLabel(
+            time: "9:30",
+            daysCaps: "ВЫХОДНЫЕ",
+            priceText: "100 ₽",
+            multiplier: nil,
+            soundName: nil
+        )
+        XCTAssertEqual(label, "Будильник 9:30, Выходные, 100 ₽")
+    }
+
+    func testEmptyOptionalsAreSkipped() {
+        // Empty / whitespace-only optional fields must not produce dangling
+        // ", , " separators.
+        let label = AlarmCell.accessibilityLabel(
+            time: "6:00",
+            daysCaps: "ПН, ВТ, СР",
+            priceText: "30 ₽",
+            multiplier: "",
+            soundName: "   "
+        )
+        XCTAssertEqual(label, "Будильник 6:00, Пн, вт, ср, 30 ₽")
+    }
+
+    func testEmptyDaysCapsOmitsTheSegment() {
+        let label = AlarmCell.accessibilityLabel(
+            time: "8:15",
+            daysCaps: "",
+            priceText: "25 ₽",
+            multiplier: nil,
+            soundName: nil
+        )
+        XCTAssertEqual(label, "Будильник 8:15, 25 ₽")
+    }
+
+    func testAlwaysStartsWithAlarmAndTime() {
+        let label = AlarmCell.accessibilityLabel(
+            time: "00:00",
+            daysCaps: "",
+            priceText: "",
+            multiplier: nil,
+            soundName: nil
+        )
+        XCTAssertEqual(label, "Будильник 00:00")
+    }
+}


### PR DESCRIPTION
Fixes #418

## Что сделано
- **prepareForReuse сбрасывает card chrome**: убирает ambient `shadow-1` сублой и выставляет `isEnabledTone = true`, чтобы переиспользованная ячейка не рисовала тень/тон предыдущего (disabled) будильника на один layout-pass до `configure`.
- **Accessibility AlarmCell**: ячейка стала a11y-контейнером с двумя элементами — карточка (составной label «Будильник 07:00, Будни · пн–пт, 50 ₽, ×2, Soft Dawn», `.summaryElement`) и SPSwitch (отдельный элемент с value «включён/выключен», нативная активация UISwitch). Чистый статический хелпер `AlarmCell.accessibilityLabel(...)` строит составной label из тех же полей, что и configure.
- **SPSwitch a11y**: добавлен нейтральный fallback `accessibilityLabel` («Переключатель»); call-site (карточка) переопределяет на контекстный «Будильник». Нативная on/off value и double-tap активация наследуются от UISwitch.

## Verify
- ✅ swiftlint: 0 errors (1 pre-existing-style warning: function_parameter_count на чистом хелпере, зеркалит существующий configure)
- ✅ xcodebuild build-for-testing: exit 0, 0 errors (derivedDataPath /tmp/dd-418, CODE_SIGNING_ALLOWED=NO)
- ✅ unit tests: AlarmCellAccessibilityTests — 5 кейсов на составной label (full / minimal / пустые опционалы / пустой daysCaps / минимум). test_sim отключён, прогон на CI.

Файл нового теста авто-включается через PBXFileSystemSynchronizedRootGroup (pbxproj не трогался).

🤖 Generated with [Claude Code](https://claude.com/claude-code)