### PR TITLE
[test] Fix flaky AlarmFiringCoordinator timeout (1.0s -> 5.0s) (#434)

### DIFF
--- a/SnoozePay/SnoozePayTests/AlarmFiringCoordinatorTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmFiringCoordinatorTests.swift
@@ -245,7 +245,12 @@ final class AlarmFiringCoordinatorTests: XCTestCase {
             captured = outcome
             exp.fulfill()
         }
-        wait(for: [exp], timeout: 1.0)
+        // 5.0s, matching the suite's `resolveSnooze` helper. The prior 1.0s was
+        // too tight for a loaded CI runner — the async handleSnooze + refund
+        // chain (≈45ms locally) intermittently overran it under parallel-job
+        // contention, leaving `captured` nil and flaking this test on most PRs
+        // (#434). This is a tolerance budget, not a perf assertion.
+        wait(for: [exp], timeout: 5.0)
 
         guard case .scheduleFailedAndRefundFailed = captured else {
             return XCTFail("Expected .scheduleFailedAndRefundFailed, got \(String(describing: captured))")


### PR DESCRIPTION
Fixes #434

## Проблема
`testHandleSnooze_schedulerFails_andRefundAlsoFails_reportsDegradedOutcome` хардкодил `wait(for: [exp], timeout: 1.0)`, тогда как остальной класс ходит через `resolveSnooze` с `timeout: 5.0`. Под нагрузкой CI (параллельные джобы, медленный раннер) async-цепочка `handleSnooze`+refund (~45ms локально) интермиттентно не укладывалась в 1s → `captured == nil` → `guard case .scheduleFailedAndRefundFailed` падал. Наблюдалось на #430 и #432 — флейк заставлял ретриггерить CI на КАЖДОМ PR.

## Фикс
`timeout: 1.0` → `5.0` (как у `resolveSnooze`). Это бюджет толерантности к нагрузке, не перф-ассерт.

## Verify
Локально тест проходит (вся `AlarmFiringCoordinatorTests` 12/12). swiftlint 0 serious.

🤖 Generated with [Claude Code](https://claude.com/claude-code)