### PR TITLE
[fix] AlarmScheduler.rescheduleAll surfaces re-arm failures (#442)

### DIFF
--- a/SnoozePay/SnoozePay/AppDelegate.swift
+++ b/SnoozePay/SnoozePay/AppDelegate.swift
@@ -30,6 +30,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     /// lifetime alongside `rescheduleObserverTokens`.
     private var resumeAudioObserverToken: NSObjectProtocol?
 
+    /// Latch so a persistent re-arm failure surfaces a banner only once per
+    /// episode rather than on every foreground (#442). Reset to 0 by a fully-
+    /// successful re-arm.
+    private var lastRescheduleFailedCount = 0
+
     func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
@@ -140,21 +145,36 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 forName: name,
                 object: nil,
                 queue: .main
-            ) { _ in
-                AppDelegate.rescheduleSavedAlarms(trigger: name)
+            ) { [weak self] _ in
+                self?.rescheduleSavedAlarms(trigger: name)
             }
         }
     }
 
-    /// Re-arm every saved alarm against the current clock / timezone / backend.
-    /// `static` so the `@Sendable` observer closure does not capture `self`
-    /// (the work touches only the `AlarmScheduler` / `AlarmRepository`
-    /// singletons, which manage their own state).
-    private static func rescheduleSavedAlarms(trigger: Notification.Name) {
+    /// Re-arm every saved alarm against the current clock / timezone / backend,
+    /// then surface an aggregate banner if any failed to re-arm (#442). Instance
+    /// method (was `static`) so the outcome can be deduped via
+    /// `lastRescheduleFailedCount`; the observer captures `self` weakly.
+    private func rescheduleSavedAlarms(trigger: Notification.Name) {
         AppLogger.appDelegate.info(
             "re-arming saved alarms (trigger=\(trigger.rawValue, privacy: .public))"
         )
-        AlarmScheduler.shared.rescheduleAll(AlarmRepository.shared.fetchAll())
+        AlarmScheduler.shared.rescheduleAll(AlarmRepository.shared.fetchAll()) { [weak self] failedCount in
+            self?.handleRescheduleOutcome(failedCount: failedCount)
+        }
+    }
+
+    /// Surface a re-arm failure ONCE per episode: post a banner when failures
+    /// first appear and stay quiet until a fully-successful re-arm (count 0)
+    /// clears the latch, so a persistent failure (e.g. revoked permission)
+    /// doesn't banner on every foreground (#442).
+    private func handleRescheduleOutcome(failedCount: Int) {
+        defer { lastRescheduleFailedCount = failedCount }
+        guard failedCount > 0, lastRescheduleFailedCount == 0 else { return }
+        AppLogger.appDelegate.fault(
+            "rescheduleAll: \(failedCount, privacy: .public) alarms failed to re-arm"
+        )
+        Self.postRescheduleFailedBanner(failedCount: failedCount)
     }
 
     /// Observe `AudioService.resumeAudioFailedNotification` so a silent
@@ -194,6 +214,33 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             if let error = error {
                 AppLogger.appDelegate.fault(
                     "resume-audio-failed banner failed: \(error.localizedDescription, privacy: .public)"
+                )
+            }
+        }
+    }
+
+    /// Post a time-sensitive local notification when one or more alarms failed
+    /// to re-arm on a clock/timezone/reboot/permission change (#442). The re-arm
+    /// runs in the background (no UI on screen), so a system-delivered banner is
+    /// the only surface that reaches the user.
+    private static func postRescheduleFailedBanner(failedCount: Int) {
+        let content = UNMutableNotificationContent()
+        content.title = "Будильники не перевзведены"
+        content.body = "Не удалось перепланировать будильники (\(failedCount)) — "
+            + "откройте приложение и проверьте разрешения на уведомления."
+        content.sound = .default
+        content.interruptionLevel = .timeSensitive
+
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
+        let request = UNNotificationRequest(
+            identifier: "reschedule_failed_\(UUID().uuidString)",
+            content: content,
+            trigger: trigger
+        )
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error = error {
+                AppLogger.appDelegate.fault(
+                    "reschedule-failed banner failed: \(error.localizedDescription, privacy: .public)"
                 )
             }
         }

