### PR TITLE
[fix] AlarmsList weeklyDelta: exclude refunded charges + surface ledger corruption (#440)

### DIFF
--- a/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
+++ b/SnoozePay/SnoozePay/ViewModels/AlarmsListViewModel.swift
@@ -133,6 +133,20 @@ final class AlarmsListViewModel {
         } catch {
             alarms = []
         }
+        // Surface a corrupt transaction ledger here too (#440). The weekly-delta
+        // header reads the lossy `fetchAll`, which collapses a corrupt blob to
+        // "no charges" and silently hides the row — so the main screen would give
+        // no signal that financial history is unreadable (it would otherwise
+        // surface only later on Statistics/Wallet, or when a snooze charge fails
+        // at firing). Probe the checked variant and drive the same `onLoadError`
+        // banner used for alarm/balance corruption.
+        do {
+            _ = try transactionRepository.fetchAllChecked()
+        } catch let error as TransactionRepository.RepositoryError {
+            onLoadError?(error)
+        } catch {
+            // Non-typed decode error — swallow to match the alarm-fetch fallback.
+        }
         balance = balanceService.balance
         onAlarmsUpdated?()
         onBalanceUpdated?(balance)
@@ -417,9 +431,17 @@ final class AlarmsListViewModel {
         guard let weekAgo = Calendar.current.date(byAdding: .day, value: -7, to: Date()) else {
             return nil
         }
-        let charges = transactionRepository.fetchCharges(since: weekAgo)
-        guard !charges.isEmpty else { return nil }
-        let totalCharged = charges.reduce(0.0) { $0 + $1.amount }
+        // Exclude REFUNDED charges (a snooze that failed to schedule is auto-
+        // refunded and per design "doesn't count") so the header doesn't
+        // overstate the week's spend (#440). `realCharges` is computed over the
+        // FULL ledger first — a charge refunded by a later top-up is still
+        // excluded — then filtered to the rolling 7-day window. Display-only, so
+        // the lossy `fetchAll` is fine; a corrupt ledger is surfaced separately
+        // in `loadData()`.
+        let weekCharges = TransactionRepository.realCharges(from: transactionRepository.fetchAll())
+            .filter { $0.createdAt >= weekAgo }
+        guard !weekCharges.isEmpty else { return nil }
+        let totalCharged = weekCharges.reduce(0.0) { $0 + $1.amount }
         guard totalCharged > 0 else { return nil }
         return -Decimal(totalCharged)
     }

--- a/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmsListViewModelTests.swift
@@ -735,3 +735,109 @@ final class AlarmsListViewModelCorruptionTests: XCTestCase {
                        "A fresh corruption episode after ack must re-fire the alert")
     }
 }
