### PR TITLE
[fix] Wallet: surface balance corruption + lossy-ledger error state (#419)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Wallet/DepositBottomSheetViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Wallet/DepositBottomSheetViewController.swift
@@ -353,6 +353,15 @@ final class DepositBottomSheetViewController: UIViewController {
 
     @objc private func depositTapped() {
         guard !purchaseInFlight else { return }
+        // Detect a corrupt balance BEFORE attempting a top-up (#419). The
+        // BalanceService mutation gate stays locked until the user resets via
+        // `acknowledgeCorruption()`, so a top-up here would always fail back
+        // into the generic "Покупка не выполнена" retry loop the user can't
+        // satisfy. Surface a corruption-specific message instead.
+        guard !BalanceService.shared.balanceCorrupted else {
+            presentBalanceCorruptionAlert()
+            return
+        }
         guard let preset = DepositPresets.preset(forAmount: selectedAmount) else { return }
         purchaseInFlight = true
         depositButton.isEnabled = false
@@ -418,6 +427,25 @@ final class DepositBottomSheetViewController: UIViewController {
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
             self?.dismiss(animated: true)
         }
+    }
+
+    /// Corruption-specific alert shown when the user taps "Пополнить" while
+    /// the stored balance is corrupt (#419). Unlike the generic purchase
+    /// failure, this routes the user to reset the balance — the top-up gate
+    /// stays locked until `acknowledgeCorruption()` runs, so retrying the
+    /// purchase as the generic copy suggests can never succeed.
+    private func presentBalanceCorruptionAlert() {
+        let alert = UIAlertController(
+            title: "Баланс повреждён",
+            message: "Сохранённый баланс некорректен. Пополнение недоступно, "
+                + "пока вы не сбросите баланс в ноль.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "Сбросить", style: .destructive) { _ in
+            BalanceService.shared.acknowledgeCorruption()
+        })
+        alert.addAction(UIAlertAction(title: "Отмена", style: .cancel))
+        present(alert, animated: true)
     }
 
     private func handlePurchaseFailure(message: String?) {

--- a/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletTransactionHistoryViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletTransactionHistoryViewController.swift
@@ -96,7 +96,16 @@ final class WalletTransactionHistoryViewController: UIViewController {
             sub.removeFromSuperview()
         }
 
-        let all = TransactionRepository.shared.fetchAll()
+        // Checked read so a corrupt ledger renders a distinct error banner
+        // instead of the friendly "нет операций" empty-state, which would let
+        // the user assume their history was wiped (#419) — matches the honest
+        // load-failure treatment in `StatisticsViewModel`.
+        let load = WalletLedgerLoad.load(from: TransactionRepository.shared)
+        guard !load.didFail else {
+            populateLoadErrorState()
+            return
+        }
+        let all = load.transactions
         // Period narrows by date; the summary card aggregates this whole
         // period set so its totals stay stable as the user toggles chips.
         let periodVisible = period.filter(all)
@@ -172,7 +181,10 @@ final class WalletTransactionHistoryViewController: UIViewController {
     }
 
     @objc private func periodChipTapped() {
-        let all = TransactionRepository.shared.fetchAll()
+        // Tolerate a decode failure here (the year range just narrows to the
+        // current year) — the load-error banner from `reload()` already tells
+        // the user the ledger is unreadable (#419).
+        let all = WalletLedgerLoad.load(from: TransactionRepository.shared).transactions
         let currentYear = YearMonth(date: Date()).year
         let earliestYear = all.map { YearMonth(date: $0.createdAt).year }.min() ?? currentYear
         let years = Array(min(earliestYear, currentYear)...currentYear)
@@ -261,38 +273,6 @@ final class WalletTransactionHistoryViewController: UIViewController {
         column.spacing = AppSpacing.sp1
         column.alignment = alignment == .right ? .trailing : .leading
         return column
-    }
-
-    private func makeEmptyCard(
-        hasAnyTransactions: Bool = false,
-        periodHasTransactions: Bool = false
-    ) -> UIView {
-        let card = SPCard(tone: .surface, padding: AppSpacing.sp6, cornerRadius: AppRadius.lg)
-        card.translatesAutoresizingMaskIntoConstraints = false
-        let label = UILabel()
-        let message: String
-        if !hasAnyTransactions {
-            message = "Здесь появятся пополнения, списания и бонусы."
-        } else if periodHasTransactions && typeFilter != .all {
-            // Period has rows but the active type chip filtered them all out.
-            message = "За выбранный период таких операций нет."
-        } else {
-            message = "За выбранный период операций нет."
-        }
-        label.text = message
-        label.font = AppTypography.body
-        label.textColor = AppColors.fg3
-        label.numberOfLines = 0
-        label.textAlignment = .center
-        label.translatesAutoresizingMaskIntoConstraints = false
-        card.addSubview(label)
-        NSLayoutConstraint.activate([
-            label.leadingAnchor.constraint(equalTo: card.layoutMarginsGuide.leadingAnchor),
-            label.trailingAnchor.constraint(equalTo: card.layoutMarginsGuide.trailingAnchor),
-            label.topAnchor.constraint(equalTo: card.layoutMarginsGuide.topAnchor),
-            label.bottomAnchor.constraint(equalTo: card.layoutMarginsGuide.bottomAnchor)
-        ])
-        return card
     }
 
     private func makeGroupHeader(text: String) -> UILabel {
@@ -551,5 +531,72 @@ extension WalletTransactionHistoryViewController {
         guard picked != typeFilter else { return }
         typeFilter = picked
         reload()
+    }
+
+    func makeEmptyCard(
+        hasAnyTransactions: Bool = false,
+        periodHasTransactions: Bool = false
+    ) -> UIView {
+        let card = SPCard(tone: .surface, padding: AppSpacing.sp6, cornerRadius: AppRadius.lg)
+        card.translatesAutoresizingMaskIntoConstraints = false
+        let label = UILabel()
+        let message: String
+        if !hasAnyTransactions {
+            message = "Здесь появятся пополнения, списания и бонусы."
+        } else if periodHasTransactions && typeFilter != .all {
+            // Period has rows but the active type chip filtered them all out.
+            message = "За выбранный период таких операций нет."
+        } else {
+            message = "За выбранный период операций нет."
+        }
+        label.text = message
+        label.font = AppTypography.body
+        label.textColor = AppColors.fg3
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(label)
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: card.layoutMarginsGuide.leadingAnchor),
+            label.trailingAnchor.constraint(equalTo: card.layoutMarginsGuide.trailingAnchor),
+            label.topAnchor.constraint(equalTo: card.layoutMarginsGuide.topAnchor),
+            label.bottomAnchor.constraint(equalTo: card.layoutMarginsGuide.bottomAnchor)
+        ])
+        return card
+    }
+
+    /// Builds the period chip + a distinct error card into `stack` when the
+    /// ledger fails to decode (#419). Kept in this extension so the main type
+    /// body stays under the SwiftLint cap.
+    func populateLoadErrorState() {
+        let chipRow = makePeriodChipRow()
+        stack.addArrangedSubview(chipRow)
+        stack.setCustomSpacing(AppSpacing.sp4, after: chipRow)
+        stack.addArrangedSubview(makeLoadErrorCard())
+    }
+
+    /// Distinct card for a decode failure (#419) — the corrupt-ledger case
+    /// must read as "не удалось загрузить", not the friendly empty-state, so
+    /// the user doesn't recreate data over a recoverable blob. Tinted with the
+    /// pain colour to set it apart from `makeEmptyCard`; mirrors how
+    /// `StatisticsViewModel` surfaces its checked-load error.
+    func makeLoadErrorCard() -> UIView {
+        let card = SPCard(tone: .surface, padding: AppSpacing.sp6, cornerRadius: AppRadius.lg)
+        card.translatesAutoresizingMaskIntoConstraints = false
+        let label = UILabel()
+        label.text = "Не удалось загрузить историю"
+        label.font = AppTypography.body
+        label.textColor = AppColors.pain400
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(label)
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: card.layoutMarginsGuide.leadingAnchor),
+            label.trailingAnchor.constraint(equalTo: card.layoutMarginsGuide.trailingAnchor),
+            label.topAnchor.constraint(equalTo: card.layoutMarginsGuide.topAnchor),
+            label.bottomAnchor.constraint(equalTo: card.layoutMarginsGuide.bottomAnchor)
+        ])
+        return card
     }
 }

