### PR TITLE
[fix] Surface silent resume audio failure on lock screen (#405)

### DIFF
--- a/SnoozePay/SnoozePay/AppDelegate.swift
+++ b/SnoozePay/SnoozePay/AppDelegate.swift
@@ -26,6 +26,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     /// never explicitly removed.
     private var rescheduleObserverTokens: [NSObjectProtocol] = []
 
+    /// Token for the resume-audio-failure observer (#405). Held for the app's
+    /// lifetime alongside `rescheduleObserverTokens`.
+    private var resumeAudioObserverToken: NSObjectProtocol?
+
     func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
@@ -70,6 +74,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // or never re-arm onto the notification fallback after AlarmKit is
         // revoked (#427). The first foreground after launch covers reboot.
         registerAlarmRescheduleObservers()
+
+        // Surface a silent resume-time audio failure as a lock-screen banner
+        // (#405). When the audio session can't be re-activated on resume and the
+        // firing screen isn't visible, the in-app banner never reaches the user;
+        // this observer turns AudioService's process notification into a
+        // time-sensitive local notification they actually see.
+        registerResumeAudioFailedObserver()
 
         // Reclaim orphaned custom-theme JPEGs (#357): re-picking a photo or
         // deleting a `.custom`-themed alarm leaves its image on disk forever.
@@ -144,6 +155,48 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             "re-arming saved alarms (trigger=\(trigger.rawValue, privacy: .public))"
         )
         AlarmScheduler.shared.rescheduleAll(AlarmRepository.shared.fetchAll())
+    }
+
+    /// Observe `AudioService.resumeAudioFailedNotification` so a silent
+    /// resume-time audio failure is surfaced as a lock-screen banner even when
+    /// no firing screen is visible (#405). `static` handler so the `@Sendable`
+    /// closure doesn't capture `self`.
+    private func registerResumeAudioFailedObserver() {
+        resumeAudioObserverToken = NotificationCenter.default.addObserver(
+            forName: AudioService.resumeAudioFailedNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            AppDelegate.postResumeAudioFailedBanner()
+        }
+    }
+
+    /// Post a time-sensitive local notification telling the user their alarm
+    /// is sounding silently because the audio session could not be reclaimed on
+    /// resume. Mirrors `postSnoozeScheduleFailedBanner` — a banner the system
+    /// delivers is the only surface that reaches a user who isn't looking at
+    /// the firing screen (#405).
+    private static func postResumeAudioFailedBanner() {
+        let content = UNMutableNotificationContent()
+        content.title = "Будильник звучит беззвучно"
+        content.body = "Не удалось включить звук — откройте приложение и выключите будильник вручную."
+        content.sound = .default
+        // Time-sensitive so it pierces Focus the way the alarm itself would.
+        content.interruptionLevel = .timeSensitive
+
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
+        let request = UNNotificationRequest(
+            identifier: "resume_audio_failed_\(UUID().uuidString)",
+            content: content,
+            trigger: trigger
+        )
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error = error {
+                AppLogger.appDelegate.fault(
+                    "resume-audio-failed banner failed: \(error.localizedDescription, privacy: .public)"
+                )
+            }
+        }
     }
 
     // MARK: - Permission UI

--- a/SnoozePay/SnoozePay/Services/AudioService.swift
+++ b/SnoozePay/SnoozePay/Services/AudioService.swift
@@ -43,6 +43,16 @@ final class AudioService {
     static let stateChangedNotification = Notification.Name("snoozepay.audio.stateChanged")
     static let stateUserInfoKey = "state"
 
+    /// Posted when a RESUME re-activates the audio session and that
+    /// re-activation FAILS (`resumePlaybackLocked` → `.silentBecauseConfigFailed`).
+    /// Unlike `stateChangedNotification`, which only the on-screen firing VC
+    /// observes, this is consumed by `AppDelegate` to post a time-sensitive
+    /// local notification — so a silent failed wake is surfaced even when no
+    /// firing screen is visible (locked-screen wake / AlarmKit path / top-up
+    /// sheet on top). See `AlarmFiringViewController` for the in-app banner that
+    /// still covers the on-screen case (#405).
+    static let resumeAudioFailedNotification = Notification.Name("snoozepay.audio.resumeFailed")
+
     /// Serializes every read/write of the mutable fields below (#202).
     /// `startAlarmSound` can arrive on a UN-delegate background thread while
     /// `stopAlarmSound` runs on main — without this queue the four fields can
@@ -426,6 +436,19 @@ final class AudioService {
             )
             _isPaused = false
             _state = .silentBecauseConfigFailed
+            // On a resume the firing screen that normally renders the
+            // `.silentBecauseConfigFailed` banner is often NOT on screen
+            // (locked-screen wake, AlarmKit/notification path, or a top-up sheet
+            // on top), so the failure had only a Console-log trace — a silent
+            // failed wake (#405). Vibration uses AudioToolbox, which works
+            // without an audio session, so keep buzzing; and post a process
+            // notification that `AppDelegate` turns into a time-sensitive local
+            // banner the user actually sees on the lock screen.
+            startVibration()
+            NotificationCenter.default.post(
+                name: Self.resumeAudioFailedNotification,
+                object: self
+            )
             return
         }
         // `play()` returns false only if the queue refuses — which on a paused


### PR DESCRIPTION
Fixes #405

## Проблема (gauntlet PR #404, silent-failure-hunter MEDIUM)
Когда реактивация аудио-сессии падает на resume-пути (`resumePlaybackLocked` -> `.silentBecauseConfigFailed`), а `AlarmFiringViewController` не на экране (locked-screen wake, AlarmKit/notification-путь, top-up шит сверху) — единственным сигналом был in-app баннер, которого не видно. Тихий проваленный wake; единственный след — Console-лог.

## Фикс
В catch-ветке `resumePlaybackLocked` теперь дополнительно:
1. **Вибрация** — `startVibration()` (AudioToolbox `kSystemSoundID_Vibrate` работает без активной аудио-сессии), физический сигнал есть даже когда звук мёртв.
2. **Lock-screen баннер** — постится in-process `AudioService.resumeAudioFailedNotification`, который `AppDelegate` превращает в time-sensitive local notification (зеркалит существующий `postSnoozeScheduleFailedBanner`). Пользователь видит «Будильник звучит беззвучно» на залоченном экране.

On-screen баннер `AlarmFiringViewController` по-прежнему покрывает видимый случай — additive.

## Тесты
Ветка `configureAudioSession()` throws не имеет mock-seam'а (как и #406) — не юнит-тестируется чисто. Build succeeded, swiftlint 0 violations в затронутых файлах.