+
+/// Weekly-delta refund exclusion + transaction-ledger corruption surfacing on
+/// the alarms list (#440).
+final class AlarmsListWeeklyDeltaTests: XCTestCase {
+
+    private var testDefaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "test.alarmsListWeeklyDelta.\(UUID().uuidString)"
+        testDefaults = UserDefaults(suiteName: suiteName)!
+    }
+
+    override func tearDown() {
+        testDefaults.removePersistentDomain(forName: suiteName)
+        testDefaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    private func makeVM(txnRepo: TransactionRepository) -> AlarmsListViewModel {
+        let center = NotificationCenter()
+        return AlarmsListViewModel(
+            alarmRepository: AlarmRepository(
+                defaults: testDefaults,
+                scheduler: AlarmsListViewModelTests.StubScheduler()
+            ),
+            balanceService: BalanceService(defaults: testDefaults, notificationCenter: center),
+            transactionRepository: txnRepo,
+            notificationCenter: center
+        )
+    }
+
+    private func daysAgo(_ number: Int) -> Date {
+        Calendar.current.date(byAdding: .day, value: -number, to: Date())!
+    }
+
+    // MARK: - Refund exclusion
+
+    func testWeeklyDelta_excludesRefundedCharge() {
+        let repo = TransactionRepository(defaults: testDefaults)
+        let refundedID = UUID()
+        // Two charges this week; one refunded by an offsetting top-up.
+        XCTAssertTrue(repo.record(Transaction(type: .charge, amount: 30, createdAt: daysAgo(1))))
+        XCTAssertTrue(repo.record(Transaction(id: refundedID, type: .charge, amount: 50, createdAt: daysAgo(2))))
+        XCTAssertTrue(repo.record(
+            Transaction(type: .topup, amount: 50, createdAt: daysAgo(2), refundsTransactionID: refundedID)
+        ))
+
+        // Only the 30 non-refunded charge counts → -30, not -80.
+        XCTAssertEqual(makeVM(txnRepo: repo).weeklyDelta, Decimal(-30),
+                       "Refunded charge must be excluded from the weekly delta")
+    }
+
+    func testWeeklyDelta_allChargesRefunded_hidesRow() {
+        let repo = TransactionRepository(defaults: testDefaults)
+        let refundedID = UUID()
+        XCTAssertTrue(repo.record(Transaction(id: refundedID, type: .charge, amount: 50, createdAt: daysAgo(1))))
+        XCTAssertTrue(repo.record(
+            Transaction(type: .topup, amount: 50, createdAt: daysAgo(1), refundsTransactionID: refundedID)
+        ))
+
+        XCTAssertNil(makeVM(txnRepo: repo).weeklyDelta,
+                     "A week whose only charge was refunded must hide the delta row")
+    }
+
+    func testWeeklyDelta_countsNonRefundedCharge() {
+        let repo = TransactionRepository(defaults: testDefaults)
+        XCTAssertTrue(repo.record(Transaction(type: .charge, amount: 40, createdAt: daysAgo(3))))
+        XCTAssertEqual(makeVM(txnRepo: repo).weeklyDelta, Decimal(-40))
+    }
+
+    func testWeeklyDelta_ignoresChargesOlderThanWeek() {
+        let repo = TransactionRepository(defaults: testDefaults)
+        XCTAssertTrue(repo.record(Transaction(type: .charge, amount: 40, createdAt: daysAgo(10))))
+        XCTAssertNil(makeVM(txnRepo: repo).weeklyDelta,
+                     "Charges older than 7 days must not appear in the weekly delta")
+    }
+
+    // MARK: - Ledger corruption surfacing
+
+    func testLoadData_corruptLedger_surfacesOnLoadError() {
+        testDefaults.set(Data("{ not valid json".utf8), forKey: "stored_transactions")
+        let vm = makeVM(txnRepo: TransactionRepository(defaults: testDefaults))
+
+        var received: LocalizedError?
+        vm.onLoadError = { received = $0 }
+        vm.loadData()
+
+        XCTAssertTrue(received is TransactionRepository.RepositoryError,
+                      "A corrupt transaction ledger must surface via onLoadError on the alarms list")
+    }
+
+    func testLoadData_healthyLedger_doesNotSurfaceTransactionError() {
+        let repo = TransactionRepository(defaults: testDefaults)
+        XCTAssertTrue(repo.record(Transaction(type: .charge, amount: 10, createdAt: daysAgo(1))))
+        let vm = makeVM(txnRepo: repo)
+
+        var fired = false
+        vm.onLoadError = { _ in fired = true }
+        vm.loadData()
+
+        XCTAssertFalse(fired, "A healthy ledger must not surface a load error")
+    }
+}


### PR DESCRIPTION
Fixes #440

## Проблема (audit 2026-07-01, code-reviewer + silent-failure-hunter)
Два дефекта в sticky-header `weeklyDelta`:
1. **Refunded charges завышали трату.** `weeklyDelta` суммировал `fetchCharges(since:)` (сырые charges, включая авто-возвращённые при провале планирования снуза) — полностью возвращённый штраф всё равно показывался как напр. «−50 ₽» за неделю, противореча кошельку.
2. **Порча леджера невидима на главном.** `loadData` сурфейсил порчу `AlarmRepository`/`BalanceService`, но никогда не пробовал transaction-ledger; lossy weekly-delta read схлопывал порченый blob в «нет charges» и прятал строку без сигнала.

## Фикс
1. `weeklyDelta` теперь гонит charges через `TransactionRepository.realCharges(from:)` над ПОЛНЫМ леджером (charge, возвращённый более поздним топапом, тоже исключается), затем фильтрует rolling-7-day окно.
2. `loadData` пробует `fetchAllChecked()` и драйвит тот же `onLoadError` баннер, что для alarm/balance порчи.

## Тесты (новый `AlarmsListWeeklyDeltaTests`, 6 шт)
refund-исключение, all-refunded прячет строку, non-refunded считается, charge старше недели игнорируется, corrupt-ledger → onLoadError, healthy → без ошибки. Все зелёные + существующие 24 VM-теста не сломаны. swiftlint 0.

Связано: тот же refund-корень, что #400 (WokeMorning — другая поверхность) и #439 (StreakCalculator). Порча-паттерн #419.