### PR TITLE
[fix] BalanceService: guard topUp/charge for finite>0 + creditPromotion tests (#441)

### DIFF
--- a/SnoozePay/SnoozePay/Services/BalanceService.swift
+++ b/SnoozePay/SnoozePay/Services/BalanceService.swift
@@ -129,6 +129,13 @@ final class BalanceService {
     /// Returns `nil` on the same failure modes as `charge` — insufficient
     /// funds, corrupted balance, or repository write rejection.
     func chargeWithReceipt(amount: Double, alarmID: UUID?) -> Transaction? {
+        // Reject non-finite / non-positive amounts up front, matching
+        // `creditPromotion`'s contract (#441). Without this a negative amount
+        // passes the `current >= amount` guard and records a `.charge` that
+        // INCREASES the balance (and injects a phantom snooze day into
+        // streak/stats); a NaN would persist into storage before the read-time
+        // corruption guard catches it.
+        guard amount.isFinite, amount > 0 else { return nil }
         let transaction = Transaction(
             type: .charge,
             amount: amount,
@@ -175,6 +182,12 @@ final class BalanceService {
     /// (issue #133). Organic top-ups (IAP, dev tools) leave it `nil`.
     @discardableResult
     func topUp(amount: Double, refundsTransactionID: UUID? = nil) -> Bool {
+        // Reject non-finite / non-positive amounts, matching `creditPromotion`
+        // (#441): a negative top-up would record a positive-typed `.topup` while
+        // DECREASING the balance (ledger/balance divergence that can drive
+        // `user_balance` negative and latch #119 corruption); a NaN would
+        // persist into storage before the read-time guard fires.
+        guard amount.isFinite, amount > 0 else { return false }
         let result: (recorded: Bool, newBalance: Double) = queue.sync {
             let current = readRawBalance()
             guard !_balanceCorrupted else { return (false, current) }

--- a/SnoozePay/SnoozePayTests/BalanceServiceTests.swift
+++ b/SnoozePay/SnoozePayTests/BalanceServiceTests.swift
@@ -721,3 +721,100 @@ final class CreateAlarmViewModelTests: XCTestCase {
         XCTAssertEqual(saved?.name, "Будильник")
     }
 }
+
+/// Amount-validation guards on the `Double` money APIs (`topUp` / `charge`)
+/// and `creditPromotion` coverage (#441). The guards close the one asymmetric
+/// hole where the sibling `creditPromotion` validated `isFinite && > 0` but
+/// `topUp` / `chargeWithReceipt` did not.
+final class BalanceServiceAmountValidationTests: XCTestCase {
+
+    private var testDefaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "test.balanceGuard.\(UUID().uuidString)"
+        testDefaults = UserDefaults(suiteName: suiteName)!
+    }
+
+    override func tearDown() {
+        testDefaults.removePersistentDomain(forName: suiteName)
+        testDefaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    private func makeService(balance: Double) -> BalanceService {
+        testDefaults.set(balance, forKey: "user_balance")
+        return BalanceService(defaults: testDefaults, notificationCenter: NotificationCenter())
+    }
+
+    private func promotions() -> [Transaction] {
+        TransactionRepository(defaults: testDefaults).fetchAll().filter { $0.type == .promotion }
+    }
+
+    // MARK: - topUp guard
+
+    func testTopUp_negativeAmount_rejectedNoMutation() {
+        let service = makeService(balance: 100)
+        XCTAssertFalse(service.topUp(amount: -50), "Negative top-up must be rejected")
+        XCTAssertEqual(service.balance, 100, "A rejected top-up must not change the balance")
+    }
+
+    func testTopUp_nonFiniteAmount_rejected() {
+        let service = makeService(balance: 100)
+        XCTAssertFalse(service.topUp(amount: .nan))
+        XCTAssertFalse(service.topUp(amount: .infinity))
+        XCTAssertEqual(service.balance, 100)
+    }
+
+    func testTopUp_zeroAmount_rejected() {
+        let service = makeService(balance: 100)
+        XCTAssertFalse(service.topUp(amount: 0))
+        XCTAssertEqual(service.balance, 100)
+    }
+
+    // MARK: - chargeWithReceipt guard
+
+    func testChargeWithReceipt_negativeAmount_rejectedNoMutation() {
+        let service = makeService(balance: 100)
+        XCTAssertNil(service.chargeWithReceipt(amount: -50, alarmID: nil),
+                     "Negative charge must be rejected (would otherwise INCREASE the balance)")
+        XCTAssertEqual(service.balance, 100)
+    }
+
+    func testChargeWithReceipt_nonFiniteAmount_rejected() {
+        let service = makeService(balance: 100)
+        XCTAssertNil(service.chargeWithReceipt(amount: .nan, alarmID: nil))
+        XCTAssertEqual(service.balance, 100)
+    }
+
+    // MARK: - creditPromotion
+
+    func testCreditPromotion_validAmount_creditsAndRecordsPromotion() {
+        let service = makeService(balance: 0)
+        XCTAssertTrue(service.creditPromotion(amount: 200))
+        XCTAssertEqual(service.balance, 200)
+
+        let recorded = promotions()
+        XCTAssertEqual(recorded.count, 1, "Exactly one .promotion entry must be recorded")
+        XCTAssertEqual(recorded.first?.amount, 200)
+    }
+
+    func testCreditPromotion_nonPositiveOrNaN_rejected() {
+        let service = makeService(balance: 50)
+        XCTAssertFalse(service.creditPromotion(amount: 0))
+        XCTAssertFalse(service.creditPromotion(amount: -10))
+        XCTAssertFalse(service.creditPromotion(amount: .nan))
+        XCTAssertEqual(service.balance, 50)
+        XCTAssertTrue(promotions().isEmpty)
+    }
+
+    func testCreditPromotion_corruptedBalance_rejectedNoMutation() {
+        // A negative stored balance latches the corruption gate at init.
+        let service = makeService(balance: -5)
+        XCTAssertFalse(service.creditPromotion(amount: 100),
+                       "creditPromotion must refuse while the balance is corrupt")
+        XCTAssertTrue(promotions().isEmpty, "No promotion entry may be recorded into a corrupt ledger")
+    }
+}


### PR DESCRIPTION
Fixes #441

## Проблема (audit 2026-07-01, type-design-analyzer + pr-test-analyzer)
`topUp` и `chargeWithReceipt` принимали любой `Double`, в отличие от sibling `creditPromotion`, который гардит `amount.isFinite && > 0`. Асимметрия в контракте money-API синглтона.

## Фикс
Добавлен `guard amount.isFinite, amount > 0` в начало `chargeWithReceipt` (→ nil) и `topUp` (→ false), зеркаля `creditPromotion`.

Без него: `topUp(-X)` записал бы positive-typed `.topup` при УМЕНЬШЕНИИ баланса (расхождение ledger/balance, может залатчить #119); `charge(-X)` прошёл бы `current >= amount` и записал `.charge`, УВЕЛИЧИВАЮЩИЙ баланс + фантомный снуз-день в статистику; NaN персистился бы до read-time guard'а. Все живые вызовы гардят сами → это defense-in-depth.

## Тесты (новый `BalanceServiceAmountValidationTests`, 8 шт)
topUp/charge реджектят negative/NaN/infinity/zero без мутации; creditPromotion кредитует + пишет ровно одну `.promotion`, реджектит non-positive/NaN, отказывает в порченый ledger. 21 существующий BalanceServiceTest не сломан. swiftlint 0.