### PR TITLE
[test] Cover StoreKitRestoreErrorCopy SKError branches (#444)

### DIFF
--- a/SnoozePay/SnoozePayTests/StoreKitRestoreErrorCopyTests.swift
+++ b/SnoozePay/SnoozePayTests/StoreKitRestoreErrorCopyTests.swift
@@ -43,4 +43,32 @@ final class StoreKitRestoreErrorCopyTests: XCTestCase {
         XCTAssertTrue(message.contains("Boom"))
         XCTAssertTrue(message.contains("свяжитесь с поддержкой"))
     }
+
+    // MARK: - SKError family (#444)
+
+    /// `SKError` bridges from an `NSError` in `SKErrorDomain`, so construct via
+    /// `NSError` rather than the underscored `init(_nsError:)` SPI.
+    private func skError(_ code: SKError.Code) -> Error {
+        NSError(domain: SKErrorDomain, code: code.rawValue)
+    }
+
+    func testSKPaymentNotAllowed_mapsToScreenTimeAdvice() {
+        XCTAssertEqual(
+            StoreKitRestoreErrorCopy.message(for: skError(.paymentNotAllowed)),
+            "В вашем Apple ID запрещены покупки. Проверьте настройки экранного времени."
+        )
+    }
+
+    func testSKCloudServicePermissionDenied_mapsToICloudAdvice() {
+        XCTAssertEqual(
+            StoreKitRestoreErrorCopy.message(for: skError(.cloudServicePermissionDenied)),
+            "Проверьте подключение к интернету и доступ к iCloud в Настройках."
+        )
+    }
+
+    func testSKUnknownCode_fallsBackToSupportHint() {
+        let message = StoreKitRestoreErrorCopy.message(for: skError(.unknown))
+        XCTAssertTrue(message.contains("свяжитесь с поддержкой"),
+                      "An unmapped SKError code must fall through to the generic support hint")
+    }
 }


### PR DESCRIPTION
Fixes #444

## Проблема (audit 2026-07-01, pr-test-analyzer)
`skErrorMessage` (всё семейство `SKError` — `.paymentNotAllowed`, `.cloudService*`) не покрыто; copy-тест гонял только `StoreKitError`, `URLError`, `NSURLErrorDomain`. Рефактор, переупорядочивший приоритет-walk `message(for:)` или уронивший SKError-кейс, молча свалился бы в raw `localizedDescription` — непереведённая системная ошибка при restore.

## Тесты (+3 в `StoreKitRestoreErrorCopyTests`)
`.paymentNotAllowed` → screen-time совет, `.cloudServicePermissionDenied` → iCloud совет, unmapped `.unknown` → generic support-hint fallback. SKError строится из NSError в SKErrorDomain (стандартный bridging).

Только тест на маппинг error-копирайта — не трогает signing/entitlements/StoreKit-конфиг/billing. swiftlint 0. 9/9 в классе зелёные.