### PR TITLE
[ui] Contextual VoiceOver labels for settings switches (#425)

### DIFF
--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/ProgressiveScaleCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/ProgressiveScaleCell.swift
@@ -99,6 +99,10 @@ final class ProgressiveScaleCell: UITableViewCell {
         contentStack.setCustomSpacing(AppSpacing.sp3, after: subtitleLabel)
 
         toggle.translatesAutoresizingMaskIntoConstraints = false
+        // VoiceOver otherwise reads the brand `SPSwitch` as the generic
+        // "Переключатель". Give it the row's title so the control is
+        // self-describing, mirroring AlarmCell's pattern (#425).
+        toggle.accessibilityLabel = titleLabel.text
 
         contentView.addSubview(contentStack)
         contentView.addSubview(toggle)

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/VibrationCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/Cells/VibrationCell.swift
@@ -50,6 +50,11 @@ final class VibrationCell: UITableViewCell {
         backgroundColor = AppColors.bg1
         selectionStyle = .none
         toggle.translatesAutoresizingMaskIntoConstraints = false
+        // Without this VoiceOver announces the brand `SPSwitch` as the generic
+        // "Переключатель"; the adjacent title reads separately but the switch
+        // itself carries no context. Mirror AlarmCell's contextual-label pattern
+        // (#425) so the control is self-describing.
+        toggle.accessibilityLabel = titleLabel.text
 
         contentView.addSubview(iconView)
         contentView.addSubview(titleLabel)

--- a/SnoozePay/SnoozePay/ViewControllers/Alarms/VolumePickerViewController.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Alarms/VolumePickerViewController.swift
@@ -199,6 +199,10 @@ final class VolumePickerViewController: UIViewController {
             fadeRow.topAnchor.constraint(equalTo: fadeRowContainer.layoutMarginsGuide.topAnchor),
             fadeRow.bottomAnchor.constraint(equalTo: fadeRowContainer.layoutMarginsGuide.bottomAnchor)
         ])
+        // VoiceOver otherwise announces the brand `SPSwitch` as the generic
+        // "Переключатель". Give it the fade row's title so the control is
+        // self-describing (#425), mirroring the volume slider's label above.
+        fadeSwitch.accessibilityLabel = "Постепенно нарастает"
         fadeSwitch.addTarget(self, action: #selector(fadeToggled), for: .valueChanged)
     }
 

--- a/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsIconRowCell.swift
+++ b/SnoozePay/SnoozePay/ViewControllers/Settings/SettingsIconRowCell.swift
@@ -179,6 +179,11 @@ final class SettingsIconRowCell: UITableViewCell {
         trailingSwitch.isOn = isOn
         trailingSwitch.isEnabled = enabled
         trailingSwitch.alpha = enabled ? 1.0 : 0.5
+        // VoiceOver otherwise announces the brand `SPSwitch` as the generic
+        // "Переключатель". This cell is reused for several rows (Critical Alerts,
+        // …), so take the label from the configured row title to stay contextual
+        // (#425), mirroring AlarmCell's pattern.
+        trailingSwitch.accessibilityLabel = title
         onSwitchChange = onChange
     }
 
@@ -194,5 +199,6 @@ final class SettingsIconRowCell: UITableViewCell {
         trailingSwitch.isHidden = true
         trailingSwitch.isEnabled = true
         trailingSwitch.alpha = 1.0
+        trailingSwitch.accessibilityLabel = nil
     }
 }

--- a/SnoozePay/SnoozePayTests/SwitchAccessibilityLabelTests.swift
+++ b/SnoozePay/SnoozePayTests/SwitchAccessibilityLabelTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import SnoozePay
+
+/// Issue #425 — the brand `SPSwitch` in the Vibration / Critical Alerts /
+/// Progressive rows was announced by VoiceOver as the generic "Переключатель"
+/// with no context. Each switch now carries a contextual `accessibilityLabel`
+/// taken from its row title. These tests find the switch in each cell's view
+/// tree and assert the label, so a future refactor can't silently drop it.
+final class SwitchAccessibilityLabelTests: XCTestCase {
+
+    /// Depth-first search for the first `SPSwitch` in a view subtree — the
+    /// switches are private subviews, so we locate them structurally rather
+    /// than exposing internals just for the test.
+    private func firstSwitch(in view: UIView) -> SPSwitch? {
+        for subview in view.subviews {
+            if let found = subview as? SPSwitch { return found }
+            if let nested = firstSwitch(in: subview) { return nested }
+        }
+        return nil
+    }
+
+    func testVibrationCellSwitchHasContextualLabel() {
+        let cell = VibrationCell(style: .default, reuseIdentifier: nil)
+        cell.configure(isOn: true)
+        let toggle = firstSwitch(in: cell.contentView)
+        XCTAssertEqual(toggle?.accessibilityLabel, "Вибрация")
+    }
+
+    func testProgressiveScaleCellSwitchHasContextualLabel() {
+        let cell = ProgressiveScaleCell(style: .default, reuseIdentifier: nil)
+        cell.configure(isOn: false, chain: [50, 100], accessibilityChain: "50, 100")
+        let toggle = firstSwitch(in: cell.contentView)
+        XCTAssertEqual(toggle?.accessibilityLabel, "Прогрессивный режим")
+    }
+
+    func testSettingsIconRowSwitchTakesRowTitleAsLabel() {
+        let cell = SettingsIconRowCell(style: .default, reuseIdentifier: nil)
+        cell.configureSwitch(
+            systemName: "bell.badge",
+            iconColor: .systemRed,
+            title: "Критические уведомления",
+            isOn: false,
+            onChange: { _ in }
+        )
+        let toggle = firstSwitch(in: cell.contentView)
+        XCTAssertEqual(toggle?.accessibilityLabel, "Критические уведомления")
+    }
+
+    func testSettingsIconRowSwitchLabelClearedOnReuse() {
+        let cell = SettingsIconRowCell(style: .default, reuseIdentifier: nil)
+        cell.configureSwitch(
+            systemName: "bell.badge",
+            iconColor: .systemRed,
+            title: "Критические уведомления",
+            isOn: false,
+            onChange: { _ in }
+        )
+        cell.prepareForReuse()
+        let toggle = firstSwitch(in: cell.contentView)
+        XCTAssertNil(toggle?.accessibilityLabel,
+                     "Stale label must not leak to the next row the cell is reused for")
+    }
+}


### PR DESCRIPTION
Fixes #425

## Проблема
После #418 кастомные `SPSwitch` в Vibration / Critical Alerts / Progressive / VolumePicker fade анонсировались VoiceOver'ом дженерик-лейблом «Переключатель» — соседний title читался отдельно, сам контрол контекста не нёс.

## Фикс
Контекстный `accessibilityLabel` на каждый свитч, по паттерну AlarmCell:
- **VibrationCell** → «Вибрация» (из titleLabel)
- **ProgressiveScaleCell** → «Прогрессивный режим»
- **SettingsIconRowCell** (Critical Alerts и др.) — переиспользуемая ячейка, берёт лейбл из конфигурируемого `title`, сбрасывает в `prepareForReuse`
- **VolumePicker `fadeSwitch`** → «Постепенно нарастает»

## Тесты
`SwitchAccessibilityLabelTests` — рекурсивный поиск `SPSwitch` в дереве ячейки + проверка лейбла (без вскрытия приватных полей), включая сброс лейбла при reuse. 4/4 PASS. build_sim SUCCEEDED, swiftlint 0 violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)