--- a/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletViewController+Layout.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletViewController+Layout.swift
@@ -149,6 +149,30 @@ extension WalletViewController {
         return card
     }
 
+    /// Distinct error card shown when the ledger fails to decode (#419) — a
+    /// corrupt blob must read as "не удалось загрузить", NOT the friendly
+    /// "нет операций" empty-state, so the user doesn't assume their history
+    /// was wiped. Tinted with the pain colour to set it apart from the empty
+    /// card, mirroring how `StatisticsViewModel` surfaces its load error.
+    func makeTxPreviewErrorCard() -> UIView {
+        let card = SPCard(tone: .surface, padding: AppSpacing.sp5, cornerRadius: AppRadius.md)
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = AppTypography.body
+        label.textColor = AppColors.pain400
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        label.text = "Не удалось загрузить историю"
+        card.addSubview(label)
+        NSLayoutConstraint.activate([
+            label.topAnchor.constraint(equalTo: card.layoutMarginsGuide.topAnchor),
+            label.bottomAnchor.constraint(equalTo: card.layoutMarginsGuide.bottomAnchor),
+            label.leadingAnchor.constraint(equalTo: card.layoutMarginsGuide.leadingAnchor),
+            label.trailingAnchor.constraint(equalTo: card.layoutMarginsGuide.trailingAnchor)
+        ])
+        return card
+    }
+
     /// 36×36 rounded icon tile — red flame tint for charges, green tint
     /// for credits. Matches `WalletTransactionHistoryViewController` rows.
     private func makeTxIcon(systemName: String, isDebit: Bool) -> UIView {

--- a/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Wallet/WalletViewController.swift
@@ -40,6 +40,13 @@ final class WalletViewController: UIViewController {
         action: #selector(presentDepositSheet)
     )
 
+    /// Dedupe latch so the balance-corruption alert fires once per episode
+    /// even though `viewWillAppear` runs on every tab switch (and the live
+    /// notification + the pulled cold-start state could otherwise double-fire).
+    /// Reset after the user acknowledges so a future re-corruption surfaces
+    /// again. Mirrors `AlarmsListViewModel.hasSurfacedBalanceCorruption` (#206).
+    private var hasSurfacedBalanceCorruption = false
+
     // MARK: - Init
 
     init() {
@@ -85,6 +92,18 @@ final class WalletViewController: UIViewController {
             name: BalanceService.balanceChangedNotification,
             object: nil
         )
+        // Wallet is the primary balance/top-up surface — it must surface a
+        // corrupt `user_balance` (negative / NaN / infinite), which clamps to
+        // `0` in `BalanceService.balance` and would otherwise render as a
+        // silent "0 ₽" with no recovery path (#419). Covers corruption that
+        // latches while this VC is alive; cold-start corruption is pulled in
+        // `viewWillAppear` since NotificationCenter doesn't retro-deliver (#206).
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(balanceCorrupted),
+            name: BalanceService.balanceCorruptedNotification,
+            object: nil
+        )
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -95,6 +114,10 @@ final class WalletViewController: UIViewController {
         // here re-hides it.
         navigationController?.setNavigationBarHidden(true, animated: animated)
         refresh()
+        // Pull corruption latched BEFORE this VC observed it (cold start: the
+        // BalanceService init-time probe posts with no listener attached, and
+        // NotificationCenter drops it for late subscribers — #206).
+        surfacePendingBalanceCorruption()
     }
 
     // MARK: - Layout
@@ -173,23 +196,72 @@ final class WalletViewController: UIViewController {
     private func refresh() {
         let balance = BalanceService.shared.balance
         let decimal = Decimal(balance)
-        let delta = WalletStats.weeklyDelta()
+        // Checked read so a corrupt ledger drives the error banner instead of
+        // the lossy `fetchAll()` rendering a deceptive empty preview (#419).
+        // Shared across the delta, the chart and the preview so a single
+        // decode failure classifies all three the same way.
+        let load = WalletLedgerLoad.load(from: TransactionRepository.shared)
+        let transactions = load.transactions
+        let delta = load.didFail ? nil : WalletStats.weeklyDelta(from: transactions)
         let hint = WalletHints.affordHint(forBalance: balance, averagePrice: 50)
         balanceCard.update(balance: decimal, delta: delta, hint: hint)
-        weeklyChart.update(values: WalletStats.weeklyPenaltyTotals())
-        rebuildTxPreview()
+        weeklyChart.update(values: WalletStats.weeklyPenaltyTotals(from: transactions))
+        rebuildTxPreview(load: load)
     }
 
-    private func rebuildTxPreview() {
+    private func rebuildTxPreview(load: WalletLedgerLoad) {
         for sub in txPreviewHost.arrangedSubviews {
             txPreviewHost.removeArrangedSubview(sub)
             sub.removeFromSuperview()
         }
+        guard !load.didFail else {
+            txPreviewHost.addArrangedSubview(makeTxPreviewErrorCard())
+            return
+        }
         let items = WalletTransactionPreview.items(
-            from: TransactionRepository.shared.fetchAll(),
+            from: load.transactions,
             alarmLookup: { AlarmRepository.shared.fetch(id: $0) }
         )
         txPreviewHost.addArrangedSubview(makeTxPreviewCard(items: items))
+    }
+
+    // MARK: - Balance corruption (#119 / #206 / #419)
+
+    @objc private func balanceCorrupted(_ note: Notification) {
+        let raw = note.userInfo?[BalanceService.balanceCorruptedRawValueKey] as? Double
+        DispatchQueue.main.async { [weak self] in
+            self?.surfaceBalanceCorruption(rawValue: raw)
+        }
+    }
+
+    /// Pulls corruption state latched before this VC attached its observer.
+    private func surfacePendingBalanceCorruption() {
+        guard BalanceService.shared.balanceCorrupted else { return }
+        surfaceBalanceCorruption(rawValue: BalanceService.shared.corruptedRawValue)
+    }
+
+    private func surfaceBalanceCorruption(rawValue: Double?) {
+        guard !hasSurfacedBalanceCorruption else { return }
+        hasSurfacedBalanceCorruption = true
+
+        let alert = UIAlertController(
+            title: "Баланс повреждён",
+            message: "Сохранённый баланс некорректен и был сброшен в ноль. "
+                + "Пополнения временно недоступны, пока вы не подтвердите сброс.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "Сбросить", style: .destructive) { [weak self] _ in
+            BalanceService.shared.acknowledgeCorruption()
+            // Allow a future re-corruption episode to surface a fresh alert.
+            self?.hasSurfacedBalanceCorruption = false
+            self?.refresh()
+        })
+        alert.addAction(UIAlertAction(title: "Позже", style: .cancel) { [weak self] _ in
+            // Keep the gate visible: a dismissed alert must still re-prompt on
+            // the next appearance until the user resets.
+            self?.hasSurfacedBalanceCorruption = false
+        })
+        present(alert, animated: true)
     }
 
     // MARK: - Navigation
@@ -220,12 +292,17 @@ enum WalletStats {
 
     /// Net change over the last 7 days. Positive = the user added more
     /// than they paid in penalties; negative = penalties dominated.
-    static func weeklyDelta() -> Decimal? {
+    ///
+    /// Takes a pre-loaded, decode-checked transaction list (#419) so the
+    /// caller's single `WalletLedgerLoad` drives the delta, the chart and the
+    /// preview together — a corrupt ledger surfaces a banner instead of these
+    /// reading a lossy `fetchAll()` and silently rendering a zero delta.
+    static func weeklyDelta(from transactions: [Transaction]) -> Decimal? {
         let calendar = Calendar.current
         guard let weekAgo = calendar.date(byAdding: .day, value: -7, to: Date()) else {
             return nil
         }
-        let recent = TransactionRepository.shared.fetchAll().filter {
+        let recent = transactions.filter {
             $0.createdAt >= weekAgo
         }
         guard !recent.isEmpty else { return nil }
@@ -244,12 +321,12 @@ enum WalletStats {
 
     /// Per-day pain totals for the trailing 7-day window, oldest → newest.
     /// Used by `WalletWeeklyChartView` — only `.charge` rows contribute.
-    static func weeklyPenaltyTotals() -> [Decimal] {
+    /// Takes the caller's decode-checked transaction list (#419).
+    static func weeklyPenaltyTotals(from transactions: [Transaction]) -> [Decimal] {
         let calendar = Calendar.current
         let today = calendar.startOfDay(for: Date())
         var totals = Array(repeating: Decimal.zero, count: 7)
-        let all = TransactionRepository.shared.fetchAll()
-        for transaction in all where transaction.type == .charge {
+        for transaction in transactions where transaction.type == .charge {
             let day = calendar.startOfDay(for: transaction.createdAt)
             guard let diff = calendar.dateComponents([.day], from: day, to: today).day else {
                 continue

--- a/SnoozePay/SnoozePay/ViewModels/WalletLedgerLoad.swift
+++ b/SnoozePay/SnoozePay/ViewModels/WalletLedgerLoad.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Read seam the Wallet surfaces share so the reload decision — "render
+/// rows / empty-state vs. a load-error banner" — can be unit-tested with a
+/// mock that fails its decode without standing up `UserDefaults` corruption
+/// (issue #419). `TransactionRepository` is the production conformer.
+///
+/// Mirrors the `fetchAllChecked()` contract: a decode failure throws instead
+/// of being swallowed into a misleading `[]` (the lossy `fetchAll()` was what
+/// let a corrupt ledger render as the friendly "нет операций" empty-state).
+protocol WalletLedgerReading {
+    func fetchAllChecked() throws -> [Transaction]
+}
+
+extension TransactionRepository: WalletLedgerReading {}
+
+/// Outcome of a checked ledger read for a Wallet surface. The VCs branch on
+/// this to pick rendering: `.loaded` drives rows / empty-state, `.failed`
+/// drives the distinct "Не удалось загрузить историю" banner — the same
+/// honest-corruption treatment `StatisticsViewModel` gives its load (#72/#419).
+enum WalletLedgerLoad {
+    case loaded([Transaction])
+    case failed
+
+    /// Performs the checked read and collapses any error into `.failed`.
+    /// Centralised so the three Wallet read sites (preview, weekly stats,
+    /// full history) can never drift on how a decode failure is classified.
+    static func load(from repository: WalletLedgerReading) -> WalletLedgerLoad {
+        do {
+            return .loaded(try repository.fetchAllChecked())
+        } catch {
+            return .failed
+        }
+    }
+
+    /// Transactions to render, or `[]` when the load failed (the caller shows
+    /// the error banner instead of trusting this emptiness as "no operations").
+    var transactions: [Transaction] {
+        switch self {
+        case .loaded(let txs): return txs
+        case .failed: return []
+        }
+    }
+
+    /// `true` when the ledger could not be decoded — the surface must show a
+    /// load-error banner rather than a friendly empty-state.
+    var didFail: Bool {
+        switch self {
+        case .loaded: return false
+        case .failed: return true
+        }
+    }
+}

--- a/SnoozePay/SnoozePayTests/WalletLedgerLoadTests.swift
+++ b/SnoozePay/SnoozePayTests/WalletLedgerLoadTests.swift
@@ -1,0 +1,162 @@
+import XCTest
+@testable import SnoozePay
+
+/// Unit tests for the Wallet reload decision logic (#419).
+///
+/// The Wallet surfaces (preview, weekly stats, full history) previously read
+/// the lossy `TransactionRepository.fetchAll()`, so a corrupt ledger rendered
+/// as the friendly "нет операций" empty-state. `WalletLedgerLoad` now wraps a
+/// decode-checked read and classifies the outcome so the VCs render a distinct
+/// error banner instead — these tests pin that classification with a mock that
+/// throws (mirroring `StatisticsViewModel`'s checked load), and verify the real
+/// `TransactionRepository` path against a corrupt blob written to disk.
+final class WalletLedgerLoadTests: XCTestCase {
+
+    // MARK: - Mock
+
+    /// Outcome a `MockLedger` replays — a fixed list or a decode failure,
+    /// standing in for a corrupt `UserDefaults` blob without one.
+    private enum MockOutcome {
+        case success([Transaction])
+        case failure
+    }
+
+    /// Mock ledger reader driving the reload decision under test.
+    private final class MockLedger: WalletLedgerReading {
+        let outcome: MockOutcome
+
+        init(outcome: MockOutcome) {
+            self.outcome = outcome
+        }
+
+        func fetchAllChecked() throws -> [Transaction] {
+            switch outcome {
+            case .success(let txs):
+                return txs
+            case .failure:
+                throw TransactionRepository.RepositoryError.decodeFailure(
+                    underlying: NSError(domain: "test", code: 1)
+                )
+            }
+        }
+    }
+
+    // MARK: - Decision: failure → error-state, NOT empty-state
+
+    func testLoad_whenDecodeFails_classifiesAsFailed() {
+        let load = WalletLedgerLoad.load(from: MockLedger(outcome: .failure))
+
+        XCTAssertTrue(load.didFail, "A decode failure must surface the error banner")
+        XCTAssertTrue(load.transactions.isEmpty)
+    }
+
+    func testLoad_whenDecodeFails_yieldsNoTransactions_butIsDistinctFromEmpty() {
+        let failed = WalletLedgerLoad.load(from: MockLedger(outcome: .failure))
+        let empty = WalletLedgerLoad.load(from: MockLedger(outcome: .success([])))
+
+        // Both have zero transactions...
+        XCTAssertTrue(failed.transactions.isEmpty)
+        XCTAssertTrue(empty.transactions.isEmpty)
+        // ...but only the failure drives the error banner — the empty ledger
+        // must keep the friendly empty-state (the #419 regression was these
+        // two being indistinguishable through lossy `fetchAll()`).
+        XCTAssertTrue(failed.didFail)
+        XCTAssertFalse(empty.didFail)
+    }
+
+    // MARK: - Decision: success → loaded with the rows
+
+    func testLoad_whenDecodeSucceeds_classifiesAsLoadedWithRows() {
+        let txs = [
+            Transaction(type: .topup, amount: 500),
+            Transaction(type: .charge, amount: 50)
+        ]
+        let load = WalletLedgerLoad.load(from: MockLedger(outcome: .success(txs)))
+
+        XCTAssertFalse(load.didFail)
+        XCTAssertEqual(load.transactions.count, 2)
+    }
+
+    func testLoad_whenLedgerEmpty_isLoadedNotFailed() {
+        let load = WalletLedgerLoad.load(from: MockLedger(outcome: .success([])))
+
+        XCTAssertFalse(load.didFail, "An empty ledger is a legitimate empty-state, not an error")
+        XCTAssertTrue(load.transactions.isEmpty)
+    }
+
+    // MARK: - Real repository: corrupt blob → failed
+
+    func testLoad_realRepository_withCorruptBlob_isFailed() {
+        let suiteName = "test.walletLedger.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        // Write bytes that can't decode into `[Transaction]` — the exact
+        // corruption mode `fetchAllChecked()` is meant to catch (#72/#210).
+        defaults.set(Data("{not valid json".utf8), forKey: "stored_transactions")
+        let repo = TransactionRepository(defaults: defaults)
+
+        let load = WalletLedgerLoad.load(from: repo)
+
+        XCTAssertTrue(load.didFail, "Corrupt persisted ledger must classify as failed")
+        XCTAssertTrue(repo.lastLoadFailed, "Checked read latches the repository lock")
+    }
+
+    func testLoad_realRepository_withValidLedger_isLoaded() {
+        let suiteName = "test.walletLedger.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let repo = TransactionRepository(defaults: defaults)
+        repo.record(Transaction(type: .topup, amount: 300))
+
+        let load = WalletLedgerLoad.load(from: repo)
+
+        XCTAssertFalse(load.didFail)
+        XCTAssertEqual(load.transactions.count, 1)
+    }
+}
+
+/// Tests the Deposit-sheet gating decision (#419): a corrupt balance must be
+/// detected BEFORE attempting a top-up, since `BalanceService` keeps the
+/// mutation gate locked until `acknowledgeCorruption()` — so a top-up would
+/// always fail back into the generic, unsatisfiable retry loop.
+final class DepositCorruptionGateTests: XCTestCase {
+
+    private var testDefaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "test.depositGate.\(UUID().uuidString)"
+        testDefaults = UserDefaults(suiteName: suiteName)!
+    }
+
+    override func tearDown() {
+        testDefaults.removePersistentDomain(forName: suiteName)
+        super.tearDown()
+    }
+
+    func testCorruptBalance_isDetected_andTopUpStaysGated() {
+        // Seed a negative (corrupt) balance, then construct the service so its
+        // init-time probe latches the corruption flag.
+        testDefaults.set(-100.0, forKey: "user_balance")
+        let service = BalanceService(defaults: testDefaults, notificationCenter: NotificationCenter())
+
+        // The Deposit sheet's pre-top-up guard reads exactly this flag.
+        XCTAssertTrue(service.balanceCorrupted, "Negative balance must flip the corruption flag")
+
+        // And the gate would have blocked the top-up anyway — proving the
+        // detection guard isn't merely cosmetic: without it the user hits the
+        // generic failure they can't satisfy.
+        XCTAssertFalse(service.topUp(amount: 50), "Top-up must stay gated while corrupt")
+    }
+
+    func testHealthyBalance_isNotFlaggedCorrupt() {
+        testDefaults.set(500.0, forKey: "user_balance")
+        let service = BalanceService(defaults: testDefaults, notificationCenter: NotificationCenter())
+
+        XCTAssertFalse(service.balanceCorrupted)
+        XCTAssertTrue(service.topUp(amount: 50), "Healthy balance accepts top-up")
+    }
+}


### PR DESCRIPTION
Fixes #419

## Что сделано
- **Corrupt balance now has a recovery path.** `WalletViewController` observes `balanceCorruptedNotification` and checks `BalanceService.shared.balanceCorrupted` in `viewWillAppear` (mirroring `AlarmsListViewModel.checkPendingCorruption` / #206), presenting a reset alert that routes to `acknowledgeCorruption()`. `DepositBottomSheetViewController.depositTapped()` detects the corruption gate **before** attempting a top-up and shows a corruption-specific message instead of the generic, unsatisfiable "Покупка не выполнена" retry loop.
- **Corrupt ledger no longer renders as a friendly empty-state.** New `WalletLedgerLoad` wraps the decode-checked `fetchAllChecked()` read; `WalletViewController` (preview + weekly delta/chart) and `WalletTransactionHistoryViewController.reload()` now branch on it and render a distinct "Не удалось загрузить историю" banner, like `StatisticsViewModel` does — instead of the lossy `fetchAll()` masking a corrupt blob as "нет операций".
- Out of scope (#358/#359/#400) left untouched: refund-as-`.topup`, StoreKit price, revenue accounting.

## Verify
- ✅ swiftlint: 0 errors in touched files (1 pre-existing line-length warning in `DepositBottomSheetViewController`, not in this diff)
- ✅ `xcodebuild build-for-testing` (iphonesimulator, generic destination): exit 0
- ✅ tests: `WalletLedgerLoadTests` + `DepositCorruptionGateTests` — 8/8 passed (mock repo with `lastLoadFailed`/decode-failure → error-state not empty-state; corrupt `balanceCorrupted` flag detected and top-up stays gated)

## Tests added
`SnoozePayTests/WalletLedgerLoadTests.swift`:
- decode failure → `.failed` (error banner), distinct from empty `.loaded([])` (the #419 regression)
- real `TransactionRepository` with a corrupt blob → `didFail == true` + `lastLoadFailed`
- negative `user_balance` → `balanceCorrupted == true` and `topUp` stays gated