### PR TITLE
[fix] Re-arm alarms on timezone/DST/reboot/auth change (#427)

### DIFF
--- a/SnoozePay/SnoozePay/AppDelegate.swift
+++ b/SnoozePay/SnoozePay/AppDelegate.swift
@@ -20,6 +20,12 @@ private final class ObserverBox: @unchecked Sendable {
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
+    /// Tokens for the time-change / activation observers that drive alarm
+    /// re-arming (#427). Held for the app's lifetime so the observers stay
+    /// registered; the `AppDelegate` lives as long as the process, so they are
+    /// never explicitly removed.
+    private var rescheduleObserverTokens: [NSObjectProtocol] = []
+
     func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
@@ -56,6 +62,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // system alert (#379). No-op on iOS < 26 / when AlarmKit is absent.
         AlarmKitAlertObserver.shared.start()
 
+        // Re-arm saved alarms whenever the wall-clock interpretation of their
+        // triggers may have shifted (timezone / DST change, reboot) or the
+        // backend that should own them may have changed (AlarmKit / notification
+        // authorization toggled in Settings). Without this, alarms keep whatever
+        // triggers they had at save time and silently fire at the wrong time —
+        // or never re-arm onto the notification fallback after AlarmKit is
+        // revoked (#427). The first foreground after launch covers reboot.
+        registerAlarmRescheduleObservers()
+
         // Reclaim orphaned custom-theme JPEGs (#357): re-picking a photo or
         // deleting a `.custom`-themed alarm leaves its image on disk forever.
         // Sweep off the main thread against the live alarm set — only files no
@@ -85,6 +100,51 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         didDiscardSceneSessions sceneSessions: Set<UISceneSession>
     ) {}
+
+    // MARK: - Alarm re-arming (#427)
+
+    /// Observe the two system signals that can silently invalidate already
+    /// scheduled alarm triggers and re-arm every saved alarm in response:
+    ///
+    /// - `significantTimeChangeNotification` — posted on timezone change, DST
+    ///   transition, and midnight rollover. This is the primary defence against
+    ///   an alarm firing at the wrong wall-clock after the user crosses a
+    ///   timezone or the clocks shift.
+    /// - `didBecomeActiveNotification` — posted on every foreground, including
+    ///   the first one after a cold launch (so reboot is covered) and after the
+    ///   user returns from Settings having toggled AlarmKit / notification
+    ///   permission (so `usesAlarmKit` is re-evaluated and the alarm moves to
+    ///   the correct backend).
+    ///
+    /// Re-arming is idempotent — for an unchanged alarm `cancel` + `schedule`
+    /// re-adds the same deterministic notification identifiers — so firing it on
+    /// every activation only recomputes triggers, never duplicates them.
+    private func registerAlarmRescheduleObservers() {
+        let names: [Notification.Name] = [
+            UIApplication.significantTimeChangeNotification,
+            UIApplication.didBecomeActiveNotification
+        ]
+        rescheduleObserverTokens = names.map { name in
+            NotificationCenter.default.addObserver(
+                forName: name,
+                object: nil,
+                queue: .main
+            ) { _ in
+                AppDelegate.rescheduleSavedAlarms(trigger: name)
+            }
+        }
+    }
+
+    /// Re-arm every saved alarm against the current clock / timezone / backend.
+    /// `static` so the `@Sendable` observer closure does not capture `self`
+    /// (the work touches only the `AlarmScheduler` / `AlarmRepository`
+    /// singletons, which manage their own state).
+    private static func rescheduleSavedAlarms(trigger: Notification.Name) {
+        AppLogger.appDelegate.info(
+            "re-arming saved alarms (trigger=\(trigger.rawValue, privacy: .public))"
+        )
+        AlarmScheduler.shared.rescheduleAll(AlarmRepository.shared.fetchAll())
+    }
 
     // MARK: - Permission UI
 

--- a/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
@@ -687,6 +687,40 @@ final class AlarmScheduler: AlarmScheduling {
         notificationCenter.removeAllPendingNotificationRequests()
     }
 
+    /// Re-arm every enabled alarm from scratch — cancel its existing triggers
+    /// (both backends) and schedule it again. Mirrors the `cancel` → `schedule`
+    /// sequence `AlarmRepository.save(_:)` already uses, so the wallet / backend
+    /// semantics are identical to a normal save.
+    ///
+    /// Called when something that silently invalidates already-scheduled
+    /// triggers may have changed out from under us (#427):
+    ///
+    /// - **Timezone / DST shift.** `UNCalendarNotificationTrigger` interprets
+    ///   its date components in `Calendar.current` at fire time, so a one-time
+    ///   alarm armed in TZ A fires at the wrong wall-clock after moving to TZ B,
+    ///   and a repeating trigger drifts an hour across a DST boundary. Re-arming
+    ///   recomputes every trigger against the current calendar.
+    /// - **Reboot.** Re-evaluates triggers in case the clock / timezone changed
+    ///   while the device was powered off.
+    /// - **Authorization change.** `usesAlarmKit` is computed live from the
+    ///   AlarmKit grant, so toggling AlarmKit / notification permission in
+    ///   Settings flips which backend should own each alarm. Without re-arming,
+    ///   an alarm scheduled under the old grant is never moved to the now-correct
+    ///   backend (e.g. AlarmKit revoked → no notification fallback is ever armed).
+    ///
+    /// Disabled alarms are skipped: they hold no triggers to re-arm and
+    /// `schedule(_:)` is already a no-op for them.
+    func rescheduleAll(_ alarms: [Alarm]) {
+        let enabled = alarms.filter { $0.enabled }
+        AppLogger.scheduler.info(
+            "rescheduleAll: re-arming \(enabled.count, privacy: .public) of \(alarms.count, privacy: .public) alarms"
+        )
+        for alarm in enabled {
+            cancel(alarm.id)
+            schedule(alarm)
+        }
+    }
+
     /// Stop a currently-alerting AlarmKit (Strategy A) system alarm — invoked
     /// from `AlarmKitActionRouter` when the user taps stop / snooze on the
     /// system alert. No-op on iOS < 26 / when no AlarmKit backend is wired

--- a/SnoozePay/SnoozePayTests/AlarmSchedulerRescheduleAllTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmSchedulerRescheduleAllTests.swift
@@ -1,0 +1,129 @@
+import XCTest
+import UserNotifications
+@testable import SnoozePay
+
+/// Issue #427 — saved alarms were never re-armed after a timezone / DST shift,
+/// a reboot, or an AlarmKit / notification authorization change, so they could
+/// fire at the wrong wall-clock time or stop firing entirely. `rescheduleAll`
+/// is the re-arm primitive AppDelegate calls from the relevant system signals.
+/// It must `cancel` + `schedule` every **enabled** alarm and leave **disabled**
+/// ones untouched (they hold no triggers to re-arm).
+final class AlarmSchedulerRescheduleAllTests: XCTestCase {
+
+    /// The schedule path hops through `DispatchQueue.main.async` (the 64-pending
+    /// pre-flight) before reaching `add`. Enqueueing a fulfilment block on main
+    /// after `rescheduleAll` lets those queued schedule turns run first (FIFO),
+    /// so `add` has landed by the time assertions run.
+    private func drainMainQueue() {
+        let drained = expectation(description: "main queue drained")
+        DispatchQueue.main.async { drained.fulfill() }
+        wait(for: [drained], timeout: 5)
+    }
+
+    private func dailyAlarm(name: String, enabled: Bool) -> Alarm {
+        // A 7-day repeat guarantees a trigger regardless of the current time, so
+        // the schedule path actually reaches `add` for enabled alarms.
+        Alarm(repeatDays: [0, 1, 2, 3, 4, 5, 6], name: name, enabled: enabled)
+    }
+
+    func testRescheduleAll_reschedulesEnabled_skipsDisabled() {
+        let center = RecordingNotificationCenter()
+        let scheduler = AlarmScheduler(notificationCenter: center)
+
+        let on = dailyAlarm(name: "On", enabled: true)
+        let off = dailyAlarm(name: "Off", enabled: false)
+
+        scheduler.rescheduleAll([on, off])
+        drainMainQueue()
+
+        // Enabled alarm was re-armed: at least one notification request added,
+        // every added identifier belongs to it.
+        XCTAssertFalse(center.addedIdentifiers.isEmpty,
+                       "Enabled alarm must be rescheduled (add called)")
+        XCTAssertTrue(
+            center.addedIdentifiers.allSatisfy { $0.contains(on.id.uuidString) },
+            "Every added request must belong to the enabled alarm"
+        )
+
+        // Disabled alarm was skipped entirely — its id appears in neither the
+        // adds nor the cancel removals.
+        XCTAssertFalse(
+            center.addedIdentifiers.contains { $0.contains(off.id.uuidString) },
+            "Disabled alarm must not be scheduled"
+        )
+        XCTAssertFalse(
+            center.removedIdentifiers.contains { $0.contains(off.id.uuidString) },
+            "Disabled alarm must not be cancelled (nothing to re-arm)"
+        )
+
+        // Enabled alarm was cancelled before being re-scheduled (cancel removes
+        // its explicit pending identifiers synchronously).
+        XCTAssertTrue(
+            center.removedIdentifiers.contains { $0.contains(on.id.uuidString) },
+            "Enabled alarm must be cancelled before reschedule"
+        )
+    }
+
+    func testRescheduleAll_allDisabled_doesNothing() {
+        let center = RecordingNotificationCenter()
+        let scheduler = AlarmScheduler(notificationCenter: center)
+
+        scheduler.rescheduleAll([
+            dailyAlarm(name: "A", enabled: false),
+            dailyAlarm(name: "B", enabled: false)
+        ])
+
+        XCTAssertTrue(center.addedIdentifiers.isEmpty,
+                      "No enabled alarms — nothing should be scheduled")
+    }
+
+    func testRescheduleAll_emptyList_doesNothing() {
+        let center = RecordingNotificationCenter()
+        let scheduler = AlarmScheduler(notificationCenter: center)
+
+        scheduler.rescheduleAll([])
+
+        XCTAssertTrue(center.addedIdentifiers.isEmpty)
+        XCTAssertTrue(center.removedIdentifiers.isEmpty)
+    }
+}
+
+// MARK: - Test double
+
+/// `NotificationScheduling` stub that answers the 64-pending pre-flight
+/// immediately (so `schedule` reaches `add` synchronously) and records every
+/// added / removed identifier for assertions.
+private final class RecordingNotificationCenter: NotificationScheduling {
+    private(set) var addedIdentifiers: [String] = []
+    private(set) var removedIdentifiers: [String] = []
+
+    func add(
+        _ request: UNNotificationRequest,
+        withCompletionHandler completion: ((Error?) -> Void)?
+    ) {
+        addedIdentifiers.append(request.identifier)
+        completion?(nil)
+    }
+    func getPendingNotificationRequests(
+        completionHandler: @escaping ([UNNotificationRequest]) -> Void
+    ) {
+        completionHandler([])
+    }
+    func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {
+        removedIdentifiers.append(contentsOf: identifiers)
+    }
+    func removeDeliveredNotifications(withIdentifiers identifiers: [String]) {}
+    func getDeliveredNotifications(
+        completionHandler: @escaping ([UNNotification]) -> Void
+    ) {
+        completionHandler([])
+    }
+    func setNotificationCategories(_ categories: Set<UNNotificationCategory>) {}
+    func removeAllPendingNotificationRequests() {}
+    func requestAuthorization(
+        options: UNAuthorizationOptions,
+        completionHandler: @escaping (Bool, Error?) -> Void
+    ) {
+        completionHandler(false, nil)
+    }
+}


### PR DESCRIPTION
Fixes #427

## Проблема
Не было пути перевзвода будильников после reboot / смены timezone / DST / смены авторизации. `UNCalendarNotificationTrigger` интерпретируется в `Calendar.current` на момент срабатывания — будильник, запланированный в TZ A, после переезда в TZ B звонит не в то wall-clock время, repeating-триггеры сдвигаются на DST. А `usesAlarmKit` вычисляется live: снял AlarmKit-auth в Settings — на relaunch ничего не перепланировало будильник через notification-fallback.

## Фикс
- `AlarmScheduler.rescheduleAll(_:)` — cancel + schedule каждого **enabled** будильника (та же последовательность, что и `AlarmRepository.save`), disabled пропускаются.
- Вызов из `AppDelegate`:
  - `significantTimeChangeNotification` — TZ / DST / полночь.
  - `didBecomeActiveNotification` — первый foreground после cold launch покрывает reboot; возврат из Settings покрывает смену AlarmKit/notification auth (`usesAlarmKit` перевычисляется, будильник переезжает на корректный backend).
- Re-arm идемпотентен: для неизменного будильника `cancel` + `schedule` переустанавливает те же детерминированные notification-id, без дублей.

## Тесты
`AlarmSchedulerRescheduleAllTests`:
- `testRescheduleAll_reschedulesEnabled_skipsDisabled`
- `testRescheduleAll_allDisabled_doesNothing`
- `testRescheduleAll_emptyList_doesNothing`

Локально: build_sim SUCCEEDED, 3/3 теста PASS, swiftlint 0 serious.

⚠️ Device-проверка на реальном iOS 26 (физическая смена TZ/DST) желательна — оставлено на PM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)