### PR TITLE
[test] Terminate app in E2E tearDown to fix NoBalanceTopUp flake (#438)

### DIFF
--- a/SnoozePay/SnoozePayUITests/CreateAlarmUITests.swift
+++ b/SnoozePay/SnoozePayUITests/CreateAlarmUITests.swift
@@ -23,6 +23,14 @@ final class CreateAlarmUITests: XCTestCase {
         continueAfterFailure = false
     }
 
+    override func tearDown() {
+        // Terminate the app under test so a leftover firing/snooze instance
+        // can't survive into the next E2E class's launch() and make its
+        // implicit terminate fail (#438).
+        XCUIApplication().terminate()
+        super.tearDown()
+    }
+
     func testCreateAlarmAddsRowToList() {
         let app = XCUIApplication()
         app.launchArguments = ["-uitour", "create", "-uitour-reset"]

--- a/SnoozePay/SnoozePayUITests/FiringFlowUITests.swift
+++ b/SnoozePay/SnoozePayUITests/FiringFlowUITests.swift
@@ -27,6 +27,14 @@ final class FiringFlowUITests: XCTestCase {
         continueAfterFailure = false
     }
 
+    override func tearDown() {
+        // Terminate the app under test so a leftover firing/snooze instance
+        // can't survive into the next E2E class's launch() and make its
+        // implicit terminate fail (#438).
+        XCUIApplication().terminate()
+        super.tearDown()
+    }
+
     func testFiringSnoozeWakeFlow() {
         let app = XCUIApplication()
         // `-uitour firing` mounts AlarmFiringViewController as root;

--- a/SnoozePay/SnoozePayUITests/NoBalanceTopUpUITests.swift
+++ b/SnoozePay/SnoozePayUITests/NoBalanceTopUpUITests.swift
@@ -23,6 +23,14 @@ final class NoBalanceTopUpUITests: XCTestCase {
         continueAfterFailure = false
     }
 
+    override func tearDown() {
+        // Terminate the app under test so a leftover firing/snooze instance
+        // can't survive into the next E2E class's launch() and make its
+        // implicit terminate fail (#438).
+        XCUIApplication().terminate()
+        super.tearDown()
+    }
+
     func testNoBalanceTopUpReenablesSnooze() {
         let app = XCUIApplication()
         app.launchArguments = ["-uitour", "firing-nobalance"]

--- a/SnoozePay/SnoozePayUITests/OnboardingFlowUITests.swift
+++ b/SnoozePay/SnoozePayUITests/OnboardingFlowUITests.swift
@@ -22,6 +22,14 @@ final class OnboardingFlowUITests: XCTestCase {
         continueAfterFailure = false
     }
 
+    override func tearDown() {
+        // Terminate the app under test so a leftover firing/snooze instance
+        // can't survive into the next E2E class's launch() and make its
+        // implicit terminate fail (#438).
+        XCUIApplication().terminate()
+        super.tearDown()
+    }
+
     func testOnboardingThroughPermissionsToMain() {
         let app = XCUIApplication()
         app.launchArguments = ["-uitour", "onboarding"]

--- a/SnoozePay/SnoozePayUITests/ProgressiveSnoozeUITests.swift
+++ b/SnoozePay/SnoozePayUITests/ProgressiveSnoozeUITests.swift
@@ -20,6 +20,14 @@ final class ProgressiveSnoozeUITests: XCTestCase {
         continueAfterFailure = false
     }
 
+    override func tearDown() {
+        // Terminate the app under test so a leftover firing/snooze instance
+        // can't survive into the next E2E class's launch() and make its
+        // implicit terminate fail (#438).
+        XCUIApplication().terminate()
+        super.tearDown()
+    }
+
     func testProgressiveSnoozeShowsPillAndLadder() {
         let app = XCUIApplication()
         app.launchArguments = ["-uitour", "firing-progressive", "-uitour-balance", "1000"]


### PR DESCRIPTION
Fixes #438

## Проблема
`NoBalanceTopUpUITests.testNoBalanceTopUpReenablesSnooze` падал интермиттентно (~50%) на `app.launch()` с `Failed to terminate Ivan-Emelyanov.SnoozePay` — блокировал множество несвязанных PR и заставлял гонять CI по кругу (за эту сессию ~8 раз).

## Причина
Ни один из 5 E2E-классов не терминировал app-under-test: каждый создаёт локальный `XCUIApplication()`, лаунчит, но никогда не терминирует. Инстанс предыдущего класса (firing/snooze-тест оставляет аудио + таймеры) висел; `launch()` следующего класса не мог его убить.

## Фикс
`tearDown` в каждом из 5 E2E-классов → `XCUIApplication().terminate()`. Он таргетит app-under-test независимо от того, какой инстанс его лаунчил, так что правок тест-методов не нужно — каждый тест оставляет чистый лист для следующего launch.

Файлы: FiringFlow / NoBalanceTopUp / Onboarding / ProgressiveSnooze / CreateAlarm UITests.

Верификация — сам CI: если фикс рабочий, прогон E2E этого PR стабилен. swiftlint 0.