### PR TITLE
[fix] resume play()==false falls to .vibrationOnly (#406)

### DIFF
--- a/SnoozePay/SnoozePay/Services/AudioService.swift
+++ b/SnoozePay/SnoozePay/Services/AudioService.swift
@@ -430,9 +430,16 @@ final class AudioService {
         }
         // `play()` returns false only if the queue refuses — which on a paused
         // looping player should not happen once the session is active again.
-        // Log so a residual desync is diagnosable.
+        // If it does, leaving `_state == .playing` shows a "ringing" firing
+        // screen that only vibrates: silent, banner hidden, no surfaced failure.
+        // Mirror `startAlarmSoundLocked`'s play()==false branch and fall to
+        // `.vibrationOnly` so the UI reflects the real state (#406).
         if !player.play() {
             AppLogger.audio.error("resumePlaybackLocked: AVAudioPlayer.play() returned false")
+            _isPaused = false
+            _state = .vibrationOnly
+            startVibration()
+            return
         }
         startVibration()
         _isPaused = false


### PR DESCRIPTION
Fixes #406

## Проблема (silent-failure-hunter, PR #404, MEDIUM)
`resumePlaybackLocked` логировал `play() returned false`, но оставлял `_state == .playing` → звука нет, вибрация идёт, баннер скрыт. Юзер видит «звонящий» firing-экран, который только вибрирует. `startAlarmSoundLocked` тот же случай переводит в `.vibrationOnly`.

## Фикс
Зеркалю `.vibrationOnly`-переход на resume-пути: при `play() == false` ставлю `_isPaused = false`, `_state = .vibrationOnly`, `startVibration()`, `return` — UI отражает реальное состояние (state-наблюдатель `_state.didSet` уже постит нотификацию для firing-экрана).

## Тесты
Нет нового юнит-теста: `AudioService` оборачивает конкретный `AVAudioPlayer` без injection-seam'а, поэтому `play()==false` нельзя форсировать без архитектурного рефактора (протокол-врап всех play/stop/pause + конструирование). Симметричная ветка `startAlarmSoundLocked` не покрыта по той же причине. Изменение — 1:1 зеркало shipped-поведения. build_sim SUCCEEDED, swiftlint 0 serious.

🤖 Generated with [Claude Code](https://claude.com/claude-code)