### PR TITLE
[fix] Refresh AlarmsList header balanceHint on successful toggle (#429)

### DIFF
--- a/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
@@ -275,6 +275,17 @@ final class AlarmsListViewModel {
             onAlarmsUpdated?()
             return
         }
+
+        // Success path: the new enabled state is persisted (the `guard` above
+        // passed). The cell repaints its own switch, but the sticky header's
+        // affordability hint (`balanceHint`, derived from `averagePenalty`)
+        // shifts when an alarm with an outlier penalty is toggled — without a
+        // refresh here the header pill keeps the stale "~N откладываний" number
+        // until the next `viewWillAppear` (#429). `onBalanceUpdated` re-resolves
+        // the header without a full table reload (the cell already updated). A
+        // later async scheduling failure re-fires the header via the
+        // rollback path's `onAlarmsUpdated`, re-syncing it to the reverted state.
+        onBalanceUpdated?(balance)
     }
 
     // MARK: - Delete

--- a/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
@@ -292,6 +292,29 @@ final class AlarmsListViewModelTests: XCTestCase {
         )
     }
 
+    /// Issue #429: a successful toggle changes `averagePenalty`, which the
+    /// sticky header's `balanceHint` ("Хватит на ~N откладываний") is derived
+    /// from. The cell repaints itself, but the header must also refresh — so the
+    /// success path fires `onBalanceUpdated` (lighter than `onAlarmsUpdated`: no
+    /// table reload). Without it the affordability pill kept a stale number until
+    /// the next viewWillAppear.
+    func testToggleAlarm_successFiresOnBalanceUpdatedForHeaderRefresh() {
+        repo.save(Alarm(penaltyAmount: 50, enabled: true))
+
+        let vm = makeViewModel()
+        vm.loadData()
+
+        var balanceEmissions = 0
+        vm.onBalanceUpdated = { _ in balanceEmissions += 1 }
+
+        vm.toggleAlarm(id: vm.alarms[0].id, enabled: false)
+
+        XCTAssertEqual(
+            balanceEmissions, 1,
+            "Successful toggle must fire onBalanceUpdated so the header re-resolves balanceHint (#429)"
+        )
+    }
+
     // MARK: - toggleAlarm(id:enabled:)
 
     /// Regression for issue #35: when the alarm exists in the VM's in-memory snapshot


### PR DESCRIPTION
Fixes #429

## Проблема
`AlarmsListViewModel.toggleAlarm` на УСПЕШНОМ toggle мутировал `alarms[index]` и возвращался молча — ячейка перекрашивалась сама, но `onBalanceUpdated`/`onAlarmsUpdated` не фаерился (только на failure/rollback). Header (`balanceHint` «Хватит на ~N откладываний», зависящий от `averagePenalty`) держал старое число до следующего `viewWillAppear`. Toggle будильника с outlier-штрафом тихо сдвигал affordability-математику.

## Фикс
На success-пути `toggleAlarm` (после прохождения `guard didUpdate`) фаерим `onBalanceUpdated?(balance)` → header перерезолвит `balanceHint`. Выбран `onBalanceUpdated`, а не `onAlarmsUpdated`, чтобы сохранить существующий контракт «успешный toggle не делает table reload» (ячейка уже обновилась) — этот контракт зафиксирован тестами `testToggleAlarm_emitsOnAlarmsUpdatedExactlyOnce` / `_schedulingSuccess_doesNotFireOnLoadError`, оба остаются зелёными.

Async scheduling-failure по-прежнему перефаеривает header через rollback-путь (`onAlarmsUpdated`), ресинкая его к откатанному состоянию.

## Scope
Вторичный пункт из тела issue (`weeklyDelta` читает lossy `fetchCharges`) оставлен отдельным follow-up'ом — там другая поверхность (баннер corrupt-ledger), не смешиваю.

## Тесты
`testToggleAlarm_successFiresOnBalanceUpdatedForHeaderRefresh` + 23 существующих теста класса — 24/24 PASS. build_sim SUCCEEDED, swiftlint 0 violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)