--- a/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
+++ b/SnoozePay/SnoozePay/Services/AlarmScheduler.swift
@@ -710,14 +710,49 @@ final class AlarmScheduler: AlarmScheduling {
     ///
     /// Disabled alarms are skipped: they hold no triggers to re-arm and
     /// `schedule(_:)` is already a no-op for them.
-    func rescheduleAll(_ alarms: [Alarm]) {
+    /// - Parameter completion: invoked on the main queue once every re-arm has
+    ///   resolved, carrying the number that FAILED to re-arm. Previously each
+    ///   `schedule` was fired with a `nil` completion, so every typed
+    ///   `SchedulingError` (pending-limit, system, cancelled, AlarmKit reject +
+    ///   fallback-also-failed) was silently dropped — an alarm could fail to
+    ///   re-arm after a DST/TZ shift, reboot or permission change and never
+    ///   ring, with only a Console log (#442). Aggregating the outcomes lets the
+    ///   caller surface it (see `AppDelegate.handleRescheduleOutcome`).
+    func rescheduleAll(_ alarms: [Alarm], completion: ((_ failedCount: Int) -> Void)? = nil) {
         let enabled = alarms.filter { $0.enabled }
         AppLogger.scheduler.info(
             "rescheduleAll: re-arming \(enabled.count, privacy: .public) of \(alarms.count, privacy: .public) alarms"
         )
+        guard !enabled.isEmpty else {
+            completion?(0)
+            return
+        }
+
+        let group = DispatchGroup()
+        let lock = NSLock()
+        var failedCount = 0
+
         for alarm in enabled {
             cancel(alarm.id)
-            schedule(alarm)
+            group.enter()
+            schedule(alarm) { result in
+                if case .failure = result {
+                    lock.lock()
+                    failedCount += 1
+                    lock.unlock()
+                }
+                group.leave()
+            }
+        }
+
+        group.notify(queue: .main) {
+            if failedCount > 0 {
+                let total = enabled.count
+                AppLogger.scheduler.error(
+                    "rescheduleAll failed: \(failedCount, privacy: .public)/\(total, privacy: .public)"
+                )
+            }
+            completion?(failedCount)
         }
     }
 

--- a/SnoozePay/SnoozePayTests/AlarmSchedulerRescheduleAllTests.swift
+++ b/SnoozePay/SnoozePayTests/AlarmSchedulerRescheduleAllTests.swift
@@ -86,6 +86,52 @@ final class AlarmSchedulerRescheduleAllTests: XCTestCase {
         XCTAssertTrue(center.addedIdentifiers.isEmpty)
         XCTAssertTrue(center.removedIdentifiers.isEmpty)
     }
+
+    // MARK: - Failure aggregation (#442)
+
+    func testRescheduleAll_allSchedulesSucceed_reportsZeroFailed() {
+        let center = RecordingNotificationCenter()
+        let scheduler = AlarmScheduler(notificationCenter: center)
+
+        let exp = expectation(description: "completion")
+        var reported: Int?
+        scheduler.rescheduleAll([
+            dailyAlarm(name: "A", enabled: true),
+            dailyAlarm(name: "B", enabled: true)
+        ]) { reported = $0; exp.fulfill() }
+
+        wait(for: [exp], timeout: 5)
+        XCTAssertEqual(reported, 0, "All schedules succeeded → zero failures reported")
+    }
+
+    func testRescheduleAll_scheduleFailures_reportsFailedCount() {
+        let center = FailingNotificationCenter()
+        let scheduler = AlarmScheduler(notificationCenter: center)
+
+        let exp = expectation(description: "completion")
+        var reported: Int?
+        scheduler.rescheduleAll([
+            dailyAlarm(name: "A", enabled: true),
+            dailyAlarm(name: "B", enabled: true),
+            dailyAlarm(name: "Off", enabled: false)
+        ]) { reported = $0; exp.fulfill() }
+
+        wait(for: [exp], timeout: 5)
+        XCTAssertEqual(reported, 2,
+                       "Both enabled alarms failed to re-arm → failedCount 2 (disabled skipped)")
+    }
+
+    func testRescheduleAll_emptyEnabled_reportsZeroImmediately() {
+        let center = RecordingNotificationCenter()
+        let scheduler = AlarmScheduler(notificationCenter: center)
+
+        let exp = expectation(description: "completion")
+        var reported: Int?
+        scheduler.rescheduleAll([dailyAlarm(name: "Off", enabled: false)]) { reported = $0; exp.fulfill() }
+
+        wait(for: [exp], timeout: 5)
+        XCTAssertEqual(reported, 0)
+    }
 }
 
 // MARK: - Test double
@@ -112,6 +158,39 @@ private final class RecordingNotificationCenter: NotificationScheduling {
     func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {
         removedIdentifiers.append(contentsOf: identifiers)
     }
+    func removeDeliveredNotifications(withIdentifiers identifiers: [String]) {}
+    func getDeliveredNotifications(
+        completionHandler: @escaping ([UNNotification]) -> Void
+    ) {
+        completionHandler([])
+    }
+    func setNotificationCategories(_ categories: Set<UNNotificationCategory>) {}
+    func removeAllPendingNotificationRequests() {}
+    func requestAuthorization(
+        options: UNAuthorizationOptions,
+        completionHandler: @escaping (Bool, Error?) -> Void
+    ) {
+        completionHandler(false, nil)
+    }
+}
+
+/// `NotificationScheduling` stub whose `add` always fails, so every `schedule`
+/// resolves to `.failure` — drives `rescheduleAll`'s failure aggregation (#442).
+private final class FailingNotificationCenter: NotificationScheduling {
+    struct AddError: Error {}
+
+    func add(
+        _ request: UNNotificationRequest,
+        withCompletionHandler completion: ((Error?) -> Void)?
+    ) {
+        completion?(AddError())
+    }
+    func getPendingNotificationRequests(
+        completionHandler: @escaping ([UNNotificationRequest]) -> Void
+    ) {
+        completionHandler([])
+    }
+    func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {}
     func removeDeliveredNotifications(withIdentifiers identifiers: [String]) {}
     func getDeliveredNotifications(
         completionHandler: @escaping ([UNNotification]) -> Void


### PR DESCRIPTION
Fixes #442

## Проблема (audit 2026-07-01, silent-failure-hunter)
`rescheduleAll` вызывал каждый `schedule` с `nil` completion — каждая типизированная `SchedulingError` (pending-limit, system, cancelled, AlarmKit-reject + fallback-тоже-упал) отбрасывалась. После DST/TZ-сдвига, ребута или смены разрешения один/несколько будильников могли молча не перевстать и никогда не прозвонить (только Console-лог). Класс phantom-success #118/#199/#417, реинтродьюснутый для bulk re-arm. Регрессионная поверхность моего же #427.

## Фикс
- `rescheduleAll` агрегирует per-alarm исходы через `DispatchGroup` и репортит `failedCount` в новый completion (main-queue).
- `AppDelegate` сурфейсит это time-sensitive local-баннером, **дедуп раз в эпизод** (персистентный провал не баннерит каждый foreground; сброс латча при полностью успешном re-arm). Observer теперь захватывает `self` слабо, чтобы латч жил на инстансе.

## Тесты (расширен `AlarmSchedulerRescheduleAllTests`, +3)
all-succeed → 0, N enabled провалились → N (disabled пропущены), empty-enabled → 0 — через новый `FailingNotificationCenter`. Все 6 в классе зелёные локально. swiftlint: мои строки ≤120, 0 errors.